### PR TITLE
release: v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-02-23
+
 ### Added
 - **Gradle ecosystem support** — New `deps-gradle` crate with support for three manifest formats
   - Version Catalog parser (`gradle/libs.versions.toml`) via toml-span with reliable span tracking
@@ -19,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Gradle variable resolution** — `$var` and `${var}` in `build.gradle`/`build.gradle.kts` resolved from `gradle.properties` (walks parent directories)
 - **settings.gradle parsing** — Extract plugin dependencies from `pluginManagement { plugins { } }` blocks (Groovy and Kotlin DSL)
 - **Google Maven repository support** — Android packages (`androidx.*`, `com.google.firebase.*`, `com.google.android.*`, `com.android.*`) now resolve from Google Maven instead of Maven Central
+- **Gradle Plugin Portal fallback** — Packages not found on Maven Central are now retried on `plugins.gradle.org/m2`, resolving 404 errors for Gradle-exclusive plugins
 
 ### Changed
 - **Migrate deps-cargo and deps-pypi from toml_edit to toml-span** — Reliable span tracking for all values including inline tables; eliminates text-search fallbacks for position tracking
@@ -366,7 +369,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TLS enforced via rustls
 - cargo-deny configured for vulnerability scanning
 
-[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/bug-ops/deps-lsp/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/bug-ops/deps-lsp/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/bug-ops/deps-lsp/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/bug-ops/deps-lsp/compare/v0.6.0...v0.6.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "deps-bundler"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "deps-cargo"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "deps-core"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "deps-dart"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "deps-go"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "deps-gradle"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "deps-core",
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "deps-lsp"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "deps-maven"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "deps-core",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "deps-npm"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "deps-pypi"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/deps-zed"]
 resolver = "3"
 
 [workspace.package]
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Andrei G"]
@@ -15,16 +15,16 @@ repository = "https://github.com/bug-ops/deps-lsp"
 async-trait = "0.1"
 criterion = "0.8"
 dashmap = "6.1"
-deps-core = { version = "0.7.1", path = "crates/deps-core" }
-deps-cargo = { version = "0.7.1", path = "crates/deps-cargo" }
-deps-npm = { version = "0.7.1", path = "crates/deps-npm" }
-deps-pypi = { version = "0.7.1", path = "crates/deps-pypi" }
-deps-go = { version = "0.7.1", path = "crates/deps-go" }
-deps-bundler = { version = "0.7.1", path = "crates/deps-bundler" }
-deps-dart = { version = "0.7.1", path = "crates/deps-dart" }
-deps-maven = { version = "0.7.1", path = "crates/deps-maven" }
-deps-gradle = { version = "0.7.1", path = "crates/deps-gradle" }
-deps-lsp = { version = "0.7.1", path = "crates/deps-lsp" }
+deps-core = { version = "0.8.0", path = "crates/deps-core" }
+deps-cargo = { version = "0.8.0", path = "crates/deps-cargo" }
+deps-npm = { version = "0.8.0", path = "crates/deps-npm" }
+deps-pypi = { version = "0.8.0", path = "crates/deps-pypi" }
+deps-go = { version = "0.8.0", path = "crates/deps-go" }
+deps-bundler = { version = "0.8.0", path = "crates/deps-bundler" }
+deps-dart = { version = "0.8.0", path = "crates/deps-dart" }
+deps-maven = { version = "0.8.0", path = "crates/deps-maven" }
+deps-gradle = { version = "0.8.0", path = "crates/deps-gradle" }
+deps-lsp = { version = "0.8.0", path = "crates/deps-lsp" }
 futures = "0.3"
 insta = "1"
 mockito = "1"

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ deps-lsp is optimized for responsiveness:
 | Ruby | Bundler | `Gemfile` | ✅ Supported |
 | Dart | Pub | `pubspec.yaml` | ✅ Supported |
 | Java | Maven | `pom.xml` | ✅ Supported |
-| Java | Gradle | `libs.versions.toml`, `build.gradle.kts`, `build.gradle` | ✅ Supported |
+| Java | Gradle | `libs.versions.toml`, `build.gradle.kts`, `build.gradle`, `settings.gradle` | ✅ Supported |
 
 > [!NOTE]
-> PyPI support includes PEP 621, PEP 735 (dependency-groups), and Poetry formats. Go support includes require, replace, and exclude directives with pseudo-version handling. Bundler support includes git, path, and GitHub sources plus pessimistic version requirements (`~>`). Dart support includes hosted, git, path, and SDK dependency sources with caret version semantics. Maven support covers `dependencies`, `dependencyManagement`, and `build/plugins` sections with Maven qualifier-aware version comparison. Gradle support covers Version Catalogs (`libs.versions.toml`), Kotlin DSL (`build.gradle.kts`), and Groovy DSL (`build.gradle`) with version.ref resolution.
+> PyPI support includes PEP 621, PEP 735 (dependency-groups), and Poetry formats. Go support includes require, replace, and exclude directives with pseudo-version handling. Bundler support includes git, path, and GitHub sources plus pessimistic version requirements (`~>`). Dart support includes hosted, git, path, and SDK dependency sources with caret version semantics. Maven support covers `dependencies`, `dependencyManagement`, and `build/plugins` sections with Maven qualifier-aware version comparison. Gradle support covers Version Catalogs (`libs.versions.toml`), Kotlin DSL (`build.gradle.kts`), Groovy DSL (`build.gradle`), and `settings.gradle` plugin declarations with version.ref resolution. Packages are resolved from Maven Central, Google Maven (Android), and Gradle Plugin Portal (fallback).
 
 ## Installation
 
@@ -61,7 +61,7 @@ deps-lsp is optimized for responsiveness:
 cargo install deps-lsp
 ```
 
-Latest published crate version: `0.7.1`.
+Latest published crate version: `0.8.0`.
 
 > [!TIP]
 > Use `cargo binstall deps-lsp` for faster installation without compilation.

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -38,7 +38,6 @@ description = "{Ecosystem} support for deps-lsp"
 
 [dependencies]
 deps-core = { path = "../deps-core" }
-async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -143,7 +142,10 @@ Create ecosystem-specific types in `types.rs`:
 ```rust
 //! Types for {Ecosystem} dependency management.
 
+use std::any::Any;
 use tower_lsp_server::ls_types::Range;
+
+pub use deps_core::parser::DependencySource;
 
 /// A dependency from the manifest file.
 #[derive(Debug, Clone)]
@@ -156,6 +158,8 @@ pub struct {Ecosystem}Dependency {
     pub version_req: Option<String>,
     /// LSP range of version in source
     pub version_range: Option<Range>,
+    /// Dependency source (registry, git, path)
+    pub source: DependencySource,
     /// Dependency section (dependencies, dev, etc.)
     pub section: {Ecosystem}DependencySection,
 }
@@ -194,8 +198,8 @@ impl deps_core::Dependency for {Ecosystem}Dependency {
         self.version_range
     }
 
-    fn is_workspace_inherited(&self) -> bool {
-        false // Override if ecosystem supports workspace inheritance
+    fn source(&self) -> DependencySource {
+        self.source
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -214,7 +218,7 @@ impl deps_core::Version for {Ecosystem}Version {
 
     fn is_prerelease(&self) -> bool {
         // Implement based on ecosystem's prerelease conventions
-        self.version.contains("-") || self.version.contains("alpha") || self.version.contains("beta")
+        self.version.contains('-') || self.version.contains("alpha") || self.version.contains("beta")
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -233,7 +237,8 @@ Create manifest parser in `parser.rs` with **position tracking**:
 use crate::error::Result;
 use crate::types::{Ecosystem}Dependency;
 use std::any::Any;
-use tower_lsp_server::ls_types::{Position, Range, Uri};
+use tower_lsp_server::ls_types::{Uri};
+use deps_core::lsp_helpers::LineOffsetTable;
 
 /// Parse result containing dependencies and metadata.
 #[derive(Debug)]
@@ -263,32 +268,6 @@ impl deps_core::ParseResult for {Ecosystem}ParseResult {
     }
 }
 
-/// Line offset table for O(log n) position lookups.
-struct LineOffsetTable {
-    offsets: Vec<usize>,
-}
-
-impl LineOffsetTable {
-    fn new(content: &str) -> Self {
-        let mut offsets = vec![0];
-        for (i, c) in content.char_indices() {
-            if c == '\n' {
-                offsets.push(i + 1);
-            }
-        }
-        Self { offsets }
-    }
-
-    fn position_from_offset(&self, offset: usize) -> Position {
-        let line = match self.offsets.binary_search(&offset) {
-            Ok(line) => line,
-            Err(line) => line.saturating_sub(1),
-        };
-        let character = (offset - self.offsets[line]) as u32;
-        Position::new(line as u32, character)
-    }
-}
-
 /// Parse manifest file and extract dependencies with positions.
 pub fn parse_{manifest}(content: &str, uri: &Uri) -> Result<{Ecosystem}ParseResult> {
     let line_table = LineOffsetTable::new(content);
@@ -296,7 +275,7 @@ pub fn parse_{manifest}(content: &str, uri: &Uri) -> Result<{Ecosystem}ParseResu
     // TODO: Implement actual parsing logic
     // Key requirements:
     // 1. Track byte offsets for every dependency name and version
-    // 2. Convert offsets to LSP Position using LineOffsetTable
+    // 2. Convert offsets to LSP Position using line_table.byte_offset_to_position(content, offset)
     // 3. Handle all dependency sections
 
     Ok({Ecosystem}ParseResult {
@@ -315,7 +294,8 @@ Create registry client in `registry.rs`:
 
 use crate::error::Result;
 use crate::types::{Ecosystem}Version;
-use deps_core::HttpCache;
+use deps_core::{HttpCache, ecosystem::BoxFuture};
+use std::any::Any;
 use std::sync::Arc;
 
 const REGISTRY_URL: &str = "https://registry.example.com";
@@ -330,7 +310,7 @@ impl {Ecosystem}Registry {
         Self { cache }
     }
 
-    /// Fetch all versions for a package.
+    /// Fetches all versions for a package.
     pub async fn get_versions(&self, name: &str) -> Result<Vec<{Ecosystem}Version>> {
         let url = format!("{}/{}", REGISTRY_URL, urlencoding::encode(name));
 
@@ -343,7 +323,7 @@ impl {Ecosystem}Registry {
         Ok(vec![])
     }
 
-    /// Get latest version matching a requirement.
+    /// Gets the latest version matching a requirement.
     pub async fn get_latest_matching(
         &self,
         name: &str,
@@ -356,24 +336,46 @@ impl {Ecosystem}Registry {
     }
 }
 
-// Implement deps_core::Registry trait
-#[async_trait::async_trait]
+// Implement deps_core::Registry trait using BoxFuture (no async_trait)
 impl deps_core::Registry for {Ecosystem}Registry {
-    async fn get_versions(&self, name: &str) -> deps_core::Result<Vec<Box<dyn deps_core::Version>>> {
-        let versions = self.get_versions(name).await?;
-        Ok(versions
-            .into_iter()
-            .map(|v| Box::new(v) as Box<dyn deps_core::Version>)
-            .collect())
+    fn get_versions<'a>(
+        &'a self,
+        name: &'a str,
+    ) -> BoxFuture<'a, deps_core::error::Result<Vec<Box<dyn deps_core::Version>>>> {
+        Box::pin(async move {
+            let versions = self.get_versions(name).await?;
+            Ok(versions
+                .into_iter()
+                .map(|v| Box::new(v) as Box<dyn deps_core::Version>)
+                .collect())
+        })
     }
 
-    async fn get_latest_matching(
-        &self,
-        name: &str,
-        version_req: &str,
-    ) -> deps_core::Result<Option<Box<dyn deps_core::Version>>> {
-        let version = self.get_latest_matching(name, version_req).await?;
-        Ok(version.map(|v| Box::new(v) as Box<dyn deps_core::Version>))
+    fn get_latest_matching<'a>(
+        &'a self,
+        name: &'a str,
+        req: &'a str,
+    ) -> BoxFuture<'a, deps_core::error::Result<Option<Box<dyn deps_core::Version>>>> {
+        Box::pin(async move {
+            let version = self.get_latest_matching(name, req).await?;
+            Ok(version.map(|v| Box::new(v) as Box<dyn deps_core::Version>))
+        })
+    }
+
+    fn search<'a>(
+        &'a self,
+        _query: &'a str,
+        _limit: usize,
+    ) -> BoxFuture<'a, deps_core::error::Result<Vec<Box<dyn deps_core::Metadata>>>> {
+        Box::pin(async move { Ok(vec![]) })
+    }
+
+    fn package_url(&self, name: &str) -> String {
+        format!("{}/{}", REGISTRY_URL, urlencoding::encode(name))
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 ```
@@ -385,22 +387,23 @@ Create the main ecosystem implementation in `ecosystem.rs`:
 ```rust
 //! {Ecosystem} implementation for deps-lsp.
 
-use async_trait::async_trait;
 use std::any::Any;
-use std::collections::HashMap;
 use std::sync::Arc;
-use tower_lsp_server::ls_types::*;
+use tower_lsp_server::ls_types::{CompletionItem, Position, Uri};
 
 use deps_core::{
-    Ecosystem, EcosystemConfig, HttpCache, lsp_helpers,
-    ParseResult as ParseResultTrait, Registry, Result,
+    Ecosystem, HttpCache, ParseResult as ParseResultTrait, Registry, Result,
+    ecosystem::BoxFuture,
+    lockfile::LockFileProvider,
+    lsp_helpers::EcosystemFormatter,
 };
 
 use crate::formatter::{Ecosystem}Formatter;
+use crate::lockfile::{Ecosystem}LockfileParser;
 use crate::parser::parse_{manifest};
 use crate::registry::{Ecosystem}Registry;
 
-/// {Ecosystem} implementation.
+/// {Ecosystem} ecosystem implementation.
 pub struct {Ecosystem}Ecosystem {
     registry: Arc<{Ecosystem}Registry>,
     formatter: {Ecosystem}Formatter,
@@ -415,7 +418,9 @@ impl {Ecosystem}Ecosystem {
     }
 }
 
-#[async_trait]
+// Required sealed trait impl — prevents external implementations
+impl deps_core::ecosystem::private::Sealed for {Ecosystem}Ecosystem {}
+
 impl Ecosystem for {Ecosystem}Ecosystem {
     fn id(&self) -> &'static str {
         "{ecosystem_id}"
@@ -429,121 +434,120 @@ impl Ecosystem for {Ecosystem}Ecosystem {
         &["{manifest_filename}"]
     }
 
-    async fn parse_manifest(
-        &self,
-        content: &str,
-        uri: &Uri,
-    ) -> Result<Box<dyn ParseResultTrait>> {
-        let result = parse_{manifest}(content, uri)?;
-        Ok(Box::new(result))
+    fn lockfile_filenames(&self) -> &[&'static str] {
+        &["{lockfile_filename}"]
     }
 
-    fn registry(&self) -> Arc<dyn Registry> {
-        self.registry.clone()
-    }
-
-    async fn generate_inlay_hints(
-        &self,
-        parse_result: &dyn ParseResultTrait,
-        cached_versions: &HashMap<String, String>,
-        resolved_versions: &HashMap<String, String>,
-        loading_state: deps_core::LoadingState,
-        config: &EcosystemConfig,
-    ) -> Vec<InlayHint> {
-        // Use shared helper for consistent behavior across ecosystems
-        lsp_helpers::generate_inlay_hints(
-            parse_result,
-            cached_versions,
-            resolved_versions,
-            loading_state,
-            config,
-            &self.formatter,
-        )
-    }
-
-    async fn generate_hover(
-        &self,
-        parse_result: &dyn ParseResultTrait,
-        position: Position,
-        cached_versions: &HashMap<String, String>,
-    ) -> Option<Hover> {
-        // Find dependency at position
-        let dep = parse_result
-            .dependencies()
-            .into_iter()
-            .find(|d| position_in_range(position, d.name_range()))?;
-
-        let versions = self.registry.get_versions(dep.name()).await.ok()?;
-
-        // Build hover markdown
-        let mut markdown = format!("# {}\n\n", dep.name());
-
-        if let Some(req) = dep.version_requirement() {
-            markdown.push_str(&format!("**Current**: `{}`\n\n", req));
-        }
-
-        if let Some(latest) = cached_versions.get(dep.name()) {
-            markdown.push_str(&format!("**Latest**: `{}`\n\n", latest));
-        }
-
-        markdown.push_str("**Recent versions**:\n");
-        for version in versions.iter().take(8) {
-            markdown.push_str(&format!("- {}\n", version.version_string()));
-        }
-
-        Some(Hover {
-            contents: HoverContents::Markup(MarkupContent {
-                kind: MarkupKind::Markdown,
-                value: markdown,
-            }),
-            range: Some(dep.name_range()),
+    fn parse_manifest<'a>(
+        &'a self,
+        content: &'a str,
+        uri: &'a Uri,
+    ) -> BoxFuture<'a, Result<Box<dyn ParseResultTrait>>> {
+        Box::pin(async move {
+            let result = parse_{manifest}(content, uri)?;
+            Ok(Box::new(result) as Box<dyn ParseResultTrait>)
         })
     }
 
-    async fn generate_code_actions(
-        &self,
-        parse_result: &dyn ParseResultTrait,
-        position: Position,
-        _cached_versions: &HashMap<String, String>,
-        uri: &Uri,
-    ) -> Vec<CodeAction> {
-        // Similar pattern: find dep at position, offer version updates
-        vec![]
+    fn registry(&self) -> Arc<dyn Registry> {
+        self.registry.clone() as Arc<dyn Registry>
     }
 
-    async fn generate_diagnostics(
-        &self,
-        parse_result: &dyn ParseResultTrait,
-        _cached_versions: &HashMap<String, String>,
-        _uri: &Uri,
-    ) -> Vec<Diagnostic> {
-        // Check for unknown packages, outdated versions, etc.
-        vec![]
+    fn lockfile_provider(&self) -> Option<Arc<dyn LockFileProvider>> {
+        Some(Arc::new({Ecosystem}LockfileParser))
     }
 
-    async fn generate_completions(
-        &self,
-        _parse_result: &dyn ParseResultTrait,
+    fn formatter(&self) -> &dyn EcosystemFormatter {
+        &self.formatter
+    }
+
+    // generate_inlay_hints, generate_hover, generate_code_actions, generate_diagnostics
+    // all have default implementations in the Ecosystem trait that delegate to lsp_helpers.
+    // Override only if custom behavior is needed.
+
+    fn generate_completions<'a>(
+        &'a self,
+        _parse_result: &'a dyn ParseResultTrait,
         _position: Position,
-        _content: &str,
-    ) -> Vec<CompletionItem> {
-        vec![]
+        _content: &'a str,
+    ) -> BoxFuture<'a, Vec<CompletionItem>> {
+        Box::pin(async move { vec![] })
     }
 
     fn as_any(&self) -> &dyn Any {
         self
     }
 }
+```
 
-fn position_in_range(pos: Position, range: Range) -> bool {
-    !(range.end.line < pos.line
-        || (range.end.line == pos.line && range.end.character < pos.character)
-        || pos.line < range.start.line
-        || (pos.line == range.start.line && pos.character < range.start.character))
+## Step 7: Implement the Lock File Provider
+
+Create lock file parser in `lockfile.rs`:
+
+```rust
+//! Lock file parsing for {Ecosystem}.
+
+use std::path::{Path, PathBuf};
+
+use deps_core::lockfile::{
+    LockFileProvider, ResolvedPackage, ResolvedPackages, ResolvedSource,
+    locate_lockfile_for_manifest,
+};
+use tower_lsp_server::ls_types::Uri;
+
+/// Lock file parser for {Ecosystem}.
+pub struct {Ecosystem}LockfileParser;
+
+impl LockFileProvider for {Ecosystem}LockfileParser {
+    fn locate_lockfile(&self, manifest_uri: &Uri) -> Option<PathBuf> {
+        locate_lockfile_for_manifest(manifest_uri, &["{lockfile_name}"])
+    }
+
+    fn parse_lockfile<'a>(
+        &'a self,
+        lockfile_path: &'a Path,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = deps_core::error::Result<ResolvedPackages>> + Send + 'a>> {
+        Box::pin(async move {
+            let content = tokio::fs::read_to_string(lockfile_path)
+                .await
+                .map_err(deps_core::DepsError::Io)?;
+
+            parse_lock_content(&content)
+        })
+    }
+}
+
+fn parse_lock_content(content: &str) -> deps_core::error::Result<ResolvedPackages> {
+    let mut packages = ResolvedPackages::new();
+
+    // TODO: Parse lock file and call packages.insert(ResolvedPackage { ... })
+
+    Ok(packages)
 }
 ```
 
-## Step 7: Create lib.rs
+## Step 8: Implement the Formatter
+
+Create the formatter in `formatter.rs`:
+
+```rust
+use deps_core::lsp_helpers::EcosystemFormatter;
+
+pub struct {Ecosystem}Formatter;
+
+impl EcosystemFormatter for {Ecosystem}Formatter {
+    fn format_version_for_text_edit(&self, version: &str) -> String {
+        // Format version string for use in code action text edits
+        format!("\"{}\"", version)
+    }
+
+    fn package_url(&self, name: &str) -> String {
+        format!("https://registry.example.com/packages/{}", name)
+    }
+}
+```
+
+## Step 9: Create lib.rs
 
 Expose public API in `lib.rs`:
 
@@ -552,7 +556,8 @@ Expose public API in `lib.rs`:
 
 pub mod ecosystem;
 pub mod error;
-pub mod lockfile;  // if implemented
+pub mod formatter;
+pub mod lockfile;
 pub mod parser;
 pub mod registry;
 pub mod types;
@@ -564,7 +569,7 @@ pub use registry::{Ecosystem}Registry;
 pub use types::{{Ecosystem}Dependency, {Ecosystem}Version};
 ```
 
-## Step 8: Register the Ecosystem
+## Step 10: Register the Ecosystem
 
 In `deps-lsp/src/lib.rs`, add your ecosystem using the macros:
 
@@ -588,6 +593,10 @@ pub fn register_ecosystems(registry: &EcosystemRegistry, cache: Arc<HttpCache>) 
     register!("npm", NpmEcosystem, registry, &cache);
     register!("pypi", PypiEcosystem, registry, &cache);
     register!("go", GoEcosystem, registry, &cache);
+    register!("bundler", BundlerEcosystem, registry, &cache);
+    register!("dart", DartEcosystem, registry, &cache);
+    register!("maven", MavenEcosystem, registry, &cache);
+    register!("gradle", GradleEcosystem, registry, &cache);
 
     // Add your ecosystem here:
     register!("{ecosystem_id}", {Ecosystem}Ecosystem, registry, &cache);
@@ -596,9 +605,9 @@ pub fn register_ecosystems(registry: &EcosystemRegistry, cache: Arc<HttpCache>) 
 
 The macros handle feature-gating automatically. When the feature is disabled, both the re-exports and registration are compiled out.
 
-## Step 9: Add Tests
+## Step 11: Add Tests
 
-Create comprehensive tests:
+Create comprehensive tests co-located with each module:
 
 ```rust
 #[cfg(test)]
@@ -643,12 +652,12 @@ mod tests {
 Before submitting a PR for a new ecosystem:
 
 - [ ] Error types with conversions to `deps_core::DepsError`
-- [ ] Types implementing `Dependency` and `Version` traits
+- [ ] Types implementing `Dependency` and `Version` traits (with `source()` method)
 - [ ] Parser with accurate position tracking for names AND versions
-- [ ] Lock file parser implementing `LockFileProvider` trait
-- [ ] Formatter implementing `EcosystemFormatter` trait
-- [ ] Registry client with HTTP caching
-- [ ] Ecosystem trait implementation with all LSP features
+- [ ] Lock file parser implementing `LockFileProvider` trait (`locate_lockfile` + `parse_lockfile`)
+- [ ] Formatter implementing `EcosystemFormatter` trait (`format_version_for_text_edit` + `package_url`)
+- [ ] Registry client implementing `deps_core::Registry` trait with BoxFuture signatures
+- [ ] Ecosystem impl with `impl deps_core::ecosystem::private::Sealed` block
 - [ ] Unit tests for parser edge cases
 - [ ] Integration tests for registry (can be `#[ignore]`)
 - [ ] Documentation in lib.rs with examples
@@ -657,13 +666,59 @@ Before submitting a PR for a new ecosystem:
 - [ ] Re-exports via `ecosystem!()` macro in deps-lsp/src/lib.rs
 - [ ] Registration via `register!()` macro in deps-lsp/src/lib.rs
 
-## Examples
+## Reference Implementations
 
 See existing implementations for reference:
-- `crates/deps-cargo/` - Rust/Cargo.toml with crates.io
-- `crates/deps-npm/` - JavaScript/package.json with npm
-- `crates/deps-pypi/` - Python/pyproject.toml with PyPI
+- `crates/deps-cargo/` - Rust/Cargo.toml with crates.io sparse index
+- `crates/deps-npm/` - JavaScript/package.json with npm registry
+- `crates/deps-pypi/` - Python/pyproject.toml with PyPI API
 - `crates/deps-go/` - Go/go.mod with proxy.golang.org
+- `crates/deps-bundler/` - Ruby/Gemfile with RubyGems
+- `crates/deps-dart/` - Dart/pubspec.yaml with pub.dev
+- `crates/deps-maven/` - Java/pom.xml with Maven Central
+- `crates/deps-gradle/` - Kotlin/Gradle version catalogs
+
+## Key API Contracts
+
+### No async_trait
+
+All trait methods use `BoxFuture` instead of `#[async_trait]`:
+
+```rust
+// Correct
+fn parse_manifest<'a>(
+    &'a self,
+    content: &'a str,
+    uri: &'a Uri,
+) -> deps_core::ecosystem::BoxFuture<'a, Result<Box<dyn ParseResult>>> {
+    Box::pin(async move { ... })
+}
+
+// Wrong — do not use
+#[async_trait]
+async fn parse_manifest(&self, content: &str, uri: &Uri) -> Result<Box<dyn ParseResult>> { ... }
+```
+
+### Position Tracking
+
+Use `deps_core::lsp_helpers::LineOffsetTable` for byte offset to LSP position conversion:
+
+```rust
+use deps_core::lsp_helpers::LineOffsetTable;
+
+let table = LineOffsetTable::new(content);
+let position = table.byte_offset_to_position(content, byte_offset);
+```
+
+### LockFileProvider Signatures
+
+```rust
+impl LockFileProvider for MyLockParser {
+    fn locate_lockfile(&self, manifest_uri: &Uri) -> Option<PathBuf> { ... }
+    fn parse_lockfile<'a>(&'a self, lockfile_path: &'a Path)
+        -> Pin<Box<dyn Future<Output = Result<ResolvedPackages>> + Send + 'a>> { ... }
+}
+```
 
 ## Templates
 

--- a/templates/deps-ecosystem/Cargo.toml.template
+++ b/templates/deps-ecosystem/Cargo.toml.template
@@ -13,7 +13,6 @@ description = "{ECOSYSTEM_DISPLAY} support for deps-lsp"
 
 [dependencies]
 deps-core = { path = "../deps-core" }
-async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/templates/deps-ecosystem/src/ecosystem.rs.template
+++ b/templates/deps-ecosystem/src/ecosystem.rs.template
@@ -1,15 +1,12 @@
-use async_trait::async_trait;
 use std::any::Any;
-use std::collections::HashMap;
 use std::sync::Arc;
-use tower_lsp_server::ls_types::{
-    CodeAction, CompletionItem, Diagnostic, Hover, InlayHint, Position, Uri,
-};
+use tower_lsp_server::ls_types::{CompletionItem, Position, Uri};
 
 use deps_core::{
-    Ecosystem, EcosystemConfig, HttpCache, ParseResult as ParseResultTrait, Registry, Result,
+    Ecosystem, HttpCache, ParseResult as ParseResultTrait, Registry, Result,
+    ecosystem::BoxFuture,
     lockfile::LockFileProvider,
-    lsp_helpers,
+    lsp_helpers::EcosystemFormatter,
 };
 
 use crate::formatter::{ECOSYSTEM_PASCAL}Formatter;
@@ -17,12 +14,14 @@ use crate::lockfile::{ECOSYSTEM_PASCAL}LockfileParser;
 use crate::parser::parse_{ECOSYSTEM_SNAKE};
 use crate::registry::{ECOSYSTEM_PASCAL}Registry;
 
+/// {ECOSYSTEM_DISPLAY} ecosystem implementation.
 pub struct {ECOSYSTEM_PASCAL}Ecosystem {
     registry: Arc<{ECOSYSTEM_PASCAL}Registry>,
     formatter: {ECOSYSTEM_PASCAL}Formatter,
 }
 
 impl {ECOSYSTEM_PASCAL}Ecosystem {
+    /// Creates a new {ECOSYSTEM_DISPLAY} ecosystem with the given HTTP cache.
     pub fn new(cache: Arc<HttpCache>) -> Self {
         Self {
             registry: Arc::new({ECOSYSTEM_PASCAL}Registry::new(cache)),
@@ -31,7 +30,8 @@ impl {ECOSYSTEM_PASCAL}Ecosystem {
     }
 }
 
-#[async_trait]
+impl deps_core::ecosystem::private::Sealed for {ECOSYSTEM_PASCAL}Ecosystem {}
+
 impl Ecosystem for {ECOSYSTEM_PASCAL}Ecosystem {
     fn id(&self) -> &'static str {
         "{ECOSYSTEM_SNAKE}"
@@ -45,93 +45,40 @@ impl Ecosystem for {ECOSYSTEM_PASCAL}Ecosystem {
         &["{MANIFEST_FILE}"]
     }
 
-    async fn parse_manifest(
-        &self,
-        content: &str,
-        uri: &Uri,
-    ) -> Result<Box<dyn ParseResultTrait>> {
-        let result = parse_{ECOSYSTEM_SNAKE}(content, uri)?;
-        Ok(Box::new(result))
+    fn lockfile_filenames(&self) -> &[&'static str] {
+        &["{LOCK_FILE}"]
+    }
+
+    fn parse_manifest<'a>(
+        &'a self,
+        content: &'a str,
+        uri: &'a Uri,
+    ) -> BoxFuture<'a, Result<Box<dyn ParseResultTrait>>> {
+        Box::pin(async move {
+            let result = parse_{ECOSYSTEM_SNAKE}(content, uri)?;
+            Ok(Box::new(result) as Box<dyn ParseResultTrait>)
+        })
     }
 
     fn registry(&self) -> Arc<dyn Registry> {
-        self.registry.clone()
+        self.registry.clone() as Arc<dyn Registry>
     }
 
     fn lockfile_provider(&self) -> Option<Arc<dyn LockFileProvider>> {
         Some(Arc::new({ECOSYSTEM_PASCAL}LockfileParser))
     }
 
-    async fn generate_inlay_hints(
-        &self,
-        parse_result: &dyn ParseResultTrait,
-        cached_versions: &HashMap<String, String>,
-        resolved_versions: &HashMap<String, String>,
-        loading_state: deps_core::LoadingState,
-        config: &EcosystemConfig,
-    ) -> Vec<InlayHint> {
-        lsp_helpers::generate_inlay_hints(
-            parse_result,
-            cached_versions,
-            resolved_versions,
-            loading_state,
-            config,
-            &self.formatter,
-        )
+    fn formatter(&self) -> &dyn EcosystemFormatter {
+        &self.formatter
     }
 
-    async fn generate_hover(
-        &self,
-        parse_result: &dyn ParseResultTrait,
-        position: Position,
-        cached_versions: &HashMap<String, String>,
-        resolved_versions: &HashMap<String, String>,
-    ) -> Option<Hover> {
-        lsp_helpers::generate_hover(
-            parse_result,
-            position,
-            cached_versions,
-            resolved_versions,
-            self.registry.as_ref(),
-            &self.formatter,
-        )
-        .await
-    }
-
-    async fn generate_code_actions(
-        &self,
-        parse_result: &dyn ParseResultTrait,
-        position: Position,
-        _cached_versions: &HashMap<String, String>,
-        uri: &Uri,
-    ) -> Vec<CodeAction> {
-        lsp_helpers::generate_code_actions(
-            parse_result,
-            position,
-            uri,
-            self.registry.as_ref(),
-            &self.formatter,
-        )
-        .await
-    }
-
-    async fn generate_diagnostics(
-        &self,
-        parse_result: &dyn ParseResultTrait,
-        _cached_versions: &HashMap<String, String>,
-        _uri: &Uri,
-    ) -> Vec<Diagnostic> {
-        lsp_helpers::generate_diagnostics(parse_result, self.registry.as_ref(), &self.formatter)
-            .await
-    }
-
-    async fn generate_completions(
-        &self,
-        _parse_result: &dyn ParseResultTrait,
+    fn generate_completions<'a>(
+        &'a self,
+        _parse_result: &'a dyn ParseResultTrait,
         _position: Position,
-        _content: &str,
-    ) -> Vec<CompletionItem> {
-        vec![]
+        _content: &'a str,
+    ) -> BoxFuture<'a, Vec<CompletionItem>> {
+        Box::pin(async move { vec![] })
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/templates/deps-ecosystem/src/formatter.rs.template
+++ b/templates/deps-ecosystem/src/formatter.rs.template
@@ -3,7 +3,7 @@ use deps_core::lsp_helpers::EcosystemFormatter;
 pub struct {ECOSYSTEM_PASCAL}Formatter;
 
 impl EcosystemFormatter for {ECOSYSTEM_PASCAL}Formatter {
-    fn format_version_for_code_action(&self, version: &str) -> String {
+    fn format_version_for_text_edit(&self, version: &str) -> String {
         // TODO: Format version according to ecosystem conventions
         format!("\"{}\"", version)
     }
@@ -22,7 +22,7 @@ mod tests {
     fn test_format_version() {
         let formatter = {ECOSYSTEM_PASCAL}Formatter;
         assert_eq!(
-            formatter.format_version_for_code_action("1.0.0"),
+            formatter.format_version_for_text_edit("1.0.0"),
             "\"1.0.0\""
         );
     }

--- a/templates/deps-ecosystem/src/lockfile.rs.template
+++ b/templates/deps-ecosystem/src/lockfile.rs.template
@@ -1,64 +1,43 @@
 //! Lock file parsing for {ECOSYSTEM_DISPLAY}.
 
-use std::collections::HashMap;
-use std::path::Path;
-use std::sync::Arc;
+use std::path::{Path, PathBuf};
 
-use async_trait::async_trait;
-use deps_core::lockfile::{LockFileProvider, LockedPackage};
-use tokio::fs;
+use deps_core::lockfile::{LockFileProvider, ResolvedPackages, locate_lockfile_for_manifest};
+use tower_lsp_server::ls_types::Uri;
 
 /// Lock file parser for {ECOSYSTEM_DISPLAY}.
 pub struct {ECOSYSTEM_PASCAL}LockfileParser;
 
-#[async_trait]
 impl LockFileProvider for {ECOSYSTEM_PASCAL}LockfileParser {
-    fn lock_filename(&self) -> &'static str {
-        "{LOCK_FILE}"
+    fn locate_lockfile(&self, manifest_uri: &Uri) -> Option<PathBuf> {
+        locate_lockfile_for_manifest(manifest_uri, &["{LOCK_FILE}"])
     }
 
-    async fn parse_lockfile(
-        &self,
-        manifest_dir: &Path,
-    ) -> deps_core::Result<HashMap<String, LockedPackage>> {
-        let lock_path = manifest_dir.join(self.lock_filename());
+    fn parse_lockfile<'a>(
+        &'a self,
+        lockfile_path: &'a Path,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = deps_core::error::Result<ResolvedPackages>> + Send + 'a>> {
+        Box::pin(async move {
+            let content = tokio::fs::read_to_string(lockfile_path)
+                .await
+                .map_err(deps_core::DepsError::Io)?;
 
-        if !lock_path.exists() {
-            return Ok(HashMap::new());
-        }
-
-        let content = fs::read_to_string(&lock_path)
-            .await
-            .map_err(|e| deps_core::DepsError::Io(e))?;
-
-        parse_lock_content(&content)
-    }
-
-    async fn is_stale(&self, manifest_dir: &Path) -> bool {
-        let lock_path = manifest_dir.join(self.lock_filename());
-        let manifest_path = manifest_dir.join("{MANIFEST_FILE}");
-
-        match (fs::metadata(&lock_path).await, fs::metadata(&manifest_path).await) {
-            (Ok(lock_meta), Ok(manifest_meta)) => {
-                match (lock_meta.modified(), manifest_meta.modified()) {
-                    (Ok(lock_time), Ok(manifest_time)) => manifest_time > lock_time,
-                    _ => false,
-                }
-            }
-            _ => false,
-        }
+            parse_lock_content(&content)
+        })
     }
 }
 
-/// Parse lock file content into package map.
-fn parse_lock_content(content: &str) -> deps_core::Result<HashMap<String, LockedPackage>> {
-    let mut packages = HashMap::new();
+/// Parse lock file content into resolved packages.
+fn parse_lock_content(content: &str) -> deps_core::error::Result<ResolvedPackages> {
+    let mut packages = ResolvedPackages::new();
 
     // TODO: Implement lock file parsing logic
     // Key requirements:
     // 1. Parse each locked package entry
-    // 2. Extract package name and resolved version
-    // 3. Handle ecosystem-specific format
+    // 2. Create ResolvedPackage with name, version, and source
+    // 3. Call packages.insert(resolved_package)
+
+    let _ = content;
 
     Ok(packages)
 }
@@ -71,11 +50,5 @@ mod tests {
     fn test_parse_empty_lockfile() {
         let result = parse_lock_content("").unwrap();
         assert!(result.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_lockfile_provider_interface() {
-        let parser = {ECOSYSTEM_PASCAL}LockfileParser;
-        assert_eq!(parser.lock_filename(), "{LOCK_FILE}");
     }
 }

--- a/templates/deps-ecosystem/src/registry.rs.template
+++ b/templates/deps-ecosystem/src/registry.rs.template
@@ -1,17 +1,13 @@
 //! {REGISTRY_NAME} API client with HTTP caching.
 
-use crate::error::{ECOSYSTEM_PASCAL}Error, Result;
+use crate::error::{ECOSYSTEM_PASCAL}Error;
 use crate::types::{ECOSYSTEM_PASCAL}Version;
-use deps_core::HttpCache;
+use deps_core::{HttpCache, ecosystem::BoxFuture};
+use std::any::Any;
 use std::sync::Arc;
 
 /// Base URL for the package registry.
 const REGISTRY_URL: &str = "{REGISTRY_URL}";
-
-/// Generate package URL for documentation links.
-pub fn package_url(name: &str) -> String {
-    format!("{}/{}", REGISTRY_URL, urlencoding::encode(name))
-}
 
 /// {REGISTRY_NAME} API client.
 pub struct {ECOSYSTEM_PASCAL}Registry {
@@ -19,12 +15,12 @@ pub struct {ECOSYSTEM_PASCAL}Registry {
 }
 
 impl {ECOSYSTEM_PASCAL}Registry {
-    /// Create a new registry client with shared HTTP cache.
+    /// Creates a new registry client with shared HTTP cache.
     pub fn new(cache: Arc<HttpCache>) -> Self {
         Self { cache }
     }
 
-    /// Fetch all versions for a package.
+    /// Fetches all versions for a package.
     ///
     /// # Examples
     ///
@@ -40,7 +36,7 @@ impl {ECOSYSTEM_PASCAL}Registry {
     /// let versions = registry.get_versions("package-name").await.unwrap();
     /// # }
     /// ```
-    pub async fn get_versions(&self, name: &str) -> Result<Vec<{ECOSYSTEM_PASCAL}Version>> {
+    pub async fn get_versions(&self, name: &str) -> crate::error::Result<Vec<{ECOSYSTEM_PASCAL}Version>> {
         let url = format!("{}/{}", REGISTRY_URL, urlencoding::encode(name));
 
         let data = self
@@ -57,55 +53,78 @@ impl {ECOSYSTEM_PASCAL}Registry {
         //         source: Box::new(e),
         //     })?;
 
-        let _ = data; // Remove when implementing
+        let _ = data;
 
         Ok(vec![])
     }
 
-    /// Get latest version matching a requirement.
+    /// Gets the latest version matching a requirement.
     pub async fn get_latest_matching(
         &self,
         name: &str,
         version_req: &str,
-    ) -> Result<Option<{ECOSYSTEM_PASCAL}Version>> {
+    ) -> crate::error::Result<Option<{ECOSYSTEM_PASCAL}Version>> {
         let versions = self.get_versions(name).await?;
 
         // TODO: Implement version matching based on ecosystem's versioning scheme
-        // Most ecosystems use semver or similar
-
-        let _ = version_req; // Remove when implementing
+        let _ = version_req;
 
         Ok(versions.into_iter().find(|v| !v.yanked))
     }
 
-    /// Search for packages by query.
-    pub async fn search(&self, query: &str, limit: usize) -> Result<Vec<String>> {
+    /// Searches for packages by query.
+    pub async fn search(&self, query: &str, limit: usize) -> crate::error::Result<Vec<crate::types::{ECOSYSTEM_PASCAL}Metadata>> {
         // TODO: Implement search if registry supports it
         let _ = (query, limit);
         Ok(vec![])
     }
 }
 
-#[async_trait::async_trait]
 impl deps_core::Registry for {ECOSYSTEM_PASCAL}Registry {
-    async fn get_versions(
-        &self,
-        name: &str,
-    ) -> deps_core::Result<Vec<Box<dyn deps_core::Version>>> {
-        let versions = self.get_versions(name).await?;
-        Ok(versions
-            .into_iter()
-            .map(|v| Box::new(v) as Box<dyn deps_core::Version>)
-            .collect())
+    fn get_versions<'a>(
+        &'a self,
+        name: &'a str,
+    ) -> BoxFuture<'a, deps_core::error::Result<Vec<Box<dyn deps_core::Version>>>> {
+        Box::pin(async move {
+            let versions = self.get_versions(name).await?;
+            Ok(versions
+                .into_iter()
+                .map(|v| Box::new(v) as Box<dyn deps_core::Version>)
+                .collect())
+        })
     }
 
-    async fn get_latest_matching(
-        &self,
-        name: &str,
-        version_req: &str,
-    ) -> deps_core::Result<Option<Box<dyn deps_core::Version>>> {
-        let version = self.get_latest_matching(name, version_req).await?;
-        Ok(version.map(|v| Box::new(v) as Box<dyn deps_core::Version>))
+    fn get_latest_matching<'a>(
+        &'a self,
+        name: &'a str,
+        req: &'a str,
+    ) -> BoxFuture<'a, deps_core::error::Result<Option<Box<dyn deps_core::Version>>>> {
+        Box::pin(async move {
+            let version = self.get_latest_matching(name, req).await?;
+            Ok(version.map(|v| Box::new(v) as Box<dyn deps_core::Version>))
+        })
+    }
+
+    fn search<'a>(
+        &'a self,
+        query: &'a str,
+        limit: usize,
+    ) -> BoxFuture<'a, deps_core::error::Result<Vec<Box<dyn deps_core::Metadata>>>> {
+        Box::pin(async move {
+            let results = self.search(query, limit).await?;
+            Ok(results
+                .into_iter()
+                .map(|m| Box::new(m) as Box<dyn deps_core::Metadata>)
+                .collect())
+        })
+    }
+
+    fn package_url(&self, name: &str) -> String {
+        format!("{}/{}", REGISTRY_URL, urlencoding::encode(name))
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 
@@ -115,14 +134,10 @@ mod tests {
 
     #[test]
     fn test_package_url() {
-        let url = package_url("my-package");
+        let cache = Arc::new(HttpCache::new());
+        let registry = {ECOSYSTEM_PASCAL}Registry::new(cache);
+        let url = registry.package_url("my-package");
         assert!(url.contains("my-package"));
-    }
-
-    #[test]
-    fn test_package_url_escapes_special_chars() {
-        let url = package_url("@scope/package");
-        assert!(url.contains("%40scope"));
     }
 
     #[tokio::test]

--- a/templates/deps-ecosystem/src/types.rs.template
+++ b/templates/deps-ecosystem/src/types.rs.template
@@ -3,6 +3,8 @@
 use std::any::Any;
 use tower_lsp_server::ls_types::Range;
 
+pub use deps_core::parser::DependencySource;
+
 /// A dependency from the manifest file.
 #[derive(Debug, Clone)]
 pub struct {ECOSYSTEM_PASCAL}Dependency {
@@ -10,11 +12,13 @@ pub struct {ECOSYSTEM_PASCAL}Dependency {
     pub name: String,
     /// LSP range of the name in source
     pub name_range: Range,
-    /// Version requirement
+    /// Version requirement (e.g., "^1.0", ">=2.0")
     pub version_req: Option<String>,
     /// LSP range of version in source
     pub version_range: Option<Range>,
-    /// Dependency section
+    /// Dependency source (registry, git, path)
+    pub source: DependencySource,
+    /// Dependency section (dependencies, dev, etc.)
     pub section: {ECOSYSTEM_PASCAL}DependencySection,
 }
 
@@ -31,6 +35,14 @@ pub enum {ECOSYSTEM_PASCAL}DependencySection {
 pub struct {ECOSYSTEM_PASCAL}Version {
     pub version: String,
     pub yanked: bool,
+}
+
+/// Package metadata for search results.
+#[derive(Debug, Clone)]
+pub struct {ECOSYSTEM_PASCAL}Metadata {
+    pub name: String,
+    pub description: Option<String>,
+    pub latest_version: String,
 }
 
 impl deps_core::Dependency for {ECOSYSTEM_PASCAL}Dependency {
@@ -50,8 +62,8 @@ impl deps_core::Dependency for {ECOSYSTEM_PASCAL}Dependency {
         self.version_range
     }
 
-    fn is_workspace_inherited(&self) -> bool {
-        false
+    fn source(&self) -> DependencySource {
+        self.source
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -80,6 +92,32 @@ impl deps_core::Version for {ECOSYSTEM_PASCAL}Version {
     }
 }
 
+impl deps_core::Metadata for {ECOSYSTEM_PASCAL}Metadata {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
+    fn repository(&self) -> Option<&str> {
+        None
+    }
+
+    fn documentation(&self) -> Option<&str> {
+        None
+    }
+
+    fn latest_version(&self) -> &str {
+        &self.latest_version
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -92,6 +130,7 @@ mod tests {
             name_range: Range::new(Position::new(0, 0), Position::new(0, 8)),
             version_req: Some("1.0.0".into()),
             version_range: Some(Range::new(Position::new(0, 10), Position::new(0, 15))),
+            source: DependencySource::Registry,
             section: {ECOSYSTEM_PASCAL}DependencySection::Dependencies,
         };
 


### PR DESCRIPTION
## Summary

- Bump version from 0.7.1 to 0.8.0
- Gradle ecosystem support (Version Catalog, Kotlin/Groovy DSL, settings.gradle)
- Gradle Plugin Portal fallback for packages not on Maven Central
- Google Maven repository support for Android packages
- toml_edit → toml-span migration for deps-cargo and deps-pypi
- Legacy trait system removal and code deduplication across ecosystems

## Checklist

- [x] Version updated in all manifests
- [x] CHANGELOG.md has release section with date
- [x] README reflects new version
- [x] All CI checks pass
- [x] Ready for tagging after merge