### PR TITLE
docs: update README structure and CHANGELOG for v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,29 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-12-22
+
 ### Added
-- Phase 1: Cargo.toml parser implementation (in progress)
+- **npm/package.json support** — Full ecosystem support for npm packages
+  - Package name autocomplete from npm registry
+  - Version hints and diagnostics
+  - Hover information with version list
+- **Multi-crate architecture** — Extracted shared code into reusable crates
+  - `deps-core`: Shared types, HTTP cache, error handling, traits
+  - `deps-cargo`: Cargo.toml parser and crates.io registry client
+  - `deps-npm`: package.json parser and npm registry client
+- **UX improvements**
+  - Emoji indicators for version status (✅ up-to-date, ❌ outdated)
+  - Version list in hover popup with docs.rs links
+  - Multiple version options in code actions (up to 5)
+  - Clickable links to crates.io/npmjs.com in inlay hints
+- **Performance improvements**
+  - Version caching in document state
+  - FULL document sync for immediate file change detection
+  - Parallel version fetching
+
+### Changed
+- MSRV bumped to 1.89 for let-chains support
+- Refactored handlers to use let-chains for cleaner code
 
 ## [0.1.0] - 2024-12-22
 
 ### Added
-- Initial project infrastructure (Phase 0)
-- LSP server scaffolding with tower-lsp
-- HTTP cache with ETag/Last-Modified validation
-- Document state management with DashMap
-- Configuration system with serde deserialization
-- Error types with thiserror
-- Cargo.toml type definitions with position tracking
-- Zed extension scaffolding (deps-zed)
-- Test infrastructure with cargo-nextest
-- Code coverage with cargo-llvm-cov (87% coverage)
-- Security scanning with cargo-deny
-- CI/CD pipeline with GitHub Actions
+- **Cargo.toml support** — Full LSP features for Rust dependencies
+  - Package name autocomplete from crates.io sparse index
+  - Version autocomplete with semver filtering
+  - Feature flag autocomplete
+  - Inlay hints showing latest available versions
+  - Diagnostics for unknown, yanked, and outdated packages
+  - Hover information with package metadata
+  - Code actions to update dependency versions
+  - Support for `[dependencies]`, `[dev-dependencies]`, `[build-dependencies]`
+  - Support for `[workspace.dependencies]` section
+- **LSP server infrastructure**
+  - tower-lsp based implementation
+  - HTTP cache with ETag/Last-Modified validation
+  - Document state management with DashMap
+  - Configuration system with serde deserialization
+  - Error types with thiserror
+- **Zed extension** (deps-zed)
+  - WASM-based extension for Zed editor
+  - Auto-download of pre-built binaries
+- **Development infrastructure**
+  - Test suite with cargo-nextest
+  - Code coverage with cargo-llvm-cov
+  - Security scanning with cargo-deny
+  - CI/CD pipeline with GitHub Actions
+  - Cross-platform builds (Linux, macOS, Windows)
 
 ### Security
 - Zero unsafe code blocks
 - TLS enforced via rustls
 - cargo-deny configured for vulnerability scanning
 
-[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/bug-ops/deps-lsp/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/bug-ops/deps-lsp/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ A universal Language Server Protocol (LSP) server for dependency management acro
 
 | Ecosystem | Manifest File | Status |
 |-----------|---------------|--------|
-| Rust/Cargo | `Cargo.toml` | In Development |
-| npm | `package.json` | Planned |
+| Rust/Cargo | `Cargo.toml` | Supported |
+| npm | `package.json` | Supported |
 | Python/PyPI | `pyproject.toml` | Planned |
 
 ## Installation
@@ -148,10 +148,13 @@ cargo deny check
 ```
 deps-lsp/
 ├── crates/
+│   ├── deps-core/      # Shared types, cache, error handling
+│   ├── deps-cargo/     # Cargo.toml parser + crates.io registry
+│   ├── deps-npm/       # package.json parser + npm registry
 │   ├── deps-lsp/       # Main LSP server
 │   └── deps-zed/       # Zed extension (WASM)
 ├── .config/            # nextest configuration
-└── .local/             # Development artifacts
+└── .github/            # CI/CD workflows
 ```
 
 ## License


### PR DESCRIPTION
## Summary

- Update project structure in README to reflect new multi-crate architecture
- Update supported ecosystems table (Cargo and npm are now Supported)
- Add comprehensive CHANGELOG entry for v0.2.0 release

## Changes

**README.md:**
- Updated project structure to show `deps-core`, `deps-cargo`, `deps-npm` crates
- Changed Cargo.toml status from "In Development" to "Supported"
- Changed package.json status from "Planned" to "Supported"

**CHANGELOG.md:**
- Added v0.2.0 section with all Phase 2 changes
- Updated v0.1.0 section with complete Phase 1 features