### PR TITLE
fix(cargo,bundler): remove quotes from format_version_for_text_edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Cargo feature completion** — LSP now provides auto-completion for feature names inside `features = [...]` arrays in Cargo.toml dependency entries (resolves #82)
 
+### Fixed
+- Code action version update no longer produces doubled quotes in Cargo.toml (`""1.0.0""`) or doubled single quotes in Gemfile (`''1.0.0''`); `format_version_for_text_edit` now returns the bare version string since the TextEdit range already excludes delimiters
+
 ## [0.9.2] - 2026-03-21
 
 ### Fixed

--- a/crates/deps-bundler/src/formatter.rs
+++ b/crates/deps-bundler/src/formatter.rs
@@ -8,7 +8,7 @@ pub struct BundlerFormatter;
 
 impl EcosystemFormatter for BundlerFormatter {
     fn format_version_for_text_edit(&self, version: &str) -> String {
-        format!("'{version}'")
+        version.to_string()
     }
 
     fn package_url(&self, name: &str) -> String {
@@ -27,8 +27,8 @@ mod tests {
     #[test]
     fn test_format_version() {
         let formatter = BundlerFormatter;
-        assert_eq!(formatter.format_version_for_text_edit("7.0.8"), "'7.0.8'");
-        assert_eq!(formatter.format_version_for_text_edit("1.0.0"), "'1.0.0'");
+        assert_eq!(formatter.format_version_for_text_edit("7.0.8"), "7.0.8");
+        assert_eq!(formatter.format_version_for_text_edit("1.0.0"), "1.0.0");
     }
 
     #[test]

--- a/crates/deps-cargo/src/formatter.rs
+++ b/crates/deps-cargo/src/formatter.rs
@@ -4,7 +4,7 @@ pub struct CargoFormatter;
 
 impl EcosystemFormatter for CargoFormatter {
     fn format_version_for_text_edit(&self, version: &str) -> String {
-        format!("\"{version}\"")
+        version.to_string()
     }
 
     fn package_url(&self, name: &str) -> String {
@@ -19,11 +19,8 @@ mod tests {
     #[test]
     fn test_format_version() {
         let formatter = CargoFormatter;
-        assert_eq!(
-            formatter.format_version_for_text_edit("1.0.214"),
-            "\"1.0.214\""
-        );
-        assert_eq!(formatter.format_version_for_text_edit("0.1.0"), "\"0.1.0\"");
+        assert_eq!(formatter.format_version_for_text_edit("1.0.214"), "1.0.214");
+        assert_eq!(formatter.format_version_for_text_edit("0.1.0"), "0.1.0");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `CargoFormatter::format_version_for_text_edit` returned `"1.0.0"` (with double quotes); TextEdit range excludes delimiters, causing `""1.0.0""` after apply
- `BundlerFormatter::format_version_for_text_edit` returned `'1.0.0'` (with single quotes); same issue, producing `''1.0.0''`
- Both formatters now return the bare version string; existing delimiters in the document are preserved by the range

## Test plan

- [ ] `cargo nextest run -p deps-cargo -p deps-bundler` — formatter tests updated and passing
- [ ] Full workspace: `cargo nextest run --workspace --all-features --no-fail-fast` — 1304 tests passed
- [ ] Manual: apply code action on `serde = "1.0.0"` in Cargo.toml → result is `serde = "1.0.228"` (no doubled quotes)
- [ ] Manual: apply code action on `gem 'rails', '7.0.0'` in Gemfile → result is valid Ruby (no doubled single quotes)

Closes #85