### PR TITLE
docs: add crates.io badges and README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # deps-lsp
 
+[![Crates.io](https://img.shields.io/crates/v/deps-lsp)](https://crates.io/crates/deps-lsp)
+[![docs.rs](https://img.shields.io/docsrs/deps-lsp)](https://docs.rs/deps-lsp)
 [![CI](https://img.shields.io/github/actions/workflow/status/bug-ops/deps-lsp/ci.yml?branch=main)](https://github.com/bug-ops/deps-lsp/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![MSRV](https://img.shields.io/badge/MSRV-1.89-blue)](https://blog.rust-lang.org/)

--- a/crates/deps-cargo/README.md
+++ b/crates/deps-cargo/README.md
@@ -1,0 +1,31 @@
+# deps-cargo
+
+[![Crates.io](https://img.shields.io/crates/v/deps-cargo)](https://crates.io/crates/deps-cargo)
+[![docs.rs](https://img.shields.io/docsrs/deps-cargo)](https://docs.rs/deps-cargo)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../../LICENSE)
+
+Cargo.toml support for deps-lsp.
+
+This crate provides parsing and registry integration for Rust's Cargo ecosystem.
+
+## Features
+
+- **TOML Parsing** — Parse `Cargo.toml` with position tracking using `toml_edit`
+- **crates.io Registry** — Sparse index client for package metadata
+- **Version Resolution** — Semver-aware version matching
+- **Workspace Support** — Handle `workspace.dependencies` inheritance
+
+## Usage
+
+```toml
+[dependencies]
+deps-cargo = "0.2"
+```
+
+```rust
+use deps_cargo::{CargoParser, CratesIoRegistry};
+```
+
+## License
+
+[MIT](../../LICENSE)

--- a/crates/deps-core/README.md
+++ b/crates/deps-core/README.md
@@ -1,0 +1,31 @@
+# deps-core
+
+[![Crates.io](https://img.shields.io/crates/v/deps-core)](https://crates.io/crates/deps-core)
+[![docs.rs](https://img.shields.io/docsrs/deps-core)](https://docs.rs/deps-core)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../../LICENSE)
+
+Core abstractions for deps-lsp: caching, errors, and traits.
+
+This crate provides the shared infrastructure used by ecosystem-specific crates like `deps-cargo` and `deps-npm`.
+
+## Features
+
+- **HTTP Cache** — ETag/Last-Modified caching for registry requests
+- **Error Types** — Unified error handling with `thiserror`
+- **Traits** — `PackageRegistry` and `ManifestParser` abstractions
+- **Document State** — Shared types for LSP document management
+
+## Usage
+
+```toml
+[dependencies]
+deps-core = "0.2"
+```
+
+```rust
+use deps_core::{HttpCache, PackageRegistry, DepsError};
+```
+
+## License
+
+[MIT](../../LICENSE)

--- a/crates/deps-npm/README.md
+++ b/crates/deps-npm/README.md
@@ -1,0 +1,31 @@
+# deps-npm
+
+[![Crates.io](https://img.shields.io/crates/v/deps-npm)](https://crates.io/crates/deps-npm)
+[![docs.rs](https://img.shields.io/docsrs/deps-npm)](https://docs.rs/deps-npm)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../../LICENSE)
+
+npm/package.json support for deps-lsp.
+
+This crate provides parsing and registry integration for the npm ecosystem.
+
+## Features
+
+- **JSON Parsing** — Parse `package.json` with position tracking
+- **npm Registry** — Client for npm registry API
+- **Version Resolution** — Node semver-aware version matching
+- **Scoped Packages** — Support for `@scope/package` format
+
+## Usage
+
+```toml
+[dependencies]
+deps-npm = "0.2"
+```
+
+```rust
+use deps_npm::{NpmParser, NpmRegistry};
+```
+
+## License
+
+[MIT](../../LICENSE)


### PR DESCRIPTION
## Summary

- Add crates.io and docs.rs badges to main README
- Create README files for all crates:
  - `deps-core` — Core abstractions
  - `deps-cargo` — Cargo.toml support
  - `deps-npm` — package.json support