### PR TITLE
chore(ci): remove sccache from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,15 +96,6 @@ jobs:
         if: matrix.use_cross
         run: cargo binstall --no-confirm cross
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.8
-
-      - name: Configure sccache
-        run: |
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-        shell: bash
-
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Summary

Remove sccache from release workflow, keeping only cargo cache via Swatinem/rust-cache.

## Changes

- Remove `mozilla-actions/sccache-action@v0.0.8` step
- Remove sccache environment variables (`RUSTC_WRAPPER`, `SCCACHE_GHA_ENABLED`)
- Keep `Swatinem/rust-cache@v2` for cargo dependency caching

## Rationale

Release builds prioritize correctness and reproducibility over incremental build speed. Standard cargo caching is sufficient for release workflows.