### PR TITLE
fix(deps): update aws-lc-sys to 0.38.0 for security fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
## Summary

- Update `aws-lc-rs` 1.15.4 -> 1.16.1 (`aws-lc-sys` 0.37.1 -> 0.38.0)
- Resolves 3 high-severity Dependabot alerts:
  - GHSA-hfpc-8r3f-gw53: PKCS7_verify Signature Validation Bypass
  - GHSA-65p9-r9h6-22vj: Timing Side-Channel in AES-CCM Tag Verification
  - GHSA-vw5v-4f2q-w9xf: PKCS7_verify Certificate Chain Validation Bypass

## Test plan

- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo nextest run` — 1247 tests passed