### PR TITLE
ci(codecov): add per-crate coverage flags

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -40,9 +40,29 @@ ignore:
   - "**/main.rs"
   - "crates/deps-zed/**/*"  # WASM extension has limited testing
 
-# Flags for different test types
+# Per-crate flags for detailed coverage tracking
 flags:
-  unittests:
+  deps-core:
+    paths:
+      - crates/deps-core/src/
+    carryforward: true
+
+  deps-cargo:
+    paths:
+      - crates/deps-cargo/src/
+    carryforward: true
+
+  deps-npm:
+    paths:
+      - crates/deps-npm/src/
+    carryforward: true
+
+  deps-pypi:
+    paths:
+      - crates/deps-pypi/src/
+    carryforward: true
+
+  deps-lsp:
     paths:
       - crates/deps-lsp/src/
     carryforward: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,26 +207,73 @@ jobs:
         with:
           shared-key: "coverage"
 
-      - name: Generate coverage
+      - name: Generate overall coverage
         run: |
           cargo llvm-cov --all-features --workspace --lcov \
             --output-path lcov.info nextest
 
-      - name: Upload to codecov
+      - name: Generate per-crate coverage
+        run: |
+          # Generate coverage for each crate separately
+          for crate in deps-core deps-cargo deps-npm deps-pypi deps-lsp; do
+            echo "Generating coverage for $crate..."
+            cargo llvm-cov --all-features --package "$crate" --lcov \
+              --output-path "lcov-$crate.info" nextest 2>/dev/null || true
+          done
+
+      - name: Upload overall coverage
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: false
           verbose: true
-          flags: unittests
-          name: codecov-umbrella
 
-      - name: Archive coverage report
+      - name: Upload deps-core coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov-deps-core.info
+          flags: deps-core
+          fail_ci_if_error: false
+
+      - name: Upload deps-cargo coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov-deps-cargo.info
+          flags: deps-cargo
+          fail_ci_if_error: false
+
+      - name: Upload deps-npm coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov-deps-npm.info
+          flags: deps-npm
+          fail_ci_if_error: false
+
+      - name: Upload deps-pypi coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov-deps-pypi.info
+          flags: deps-pypi
+          fail_ci_if_error: false
+
+      - name: Upload deps-lsp coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov-deps-lsp.info
+          flags: deps-lsp
+          fail_ci_if_error: false
+
+      - name: Archive coverage reports
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-report
-          path: lcov.info
+          name: coverage-reports
+          path: lcov*.info
           retention-days: 30
 
   # MSRV check


### PR DESCRIPTION
## Summary

- Configure Codecov flags for each crate: `deps-core`, `deps-cargo`, `deps-npm`, `deps-pypi`, `deps-lsp`
- Generate and upload per-crate coverage reports separately in CI
- Each crate README badge shows its specific coverage via `?flag=<crate>` parameter

## Changes

### `.github/codecov.yml`
- Added flag definitions with path-based routing for each crate
- Enabled carryforward to preserve coverage when crates aren't modified

### `.github/workflows/ci.yml`
- Generate per-crate coverage using `cargo llvm-cov --package <crate>`
- Upload each coverage report with its corresponding flag
- Keep overall workspace coverage for main README

## Badge Format

```markdown
# Overall (main README)
[![codecov](https://codecov.io/gh/bug-ops/deps-lsp/graph/badge.svg?token=TOKEN)]

# Per-crate (crate READMEs)
[![codecov](https://codecov.io/gh/bug-ops/deps-lsp/graph/badge.svg?token=TOKEN&flag=deps-core)]
```

## Test Plan

- [ ] CI passes
- [ ] Codecov receives flagged coverage reports
- [ ] Per-crate badges update on Codecov dashboard