### PR TITLE
feat: Release v0.5.0 - Ecosystem feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2025-12-26
+
+### Added
+- **Go modules support** — Full ecosystem support for Go packages (`deps-go` crate)
+  - go.mod parser with position tracking for all directives
+  - go.sum lock file parser for resolved versions
+  - Support for `require`, `replace`, `exclude` directives
+  - Indirect dependency detection (`// indirect` comments)
+  - Pseudo-version parsing and display
+  - proxy.golang.org registry client with HTTP caching
+  - Module path escaping for uppercase characters
+  - Inlay hints, hover, code actions, diagnostics
+- Lockfile template added to ecosystem templates
+- Formatter template added to ecosystem templates
+
+### Changed
+- **Feature flags for ecosystems** — Each ecosystem can now be enabled/disabled independently
+  - `cargo` — Cargo.toml support (default: enabled)
+  - `npm` — package.json support (default: enabled)
+  - `pypi` — pyproject.toml support (default: enabled)
+  - `go` — go.mod support (default: enabled)
+- Updated ECOSYSTEM_GUIDE.md with Go examples and lockfile/formatter requirements
+- Templates now include lockfile.rs.template and formatter.rs.template
+
 ## [0.4.1] - 2025-12-26
 
 ### Added
@@ -174,7 +198,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TLS enforced via rustls
 - cargo-deny configured for vulnerability scanning
 
-[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/bug-ops/deps-lsp/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/bug-ops/deps-lsp/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/bug-ops/deps-lsp/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/bug-ops/deps-lsp/compare/v0.3.0...v0.3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "deps-cargo"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "deps-core"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "deps-go"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "deps-core",
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "deps-lsp"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "dashmap",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "deps-npm"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "deps-pypi"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/deps-zed"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Andrei G"]
@@ -15,12 +15,12 @@ repository = "https://github.com/bug-ops/deps-lsp"
 async-trait = "0.1"
 criterion = "0.8"
 dashmap = "6.1"
-deps-core = { version = "0.4.1", path = "crates/deps-core" }
-deps-cargo = { version = "0.4.1", path = "crates/deps-cargo" }
-deps-npm = { version = "0.4.1", path = "crates/deps-npm" }
-deps-pypi = { version = "0.4.1", path = "crates/deps-pypi" }
-deps-go = { version = "0.4.1", path = "crates/deps-go" }
-deps-lsp = { version = "0.4.1", path = "crates/deps-lsp" }
+deps-core = { version = "0.5.0", path = "crates/deps-core" }
+deps-cargo = { version = "0.5.0", path = "crates/deps-cargo" }
+deps-npm = { version = "0.5.0", path = "crates/deps-npm" }
+deps-pypi = { version = "0.5.0", path = "crates/deps-pypi" }
+deps-go = { version = "0.5.0", path = "crates/deps-go" }
+deps-lsp = { version = "0.5.0", path = "crates/deps-lsp" }
 futures = "0.3"
 insta = "1"
 mockito = "1"

--- a/README.md
+++ b/README.md
@@ -82,6 +82,25 @@ Download from [GitHub Releases](https://github.com/bug-ops/deps-lsp/releases/lat
 | macOS | Apple Silicon | `deps-lsp-aarch64-apple-darwin` |
 | Windows | x86_64 | `deps-lsp-x86_64-pc-windows-msvc.exe` |
 
+### Feature Flags
+
+By default, all ecosystems are enabled. To build with specific ecosystems only:
+
+```bash
+# Only Cargo and npm support
+cargo install deps-lsp --no-default-features --features "cargo,npm"
+
+# Only Python support
+cargo install deps-lsp --no-default-features --features "pypi"
+```
+
+| Feature | Ecosystem | Default |
+|---------|-----------|---------|
+| `cargo` | Cargo.toml | ✅ |
+| `npm` | package.json | ✅ |
+| `pypi` | pyproject.toml | ✅ |
+| `go` | go.mod | ✅ |
+
 ## Editor Setup
 
 ### Zed

--- a/crates/deps-cargo/README.md
+++ b/crates/deps-cargo/README.md
@@ -22,7 +22,7 @@ This crate provides parsing and registry integration for Rust's Cargo ecosystem.
 
 ```toml
 [dependencies]
-deps-cargo = "0.4"
+deps-cargo = "0.5"
 ```
 
 ```rust

--- a/crates/deps-core/README.md
+++ b/crates/deps-core/README.md
@@ -22,7 +22,7 @@ This crate provides the shared infrastructure used by ecosystem-specific crates 
 
 ```toml
 [dependencies]
-deps-core = "0.4"
+deps-core = "0.5"
 ```
 
 ```rust

--- a/crates/deps-go/README.md
+++ b/crates/deps-go/README.md
@@ -12,6 +12,7 @@ This crate provides parsing and registry integration for Go's module ecosystem.
 ## Features
 
 - **go.mod Parsing** — Parse `go.mod` with position tracking for all directives
+- **go.sum Lock File** — Extract resolved versions from `go.sum`
 - **Directive Support** — Handle `require`, `replace`, `exclude`, and `retract` directives
 - **Indirect Dependencies** — Detect and mark indirect dependencies (`// indirect`)
 - **Pseudo-versions** — Parse and validate Go pseudo-version format
@@ -23,7 +24,7 @@ This crate provides parsing and registry integration for Go's module ecosystem.
 
 ```toml
 [dependencies]
-deps-go = "0.4"
+deps-go = "0.5"
 ```
 
 ```rust

--- a/crates/deps-lsp/Cargo.toml
+++ b/crates/deps-lsp/Cargo.toml
@@ -17,13 +17,20 @@ path = "src/main.rs"
 name = "deps_lsp"
 path = "src/lib.rs"
 
+[features]
+default = ["cargo", "npm", "pypi", "go"]
+cargo = ["dep:deps-cargo"]
+npm = ["dep:deps-npm"]
+pypi = ["dep:deps-pypi"]
+go = ["dep:deps-go"]
+
 [dependencies]
 # Internal crates
 deps-core = { workspace = true }
-deps-cargo = { workspace = true }
-deps-npm = { workspace = true }
-deps-pypi = { workspace = true }
-deps-go = { workspace = true }
+deps-cargo = { workspace = true, optional = true }
+deps-npm = { workspace = true, optional = true }
+deps-pypi = { workspace = true, optional = true }
+deps-go = { workspace = true, optional = true }
 
 # External dependencies
 dashmap = { workspace = true }

--- a/crates/deps-lsp/src/handlers/code_actions.rs
+++ b/crates/deps-lsp/src/handlers/code_actions.rs
@@ -53,9 +53,11 @@ pub async fn handle_code_actions(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::document::{DocumentState, ServerState};
+    use crate::document::ServerState;
     use crate::test_utils::test_helpers::create_test_client_and_config;
     use tower_lsp_server::ls_types::{Position, Range, TextDocumentIdentifier, Uri};
+
+    // Generic tests (no feature flag required)
 
     #[tokio::test]
     async fn test_handle_code_actions_missing_document() {
@@ -75,87 +77,99 @@ mod tests {
         assert!(result.is_empty());
     }
 
-    #[tokio::test]
-    async fn test_handle_code_actions_cargo() {
-        let state = Arc::new(ServerState::new());
-        let uri = Uri::from_file_path("/test/Cargo.toml").unwrap();
+    // Cargo-specific tests
+    #[cfg(feature = "cargo")]
+    mod cargo_tests {
+        use super::*;
+        use crate::document::{DocumentState, Ecosystem};
 
-        let ecosystem = state.ecosystem_registry.get("cargo").unwrap();
-        let content = r#"[dependencies]
+        #[tokio::test]
+        async fn test_handle_code_actions() {
+            let state = Arc::new(ServerState::new());
+            let uri = Uri::from_file_path("/test/Cargo.toml").unwrap();
+
+            let ecosystem = state.ecosystem_registry.get("cargo").unwrap();
+            let content = r#"[dependencies]
 serde = "1.0.0"
 "#
-        .to_string();
+            .to_string();
 
-        let parse_result = ecosystem
-            .parse_manifest(&content, &uri)
-            .await
-            .expect("Failed to parse manifest");
+            let parse_result = ecosystem
+                .parse_manifest(&content, &uri)
+                .await
+                .expect("Failed to parse manifest");
 
-        let doc_state = DocumentState::new_from_parse_result("cargo", content, parse_result);
-        state.update_document(uri.clone(), doc_state);
+            let doc_state = DocumentState::new_from_parse_result("cargo", content, parse_result);
+            state.update_document(uri.clone(), doc_state);
 
-        let params = CodeActionParams {
-            text_document: TextDocumentIdentifier { uri },
-            range: Range::new(Position::new(1, 9), Position::new(1, 16)),
-            context: Default::default(),
-            work_done_progress_params: Default::default(),
-            partial_result_params: Default::default(),
-        };
+            let params = CodeActionParams {
+                text_document: TextDocumentIdentifier { uri },
+                range: Range::new(Position::new(1, 9), Position::new(1, 16)),
+                context: Default::default(),
+                work_done_progress_params: Default::default(),
+                partial_result_params: Default::default(),
+            };
 
-        let (client, config) = create_test_client_and_config();
-        let _result = handle_code_actions(state, params, client, config).await;
-        // Test passes if no panic occurs
+            let (client, config) = create_test_client_and_config();
+            let _result = handle_code_actions(state, params, client, config).await;
+            // Test passes if no panic occurs
+        }
+
+        #[tokio::test]
+        async fn test_handle_code_actions_no_parse_result() {
+            let state = Arc::new(ServerState::new());
+            let uri = Uri::from_file_path("/test/Cargo.toml").unwrap();
+
+            let doc_state = DocumentState::new(Ecosystem::Cargo, "".to_string(), vec![]);
+            state.update_document(uri.clone(), doc_state);
+
+            let params = CodeActionParams {
+                text_document: TextDocumentIdentifier { uri },
+                range: Range::new(Position::new(0, 0), Position::new(0, 0)),
+                context: Default::default(),
+                work_done_progress_params: Default::default(),
+                partial_result_params: Default::default(),
+            };
+
+            let (client, config) = create_test_client_and_config();
+            let result = handle_code_actions(state, params, client, config).await;
+            assert!(result.is_empty());
+        }
     }
 
-    #[tokio::test]
-    async fn test_handle_code_actions_npm() {
-        let state = Arc::new(ServerState::new());
-        let uri = Uri::from_file_path("/test/package.json").unwrap();
+    // npm-specific tests
+    #[cfg(feature = "npm")]
+    mod npm_tests {
+        use super::*;
+        use crate::document::DocumentState;
 
-        let ecosystem = state.ecosystem_registry.get("npm").unwrap();
-        let content = r#"{"dependencies": {"express": "4.0.0"}}"#.to_string();
+        #[tokio::test]
+        async fn test_handle_code_actions() {
+            let state = Arc::new(ServerState::new());
+            let uri = Uri::from_file_path("/test/package.json").unwrap();
 
-        let parse_result = ecosystem
-            .parse_manifest(&content, &uri)
-            .await
-            .expect("Failed to parse manifest");
+            let ecosystem = state.ecosystem_registry.get("npm").unwrap();
+            let content = r#"{"dependencies": {"express": "4.0.0"}}"#.to_string();
 
-        let doc_state = DocumentState::new_from_parse_result("npm", content, parse_result);
-        state.update_document(uri.clone(), doc_state);
+            let parse_result = ecosystem
+                .parse_manifest(&content, &uri)
+                .await
+                .expect("Failed to parse manifest");
 
-        let params = CodeActionParams {
-            text_document: TextDocumentIdentifier { uri },
-            range: Range::new(Position::new(0, 25), Position::new(0, 32)),
-            context: Default::default(),
-            work_done_progress_params: Default::default(),
-            partial_result_params: Default::default(),
-        };
+            let doc_state = DocumentState::new_from_parse_result("npm", content, parse_result);
+            state.update_document(uri.clone(), doc_state);
 
-        let (client, config) = create_test_client_and_config();
-        let _result = handle_code_actions(state, params, client, config).await;
-        // Test passes if no panic occurs
-    }
+            let params = CodeActionParams {
+                text_document: TextDocumentIdentifier { uri },
+                range: Range::new(Position::new(0, 25), Position::new(0, 32)),
+                context: Default::default(),
+                work_done_progress_params: Default::default(),
+                partial_result_params: Default::default(),
+            };
 
-    #[tokio::test]
-    async fn test_handle_code_actions_no_parse_result() {
-        use crate::document::Ecosystem;
-
-        let state = Arc::new(ServerState::new());
-        let uri = Uri::from_file_path("/test/Cargo.toml").unwrap();
-
-        let doc_state = DocumentState::new(Ecosystem::Cargo, "".to_string(), vec![]);
-        state.update_document(uri.clone(), doc_state);
-
-        let params = CodeActionParams {
-            text_document: TextDocumentIdentifier { uri },
-            range: Range::new(Position::new(0, 0), Position::new(0, 0)),
-            context: Default::default(),
-            work_done_progress_params: Default::default(),
-            partial_result_params: Default::default(),
-        };
-
-        let (client, config) = create_test_client_and_config();
-        let result = handle_code_actions(state, params, client, config).await;
-        assert!(result.is_empty());
+            let (client, config) = create_test_client_and_config();
+            let _result = handle_code_actions(state, params, client, config).await;
+            // Test passes if no panic occurs
+        }
     }
 }

--- a/crates/deps-lsp/src/lib.rs
+++ b/crates/deps-lsp/src/lib.rs
@@ -11,15 +11,29 @@ mod test_utils;
 pub use deps_core::{DepsError, Result};
 
 // Re-export from deps-cargo
+#[cfg(feature = "cargo")]
 pub use deps_cargo::{
     CargoParser, CargoVersion, CrateInfo, CratesIoRegistry, DependencySection, DependencySource,
     ParseResult, ParsedDependency, parse_cargo_toml,
 };
 
 // Re-export from deps-npm
+#[cfg(feature = "npm")]
 pub use deps_npm::{
     NpmDependency, NpmDependencySection, NpmPackage, NpmParseResult, NpmRegistry, NpmVersion,
     parse_package_json,
+};
+
+// Re-export from deps-pypi
+#[cfg(feature = "pypi")]
+pub use deps_pypi::{
+    PypiDependency, PypiDependencySection, PypiEcosystem, PypiParser, PypiRegistry, PypiVersion,
+};
+
+// Re-export from deps-go
+#[cfg(feature = "go")]
+pub use deps_go::{
+    GoDependency, GoDirective, GoEcosystem, GoParseResult, GoRegistry, GoVersion, parse_go_mod,
 };
 
 // Re-export server

--- a/crates/deps-npm/README.md
+++ b/crates/deps-npm/README.md
@@ -22,7 +22,7 @@ This crate provides parsing and registry integration for the npm ecosystem.
 
 ```toml
 [dependencies]
-deps-npm = "0.4"
+deps-npm = "0.5"
 ```
 
 ```rust

--- a/crates/deps-pypi/README.md
+++ b/crates/deps-pypi/README.md
@@ -24,7 +24,7 @@ This crate provides parsing and registry integration for Python's PyPI ecosystem
 
 ```toml
 [dependencies]
-deps-pypi = "0.4"
+deps-pypi = "0.5"
 ```
 
 ```rust

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -13,10 +13,11 @@ crates/deps-{ecosystem}/
     ├── lib.rs          # Re-exports and module declarations
     ├── ecosystem.rs    # Ecosystem trait implementation
     ├── error.rs        # Ecosystem-specific error types
+    ├── formatter.rs    # Version display formatting
+    ├── lockfile.rs     # Lock file parsing
     ├── parser.rs       # Manifest file parsing with position tracking
     ├── registry.rs     # Package registry API client
-    ├── types.rs        # Dependency, Version, and other types
-    └── lockfile.rs     # Lock file parsing (optional)
+    └── types.rs        # Dependency, Version, and other types
 ```
 
 ## Step 1: Create the Crate
@@ -663,6 +664,8 @@ Before submitting a PR for a new ecosystem:
 - [ ] Error types with conversions to `deps_core::DepsError`
 - [ ] Types implementing `Dependency` and `Version` traits
 - [ ] Parser with accurate position tracking for names AND versions
+- [ ] Lock file parser implementing `LockFileProvider` trait
+- [ ] Formatter implementing `EcosystemFormatter` trait
 - [ ] Registry client with HTTP caching
 - [ ] Ecosystem trait implementation with all LSP features
 - [ ] Unit tests for parser edge cases
@@ -677,3 +680,8 @@ See existing implementations for reference:
 - `crates/deps-cargo/` - Rust/Cargo.toml with crates.io
 - `crates/deps-npm/` - JavaScript/package.json with npm
 - `crates/deps-pypi/` - Python/pyproject.toml with PyPI
+- `crates/deps-go/` - Go/go.mod with proxy.golang.org
+
+## Templates
+
+Use the templates in `templates/deps-ecosystem/` as a starting point for new ecosystems.

--- a/templates/README.md
+++ b/templates/README.md
@@ -17,6 +17,7 @@ This directory contains template files for creating new ecosystem support in dep
 | `{MANIFEST_FILE}` | Manifest filename | `pom.xml`, `go.mod`, `packages.config` |
 | `{REGISTRY_NAME}` | Registry name | `Maven Central`, `proxy.golang.org`, `NuGet.org` |
 | `{REGISTRY_URL}` | Registry API URL | `https://search.maven.org/...` |
+| `{LOCK_FILE}` | Lock file name | `pom.xml.lock`, `go.sum`, `packages.lock.json` |
 
 4. Implement the TODO sections in each file
 5. Add your crate to the workspace in `Cargo.toml`
@@ -32,7 +33,9 @@ deps-ecosystem/
     ├── error.rs.template      # Error types
     ├── types.rs.template      # Dependency/Version types
     ├── parser.rs.template     # Manifest parser (IMPORTANT!)
+    ├── lockfile.rs.template   # Lock file parser
     ├── registry.rs.template   # Package registry client
+    ├── formatter.rs.template  # Version display formatting
     └── ecosystem.rs.template  # Main Ecosystem trait impl
 ```
 

--- a/templates/deps-ecosystem/src/ecosystem.rs.template
+++ b/templates/deps-ecosystem/src/ecosystem.rs.template
@@ -8,10 +8,12 @@ use tower_lsp_server::ls_types::{
 
 use deps_core::{
     Ecosystem, EcosystemConfig, HttpCache, ParseResult as ParseResultTrait, Registry, Result,
+    lockfile::LockFileProvider,
     lsp_helpers,
 };
 
 use crate::formatter::{ECOSYSTEM_PASCAL}Formatter;
+use crate::lockfile::{ECOSYSTEM_PASCAL}LockfileParser;
 use crate::parser::parse_{ECOSYSTEM_SNAKE};
 use crate::registry::{ECOSYSTEM_PASCAL}Registry;
 
@@ -54,6 +56,10 @@ impl Ecosystem for {ECOSYSTEM_PASCAL}Ecosystem {
 
     fn registry(&self) -> Arc<dyn Registry> {
         self.registry.clone()
+    }
+
+    fn lockfile_provider(&self) -> Option<Arc<dyn LockFileProvider>> {
+        Some(Arc::new({ECOSYSTEM_PASCAL}LockfileParser))
     }
 
     async fn generate_inlay_hints(

--- a/templates/deps-ecosystem/src/lib.rs.template
+++ b/templates/deps-ecosystem/src/lib.rs.template
@@ -1,6 +1,9 @@
+//! {ECOSYSTEM_DISPLAY} ecosystem support for deps-lsp.
+
 pub mod ecosystem;
 pub mod error;
 pub mod formatter;
+pub mod lockfile;
 pub mod parser;
 pub mod registry;
 pub mod types;
@@ -8,6 +11,7 @@ pub mod types;
 pub use ecosystem::{ECOSYSTEM_PASCAL}Ecosystem;
 pub use error::{ECOSYSTEM_PASCAL}Error, Result;
 pub use formatter::{ECOSYSTEM_PASCAL}Formatter;
+pub use lockfile::{ECOSYSTEM_PASCAL}LockfileParser;
 pub use parser::parse_{ECOSYSTEM_SNAKE};
 pub use registry::{ECOSYSTEM_PASCAL}Registry;
 pub use types::{ECOSYSTEM_PASCAL}Dependency, {ECOSYSTEM_PASCAL}Version;

--- a/templates/deps-ecosystem/src/lockfile.rs.template
+++ b/templates/deps-ecosystem/src/lockfile.rs.template
@@ -1,0 +1,81 @@
+//! Lock file parsing for {ECOSYSTEM_DISPLAY}.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use deps_core::lockfile::{LockFileProvider, LockedPackage};
+use tokio::fs;
+
+/// Lock file parser for {ECOSYSTEM_DISPLAY}.
+pub struct {ECOSYSTEM_PASCAL}LockfileParser;
+
+#[async_trait]
+impl LockFileProvider for {ECOSYSTEM_PASCAL}LockfileParser {
+    fn lock_filename(&self) -> &'static str {
+        "{LOCK_FILE}"
+    }
+
+    async fn parse_lockfile(
+        &self,
+        manifest_dir: &Path,
+    ) -> deps_core::Result<HashMap<String, LockedPackage>> {
+        let lock_path = manifest_dir.join(self.lock_filename());
+
+        if !lock_path.exists() {
+            return Ok(HashMap::new());
+        }
+
+        let content = fs::read_to_string(&lock_path)
+            .await
+            .map_err(|e| deps_core::DepsError::Io(e))?;
+
+        parse_lock_content(&content)
+    }
+
+    async fn is_stale(&self, manifest_dir: &Path) -> bool {
+        let lock_path = manifest_dir.join(self.lock_filename());
+        let manifest_path = manifest_dir.join("{MANIFEST_FILE}");
+
+        match (fs::metadata(&lock_path).await, fs::metadata(&manifest_path).await) {
+            (Ok(lock_meta), Ok(manifest_meta)) => {
+                match (lock_meta.modified(), manifest_meta.modified()) {
+                    (Ok(lock_time), Ok(manifest_time)) => manifest_time > lock_time,
+                    _ => false,
+                }
+            }
+            _ => false,
+        }
+    }
+}
+
+/// Parse lock file content into package map.
+fn parse_lock_content(content: &str) -> deps_core::Result<HashMap<String, LockedPackage>> {
+    let mut packages = HashMap::new();
+
+    // TODO: Implement lock file parsing logic
+    // Key requirements:
+    // 1. Parse each locked package entry
+    // 2. Extract package name and resolved version
+    // 3. Handle ecosystem-specific format
+
+    Ok(packages)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_empty_lockfile() {
+        let result = parse_lock_content("").unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_lockfile_provider_interface() {
+        let parser = {ECOSYSTEM_PASCAL}LockfileParser;
+        assert_eq!(parser.lock_filename(), "{LOCK_FILE}");
+    }
+}


### PR DESCRIPTION
## Summary

- **Ecosystem feature flags**: Added optional feature flags (`cargo`, `npm`, `pypi`, `go`) allowing users to build deps-lsp with only the ecosystems they need. All features are enabled by default.
- **Test refactoring**: Reorganized ecosystem-specific tests into feature-gated modules for cleaner organization and faster builds when compiling with subset of features.
- **Version bump**: Updated to v0.5.0

## Changes

### Feature Flags
```toml
[features]
default = ["cargo", "npm", "pypi", "go"]
cargo = ["dep:deps-cargo"]
npm = ["dep:deps-npm"]
pypi = ["dep:deps-pypi"]
go = ["dep:deps-go"]
```

### Test Organization
Tests are now grouped into feature-gated modules:
- Generic tests at module root (always compiled)
- `#[cfg(feature = "cargo")] mod cargo_tests`
- `#[cfg(feature = "npm")] mod npm_tests`
- `#[cfg(feature = "pypi")] mod pypi_tests`
- `#[cfg(feature = "go")] mod go_tests`

### Files Changed
- `crates/deps-lsp/Cargo.toml` - Feature flag definitions
- `crates/deps-lsp/src/lib.rs` - Conditional re-exports
- `crates/deps-lsp/src/document/state.rs` - Feature-gated types and tests
- `crates/deps-lsp/src/document/lifecycle.rs` - Feature-gated tests
- `crates/deps-lsp/src/handlers/*.rs` - Feature-gated tests

## Test plan
- [x] All 737 tests pass with all features enabled
- [x] Build succeeds with individual features (`--features "cargo"`)
- [x] Code passes `cargo clippy` and `cargo fmt --check`