### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2025-12-25
+
+### Fixed
+- Inlay hints now compare against absolute latest stable version, not just matching major.minor
+- Pre-release versions filtered from "newer version available" diagnostics
+- Background tasks no longer exit early due to `parse_result` being lost on clone
+
+### Changed
+- Extracted `find_latest_stable()` utility for consistent version comparison across features
+
 ## [0.3.0] - 2025-12-24
 
 ### Added
@@ -126,7 +136,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TLS enforced via rustls
 - cargo-deny configured for vulnerability scanning
 
-[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/bug-ops/deps-lsp/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/bug-ops/deps-lsp/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/bug-ops/deps-lsp/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/bug-ops/deps-lsp/compare/v0.2.1...v0.2.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "deps-cargo"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "criterion",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "deps-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "deps-lsp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "dashmap 6.1.0",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "deps-npm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "criterion",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "deps-pypi"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/deps-zed"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Andrei G"]
@@ -15,11 +15,11 @@ repository = "https://github.com/bug-ops/deps-lsp"
 async-trait = "0.1"
 criterion = "0.8"
 dashmap = "6.1"
-deps-core = { version = "0.3.0", path = "crates/deps-core" }
-deps-cargo = { version = "0.3.0", path = "crates/deps-cargo" }
-deps-npm = { version = "0.3.0", path = "crates/deps-npm" }
-deps-pypi = { version = "0.3.0", path = "crates/deps-pypi" }
-deps-lsp = { version = "0.3.0", path = "crates/deps-lsp" }
+deps-core = { version = "0.3.1", path = "crates/deps-core" }
+deps-cargo = { version = "0.3.1", path = "crates/deps-cargo" }
+deps-npm = { version = "0.3.1", path = "crates/deps-npm" }
+deps-pypi = { version = "0.3.1", path = "crates/deps-pypi" }
+deps-lsp = { version = "0.3.1", path = "crates/deps-lsp" }
 futures = "0.3"
 insta = "1"
 mockito = "1"


### PR DESCRIPTION
## Release v0.3.1

### Fixed
- Inlay hints now compare against absolute latest stable version, not just matching major.minor
- Pre-release versions filtered from "newer version available" diagnostics
- Background tasks no longer exit early due to `parse_result` being lost on clone

### Changed
- Extracted `find_latest_stable()` utility for consistent version comparison across features

---

**After merge:** Create tag `v0.3.1` to trigger release workflow.