### PR TITLE
feat(gradle): add variable resolution and settings.gradle parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Parses `[versions]`, `[libraries]` sections with `version.ref` resolution
   - Recognizes all Gradle configurations: implementation, api, compileOnly, runtimeOnly, testImplementation, etc.
   - Feature-gated registration in deps-lsp (`gradle`)
+- **Gradle variable resolution** — `$var` and `${var}` in `build.gradle`/`build.gradle.kts` resolved from `gradle.properties` (walks parent directories)
+- **settings.gradle parsing** — Extract plugin dependencies from `pluginManagement { plugins { } }` blocks (Groovy and Kotlin DSL)
 - **Google Maven repository support** — Android packages (`androidx.*`, `com.google.firebase.*`, `com.google.android.*`, `com.android.*`) now resolve from Google Maven instead of Maven Central
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,7 +539,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",
- "toml_edit",
+ "toml-span",
  "tower-lsp-server",
  "tracing",
 ]
@@ -2370,6 +2370,15 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml-span"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc07a8be6a2b3913e6dc6b250fb3b7c204437dcce7213a56244de2c92c538339"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]

--- a/crates/deps-gradle/src/ecosystem.rs
+++ b/crates/deps-gradle/src/ecosystem.rs
@@ -165,7 +165,13 @@ impl Ecosystem for GradleEcosystem {
     }
 
     fn manifest_filenames(&self) -> &[&'static str] {
-        &["libs.versions.toml", "build.gradle.kts", "build.gradle"]
+        &[
+            "libs.versions.toml",
+            "build.gradle.kts",
+            "build.gradle",
+            "settings.gradle.kts",
+            "settings.gradle",
+        ]
     }
 
     fn lockfile_filenames(&self) -> &[&'static str] {
@@ -312,6 +318,8 @@ mod tests {
         assert!(eco.manifest_filenames().contains(&"libs.versions.toml"));
         assert!(eco.manifest_filenames().contains(&"build.gradle.kts"));
         assert!(eco.manifest_filenames().contains(&"build.gradle"));
+        assert!(eco.manifest_filenames().contains(&"settings.gradle.kts"));
+        assert!(eco.manifest_filenames().contains(&"settings.gradle"));
     }
 
     #[test]

--- a/crates/deps-gradle/src/parser/mod.rs
+++ b/crates/deps-gradle/src/parser/mod.rs
@@ -5,10 +5,13 @@
 pub mod catalog;
 pub mod groovy;
 pub mod kotlin;
+pub mod properties;
+pub mod settings;
 
 use crate::error::Result;
 use crate::types::GradleDependency;
 use std::any::Any;
+use std::collections::HashMap;
 use tower_lsp_server::ls_types::{Position, Range, Uri};
 
 pub use deps_core::lsp_helpers::LineOffsetTable;
@@ -18,20 +21,61 @@ pub struct GradleParseResult {
     pub uri: Uri,
 }
 
+/// Resolves `$var` and `${var}` references in dependency versions using the given properties map.
+///
+/// If a version is a variable reference and the variable is found in `properties`,
+/// the version is replaced with the resolved value. The version_range is kept as-is
+/// (pointing to the variable reference in source).
+pub fn resolve_variables(deps: &mut [GradleDependency], properties: &HashMap<String, String>) {
+    for dep in deps.iter_mut() {
+        if let Some(ref ver) = dep.version_req
+            && let Some(resolved) = resolve_variable_ref(ver, properties)
+        {
+            dep.version_req = Some(resolved);
+        }
+    }
+}
+
+/// Returns the resolved value if `value` is a `$name` or `${name}` reference. Returns `None` otherwise.
+fn resolve_variable_ref(value: &str, properties: &HashMap<String, String>) -> Option<String> {
+    let trimmed = value.trim();
+    if let Some(name) = trimmed.strip_prefix("${").and_then(|s| s.strip_suffix('}')) {
+        properties.get(name).cloned()
+    } else if let Some(name) = trimmed.strip_prefix('$') {
+        properties.get(name).cloned()
+    } else {
+        None
+    }
+}
+
 pub fn parse_gradle(content: &str, uri: &Uri) -> Result<GradleParseResult> {
     let path = uri.path().to_string();
-    if path.ends_with("libs.versions.toml") {
-        catalog::parse_version_catalog(content, uri)
+    let mut result = if path.ends_with("libs.versions.toml") {
+        catalog::parse_version_catalog(content, uri)?
+    } else if path.ends_with("settings.gradle.kts") || path.ends_with("settings.gradle") {
+        settings::parse_settings(content, uri)?
     } else if path.ends_with(".gradle.kts") {
-        kotlin::parse_kotlin_dsl(content, uri)
+        kotlin::parse_kotlin_dsl(content, uri)?
     } else if path.ends_with(".gradle") {
-        groovy::parse_groovy_dsl(content, uri)
+        groovy::parse_groovy_dsl(content, uri)?
     } else {
-        Ok(GradleParseResult {
+        return Ok(GradleParseResult {
             dependencies: vec![],
             uri: uri.clone(),
-        })
+        });
+    };
+
+    // Resolve variable references for build files (not catalogs or settings)
+    if (path.ends_with("build.gradle.kts") || path.ends_with("build.gradle"))
+        && let Some(dir) = std::path::Path::new(&path).parent()
+    {
+        let props = properties::load_gradle_properties(dir);
+        if !props.is_empty() {
+            resolve_variables(&mut result.dependencies, &props);
+        }
     }
+
+    Ok(result)
 }
 
 impl deps_core::ParseResult for GradleParseResult {
@@ -136,10 +180,92 @@ mod tests {
     }
 
     #[test]
-    fn test_dispatch_unknown() {
+    fn test_dispatch_settings_gradle() {
+        let content = "pluginManagement {\n    plugins {\n        id \"org.jetbrains.kotlin.jvm\" version \"2.1.10\"\n    }\n}\n";
         let uri = make_uri("/project/settings.gradle");
+        let result = parse_gradle(content, &uri).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+    }
+
+    #[test]
+    fn test_dispatch_settings_gradle_kts() {
+        let content = "pluginManagement {\n    plugins {\n        id(\"org.springframework.boot\") version \"3.2.0\"\n    }\n}\n";
+        let uri = make_uri("/project/settings.gradle.kts");
+        let result = parse_gradle(content, &uri).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+    }
+
+    #[test]
+    fn test_dispatch_unknown() {
+        let uri = make_uri("/project/something.xml");
         let result = parse_gradle("", &uri).unwrap();
         assert!(result.dependencies.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_variables_dollar_brace() {
+        let props: HashMap<String, String> =
+            [("kotlinVersion".to_string(), "2.1.10".to_string())].into();
+        let mut deps = vec![GradleDependency {
+            group_id: "org.jetbrains.kotlin".into(),
+            artifact_id: "kotlin-stdlib".into(),
+            name: "org.jetbrains.kotlin:kotlin-stdlib".into(),
+            name_range: Range::default(),
+            version_req: Some("${kotlinVersion}".into()),
+            version_range: None,
+            configuration: "implementation".into(),
+        }];
+        resolve_variables(&mut deps, &props);
+        assert_eq!(deps[0].version_req, Some("2.1.10".into()));
+    }
+
+    #[test]
+    fn test_resolve_variables_dollar_plain() {
+        let props: HashMap<String, String> =
+            [("springVersion".to_string(), "3.2.0".to_string())].into();
+        let mut deps = vec![GradleDependency {
+            group_id: "org.springframework.boot".into(),
+            artifact_id: "spring-boot-starter".into(),
+            name: "org.springframework.boot:spring-boot-starter".into(),
+            name_range: Range::default(),
+            version_req: Some("$springVersion".into()),
+            version_range: None,
+            configuration: "implementation".into(),
+        }];
+        resolve_variables(&mut deps, &props);
+        assert_eq!(deps[0].version_req, Some("3.2.0".into()));
+    }
+
+    #[test]
+    fn test_resolve_variables_not_found_keeps_raw() {
+        let props: HashMap<String, String> = HashMap::new();
+        let mut deps = vec![GradleDependency {
+            group_id: "com.example".into(),
+            artifact_id: "lib".into(),
+            name: "com.example:lib".into(),
+            name_range: Range::default(),
+            version_req: Some("$unknownVar".into()),
+            version_range: None,
+            configuration: "implementation".into(),
+        }];
+        resolve_variables(&mut deps, &props);
+        assert_eq!(deps[0].version_req, Some("$unknownVar".into()));
+    }
+
+    #[test]
+    fn test_resolve_variables_literal_version_unchanged() {
+        let props: HashMap<String, String> = [("v".to_string(), "9.9.9".to_string())].into();
+        let mut deps = vec![GradleDependency {
+            group_id: "com.example".into(),
+            artifact_id: "lib".into(),
+            name: "com.example:lib".into(),
+            name_range: Range::default(),
+            version_req: Some("1.2.3".into()),
+            version_range: None,
+            configuration: "implementation".into(),
+        }];
+        resolve_variables(&mut deps, &props);
+        assert_eq!(deps[0].version_req, Some("1.2.3".into()));
     }
 
     #[test]

--- a/crates/deps-gradle/src/parser/properties.rs
+++ b/crates/deps-gradle/src/parser/properties.rs
@@ -1,0 +1,103 @@
+//! Parser for gradle.properties files.
+//!
+//! Provides key-value parsing and directory-walking lookup.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Parses a gradle.properties content into key-value pairs.
+///
+/// Lines starting with `#` or empty lines are ignored.
+/// Each line is split on the first `=`.
+pub fn parse_properties(content: &str) -> HashMap<String, String> {
+    content
+        .lines()
+        .filter(|l| !l.trim_start().starts_with('#') && !l.trim().is_empty())
+        .filter_map(|l| l.split_once('='))
+        .map(|(k, v)| (k.trim().to_string(), v.trim().to_string()))
+        .collect()
+}
+
+/// Finds and parses gradle.properties files by walking up from `start_dir`.
+///
+/// Merges properties from all levels, with child values overriding parent values.
+pub fn load_gradle_properties(start_dir: &Path) -> HashMap<String, String> {
+    let mut result = HashMap::new();
+    let mut chain = Vec::new();
+    let mut dir = Some(start_dir);
+
+    while let Some(d) = dir {
+        let props_file = d.join("gradle.properties");
+        if props_file.exists() {
+            chain.push(props_file);
+        }
+        dir = d.parent();
+    }
+
+    // Apply from root to leaf so child values override parent
+    for path in chain.into_iter().rev() {
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            result.extend(parse_properties(&content));
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_basic() {
+        let content = "kotlinVersion=2.1.10\nspringVersion=3.2.0\n";
+        let props = parse_properties(content);
+        assert_eq!(
+            props.get("kotlinVersion").map(|s| s.as_str()),
+            Some("2.1.10")
+        );
+        assert_eq!(
+            props.get("springVersion").map(|s| s.as_str()),
+            Some("3.2.0")
+        );
+    }
+
+    #[test]
+    fn test_parse_ignores_comments() {
+        let content = "# this is a comment\nkey=value\n";
+        let props = parse_properties(content);
+        assert_eq!(props.len(), 1);
+        assert_eq!(props.get("key").map(|s| s.as_str()), Some("value"));
+    }
+
+    #[test]
+    fn test_parse_ignores_empty_lines() {
+        let content = "\nkey=value\n\n";
+        let props = parse_properties(content);
+        assert_eq!(props.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_trims_whitespace() {
+        let content = "  key  =  value  \n";
+        let props = parse_properties(content);
+        assert_eq!(props.get("key").map(|s| s.as_str()), Some("value"));
+    }
+
+    #[test]
+    fn test_parse_value_with_equals() {
+        // Only splits on the first '='
+        let content = "url=https://example.com?a=b\n";
+        let props = parse_properties(content);
+        assert_eq!(
+            props.get("url").map(|s| s.as_str()),
+            Some("https://example.com?a=b")
+        );
+    }
+
+    #[test]
+    fn test_parse_empty() {
+        let props = parse_properties("");
+        assert!(props.is_empty());
+    }
+}

--- a/crates/deps-gradle/src/parser/settings.rs
+++ b/crates/deps-gradle/src/parser/settings.rs
@@ -1,0 +1,224 @@
+//! Parser for settings.gradle and settings.gradle.kts files.
+//!
+//! Extracts plugin declarations from `pluginManagement { plugins { } }` blocks.
+
+use crate::error::Result;
+use crate::parser::{GradleParseResult, utf16_len};
+use crate::types::GradleDependency;
+use regex::Regex;
+use std::sync::OnceLock;
+use tower_lsp_server::ls_types::{Position, Range, Uri};
+
+/// Matches: id "plugin.id" version "1.0.0" (Groovy) or id("plugin.id") version "1.0.0" (Kotlin DSL)
+static RE_PLUGIN: OnceLock<Regex> = OnceLock::new();
+
+fn re_plugin() -> &'static Regex {
+    RE_PLUGIN.get_or_init(|| {
+        Regex::new(r#"id\s*\(?\s*['"]([^'"]+)['"]\s*\)?\s+version\s+['"]([^'"]+)['"]"#).unwrap()
+    })
+}
+
+/// Finds the LSP range of `plugin_id` within `line`.
+fn find_plugin_name_range(line: &str, line_idx: u32, plugin_id: &str) -> Range {
+    if let Some(col) = line.find(plugin_id) {
+        let col_u32 = utf16_len(&line[..col]) as u32;
+        let end_u32 = col_u32 + utf16_len(plugin_id) as u32;
+        Range::new(
+            Position::new(line_idx, col_u32),
+            Position::new(line_idx, end_u32),
+        )
+    } else {
+        Range::default()
+    }
+}
+
+/// Finds the LSP range of `version` in `line` after the `version` keyword.
+fn find_plugin_version_range(line: &str, line_idx: u32, version: &str) -> Range {
+    // Find "version" keyword, then locate the version string after it
+    if let Some(kw_pos) = line.find("version") {
+        let after_kw = &line[kw_pos + "version".len()..];
+        if let Some(rel) = after_kw.find(version) {
+            let abs_start = kw_pos + "version".len() + rel;
+            let col_start = utf16_len(&line[..abs_start]) as u32;
+            let col_end = col_start + utf16_len(version) as u32;
+            return Range::new(
+                Position::new(line_idx, col_start),
+                Position::new(line_idx, col_end),
+            );
+        }
+    }
+    Range::default()
+}
+
+/// Parses `pluginManagement { plugins { ... } }` blocks from settings.gradle / settings.gradle.kts.
+pub fn parse_settings(content: &str, uri: &Uri) -> Result<GradleParseResult> {
+    let mut dependencies = Vec::new();
+    let mut brace_depth: i32 = 0;
+    let mut in_plugin_management = false;
+    let mut pm_depth: i32 = 0;
+    let mut in_plugins = false;
+    let mut plugins_depth: i32 = 0;
+
+    for (line_idx, line) in content.lines().enumerate() {
+        let trimmed = line.trim();
+
+        // Detect pluginManagement { entry
+        if !in_plugin_management && trimmed.starts_with("pluginManagement") && trimmed.contains('{')
+        {
+            in_plugin_management = true;
+            pm_depth = brace_depth + 1;
+        }
+
+        // Detect plugins { entry inside pluginManagement
+        if in_plugin_management
+            && !in_plugins
+            && trimmed.starts_with("plugins")
+            && trimmed.contains('{')
+        {
+            in_plugins = true;
+            plugins_depth = brace_depth + 1;
+        }
+
+        // Count braces
+        for ch in line.chars() {
+            match ch {
+                '{' => brace_depth += 1,
+                '}' => {
+                    brace_depth -= 1;
+                    if in_plugins && brace_depth < plugins_depth {
+                        in_plugins = false;
+                    }
+                    if in_plugin_management && brace_depth < pm_depth {
+                        in_plugin_management = false;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if !in_plugins {
+            continue;
+        }
+
+        let line_u32 = line_idx as u32;
+
+        for caps in re_plugin().captures_iter(line) {
+            let plugin_id = caps.get(1).map_or("", |m| m.as_str()).to_string();
+            let version = caps.get(2).map_or("", |m| m.as_str()).trim().to_string();
+
+            // Convention: pluginId -> group = pluginId, artifact = pluginId.gradle.plugin
+            let artifact_id = format!("{plugin_id}.gradle.plugin");
+            let name = format!("{plugin_id}:{artifact_id}");
+
+            let name_range = find_plugin_name_range(line, line_u32, &plugin_id);
+            let version_range = find_plugin_version_range(line, line_u32, &version);
+
+            dependencies.push(GradleDependency {
+                group_id: plugin_id,
+                artifact_id,
+                name,
+                name_range,
+                version_req: Some(version),
+                version_range: Some(version_range),
+                configuration: "plugin".to_string(),
+            });
+        }
+    }
+
+    Ok(GradleParseResult {
+        dependencies,
+        uri: uri.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_uri(name: &str) -> Uri {
+        Uri::from_file_path(format!("/project/{name}")).unwrap()
+    }
+
+    #[test]
+    fn test_parse_groovy_plugin() {
+        let content = r#"pluginManagement {
+    plugins {
+        id "org.jetbrains.kotlin.jvm" version "2.1.10"
+        id 'com.google.devtools.ksp' version '2.1.10-1.0.31'
+    }
+}
+"#;
+        let result = parse_settings(content, &make_uri("settings.gradle")).unwrap();
+        assert_eq!(result.dependencies.len(), 2);
+
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.group_id, "org.jetbrains.kotlin.jvm");
+        assert_eq!(dep.artifact_id, "org.jetbrains.kotlin.jvm.gradle.plugin");
+        assert_eq!(
+            dep.name,
+            "org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin"
+        );
+        assert_eq!(dep.version_req, Some("2.1.10".into()));
+        assert_eq!(dep.configuration, "plugin");
+
+        let dep2 = &result.dependencies[1];
+        assert_eq!(dep2.group_id, "com.google.devtools.ksp");
+        assert_eq!(dep2.version_req, Some("2.1.10-1.0.31".into()));
+    }
+
+    #[test]
+    fn test_parse_kotlin_dsl_plugin() {
+        let content = r#"pluginManagement {
+    plugins {
+        id("org.springframework.boot") version "3.2.0"
+    }
+}
+"#;
+        let result = parse_settings(content, &make_uri("settings.gradle.kts")).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].group_id, "org.springframework.boot");
+        assert_eq!(result.dependencies[0].version_req, Some("3.2.0".into()));
+    }
+
+    #[test]
+    fn test_no_plugin_management_block() {
+        let content = "rootProject.name = \"my-project\"\n";
+        let result = parse_settings(content, &make_uri("settings.gradle")).unwrap();
+        assert!(result.dependencies.is_empty());
+    }
+
+    #[test]
+    fn test_plugin_without_version_skipped() {
+        let content = r#"pluginManagement {
+    plugins {
+        id "org.jetbrains.kotlin.jvm"
+    }
+}
+"#;
+        let result = parse_settings(content, &make_uri("settings.gradle")).unwrap();
+        assert!(result.dependencies.is_empty());
+    }
+
+    #[test]
+    fn test_position_tracking() {
+        let content = r#"pluginManagement {
+    plugins {
+        id "org.jetbrains.kotlin.jvm" version "2.1.10"
+    }
+}
+"#;
+        let result = parse_settings(content, &make_uri("settings.gradle")).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name_range.start.line, 2);
+        assert!(dep.version_range.is_some());
+        let vr = dep.version_range.unwrap();
+        assert_eq!(vr.start.line, 2);
+    }
+
+    #[test]
+    fn test_empty_content() {
+        let result = parse_settings("", &make_uri("settings.gradle")).unwrap();
+        assert!(result.dependencies.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- Resolve `$var`/`${var}` references in `build.gradle`/`build.gradle.kts` from `gradle.properties` files (walks parent directories)
- Parse `pluginManagement { plugins { } }` blocks in `settings.gradle`/`settings.gradle.kts` for plugin dependency tracking
- Plugin IDs mapped to Maven coordinates via `pluginId:pluginId.gradle.plugin` convention

## Test plan

- [x] 1201 tests pass (cargo nextest run)
- [x] clippy clean
- [x] fmt clean
- [ ] Manual test: open spring-boot `build.gradle` with `$kotlinVersion` — verify resolved version in inlay hints
- [ ] Manual test: open nowinandroid `settings.gradle.kts` — verify plugin diagnostics