### PR TITLE
fix(deps-cargo): sort crate search results by downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cargo feature completion** — LSP now provides auto-completion for feature names inside `features = [...]` arrays in Cargo.toml dependency entries (resolves #82)
 
 ### Fixed
+- **deps-cargo**: crate name completion now sorts search results by download count, so popular crates like `sqlx` and `thiserror` appear at the top instead of being buried or absent (resolves #95)
 - Code action version update no longer produces doubled quotes in Cargo.toml (`""1.0.0""`) or doubled single quotes in Gemfile (`''1.0.0''`); `format_version_for_text_edit` now returns the bare version string since the TextEdit range already excludes delimiters
 - **Cargo feature completion** — completion items no longer carry a `textEdit` with `range (0,0)-(0,0)`; the range was incorrect and caused strict LSP clients to insert text at the beginning of the file instead of at the cursor. `build_feature_completion` now accepts `Option<Range>` and omits `textEdit` when no range is provided, matching the behaviour of version completion (resolves #88)
 - `deps-composer`: position tracking for packages out of alphabetical order — enable `serde_json`

--- a/crates/deps-cargo/src/registry.rs
+++ b/crates/deps-cargo/src/registry.rs
@@ -165,7 +165,7 @@ impl CratesIoRegistry {
     /// ```
     pub async fn search(&self, query: &str, limit: usize) -> Result<Vec<CrateInfo>> {
         let url = format!(
-            "{}/crates?q={}&per_page={}",
+            "{}/crates?q={}&per_page={}&sort=downloads",
             SEARCH_API_BASE,
             urlencoding::encode(query),
             limit


### PR DESCRIPTION
## Summary

- crates.io default relevance sort prioritizes exact name matches over popular prefix matches
- `sql` returned obscure crates, never `sqlx`; `thiserr` put `thiserror` at position 14
- Adding `sort=downloads` to the search URL fixes both cases: `sqlx` is now 4th for `sql`, `thiserror` is 1st for `thiserr`

Resolves #95

## Test plan

- [ ] All existing tests pass (`cargo nextest run --workspace --all-features`)
- [ ] Live: open Cargo.toml, type `sql` → `sqlx` appears in completions
- [ ] Live: type `thiserr` → `thiserror` appears at the top