### PR TITLE
fix(ci): skip strip for cross-compiled binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,8 +128,8 @@ jobs:
           fi
         shell: bash
 
-      - name: Strip binary (Linux/macOS)
-        if: matrix.os != 'windows-latest'
+      - name: Strip binary (Linux/macOS, native only)
+        if: matrix.os != 'windows-latest' && !matrix.use_cross
         run: strip target/${{ matrix.target }}/release/${{ steps.binary.outputs.name }}
 
       - name: Create archive (Unix)


### PR DESCRIPTION
## Summary

- Skip `strip` command for cross-compiled targets (aarch64-linux-gnu)
- Host `strip` cannot process ARM binaries
- Rust's `strip = true` in release profile already handles stripping during compilation

## Fixes

Release workflow failing on aarch64-unknown-linux-gnu build.