### PR TITLE
fix(release): set DEBIAN_FRONTEND=noninteractive for musl cross pre-build

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -5,12 +5,17 @@
 # in addition to a C compiler, which is not guaranteed to be preinstalled in
 # the default cross-rs musl images. Install it explicitly before the build
 # to avoid non-deterministic musl cross-compile failures.
+#
+# DEBIAN_FRONTEND=noninteractive is required: installing cmake transitively
+# pulls in tzdata, whose postinst script prompts interactively for a
+# timezone. Without it, the build hangs indefinitely waiting for input that
+# never arrives in a CI container (observed on x86_64-unknown-linux-musl).
 [target.x86_64-unknown-linux-musl]
 pre-build = [
-    "apt-get update && apt-get install --assume-yes cmake",
+    "export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install --assume-yes cmake",
 ]
 
 [target.aarch64-unknown-linux-musl]
 pre-build = [
-    "apt-get update && apt-get install --assume-yes cmake",
+    "export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install --assume-yes cmake",
 ]


### PR DESCRIPTION
## Summary

- The `v0.9.5` Release run's `Build (x86_64-unknown-linux-musl)` job (https://github.com/bug-ops/deps-lsp/actions/runs/31634595664/job/94244018122) hung for 37+ minutes and had to be cancelled
- Root cause: `Cross.toml`'s pre-build step runs `apt-get install --assume-yes cmake`, which transitively installs `tzdata`; `tzdata`'s postinst script prompts interactively for a timezone, and with no TTY in the CI container the prompt blocks forever
- `aarch64-unknown-linux-musl` happened to succeed in the same run because its cross-rs image already had `tzdata` preconfigured from an earlier layer — the bug is non-deterministic per target/image state, not something that reliably reproduces every run
- Fix: `export DEBIAN_FRONTEND=noninteractive` before `apt-get` in both musl `pre-build` steps, the standard fix for this class of hang

## Test plan

- [x] `fy lint Cross.toml` is not applicable (not YAML); verified TOML is well-formed by re-reading the file
- [ ] After merge, re-run the Release workflow for `v0.9.5` and confirm `Build (x86_64-unknown-linux-musl)` completes without hanging and the asset is uploaded