### PR TITLE
fix(cargo): handle multi-byte chars in name range search

### DIFF
--- a/crates/deps-cargo/src/parser.rs
+++ b/crates/deps-cargo/src/parser.rs
@@ -233,7 +233,10 @@ fn compute_name_range_from_value(
     };
 
     if let Some(span) = value_span {
-        let search_start = span.start.saturating_sub(name.len() + 100);
+        let mut search_start = span.start.saturating_sub(name.len() + 100);
+        while search_start > 0 && !content.is_char_boundary(search_start) {
+            search_start -= 1;
+        }
         let search_end = span.start;
 
         if search_start < content.len() && search_end <= content.len() {


### PR DESCRIPTION
## Summary

- Fix panic when parsing Cargo.toml files containing multi-byte UTF-8 characters (e.g. emoji)
- `saturating_sub` on byte offset could land inside a multi-byte char, causing slice panic
- Adjust `search_start` to nearest char boundary before slicing

Reproduced with AppFlowy's `frontend/rust-lib/Cargo.toml` which contains `⚠` in comments.

## Test plan

- [x] `cargo nextest run -p deps-cargo` — 91 passed
- [x] `cargo clippy` — clean