### PR TITLE
fix(cargo,dart): handle multi-byte chars and wildcard version matching

### DIFF
--- a/crates/deps-dart/src/version.rs
+++ b/crates/deps-dart/src/version.rs
@@ -32,7 +32,7 @@ pub fn compare_versions(a: &str, b: &str) -> Ordering {
 pub fn version_matches_constraint(version: &str, constraint: &str) -> bool {
     let constraint = constraint.trim();
 
-    if constraint.is_empty() || constraint == "any" {
+    if constraint.is_empty() || constraint == "any" || constraint == "*" {
         return true;
     }
 


### PR DESCRIPTION
## Summary

- **Cargo parser**: adjust `search_start` to char boundary when slicing content for dependency name lookup, preventing panic on Cargo.toml files containing multi-byte UTF-8 characters (e.g. emoji in AppFlowy)
- **Dart version**: treat `"*"` as wildcard (alias for `"any"`) to match the convention used by deps-lsp core when fetching latest versions via `get_latest_matching(name, "*")`

## Test plan

- [x] `cargo nextest run` -- all tests pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` -- clean
- [x] Manual test: AppFlowy `pubspec.yaml` (139 deps) loads without panic, all versions resolved