### PR TITLE
fix(deps-bundler): handle wildcard in version_matches_requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `BTreeMap` alphabetical order; previously, packages appearing earlier in the file but later
   alphabetically had `name_range`/`version_range` stuck at `(0,0)→(0,0)`, breaking hover,
   inlay hints, and diagnostics (#84)
+- **deps-bundler**: `version_matches_requirement` now handles wildcard `"*"` requirement, fixing inlay hints always returning empty for Gemfile dependencies (resolves #89)
 
 ## [0.9.2] - 2026-03-21
 

--- a/crates/deps-bundler/src/version.rs
+++ b/crates/deps-bundler/src/version.rs
@@ -33,6 +33,10 @@ pub fn compare_versions(a: &str, b: &str) -> Ordering {
 pub fn version_matches_requirement(version: &str, requirement: &str) -> bool {
     let req = requirement.trim();
 
+    if req == "*" {
+        return true;
+    }
+
     // Pessimistic operator (~>)
     if req.starts_with("~>") {
         let req_ver = req.trim_start_matches("~>").trim();
@@ -176,5 +180,10 @@ mod tests {
         // Not equal
         assert!(version_matches_requirement("1.0.1", "!= 1.0.0"));
         assert!(!version_matches_requirement("1.0.0", "!= 1.0.0"));
+
+        // Wildcard
+        assert!(version_matches_requirement("1.0.0", "*"));
+        assert!(version_matches_requirement("0.0.1", "*"));
+        assert!(version_matches_requirement("99.99.99", "*"));
     }
 }


### PR DESCRIPTION
## Summary

- `version_matches_requirement` in `crates/deps-bundler/src/version.rs` did not handle the `"*"` wildcard requirement
- Background registry fetch calls `get_latest_matching(name, "*")` for each Gemfile dependency; without wildcard support it always returned `None`
- This left `cached_versions` empty, causing `generate_inlay_hints` to produce zero results

## Fix

Added a wildcard guard at the top of `version_matches_requirement`:
```rust
if req == "*" {
    return true;
}
```

Added three test cases covering wildcard behavior.

## Test plan

- [x] `cargo +nightly fmt --all -- --check` passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passed
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` — 1314 passed, 37 skipped

Closes #89