### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - FULL document sync for immediate file change detection
   - Parallel version fetching
 
+### Fixed
+- npm parser: Correct position finding for dependencies sharing version string (e.g., vitest)
+
 ### Changed
 - MSRV bumped to 1.89 for let-chains support
 - Refactored handlers to use let-chains for cleaner code
+- Extracted deps-zed to [separate repository](https://github.com/bug-ops/deps-zed) as git submodule
 
 ## [0.1.0] - 2024-12-22
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/deps-zed"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Andrei G"]
@@ -15,10 +15,10 @@ repository = "https://github.com/bug-ops/deps-lsp"
 async-trait = "0.1"
 criterion = "0.8"
 dashmap = "6.1"
-deps-core = { version = "0.1.0", path = "crates/deps-core" }
-deps-cargo = { version = "0.1.0", path = "crates/deps-cargo" }
-deps-npm = { version = "0.1.0", path = "crates/deps-npm" }
-deps-lsp = { version = "0.1.0", path = "crates/deps-lsp" }
+deps-core = { version = "0.2.0", path = "crates/deps-core" }
+deps-cargo = { version = "0.2.0", path = "crates/deps-cargo" }
+deps-npm = { version = "0.2.0", path = "crates/deps-npm" }
+deps-lsp = { version = "0.2.0", path = "crates/deps-lsp" }
 futures = "0.3"
 insta = "1"
 mockito = "1"

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Install the **Deps** extension from Zed Extensions marketplace.
 ```lua
 require('lspconfig').deps_lsp.setup({
   cmd = { "deps-lsp", "--stdio" },
-  filetypes = { "toml" },
+  filetypes = { "toml", "json" },
 })
 ```
 
@@ -77,6 +77,10 @@ require('lspconfig').deps_lsp.setup({
 # ~/.config/helix/languages.toml
 [[language]]
 name = "toml"
+language-servers = ["deps-lsp"]
+
+[[language]]
+name = "json"
 language-servers = ["deps-lsp"]
 
 [language-server.deps-lsp]


### PR DESCRIPTION
## Summary

- Bump version to 0.2.0 across workspace manifest
- Update editor configs (Neovim, Helix) in README for JSON/package.json support
- Update CHANGELOG with recent fixes (vitest parser bug) and deps-zed submodule extraction

## Release Checklist

- [x] Version bumped in `Cargo.toml`
- [x] CHANGELOG updated
- [x] README updated with npm ecosystem editor support
- [x] deps-zed remains at 0.1.0 (independent versioning)