### PR TITLE
fix(deps-cargo): omit textEdit in feature completions to avoid cursor corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Code action version update no longer produces doubled quotes in Cargo.toml (`""1.0.0""`) or doubled single quotes in Gemfile (`''1.0.0''`); `format_version_for_text_edit` now returns the bare version string since the TextEdit range already excludes delimiters
+- **Cargo feature completion** — completion items no longer carry a `textEdit` with `range (0,0)-(0,0)`; the range was incorrect and caused strict LSP clients to insert text at the beginning of the file instead of at the cursor. `build_feature_completion` now accepts `Option<Range>` and omits `textEdit` when no range is provided, matching the behaviour of version completion (resolves #88)
 
 ## [0.9.2] - 2026-03-21
 

--- a/crates/deps-cargo/src/ecosystem.rs
+++ b/crates/deps-cargo/src/ecosystem.rs
@@ -76,14 +76,12 @@ impl CargoEcosystem {
             }
         };
 
-        let insert_range = tower_lsp_server::ls_types::Range::default();
-
         // Get features and filter by prefix
         let features = latest.features();
         features
             .into_iter()
             .filter(|f| f.starts_with(prefix))
-            .map(|feature| build_feature_completion(&feature, package_name, insert_range))
+            .map(|feature| build_feature_completion(&feature, package_name, None))
             .collect()
     }
 }

--- a/crates/deps-core/src/completion.rs
+++ b/crates/deps-core/src/completion.rs
@@ -556,7 +556,8 @@ pub fn prepare_version_display_items<V: AsRef<dyn Version>>(
 ///
 /// * `feature_name` - Name of the feature flag
 /// * `package_name` - Name of the package this feature belongs to
-/// * `insert_range` - LSP range where the completion should be inserted
+/// * `insert_range` - LSP range where the completion should be inserted, or `None` to omit
+///   `textEdit` and let the client insert at cursor position via `insertText`
 ///
 /// # Returns
 ///
@@ -566,16 +567,14 @@ pub fn prepare_version_display_items<V: AsRef<dyn Version>>(
 ///
 /// ```no_run
 /// use deps_core::completion::build_feature_completion;
-/// use tower_lsp_server::ls_types::Range;
 ///
-/// let range = Range::default();
-/// let item = build_feature_completion("derive", "serde", range);
+/// let item = build_feature_completion("derive", "serde", None);
 /// assert_eq!(item.label, "derive");
 /// ```
 pub fn build_feature_completion(
     feature_name: &str,
     package_name: &str,
-    insert_range: Range,
+    insert_range: Option<Range>,
 ) -> CompletionItem {
     CompletionItem {
         label: feature_name.to_string(),
@@ -583,10 +582,12 @@ pub fn build_feature_completion(
         detail: Some(format!("Feature of {}", package_name)),
         documentation: None,
         insert_text: Some(feature_name.to_string()),
-        text_edit: Some(CompletionTextEdit::Edit(TextEdit {
-            range: insert_range,
-            new_text: feature_name.to_string(),
-        })),
+        text_edit: insert_range.map(|range| {
+            CompletionTextEdit::Edit(TextEdit {
+                range,
+                new_text: feature_name.to_string(),
+            })
+        }),
         sort_text: Some(feature_name.to_string()),
         ..Default::default()
     }
@@ -1515,14 +1516,23 @@ mod tests {
 
     #[test]
     fn test_build_feature_completion() {
-        let range = Range::default();
-        let item = build_feature_completion("derive", "serde", range);
+        let item = build_feature_completion("derive", "serde", None);
 
         assert_eq!(item.label, "derive");
         assert_eq!(item.kind, Some(CompletionItemKind::PROPERTY));
         assert_eq!(item.detail, Some("Feature of serde".to_string()));
         assert!(item.documentation.is_none());
+        assert!(item.text_edit.is_none());
         assert_eq!(item.sort_text, Some("derive".to_string()));
+    }
+
+    #[test]
+    fn test_build_feature_completion_with_range() {
+        let range = Range::default();
+        let item = build_feature_completion("derive", "serde", Some(range));
+
+        assert_eq!(item.label, "derive");
+        assert!(item.text_edit.is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `complete_features()` was passing `Range::default()` (position `(0,0)-(0,0)`) to `build_feature_completion`, generating a `textEdit` with an empty range at the document start
- Per LSP spec, `textEdit` takes precedence over `insertText`, so strict clients inserted the feature name at the beginning of the file instead of the cursor — corrupting the manifest
- Changed `build_feature_completion` to accept `Option<Range>` and omit `textEdit` when `None`, matching the existing pattern in `complete_versions_generic`

## Test plan

- [ ] `cargo nextest run -p deps-core -E 'test(feature_completion)'` — new `test_build_feature_completion` asserts `text_edit.is_none()` when `None` range is passed; `test_build_feature_completion_with_range` covers the `Some(range)` path
- [ ] Full workspace tests pass: `cargo nextest run --workspace --all-features --lib --bins`
- [ ] Open a `Cargo.toml` with `serde = { version = "1", features = ["de"] }`, place cursor inside `"de"`, trigger completion, apply a feature — text appears at cursor, not at line 0

Closes #88