### PR TITLE
fix(ci): skip cargo-nextest install for cross-compile-only test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         with:
           channel: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
-          bins: cargo-nextest
+          bins: ${{ !matrix.cross && 'cargo-nextest' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- The `Test (windows-latest / aarch64-pc-windows-msvc)` job (https://github.com/bug-ops/deps-lsp/actions/runs/31634514455/job/94246948361) fails deterministically: `cargo-nextest` has no precompiled binary for `aarch64-pc-windows-msvc`, so `moonrepo/setup-rust@v1`'s `bins: cargo-nextest` falls back to `cargo install cargo-nextest` without `--locked`, which nextest's build script rejects by design (`Nextest does not support being installed without --locked`)
- That job is cross-compile-only (`matrix.cross: true`) and never runs `cargo nextest run` in the first place (`if: ${{ !matrix.cross }}` gates the test step), so it doesn't need nextest installed at all
- Fix: only request the `cargo-nextest` bin install when `!matrix.cross`, mirroring the existing `matrix.target && ... || ''` conditional idiom already used elsewhere in this workflow

## Test plan

- [x] `fy lint .github/workflows/ci.yml` — 0 errors (pre-existing style-only notices unrelated to this change)
- [ ] CI on this PR passes, in particular `Test (windows-latest / aarch64-pc-windows-msvc)`