### PR TITLE
release: prepare v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-02-22
+
 ### Added
 - **Maven ecosystem support** — New `deps-maven` crate with pom.xml parsing and Maven Central integration
   - SAX parser via quick-xml with byte-accurate position tracking
@@ -339,7 +341,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TLS enforced via rustls
 - cargo-deny configured for vulnerability scanning
 
-[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/bug-ops/deps-lsp/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/bug-ops/deps-lsp/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/bug-ops/deps-lsp/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/bug-ops/deps-lsp/compare/v0.5.5...v0.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "deps-bundler"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "criterion",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "deps-cargo"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "criterion",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "deps-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "deps-dart"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "criterion",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "deps-go"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "criterion",
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "deps-lsp"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "criterion",
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "deps-maven"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "deps-core",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "deps-npm"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "criterion",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "deps-pypi"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/deps-zed"]
 resolver = "3"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Andrei G"]
@@ -15,15 +15,15 @@ repository = "https://github.com/bug-ops/deps-lsp"
 async-trait = "0.1"
 criterion = "0.8"
 dashmap = "6.1"
-deps-core = { version = "0.7.0", path = "crates/deps-core" }
-deps-cargo = { version = "0.7.0", path = "crates/deps-cargo" }
-deps-npm = { version = "0.7.0", path = "crates/deps-npm" }
-deps-pypi = { version = "0.7.0", path = "crates/deps-pypi" }
-deps-go = { version = "0.7.0", path = "crates/deps-go" }
-deps-bundler = { version = "0.7.0", path = "crates/deps-bundler" }
-deps-dart = { version = "0.7.0", path = "crates/deps-dart" }
-deps-maven = { version = "0.7.0", path = "crates/deps-maven" }
-deps-lsp = { version = "0.7.0", path = "crates/deps-lsp" }
+deps-core = { version = "0.7.1", path = "crates/deps-core" }
+deps-cargo = { version = "0.7.1", path = "crates/deps-cargo" }
+deps-npm = { version = "0.7.1", path = "crates/deps-npm" }
+deps-pypi = { version = "0.7.1", path = "crates/deps-pypi" }
+deps-go = { version = "0.7.1", path = "crates/deps-go" }
+deps-bundler = { version = "0.7.1", path = "crates/deps-bundler" }
+deps-dart = { version = "0.7.1", path = "crates/deps-dart" }
+deps-maven = { version = "0.7.1", path = "crates/deps-maven" }
+deps-lsp = { version = "0.7.1", path = "crates/deps-lsp" }
 futures = "0.3"
 insta = "1"
 mockito = "1"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ deps-lsp is optimized for responsiveness:
 cargo install deps-lsp
 ```
 
-Latest published crate version: `0.7.0`.
+Latest published crate version: `0.7.1`.
 
 > [!TIP]
 > Use `cargo binstall deps-lsp` for faster installation without compilation.


### PR DESCRIPTION
## Summary

- Bump version from 0.7.0 to 0.7.1
- Update CHANGELOG.md with release notes
- Update README version reference

## Checklist

- [x] Version updated in all manifests
- [x] CHANGELOG.md has release section with date
- [x] README reflects new version
- [x] All pre-release checks pass (fmt, clippy, nextest)
- [ ] Ready for tagging after merge