### PR TITLE
fix(zed): register LSP for JSON language (package.json support)

### DIFF
--- a/crates/deps-zed/extension.toml
+++ b/crates/deps-zed/extension.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/bug-ops/deps-lsp"
 
 [language_servers.deps-lsp]
 name = "Deps LSP"
-languages = ["TOML"]
+languages = ["TOML", "JSON"]


### PR DESCRIPTION
## Summary

Fixes package.json not being handled by deps-lsp in Zed.

## Problem

The extension was only registered for `TOML` language, so package.json files were being handled by the default `package-version-server` instead of deps-lsp.

## Solution

Added `JSON` to the languages list in `extension.toml`:

```toml
languages = ["TOML", "JSON"]
```

Now deps-lsp will activate for both Cargo.toml and package.json files.