### PR TITLE
feat(ci): add Windows x86 and ARM64 build targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,11 @@ jobs:
             rust: stable
             target: aarch64-pc-windows-msvc
             cross: true
+          # Test Windows x86 (32-bit)
+          - os: windows-latest
+            rust: stable
+            target: i686-pc-windows-msvc
+            cross: false
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,12 @@ jobs:
             archive: zip
             use_cross: false
 
+          # Windows x86 (32-bit)
+          - os: windows-latest
+            target: i686-pc-windows-msvc
+            archive: zip
+            use_cross: false
+
           # Windows aarch64 (ARM64)
           - os: windows-latest
             target: aarch64-pc-windows-msvc
@@ -281,6 +287,7 @@ jobs:
             - **macOS x86_64**: `deps-lsp-x86_64-apple-darwin.tar.gz`
             - **macOS ARM64**: `deps-lsp-aarch64-apple-darwin.tar.gz`
             - **Windows x64**: `deps-lsp-x86_64-pc-windows-msvc.zip`
+            - **Windows x86**: `deps-lsp-i686-pc-windows-msvc.zip`
             - **Windows ARM64**: `deps-lsp-aarch64-pc-windows-msvc.zip`
 
             Extract and add to your PATH:


### PR DESCRIPTION
## Summary

Add Windows x86 (32-bit) and ARM64 build targets to CI/CD workflows.

## Changes

### CI Workflow
- Add `i686-pc-windows-msvc` (Windows x86) to test matrix

### Release Workflow
- Add `i686-pc-windows-msvc` (Windows x86) binary release
- Add `aarch64-pc-windows-msvc` (Windows ARM64) binary release

## Platform Matrix

| Platform | x86_64 | x86 | ARM64 |
|----------|--------|-----|-------|
| Linux | ✅ | — | ✅ |
| macOS | ✅ | — | ✅ |
| Windows | ✅ | ✅ | ✅ |

**7 platform binaries** will be published on release.