### PR TITLE
fix(deps-npm): stop using now-registered package name in version completion tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **deps-npm**: version completion tests no longer assume `nonexistent-package`/`nonexistent-pkg` are unregistered on the live npm registry — npm now publishes a security-holding package under that exact name, which made `test_complete_versions_empty_prefix` flaky in CI. Tests use the same `this-package-does-not-exist-12345` placeholder already used elsewhere in the suite
+
 ## [0.9.4] - 2026-06-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **deps-npm**: version completion tests no longer assume `nonexistent-package`/`nonexistent-pkg` are unregistered on the live npm registry — npm now publishes a security-holding package under that exact name, which made `test_complete_versions_empty_prefix` flaky in CI. Tests use the same `this-package-does-not-exist-12345` placeholder already used elsewhere in the suite
 
+### Security
+- Upgrade `quick-xml` 0.39.4 → 0.41.0 to address RUSTSEC-2026-0195 (unbounded namespace-declaration allocation in `NsReader`)
+- Upgrade `crossbeam-epoch` 0.9.18 → 0.9.20 to address RUSTSEC-2026-0204 (invalid pointer dereference in `fmt::Pointer` for `Atomic`/`Shared`)
+
 ## [0.9.4] - 2026-06-29
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1626,9 +1626,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ tower-lsp-server = "0.23"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 urlencoding = "2.1"
-quick-xml = "0.39"
+quick-xml = "0.41"
 yaml-rust2 = "0.11"
 zed_extension_api = "0.7"
 

--- a/crates/deps-npm/src/ecosystem.rs
+++ b/crates/deps-npm/src/ecosystem.rs
@@ -490,7 +490,9 @@ mod tests {
         let ecosystem = NpmEcosystem::new(cache);
 
         // Empty prefix should show non-deprecated versions (up to 20)
-        let results = ecosystem.complete_versions("nonexistent-package", "").await;
+        let results = ecosystem
+            .complete_versions("this-package-does-not-exist-12345", "")
+            .await;
         // Should not panic, returns empty for unknown package
         assert!(results.is_empty());
     }
@@ -501,7 +503,9 @@ mod tests {
         let ecosystem = NpmEcosystem::new(cache);
 
         // Test ~ operator stripping
-        let results = ecosystem.complete_versions("nonexistent-pkg", "~4.0").await;
+        let results = ecosystem
+            .complete_versions("this-package-does-not-exist-12345", "~4.0")
+            .await;
         assert!(results.is_empty());
     }
 
@@ -511,7 +515,9 @@ mod tests {
         let ecosystem = NpmEcosystem::new(cache);
 
         // Test * wildcard stripping
-        let results = ecosystem.complete_versions("nonexistent-pkg", "*").await;
+        let results = ecosystem
+            .complete_versions("this-package-does-not-exist-12345", "*")
+            .await;
         assert!(results.is_empty());
     }
 
@@ -521,7 +527,9 @@ mod tests {
         let ecosystem = NpmEcosystem::new(cache);
 
         // Test < and > operator stripping
-        let results = ecosystem.complete_versions("nonexistent-pkg", "<2.0").await;
+        let results = ecosystem
+            .complete_versions("this-package-does-not-exist-12345", "<2.0")
+            .await;
         assert!(results.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- CI on #104 (quick-xml bump) is failing on `Test (ubuntu-latest)` / `Test (macos-latest)` / `Code Coverage` because `deps-npm::ecosystem::tests::test_complete_versions_empty_prefix` hits the live npm registry and asserts the package name `nonexistent-package` is unregistered
- npm now publishes a security-holding package under that exact name (confirmed via `registry.npmjs.org/nonexistent-package`), so the assertion `results.is_empty()` fails regardless of the PR's actual diff
- Switched the affected tests to the `this-package-does-not-exist-12345` placeholder already used successfully elsewhere in the same test module

## Test plan
- [x] `cargo nextest run -p deps-npm -E 'test(complete_versions)'` — 5 passed
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy -p deps-npm --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins --no-fail-fast` — 1272 passed