### PR TITLE
release: v0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.5] - 2026-08-12
+
 ### Added
 - **Release/CI**: `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` release binaries, built via `cross`, covering musl-based Linux distributions (e.g. Alpine) alongside the existing glibc targets. CI gained matching build-only cross-compile checks for both musl targets
 
@@ -446,7 +448,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TLS enforced via rustls
 - cargo-deny configured for vulnerability scanning
 
-[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.9.4...HEAD
+[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.9.5...HEAD
+[0.9.5]: https://github.com/bug-ops/deps-lsp/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/bug-ops/deps-lsp/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/bug-ops/deps-lsp/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/bug-ops/deps-lsp/compare/v0.9.1...v0.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.5] - 2026-08-12
 
+### Changed
+- **MSRV bumped to 1.91** — unlocks `str::floor_char_boundary`, used to simplify description truncation in `deps-core`
+
 ### Added
 - **Release/CI**: `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` release binaries, built via `cross`, covering musl-based Linux distributions (e.g. Alpine) alongside the existing glibc targets. CI gained matching build-only cross-compile checks for both musl targets
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -162,9 +162,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9066c49992464636f92905fa096ec58baaa4d57ec19a5c096c68d3e25ef3d136"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "deps-bundler"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "criterion",
@@ -439,7 +439,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-test",
  "tower-lsp-server",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "deps-cargo"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "criterion",
@@ -459,7 +459,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-test",
  "toml-span",
@@ -470,13 +470,13 @@ dependencies = [
 
 [[package]]
 name = "deps-composer"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "deps-core",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tower-lsp-server",
  "tracing",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "deps-core"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -498,7 +498,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-test",
  "tower-lsp-server",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "deps-dart"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "criterion",
@@ -516,7 +516,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-test",
  "tower-lsp-server",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "deps-go"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "criterion",
@@ -537,7 +537,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-test",
  "tower-lsp-server",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "deps-gradle"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "deps-core",
@@ -554,7 +554,7 @@ dependencies = [
  "insta",
  "regex",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-test",
  "toml-span",
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "deps-lsp"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "criterion",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "deps-maven"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "deps-core",
@@ -605,7 +605,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-test",
  "tower-lsp-server",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "deps-npm"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "criterion",
@@ -625,7 +625,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tower-lsp-server",
  "tracing",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "deps-pypi"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "criterion",
@@ -646,7 +646,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "toml-span",
  "tower-lsp-server",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "deps-swift"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "deps-core",
  "insta",
@@ -666,7 +666,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-test",
  "tower-lsp-server",
@@ -790,9 +790,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -805,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -815,15 +815,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -832,38 +832,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -997,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1241,7 +1241,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -1290,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1675,7 +1675,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -1698,7 +1698,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2019,9 +2019,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2314,11 +2314,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -2334,9 +2334,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2712,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2725,9 +2725,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2735,9 +2735,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2745,9 +2745,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2758,18 +2758,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/deps-zed"]
 resolver = "3"
 
 [workspace.package]
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Andrei G"]
@@ -15,18 +15,18 @@ repository = "https://github.com/bug-ops/deps-lsp"
 async-trait = "0.1"
 criterion = "0.8"
 dashmap = "6.2"
-deps-core = { version = "0.9.4", path ="crates/deps-core" }
-deps-cargo = { version = "0.9.4", path ="crates/deps-cargo" }
-deps-npm = { version = "0.9.4", path ="crates/deps-npm" }
-deps-pypi = { version = "0.9.4", path ="crates/deps-pypi" }
-deps-go = { version = "0.9.4", path ="crates/deps-go" }
-deps-bundler = { version = "0.9.4", path ="crates/deps-bundler" }
-deps-dart = { version = "0.9.4", path ="crates/deps-dart" }
-deps-maven = { version = "0.9.4", path ="crates/deps-maven" }
-deps-composer = { version = "0.9.4", path ="crates/deps-composer" }
-deps-gradle = { version = "0.9.4", path ="crates/deps-gradle" }
-deps-swift = { version = "0.9.4", path ="crates/deps-swift" }
-deps-lsp = { version = "0.9.4", path ="crates/deps-lsp" }
+deps-core = { version = "0.9.5", path ="crates/deps-core" }
+deps-cargo = { version = "0.9.5", path ="crates/deps-cargo" }
+deps-npm = { version = "0.9.5", path ="crates/deps-npm" }
+deps-pypi = { version = "0.9.5", path ="crates/deps-pypi" }
+deps-go = { version = "0.9.5", path ="crates/deps-go" }
+deps-bundler = { version = "0.9.5", path ="crates/deps-bundler" }
+deps-dart = { version = "0.9.5", path ="crates/deps-dart" }
+deps-maven = { version = "0.9.5", path ="crates/deps-maven" }
+deps-composer = { version = "0.9.5", path ="crates/deps-composer" }
+deps-gradle = { version = "0.9.5", path ="crates/deps-gradle" }
+deps-swift = { version = "0.9.5", path ="crates/deps-swift" }
+deps-lsp = { version = "0.9.5", path ="crates/deps-lsp" }
 futures = "0.3"
 insta = "1.48"
 mockito = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "3"
 [workspace.package]
 version = "0.9.5"
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.91"
 authors = ["Andrei G"]
 license = "MIT"
 repository = "https://github.com/bug-ops/deps-lsp"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/bug-ops/deps-lsp/actions/workflows/ci.yml/badge.svg)](https://github.com/bug-ops/deps-lsp/actions)
 [![codecov](https://codecov.io/gh/bug-ops/deps-lsp/graph/badge.svg?token=S71PTINTGQ)](https://codecov.io/gh/bug-ops/deps-lsp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.89-blue)](https://blog.rust-lang.org/)
+[![MSRV](https://img.shields.io/badge/MSRV-1.91-blue)](https://blog.rust-lang.org/)
 [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 
 A universal Language Server Protocol (LSP) server for dependency management across Cargo, npm, PyPI, Go, Bundler, Dart, Maven, Gradle, Swift, and Composer ecosystems.
@@ -276,7 +276,7 @@ deps-lsp is optimized for responsiveness:
 ## Development
 
 > [!IMPORTANT]
-> Requires Rust 1.89+ (Edition 2024).
+> Requires Rust 1.91+ (Edition 2024).
 
 ### Build
 

--- a/crates/deps-bundler/README.md
+++ b/crates/deps-bundler/README.md
@@ -27,7 +27,7 @@ deps-bundler = "0.9"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.89 or later.
+> Requires Rust 1.91 or later.
 
 ## Usage
 

--- a/crates/deps-bundler/README.md
+++ b/crates/deps-bundler/README.md
@@ -23,7 +23,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-bundler = "0.9.4"
+deps-bundler = "0.9"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-cargo/README.md
+++ b/crates/deps-cargo/README.md
@@ -26,7 +26,7 @@ deps-cargo = "0.9"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.89 or later.
+> Requires Rust 1.91 or later.
 
 ## Usage
 

--- a/crates/deps-cargo/README.md
+++ b/crates/deps-cargo/README.md
@@ -22,7 +22,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-cargo = "0.9.4"
+deps-cargo = "0.9"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-cargo/src/lockfile.rs
+++ b/crates/deps-cargo/src/lockfile.rs
@@ -474,7 +474,7 @@ version = 4
         std::fs::write(&lockfile_path, "version = 4").unwrap();
 
         // Use a time far in the future
-        let future_time = std::time::SystemTime::now() + std::time::Duration::from_secs(86400); // +1 day
+        let future_time = std::time::SystemTime::now() + std::time::Duration::from_hours(24);
         let parser = CargoLockParser;
 
         assert!(

--- a/crates/deps-composer/README.md
+++ b/crates/deps-composer/README.md
@@ -30,7 +30,7 @@ deps-composer = "0.9"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.89 or later.
+> Requires Rust 1.91 or later.
 
 ## Usage
 

--- a/crates/deps-composer/README.md
+++ b/crates/deps-composer/README.md
@@ -26,7 +26,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-composer = "0.9.4"
+deps-composer = "0.9"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-core/README.md
+++ b/crates/deps-core/README.md
@@ -27,7 +27,7 @@ deps-core = "0.9"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.89 or later.
+> Requires Rust 1.91 or later.
 
 ## Implementing a new ecosystem
 

--- a/crates/deps-core/src/completion.rs
+++ b/crates/deps-core/src/completion.rs
@@ -384,10 +384,7 @@ pub fn build_package_completion(metadata: &dyn Metadata, insert_range: Range) ->
     if let Some(desc) = metadata.description() {
         doc_parts.push(String::new()); // Empty line
         let truncated = if desc.len() > 200 {
-            let mut end = 200;
-            while end > 0 && !desc.is_char_boundary(end) {
-                end -= 1;
-            }
+            let end = desc.floor_char_boundary(200);
             format!("{}...", &desc[..end])
         } else {
             desc.to_string()

--- a/crates/deps-dart/README.md
+++ b/crates/deps-dart/README.md
@@ -27,7 +27,7 @@ deps-dart = "0.9"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.89 or later.
+> Requires Rust 1.91 or later.
 
 ## Usage
 

--- a/crates/deps-dart/README.md
+++ b/crates/deps-dart/README.md
@@ -23,7 +23,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-dart = "0.9.4"
+deps-dart = "0.9"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-go/README.md
+++ b/crates/deps-go/README.md
@@ -28,7 +28,7 @@ deps-go = "0.9"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.89 or later.
+> Requires Rust 1.91 or later.
 
 ## Usage
 

--- a/crates/deps-go/README.md
+++ b/crates/deps-go/README.md
@@ -24,7 +24,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-go = "0.9.4"
+deps-go = "0.9"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-go/src/lockfile.rs
+++ b/crates/deps-go/src/lockfile.rs
@@ -447,7 +447,7 @@ golang.org/x/sync v0.5.0/go.mod h1:RxMgew5V=
         std::fs::write(&lockfile_path, "").unwrap();
 
         // Use a time far in the future
-        let future_time = std::time::SystemTime::now() + std::time::Duration::from_secs(86400); // +1 day
+        let future_time = std::time::SystemTime::now() + std::time::Duration::from_hours(24);
         let parser = GoSumParser;
 
         assert!(

--- a/crates/deps-gradle/README.md
+++ b/crates/deps-gradle/README.md
@@ -30,7 +30,7 @@ deps-gradle = "0.9"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.89 or later.
+> Requires Rust 1.91 or later.
 
 ## Usage
 

--- a/crates/deps-gradle/README.md
+++ b/crates/deps-gradle/README.md
@@ -26,7 +26,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-gradle = "0.9.4"
+deps-gradle = "0.9"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-lsp/README.md
+++ b/crates/deps-lsp/README.md
@@ -40,7 +40,7 @@ All ecosystems are enabled by default. Disable unused ones to reduce binary size
 
 ```toml
 [dependencies]
-deps-lsp = { version = "0.9.4", default-features = false, features = ["cargo", "npm"] }
+deps-lsp = { version = "0.9", default-features = false, features = ["cargo", "npm"] }
 ```
 
 | Feature | Ecosystem | Default |

--- a/crates/deps-lsp/README.md
+++ b/crates/deps-lsp/README.md
@@ -26,7 +26,7 @@ cargo install deps-lsp
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.89 or later.
+> Requires Rust 1.91 or later.
 
 ## Usage
 

--- a/crates/deps-lsp/src/server.rs
+++ b/crates/deps-lsp/src/server.rs
@@ -271,13 +271,12 @@ impl LanguageServer for Backend {
         // Spawn background cleanup task for cold start rate limiter
         let state_clone = Arc::clone(&self.state);
         tokio::spawn(async move {
-            let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+            let mut interval = tokio::time::interval(std::time::Duration::from_mins(1));
             loop {
                 interval.tick().await;
-                // Clean up entries older than 5 minutes
                 state_clone
                     .cold_start_limiter
-                    .cleanup_old_entries(std::time::Duration::from_secs(300));
+                    .cleanup_old_entries(std::time::Duration::from_mins(5));
                 tracing::trace!("Cleaned up old cold start rate limit entries");
             }
         });

--- a/crates/deps-maven/README.md
+++ b/crates/deps-maven/README.md
@@ -27,7 +27,7 @@ deps-maven = "0.9"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.89 or later.
+> Requires Rust 1.91 or later.
 
 ## Usage
 

--- a/crates/deps-maven/README.md
+++ b/crates/deps-maven/README.md
@@ -23,7 +23,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-maven = "0.9.4"
+deps-maven = "0.9"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-npm/README.md
+++ b/crates/deps-npm/README.md
@@ -22,7 +22,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-npm = "0.9.4"
+deps-npm = "0.9"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-npm/README.md
+++ b/crates/deps-npm/README.md
@@ -26,7 +26,7 @@ deps-npm = "0.9"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.89 or later.
+> Requires Rust 1.91 or later.
 
 ## Usage
 

--- a/crates/deps-npm/src/lockfile.rs
+++ b/crates/deps-npm/src/lockfile.rs
@@ -630,7 +630,7 @@ mod tests {
         std::fs::write(&lockfile_path, r#"{"lockfileVersion": 3}"#).unwrap();
 
         // Use a time far in the future
-        let future_time = std::time::SystemTime::now() + std::time::Duration::from_secs(86400); // +1 day
+        let future_time = std::time::SystemTime::now() + std::time::Duration::from_hours(24);
         let parser = NpmLockParser;
 
         assert!(

--- a/crates/deps-pypi/README.md
+++ b/crates/deps-pypi/README.md
@@ -24,7 +24,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-pypi = "0.9.4"
+deps-pypi = "0.9"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-pypi/README.md
+++ b/crates/deps-pypi/README.md
@@ -28,7 +28,7 @@ deps-pypi = "0.9"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.89 or later.
+> Requires Rust 1.91 or later.
 
 ## Usage
 

--- a/crates/deps-swift/README.md
+++ b/crates/deps-swift/README.md
@@ -29,7 +29,7 @@ deps-swift = "0.9"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.89 or later.
+> Requires Rust 1.91 or later.
 
 ## Usage
 

--- a/crates/deps-swift/README.md
+++ b/crates/deps-swift/README.md
@@ -25,7 +25,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-swift = "0.9.4"
+deps-swift = "0.9"
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
## Summary

- Bump version from 0.9.4 to 0.9.5
- Update CHANGELOG.md with release notes (musl release/CI targets, npm test flakiness fix, quick-xml/crossbeam-epoch security upgrades)
- Refresh crate READMEs (dependency version pinned to minor version going forward)

## Checklist

- [x] Version updated in all manifests
- [x] CHANGELOG.md has release section with date
- [x] README reflects new version
- [x] All CI checks pass locally (fmt, clippy, nextest, rustdoc)
- [ ] Ready for tagging after merge