### PR TITLE
release: v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-03-28
+
 ### Added
 - **Cargo feature completion** — LSP now provides auto-completion for feature names inside `features = [...]` arrays in Cargo.toml dependency entries (resolves #82)
 
@@ -423,7 +425,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TLS enforced via rustls
 - cargo-deny configured for vulnerability scanning
 
-[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.9.2...HEAD
+[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.9.3...HEAD
+[0.9.3]: https://github.com/bug-ops/deps-lsp/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/bug-ops/deps-lsp/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/bug-ops/deps-lsp/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/bug-ops/deps-lsp/compare/v0.8.0...v0.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -167,9 +167,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -249,9 +249,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -294,14 +294,13 @@ checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -421,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "deps-bundler"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "criterion",
@@ -441,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "deps-cargo"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "criterion",
@@ -462,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "deps-composer"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "deps-core",
  "serde",
@@ -477,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "deps-core"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -499,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "deps-dart"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "criterion",
@@ -519,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "deps-go"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "criterion",
@@ -538,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "deps-gradle"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "deps-core",
@@ -556,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "deps-lsp"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "criterion",
@@ -588,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "deps-maven"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "deps-core",
@@ -607,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "deps-npm"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "criterion",
@@ -626,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "deps-pypi"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "criterion",
@@ -648,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "deps-swift"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "deps-core",
  "insta",
@@ -1214,9 +1213,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.46.3"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
+checksum = "6f40e41efb5f592d3a0764f818e2f08e5e21c4f368126f74f37c81bd4af7a0c6"
 dependencies = [
  "console",
  "once_cell",
@@ -1233,9 +1232,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
 dependencies = [
  "memchr",
  "serde",
@@ -1265,7 +1264,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1274,9 +1273,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -1290,10 +1311,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1423,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1916,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -2146,9 +2169,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "similar"
@@ -2678,9 +2701,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2691,23 +2714,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2715,9 +2734,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2728,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
 dependencies = [
  "unicode-ident",
 ]
@@ -2771,9 +2790,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2878,15 +2897,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/deps-zed"]
 resolver = "3"
 
 [workspace.package]
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Andrei G"]
@@ -15,20 +15,20 @@ repository = "https://github.com/bug-ops/deps-lsp"
 async-trait = "0.1"
 criterion = "0.8"
 dashmap = "6.1"
-deps-core = { version = "0.9.2", path = "crates/deps-core" }
-deps-cargo = { version = "0.9.2", path = "crates/deps-cargo" }
-deps-npm = { version = "0.9.2", path = "crates/deps-npm" }
-deps-pypi = { version = "0.9.2", path = "crates/deps-pypi" }
-deps-go = { version = "0.9.2", path = "crates/deps-go" }
-deps-bundler = { version = "0.9.2", path = "crates/deps-bundler" }
-deps-dart = { version = "0.9.2", path = "crates/deps-dart" }
-deps-maven = { version = "0.9.2", path = "crates/deps-maven" }
-deps-composer = { version = "0.9.2", path = "crates/deps-composer" }
-deps-gradle = { version = "0.9.2", path = "crates/deps-gradle" }
-deps-swift = { version = "0.9.2", path = "crates/deps-swift" }
-deps-lsp = { version = "0.9.2", path = "crates/deps-lsp" }
+deps-core = { version = "0.9.3", path = "crates/deps-core" }
+deps-cargo = { version = "0.9.3", path = "crates/deps-cargo" }
+deps-npm = { version = "0.9.3", path = "crates/deps-npm" }
+deps-pypi = { version = "0.9.3", path = "crates/deps-pypi" }
+deps-go = { version = "0.9.3", path = "crates/deps-go" }
+deps-bundler = { version = "0.9.3", path = "crates/deps-bundler" }
+deps-dart = { version = "0.9.3", path = "crates/deps-dart" }
+deps-maven = { version = "0.9.3", path = "crates/deps-maven" }
+deps-composer = { version = "0.9.3", path = "crates/deps-composer" }
+deps-gradle = { version = "0.9.3", path = "crates/deps-gradle" }
+deps-swift = { version = "0.9.3", path = "crates/deps-swift" }
+deps-lsp = { version = "0.9.3", path = "crates/deps-lsp" }
 futures = "0.3"
-insta = "1"
+insta = "1.47.0"
 mockito = "1"
 node-semver = "2.2"
 pep440_rs = "0.7"

--- a/crates/deps-bundler/README.md
+++ b/crates/deps-bundler/README.md
@@ -23,7 +23,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-bundler = "0.9.2"
+deps-bundler = "0.9.3"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-cargo/README.md
+++ b/crates/deps-cargo/README.md
@@ -22,7 +22,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-cargo = "0.9.2"
+deps-cargo = "0.9.3"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-composer/README.md
+++ b/crates/deps-composer/README.md
@@ -26,7 +26,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-composer = "0.9.2"
+deps-composer = "0.9.3"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-core/README.md
+++ b/crates/deps-core/README.md
@@ -23,7 +23,7 @@ This crate provides the shared infrastructure used by all ecosystem-specific cra
 
 ```toml
 [dependencies]
-deps-core = "0.9.2"
+deps-core = "0.9.3"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-go/README.md
+++ b/crates/deps-go/README.md
@@ -24,7 +24,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-go = "0.9.2"
+deps-go = "0.9.3"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-lsp/README.md
+++ b/crates/deps-lsp/README.md
@@ -40,7 +40,7 @@ All ecosystems are enabled by default. Disable unused ones to reduce binary size
 
 ```toml
 [dependencies]
-deps-lsp = { version = "0.9.2", default-features = false, features = ["cargo", "npm"] }
+deps-lsp = { version = "0.9.3", default-features = false, features = ["cargo", "npm"] }
 ```
 
 | Feature | Ecosystem | Default |

--- a/crates/deps-maven/README.md
+++ b/crates/deps-maven/README.md
@@ -23,7 +23,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-maven = "0.9.2"
+deps-maven = "0.9.3"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-npm/README.md
+++ b/crates/deps-npm/README.md
@@ -22,7 +22,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-npm = "0.9.2"
+deps-npm = "0.9.3"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-pypi/README.md
+++ b/crates/deps-pypi/README.md
@@ -24,7 +24,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-pypi = "0.9.2"
+deps-pypi = "0.9.3"
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
## Summary

- Bump version from 0.9.2 to 0.9.3
- Update CHANGELOG.md with release section
- Update version references in all crate READMEs

## Checklist

- [x] Version updated in all manifests
- [x] CHANGELOG.md has release section with date
- [x] READMEs reflect new version
- [x] All CI checks pass (fmt, clippy, nextest: 1317 passed)
- [ ] Ready for tagging after merge