### PR TITLE
fix(composer): enable preserve_order to fix position tracking for out-of-order packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Code action version update no longer produces doubled quotes in Cargo.toml (`""1.0.0""`) or doubled single quotes in Gemfile (`''1.0.0''`); `format_version_for_text_edit` now returns the bare version string since the TextEdit range already excludes delimiters
 - **Cargo feature completion** — completion items no longer carry a `textEdit` with `range (0,0)-(0,0)`; the range was incorrect and caused strict LSP clients to insert text at the beginning of the file instead of at the cursor. `build_feature_completion` now accepts `Option<Range>` and omits `textEdit` when no range is provided, matching the behaviour of version completion (resolves #88)
+- `deps-composer`: position tracking for packages out of alphabetical order — enable `serde_json`
+  `preserve_order` feature so `composer.json` entries are iterated in file order rather than
+  `BTreeMap` alphabetical order; previously, packages appearing earlier in the file but later
+  alphabetically had `name_range`/`version_range` stuck at `(0,0)→(0,0)`, breaking hover,
+  inlay hints, and diagnostics (#84)
 
 ## [0.9.2] - 2026-03-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,6 +2109,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/crates/deps-composer/Cargo.toml
+++ b/crates/deps-composer/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 [dependencies]
 deps-core = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["preserve_order"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tower-lsp-server = { workspace = true }

--- a/crates/deps-composer/src/parser.rs
+++ b/crates/deps-composer/src/parser.rs
@@ -381,4 +381,58 @@ mod tests {
         let result = parse_composer_json(json, &test_uri()).unwrap();
         assert_eq!(result.dependencies.len(), 0);
     }
+
+    /// Regression test for https://github.com/bug-ops/deps-lsp/issues/84
+    ///
+    /// BTreeMap iterates alphabetically: guzzlehttp/guzzle → laravel/framework →
+    /// symfony/console. Without preserve_order, laravel/framework (file line 2) was
+    /// searched after search_start had advanced past line 3, so its name_range and
+    /// version_range were left at (0,0)→(0,0).
+    #[test]
+    fn test_position_tracking_out_of_alphabetical_order() {
+        let json = r#"{
+    "require": {
+        "laravel/framework": "^10.0",
+        "guzzlehttp/guzzle": "^7.5",
+        "symfony/console": "~6.0"
+    }
+}"#;
+        let result = parse_composer_json(json, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 3);
+
+        for dep in &result.dependencies {
+            // Every dependency must have a valid (non-zero) name position.
+            assert!(
+                dep.name_range.start.line > 0,
+                "name_range for '{}' is at line 0 — position tracking regressed",
+                dep.name
+            );
+            assert!(
+                dep.version_range.is_some(),
+                "version_range for '{}' is missing",
+                dep.name
+            );
+        }
+
+        let laravel = result
+            .dependencies
+            .iter()
+            .find(|d| d.name == "laravel/framework")
+            .unwrap();
+        assert_eq!(laravel.name_range.start.line, 2);
+
+        let guzzle = result
+            .dependencies
+            .iter()
+            .find(|d| d.name == "guzzlehttp/guzzle")
+            .unwrap();
+        assert_eq!(guzzle.name_range.start.line, 3);
+
+        let symfony = result
+            .dependencies
+            .iter()
+            .find(|d| d.name == "symfony/console")
+            .unwrap();
+        assert_eq!(symfony.name_range.start.line, 4);
+    }
 }


### PR DESCRIPTION
## Summary

- Enable `serde_json` `preserve_order` feature in `deps-composer` so `composer.json` entries are iterated in file order (via `IndexMap`) rather than alphabetical order (via `BTreeMap`)
- Add regression test: `test_position_tracking_out_of_alphabetical_order` covering the exact reproduction case from the issue

## Root cause

`parse_section()` advanced `search_start` sequentially as each dependency was matched. Without `preserve_order`, `serde_json::Map` iterates alphabetically. A package appearing earlier in the file but later alphabetically was searched starting from a byte offset already past its location, leaving `name_range`/`version_range` at `(0,0)→(0,0)`.

## Impact before fix

- **Hover**: returned `null` for affected packages
- **Inlay hints**: missing version badge
- **Diagnostics**: outdated versions not flagged

Fixes #84

## Test plan

- [ ] New test `test_position_tracking_out_of_alphabetical_order` covers the exact reproduction scenario (laravel/framework → guzzlehttp/guzzle → symfony/console)
- [ ] All 1305 workspace tests pass
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [ ] `cargo +nightly fmt --all -- --check` clean