### PR TITLE
release: prepare v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-02-23
+
 ### Added
 - **PHP/Composer ecosystem support** — New `deps-composer` crate with full composer.json and composer.lock support
   - JSON parser for `require` and `require-dev` sections with position tracking
@@ -391,7 +393,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TLS enforced via rustls
 - cargo-deny configured for vulnerability scanning
 
-[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/bug-ops/deps-lsp/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/bug-ops/deps-lsp/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/bug-ops/deps-lsp/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/bug-ops/deps-lsp/compare/v0.6.1...v0.7.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "deps-bundler"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "deps-cargo"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "deps-composer"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "deps-core",
  "serde",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "deps-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "deps-dart"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "deps-go"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "deps-gradle"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "deps-core",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "deps-lsp"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "deps-maven"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "deps-core",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "deps-npm"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "deps-pypi"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "deps-swift"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "deps-core",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/deps-zed"]
 resolver = "3"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Andrei G"]
@@ -15,18 +15,18 @@ repository = "https://github.com/bug-ops/deps-lsp"
 async-trait = "0.1"
 criterion = "0.8"
 dashmap = "6.1"
-deps-core = { version = "0.8.0", path = "crates/deps-core" }
-deps-cargo = { version = "0.8.0", path = "crates/deps-cargo" }
-deps-npm = { version = "0.8.0", path = "crates/deps-npm" }
-deps-pypi = { version = "0.8.0", path = "crates/deps-pypi" }
-deps-go = { version = "0.8.0", path = "crates/deps-go" }
-deps-bundler = { version = "0.8.0", path = "crates/deps-bundler" }
-deps-dart = { version = "0.8.0", path = "crates/deps-dart" }
-deps-maven = { version = "0.8.0", path = "crates/deps-maven" }
-deps-composer = { version = "0.8.0", path = "crates/deps-composer" }
-deps-gradle = { version = "0.8.0", path = "crates/deps-gradle" }
-deps-swift = { version = "0.8.0", path = "crates/deps-swift" }
-deps-lsp = { version = "0.8.0", path = "crates/deps-lsp" }
+deps-core = { version = "0.9.0", path = "crates/deps-core" }
+deps-cargo = { version = "0.9.0", path = "crates/deps-cargo" }
+deps-npm = { version = "0.9.0", path = "crates/deps-npm" }
+deps-pypi = { version = "0.9.0", path = "crates/deps-pypi" }
+deps-go = { version = "0.9.0", path = "crates/deps-go" }
+deps-bundler = { version = "0.9.0", path = "crates/deps-bundler" }
+deps-dart = { version = "0.9.0", path = "crates/deps-dart" }
+deps-maven = { version = "0.9.0", path = "crates/deps-maven" }
+deps-composer = { version = "0.9.0", path = "crates/deps-composer" }
+deps-gradle = { version = "0.9.0", path = "crates/deps-gradle" }
+deps-swift = { version = "0.9.0", path = "crates/deps-swift" }
+deps-lsp = { version = "0.9.0", path = "crates/deps-lsp" }
 futures = "0.3"
 insta = "1"
 mockito = "1"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ deps-lsp is optimized for responsiveness:
 cargo install deps-lsp
 ```
 
-Latest published crate version: `0.8.0`.
+Latest published crate version: `0.9.0`.
 
 > [!TIP]
 > Use `cargo binstall deps-lsp` for faster installation without compilation.


### PR DESCRIPTION
## Summary

- Bump version from 0.8.0 to 0.9.0
- Update CHANGELOG.md with release notes (Composer, Swift ecosystems)
- Update README version reference

## Checklist

- [x] Version updated in all manifests
- [x] CHANGELOG.md has release section with date
- [x] README reflects new version
- [x] All CI checks pass (1247 tests, clippy, fmt)
- [ ] Ready for tagging after merge