### PR TITLE
fix(ci): install cargo-nextest via taiki-e/install-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,9 +130,10 @@ jobs:
       - uses: moonrepo/setup-rust@v1
         with:
           channel: ${{ matrix.rust }}
-          bins: cargo-nextest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: taiki-e/install-action@nextest
 
       - name: Install dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
@@ -203,10 +204,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: moonrepo/setup-rust@v1
-        with:
-          bins: cargo-llvm-cov,cargo-nextest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest, cargo-llvm-cov
 
       - name: Generate coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info nextest


### PR DESCRIPTION
## Summary
- The `test` and `coverage` jobs installed `cargo-nextest` (and `cargo-llvm-cov`) via `moonrepo/setup-rust`'s `bins:` input, which uses cargo-binstall and silently falls back to `cargo install <tool>` (without `--locked`) when the binstall fetch fails.
- Nextest's `locked-tripwire` build guard rejects unlocked source installs at compile time, so any transient binstall network failure (as seen on windows-latest in run [31642553967](https://github.com/bug-ops/deps-lsp/actions/runs/31642553967/job/94269582808)) turns into a hard CI failure instead of a retry.
- Switched both jobs to `taiki-e/install-action`, already used elsewhere in this workflow (`cargo-deny`, `cross`), which fetches prebuilt binaries directly and does not hit this fallback path.

## Test plan
- [ ] CI run on this branch passes the `test` matrix (ubuntu/macos/windows) and `coverage` job