### PR TITLE
feat(nuget): add NuGet/.NET ecosystem support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
       - uses: moonrepo/setup-rust@v1
         with:
           targets: ${{ matrix.target }}
+          cache-extra-identifier: ${{ matrix.target }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,12 +135,6 @@ jobs:
 
       - uses: taiki-e/install-action@nextest
 
-      - name: Install dependencies (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libssl-dev pkg-config
-
       - name: Run tests
         run: cargo nextest run --workspace --all-features --no-fail-fast
 
@@ -176,12 +170,6 @@ jobs:
           cache: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install dependencies (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libssl-dev pkg-config
 
       - name: Install cross
         if: matrix.use_cross_tool

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
       - uses: moonrepo/setup-rust@v1
         with:
           targets: ${{ matrix.target }}
-          cache-extra-identifier: ${{ matrix.target }}
+          cache: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **New ecosystem: NuGet (.NET)** — `deps-nuget` adds support for `.csproj`/`.fsproj`/`.vbproj` (`PackageReference`, both attribute and child-element form, with central package management entries degrading to no version requirement), `Directory.Packages.props` (`PackageVersion`), `packages.config` (normalized to an exact-pin range at parse time), and `packages.lock.json` lock files. Backed by the NuGet V3 registry API (service index resolution, flat-container version enumeration, `SearchQueryService` search). Version comparison is hand-rolled (4-component `Major.Minor.Patch.Revision`, SemVer2 prerelease precedence with case-insensitive labels, interval and floating-version syntax) since no maintained crate supports NuGet's scheme
+- `deps_core::Ecosystem` gained `manifest_extensions()`, a defaulted trait method (empty by default, zero behavior change for existing ecosystems) letting an ecosystem route by file extension when the manifest basename is unbounded (e.g. `*.csproj`). `EcosystemRegistry::get_for_filename` now falls back to a case-insensitive extension lookup after an exact filename match misses
+
 ### Changed
 - Bump `yaml-rust2` 0.11 → 0.12 (routine dependency update, no functional changes) (resolves #115)
 - Bump `h2` (transitive, via `reqwest`/`hyper`) 0.4.15 → 0.4.17, patching RUSTSEC-2026-0258 (unbounded empty DATA frames) (resolves #116)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,7 @@ dependencies = [
  "deps-gradle",
  "deps-maven",
  "deps-npm",
+ "deps-nuget",
  "deps-pypi",
  "deps-swift",
  "futures",
@@ -627,6 +628,26 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
+ "tower-lsp-server",
+ "tracing",
+ "urlencoding",
+]
+
+[[package]]
+name = "deps-nuget"
+version = "0.9.5"
+dependencies = [
+ "criterion",
+ "deps-core",
+ "insta",
+ "mockito",
+ "quick-xml",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-test",
  "tower-lsp-server",
  "tracing",
  "urlencoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ deps-go = { version = "0.9.5", path ="crates/deps-go" }
 deps-bundler = { version = "0.9.5", path ="crates/deps-bundler" }
 deps-dart = { version = "0.9.5", path ="crates/deps-dart" }
 deps-maven = { version = "0.9.5", path ="crates/deps-maven" }
+deps-nuget = { version = "0.9.5", path ="crates/deps-nuget" }
 deps-composer = { version = "0.9.5", path ="crates/deps-composer" }
 deps-gradle = { version = "0.9.5", path ="crates/deps-gradle" }
 deps-swift = { version = "0.9.5", path ="crates/deps-swift" }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![MSRV](https://img.shields.io/badge/MSRV-1.91-blue)](https://blog.rust-lang.org/)
 [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 
-A universal Language Server Protocol (LSP) server for dependency management across Cargo, npm, PyPI, Go, Bundler, Dart, Maven, Gradle, Swift, and Composer ecosystems.
+A universal Language Server Protocol (LSP) server for dependency management across Cargo, npm, PyPI, Go, Bundler, Dart, Maven, Gradle, Swift, Composer, and NuGet ecosystems.
 
 ![deps-lsp in action](https://raw.githubusercontent.com/bug-ops/deps-zed/main/assets/img.png)
 
@@ -36,6 +36,7 @@ A universal Language Server Protocol (LSP) server for dependency management acro
 | Java | Gradle | `libs.versions.toml`, `build.gradle.kts`, `build.gradle`, `settings.gradle` | Supported |
 | Swift | SPM | `Package.swift` | Supported |
 | PHP | Composer | `composer.json` | Supported |
+| C# | NuGet | `.csproj`, `.fsproj`, `.vbproj`, `Directory.Packages.props`, `packages.config` | Supported |
 
 > [!NOTE]
 > **Ecosystem details:**
@@ -47,6 +48,7 @@ A universal Language Server Protocol (LSP) server for dependency management acro
 > - **Gradle** — Version Catalogs, Kotlin/Groovy DSL, `settings.gradle` plugins; resolves from Maven Central, Google Maven, Gradle Plugin Portal
 > - **Swift** — all `.package()` forms (from, upToNextMajor/Minor, exact, range, branch, revision, path); versions via GitHub API tags
 > - **Composer** — `require`/`require-dev` sections, Packagist v2 API with metadata de-minification, Composer-specific tilde semantics (`~1.2` = `>=1.2.0 <2.0.0`)
+> - **NuGet** — `PackageReference` (attribute and child-element form), Central Package Management (`Directory.Packages.props`), legacy `packages.config`, `packages.lock.json`; NuGet V3 registry (service index, flat container, search)
 
 ## Installation
 
@@ -106,6 +108,7 @@ cargo install deps-lsp --no-default-features --features "pypi"
 | `gradle` | Java | libs.versions.toml, build.gradle.kts, build.gradle | Yes |
 | `swift` | Swift | Package.swift | Yes |
 | `composer` | PHP | composer.json | Yes |
+| `nuget` | C# | .csproj, Directory.Packages.props, packages.config | Yes |
 
 ## Usage
 
@@ -326,6 +329,7 @@ deps-lsp/
 │   ├── deps-gradle/    # Gradle parser (Version Catalog, Kotlin/Groovy DSL)
 │   ├── deps-swift/     # Package.swift parser + GitHub API registry
 │   ├── deps-composer/  # composer.json parser + Packagist registry
+│   ├── deps-nuget/     # .csproj/packages.config parser + NuGet V3 registry
 │   ├── deps-lsp/       # Main LSP server
 │   └── deps-zed/       # Zed extension (WASM)
 ├── .config/            # nextest configuration

--- a/crates/deps-core/src/ecosystem.rs
+++ b/crates/deps-core/src/ecosystem.rs
@@ -170,6 +170,17 @@ pub trait Ecosystem: Send + Sync + private::Sealed {
     /// to the appropriate ecosystem implementation.
     fn manifest_filenames(&self) -> &[&'static str];
 
+    /// File extensions this ecosystem handles when the manifest basename is
+    /// not fixed (e.g. `[".csproj", ".fsproj"]` for NuGet project files).
+    ///
+    /// Consulted by [`crate::EcosystemRegistry::get_for_filename`] only after
+    /// an exact [`manifest_filenames`](Ecosystem::manifest_filenames) match
+    /// fails. Empty by default, indicating this ecosystem is routed solely by
+    /// exact filename.
+    fn manifest_extensions(&self) -> &[&'static str] {
+        &[]
+    }
+
     /// Lock file filenames this ecosystem uses (e.g., ["Cargo.lock"])
     ///
     /// Used for file watching - LSP will monitor changes to these files

--- a/crates/deps-core/src/ecosystem_registry.rs
+++ b/crates/deps-core/src/ecosystem_registry.rs
@@ -37,6 +37,17 @@ pub struct EcosystemRegistry {
     ecosystems: DashMap<&'static str, Arc<dyn Ecosystem>>,
     /// Map from filename to ecosystem ID (for fast lookup)
     filename_map: DashMap<&'static str, &'static str>,
+    /// Map from lowercased file extension (e.g. ".csproj") to ecosystem ID.
+    ///
+    /// Consulted only when an exact `filename_map` lookup misses. Kept as a
+    /// separate `DashMap` rather than folded into `filename_map` so extension
+    /// routing cannot silently shadow an exact filename. Two ecosystems
+    /// claiming the same extension is a configuration error caught by a
+    /// `debug_assert!` in [`register`](EcosystemRegistry::register) — in a
+    /// release build (or if the assertion is otherwise skipped) `DashMap::insert`
+    /// silently last-write-wins, so the outcome is registration-order-dependent,
+    /// not deterministic.
+    extension_map: DashMap<&'static str, &'static str>,
 }
 
 impl EcosystemRegistry {
@@ -54,6 +65,7 @@ impl EcosystemRegistry {
         Self {
             ecosystems: DashMap::new(),
             filename_map: DashMap::new(),
+            extension_map: DashMap::new(),
         }
     }
 
@@ -81,6 +93,18 @@ impl EcosystemRegistry {
         // Register filename mappings
         for filename in ecosystem.manifest_filenames() {
             self.filename_map.insert(*filename, id);
+        }
+
+        // Register extension mappings (fallback for unbounded basenames, e.g. *.csproj)
+        for extension in ecosystem.manifest_extensions() {
+            debug_assert!(
+                self.extension_map
+                    .get(extension)
+                    .is_none_or(|owner| *owner == id),
+                "extension {extension:?} already claimed by ecosystem {:?}, cannot also assign it to {id:?}",
+                self.extension_map.get(extension).map(|o| *o),
+            );
+            self.extension_map.insert(*extension, id);
         }
 
         // Register ecosystem
@@ -114,6 +138,17 @@ impl EcosystemRegistry {
 
     /// Get ecosystem for a filename
     ///
+    /// Lookup is two-stage: an exact, case-sensitive match against
+    /// registered manifest filenames (e.g. `"Cargo.toml"`) is tried first;
+    /// if that misses, the filename's extension is matched case-insensitively
+    /// against registered [`Ecosystem::manifest_extensions`]. This asymmetry
+    /// is deliberate — exact filenames are canonical and case-sensitive on
+    /// Unix filesystems, while extensions on unbounded basenames (e.g.
+    /// `*.csproj`) come from MSBuild/Windows projects that commonly vary
+    /// case (`MyApp.CSPROJ`). So `MyApp.CSPROJ` routes via the extension
+    /// fallback, but `packages.Config` does **not** match the exact-name
+    /// entry for `packages.config`.
+    ///
     /// # Arguments
     ///
     /// * `filename` - Manifest filename (e.g., "Cargo.toml", "package.json")
@@ -134,7 +169,20 @@ impl EcosystemRegistry {
     /// }
     /// ```
     pub fn get_for_filename(&self, filename: &str) -> Option<Arc<dyn Ecosystem>> {
-        let id = self.filename_map.get(filename)?;
+        if let Some(id) = self.filename_map.get(filename) {
+            return self.get(*id);
+        }
+
+        // Avoid the rsplit_once/format! allocation below when no ecosystem has registered
+        // an extension (extension routing is only used by nuget today) — this runs on
+        // every exact-match miss, including every did_open/did_change via get_for_uri.
+        if self.extension_map.is_empty() {
+            return None;
+        }
+
+        let (_, extension) = filename.rsplit_once('.')?;
+        let lowercased = format!(".{}", extension.to_lowercase());
+        let id = self.extension_map.get(lowercased.as_str())?;
         self.get(*id)
     }
 
@@ -308,6 +356,62 @@ mod tests {
 
         fn lockfile_filenames(&self) -> &[&'static str] {
             self.lockfiles
+        }
+
+        fn parse_manifest<'a>(
+            &'a self,
+            _content: &'a str,
+            _uri: &'a Uri,
+        ) -> crate::ecosystem::BoxFuture<'a, crate::error::Result<Box<dyn ParseResult>>> {
+            Box::pin(async move { unimplemented!() })
+        }
+
+        fn registry(&self) -> Arc<dyn Registry> {
+            unimplemented!()
+        }
+
+        fn formatter(&self) -> &dyn EcosystemFormatter {
+            &MockFormatter
+        }
+
+        fn generate_completions<'a>(
+            &'a self,
+            _parse_result: &'a dyn ParseResult,
+            _position: Position,
+            _content: &'a str,
+        ) -> crate::ecosystem::BoxFuture<'a, Vec<CompletionItem>> {
+            Box::pin(async move { vec![] })
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    // Mock ecosystem with unbounded-basename extension routing (mirrors NuGet's *.csproj)
+    struct MockExtEcosystem {
+        id: &'static str,
+        filenames: &'static [&'static str],
+        extensions: &'static [&'static str],
+    }
+
+    impl crate::ecosystem::private::Sealed for MockExtEcosystem {}
+
+    impl Ecosystem for MockExtEcosystem {
+        fn id(&self) -> &'static str {
+            self.id
+        }
+
+        fn display_name(&self) -> &'static str {
+            self.id
+        }
+
+        fn manifest_filenames(&self) -> &[&'static str] {
+            self.filenames
+        }
+
+        fn manifest_extensions(&self) -> &[&'static str] {
+            self.extensions
         }
 
         fn parse_manifest<'a>(
@@ -566,5 +670,68 @@ mod tests {
 
         let patterns = registry.all_lockfile_patterns();
         assert!(patterns.is_empty());
+    }
+
+    #[test]
+    fn test_get_for_filename_extension_fallback() {
+        let registry = EcosystemRegistry::new();
+        registry.register(Arc::new(MockExtEcosystem {
+            id: "nuget",
+            filenames: &["Directory.Packages.props"],
+            extensions: &[".csproj", ".fsproj"],
+        }));
+
+        assert_eq!(
+            registry.get_for_filename("MyApp.csproj").unwrap().id(),
+            "nuget"
+        );
+        assert_eq!(
+            registry
+                .get_for_filename("Directory.Packages.props")
+                .unwrap()
+                .id(),
+            "nuget"
+        );
+        assert!(registry.get_for_filename("unrelated.txt").is_none());
+    }
+
+    #[test]
+    fn test_get_for_filename_extension_fallback_case_insensitive() {
+        let registry = EcosystemRegistry::new();
+        registry.register(Arc::new(MockExtEcosystem {
+            id: "nuget",
+            filenames: &["Directory.Packages.props"],
+            extensions: &[".csproj"],
+        }));
+
+        assert_eq!(
+            registry.get_for_filename("MyApp.CSPROJ").unwrap().id(),
+            "nuget"
+        );
+    }
+
+    #[test]
+    fn test_get_for_filename_exact_match_case_sensitive_not_shadowed_by_extension() {
+        let registry = EcosystemRegistry::new();
+        registry.register(Arc::new(MockExtEcosystem {
+            id: "nuget",
+            filenames: &["packages.config"],
+            extensions: &[],
+        }));
+
+        // Exact filenames stay case-sensitive: differently-cased basename does not match.
+        assert!(registry.get_for_filename("packages.Config").is_none());
+    }
+
+    #[test]
+    fn test_get_for_filename_no_extension_returns_none() {
+        let registry = EcosystemRegistry::new();
+        registry.register(Arc::new(MockExtEcosystem {
+            id: "nuget",
+            filenames: &[],
+            extensions: &[".csproj"],
+        }));
+
+        assert!(registry.get_for_filename("README").is_none());
     }
 }

--- a/crates/deps-lsp/Cargo.toml
+++ b/crates/deps-lsp/Cargo.toml
@@ -21,7 +21,7 @@ name = "deps_lsp"
 path = "src/lib.rs"
 
 [features]
-default = ["cargo", "npm", "pypi", "go", "bundler", "dart", "maven", "gradle", "swift", "composer"]
+default = ["cargo", "npm", "pypi", "go", "bundler", "dart", "maven", "gradle", "swift", "composer", "nuget"]
 cargo = ["dep:deps-cargo"]
 npm = ["dep:deps-npm"]
 pypi = ["dep:deps-pypi"]
@@ -32,6 +32,7 @@ maven = ["dep:deps-maven"]
 gradle = ["dep:deps-gradle"]
 swift = ["dep:deps-swift"]
 composer = ["dep:deps-composer"]
+nuget = ["dep:deps-nuget"]
 
 [dependencies]
 # Internal crates
@@ -46,6 +47,7 @@ deps-dart = { workspace = true, optional = true }
 deps-maven = { workspace = true, optional = true }
 deps-gradle = { workspace = true, optional = true }
 deps-swift = { workspace = true, optional = true }
+deps-nuget = { workspace = true, optional = true }
 
 # External dependencies
 dashmap = { workspace = true }

--- a/crates/deps-lsp/src/lib.rs
+++ b/crates/deps-lsp/src/lib.rs
@@ -183,6 +183,24 @@ ecosystem!(
     ]
 );
 
+// Note: `PackageInfo` is deliberately omitted from this re-export list — it collides with
+// `deps_dart::PackageInfo`, already re-exported above. Reachable directly as
+// `deps_nuget::PackageInfo` for anything that needs it.
+ecosystem!(
+    "nuget",
+    deps_nuget,
+    NuGetEcosystem,
+    [
+        NuGetDependency,
+        NuGetParseResult,
+        NuGetVersion,
+        NuGetFormatter,
+        NuGetRegistry,
+        NuGetLockParser,
+        parse_project_file,
+    ]
+);
+
 /// Registers all enabled ecosystems.
 pub fn register_ecosystems(registry: &EcosystemRegistry, cache: Arc<HttpCache>) {
     register!("cargo", CargoEcosystem, registry, &cache);
@@ -195,6 +213,7 @@ pub fn register_ecosystems(registry: &EcosystemRegistry, cache: Arc<HttpCache>) 
     register!("gradle", GradleEcosystem, registry, &cache);
     register!("swift", SwiftEcosystem, registry, &cache);
     register!("composer", ComposerEcosystem, registry, &cache);
+    register!("nuget", NuGetEcosystem, registry, &cache);
 }
 
 #[cfg(test)]
@@ -223,5 +242,7 @@ mod tests {
         assert!(registry.get("maven").is_some());
         #[cfg(feature = "composer")]
         assert!(registry.get("composer").is_some());
+        #[cfg(feature = "nuget")]
+        assert!(registry.get("nuget").is_some());
     }
 }

--- a/crates/deps-nuget/Cargo.toml
+++ b/crates/deps-nuget/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "deps-nuget"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "NuGet/.NET project file support for deps-lsp"
+publish = true
+
+[lints]
+workspace = true
+
+[dependencies]
+deps-core = { workspace = true }
+quick-xml = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["fs", "sync"] }
+tower-lsp-server = { workspace = true }
+tracing = { workspace = true }
+urlencoding = { workspace = true }
+
+[dev-dependencies]
+criterion = { workspace = true, features = ["html_reports"] }
+deps-core = { workspace = true, features = ["test-util"] }
+insta = { workspace = true, features = ["json"] }
+mockito = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio-test = { workspace = true }
+
+[[bench]]
+name = "nuget_benchmarks"
+harness = false

--- a/crates/deps-nuget/README.md
+++ b/crates/deps-nuget/README.md
@@ -1,0 +1,77 @@
+# deps-nuget
+
+[![Crates.io](https://img.shields.io/crates/v/deps-nuget)](https://crates.io/crates/deps-nuget)
+[![docs.rs](https://img.shields.io/docsrs/deps-nuget)](https://docs.rs/deps-nuget)
+[![CI](https://github.com/bug-ops/deps-lsp/actions/workflows/ci.yml/badge.svg)](https://github.com/bug-ops/deps-lsp/actions)
+[![codecov](https://codecov.io/gh/bug-ops/deps-lsp/graph/badge.svg?token=S71PTINTGQ&flag=deps-nuget)](https://codecov.io/gh/bug-ops/deps-lsp)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../../LICENSE)
+
+NuGet/.NET project file support for deps-lsp.
+
+This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) workspace. It provides NuGet/.NET ecosystem support including `.csproj`/`.fsproj`/`.vbproj`, `Directory.Packages.props`, and `packages.config` parsing, `packages.lock.json` lock file support, and NuGet V3 registry integration, and implements `deps_core::Ecosystem`.
+
+## Features
+
+- **XML parsing** — Parse `PackageReference` (attribute and child-element form), `PackageVersion`, and `packages.config` entries with byte-accurate position tracking via the `quick-xml` SAX reader
+- **NuGet V3 registry** — Service index resolution, flat-container version listing, and `SearchQueryService` search (`semVerLevel=2.0.0`)
+- **Version comparison** — 4-component NuGet versioning (`Major.Minor.Patch.Revision`), structural prerelease detection, interval range notation (`[1.0,2.0)`), and floating versions (`1.1.*`)
+- **Central Package Management** — `Directory.Packages.props`-managed dependencies parse with no inline version, so hover/completion on the package name still work
+- **Lock file support** — `packages.lock.json`, merged across target framework monikers
+
+> [!IMPORTANT]
+> Requires Rust 1.91 or later.
+
+## Installation
+
+```toml
+[dependencies]
+deps-nuget = "0.9"
+```
+
+## Usage
+
+```rust
+use deps_nuget::{parse_project_file, NuGetRegistry};
+
+let result = parse_project_file(content, &uri)?;
+let registry = NuGetRegistry::new(cache);
+let versions = registry.get_versions_typed("Newtonsoft.Json").await?;
+```
+
+## Supported manifest syntax
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Serilog">
+      <Version>3.1.1</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project>
+```
+
+Central Package Management (`Directory.Packages.props`):
+
+```xml
+<Project>
+  <ItemGroup>
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>
+```
+
+Legacy `packages.config`:
+
+```xml
+<packages>
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
+</packages>
+```
+
+> [!NOTE]
+> A bare version in `PackageReference` (e.g. `Version="6.1"`) is a floor, not an exact pin. `packages.config` versions are normalized to an exact-pin range at parse time, since they carry no range syntax of their own.
+
+## License
+
+[MIT](../../LICENSE)

--- a/crates/deps-nuget/benches/nuget_benchmarks.rs
+++ b/crates/deps-nuget/benches/nuget_benchmarks.rs
@@ -1,0 +1,295 @@
+//! Benchmarks for NuGet manifest parsing and version operations.
+//!
+//! Performance targets (based on LSP latency requirements):
+//! - Parsing small files (5 refs): < 1ms
+//! - Parsing medium files (25 refs): < 5ms
+//! - Parsing large files (100+ refs): < 20ms
+//! - Version comparison: < 10μs per operation
+//! - Range/floating resolution: < 50μs per operation
+//! - Flat-container JSON parsing: < 2ms per response
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use deps_nuget::parser::{
+    parse_directory_packages_props, parse_packages_config, parse_project_file,
+};
+use deps_nuget::registry::parse_flat_container;
+use deps_nuget::version::{compare_versions, is_prerelease, resolve_float, satisfies};
+use std::hint::black_box;
+use tower_lsp_server::ls_types::Uri;
+
+fn bench_uri() -> Uri {
+    Uri::from_file_path("/bench/App.csproj").unwrap()
+}
+
+/// Small `.csproj` with 5 `PackageReference` entries (attribute form).
+const SMALL_CSPROJ: &str = r#"<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Polly" Version="8.4.1" />
+    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="FluentValidation" Version="11.9.0" />
+  </ItemGroup>
+</Project>"#;
+
+/// Medium `.csproj` with 25 `PackageReference` entries, mixing attribute and child-element
+/// forms plus a central package management entry.
+fn generate_medium_csproj() -> String {
+    let mut content = String::from(
+        r#"<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+"#,
+    );
+    for i in 0..23 {
+        content.push_str(&format!(
+            "    <PackageReference Include=\"Package.{i}\" Version=\"{}.{}.{}\" />\n",
+            i % 10,
+            (i % 5) + 1,
+            i % 3
+        ));
+    }
+    content.push_str("    <PackageReference Include=\"ChildForm.Package\"><Version>1.2.3</Version></PackageReference>\n");
+    content.push_str("    <PackageReference Include=\"MyCompany.Shared\" />\n");
+    content.push_str("  </ItemGroup>\n</Project>");
+    content
+}
+
+/// Large `.csproj` with 100+ `PackageReference` entries.
+fn generate_large_csproj() -> String {
+    let mut content = String::from(
+        r#"<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+"#,
+    );
+    for i in 0..120 {
+        content.push_str(&format!(
+            "    <PackageReference Include=\"Package.{i}\" Version=\"{}.{}.{}.{}\" />\n",
+            i % 10,
+            (i % 20) + 1,
+            i % 5,
+            i % 4
+        ));
+    }
+    content.push_str("  </ItemGroup>\n</Project>");
+    content
+}
+
+/// `.csproj` exercising every parser edge case in one file: attribute form, child-element
+/// form, central package management, unresolved MSBuild property, and a `Condition`
+/// attribute containing a literal `Version="` trap.
+const COMPLEX_CSPROJ: &str = r#"<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Serilog"><Version>3.1.1</Version></PackageReference>
+    <PackageReference Include="MyCompany.Shared" />
+    <PackageReference Include="AutoMapper" Version="$(AutoMapperVersion)" />
+    <PackageReference Include="System.Text.Json" Condition="'$(Foo)' == 'Version=&quot;1.0.0&quot;'" Version="8.0.5" />
+  </ItemGroup>
+</Project>"#;
+
+fn bench_csproj_parsing(c: &mut Criterion) {
+    let mut group = c.benchmark_group("csproj_parsing");
+    let uri = bench_uri();
+
+    group.bench_function("small_5_refs", |b| {
+        b.iter(|| parse_project_file(black_box(SMALL_CSPROJ), &uri));
+    });
+
+    let medium = generate_medium_csproj();
+    group.bench_function("medium_25_refs", |b| {
+        b.iter(|| parse_project_file(black_box(&medium), &uri));
+    });
+
+    let large = generate_large_csproj();
+    group.bench_function("large_120_refs", |b| {
+        b.iter(|| parse_project_file(black_box(&large), &uri));
+    });
+
+    group.bench_function("complex_mixed_forms", |b| {
+        b.iter(|| parse_project_file(black_box(COMPLEX_CSPROJ), &uri));
+    });
+
+    group.finish();
+}
+
+fn bench_directory_packages_props_parsing(c: &mut Criterion) {
+    let uri = Uri::from_file_path("/bench/Directory.Packages.props").unwrap();
+    let mut content = String::from("<Project>\n  <ItemGroup>\n");
+    for i in 0..25 {
+        content.push_str(&format!(
+            "    <PackageVersion Include=\"Package.{i}\" Version=\"{}.{}.0\" />\n",
+            i % 10,
+            (i % 5) + 1
+        ));
+    }
+    content.push_str("  </ItemGroup>\n</Project>");
+
+    c.bench_function("directory_packages_props_25_entries", |b| {
+        b.iter(|| parse_directory_packages_props(black_box(&content), &uri));
+    });
+}
+
+fn bench_packages_config_parsing(c: &mut Criterion) {
+    let uri = Uri::from_file_path("/bench/packages.config").unwrap();
+    let mut content = String::from("<packages>\n");
+    for i in 0..25 {
+        content.push_str(&format!(
+            "  <package id=\"Package.{i}\" version=\"{}.{}.0\" targetFramework=\"net48\" />\n",
+            i % 10,
+            (i % 5) + 1
+        ));
+    }
+    content.push_str("</packages>");
+
+    c.bench_function("packages_config_25_entries", |b| {
+        b.iter(|| parse_packages_config(black_box(&content), &uri));
+    });
+}
+
+fn bench_version_comparison(c: &mut Criterion) {
+    let mut group = c.benchmark_group("version_comparison");
+
+    group.bench_function("simple_versions", |b| {
+        b.iter(|| compare_versions(black_box("13.0.1"), black_box("13.0.3")));
+    });
+
+    group.bench_function("four_component", |b| {
+        b.iter(|| compare_versions(black_box("1.10.0.5"), black_box("1.9.0.20")));
+    });
+
+    group.bench_function("prerelease_case_insensitive", |b| {
+        b.iter(|| compare_versions(black_box("13.0.0-RC.1"), black_box("13.0.0-rc.2")));
+    });
+
+    let versions = [
+        "13.0.3",
+        "13.0.0-beta1",
+        "12.0.1",
+        "14.0.0-preview.1",
+        "13.0.2",
+    ];
+    group.bench_function("find_latest_version", |b| {
+        b.iter(|| {
+            versions
+                .iter()
+                .max_by(|a, b| compare_versions(black_box(a), black_box(b)))
+                .copied()
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_is_prerelease(c: &mut Criterion) {
+    let mut group = c.benchmark_group("is_prerelease");
+
+    let labels = [
+        ("stable", "13.0.0"),
+        ("rtm", "13.0.0-rtm"),
+        ("servicing", "8.0.0-servicing.23"),
+        ("ci_build", "1.0.0-CI-20240101"),
+        ("preview", "7.0.0-preview.1"),
+        ("with_build_metadata", "1.0.0+build-with-dash"),
+    ];
+
+    for (name, version) in labels {
+        group.bench_with_input(BenchmarkId::from_parameter(name), &version, |b, version| {
+            b.iter(|| is_prerelease(black_box(version)));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_satisfies(c: &mut Criterion) {
+    let mut group = c.benchmark_group("satisfies");
+
+    let cases = [
+        ("bare_floor", "2.0.0", "1.0.0"),
+        ("exact_pin", "1.0.0", "[1.0.0]"),
+        ("open_minimum", "1.5.0", "[1.0,)"),
+        ("bounded", "1.5.0", "[1.0,2.0]"),
+    ];
+
+    for (name, version, range) in cases {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(name),
+            &(version, range),
+            |b, (v, r)| {
+                b.iter(|| satisfies(black_box(v), black_box(r)));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_resolve_float(c: &mut Criterion) {
+    let mut group = c.benchmark_group("resolve_float");
+
+    let versions: Vec<String> = (0..25).map(|i| format!("1.{}.{}", i % 5, i % 10)).collect();
+
+    group.bench_function("wildcard_any", |b| {
+        b.iter(|| resolve_float(black_box(&versions), black_box("*")));
+    });
+
+    group.bench_function("numeric_prefix", |b| {
+        b.iter(|| resolve_float(black_box(&versions), black_box("1.2.*")));
+    });
+
+    group.finish();
+}
+
+/// Realistic NuGet flat-container response for a popular package (based on the actual
+/// `Newtonsoft.Json` response shape, ~84 versions in production).
+fn generate_flat_container_response(count: usize) -> String {
+    let mut content = String::from(r#"{"versions": ["#);
+    for i in 0..count {
+        content.push_str(&format!(
+            "\"{}.{}.{}\"{}",
+            i % 10,
+            (i % 20) + 1,
+            i % 5,
+            if i + 1 < count { "," } else { "" }
+        ));
+    }
+    content.push_str("]}");
+    content
+}
+
+fn bench_flat_container_parsing(c: &mut Criterion) {
+    let mut group = c.benchmark_group("flat_container_parsing");
+
+    let small = generate_flat_container_response(10);
+    group.bench_function("small_10_versions", |b| {
+        b.iter(|| parse_flat_container(black_box(small.as_bytes())));
+    });
+
+    let realistic = generate_flat_container_response(84);
+    group.bench_function("realistic_84_versions", |b| {
+        b.iter(|| parse_flat_container(black_box(realistic.as_bytes())));
+    });
+
+    let large = generate_flat_container_response(500);
+    group.bench_function("large_500_versions", |b| {
+        b.iter(|| parse_flat_container(black_box(large.as_bytes())));
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_csproj_parsing,
+    bench_directory_packages_props_parsing,
+    bench_packages_config_parsing,
+    bench_version_comparison,
+    bench_is_prerelease,
+    bench_satisfies,
+    bench_resolve_float,
+    bench_flat_container_parsing,
+);
+criterion_main!(benches);

--- a/crates/deps-nuget/src/ecosystem.rs
+++ b/crates/deps-nuget/src/ecosystem.rs
@@ -1,0 +1,265 @@
+//! NuGet ecosystem implementation for deps-lsp.
+//!
+//! # Unknown/unresolvable packages
+//!
+//! Only `api.nuget.org` is queried — private feeds (`NuGet.config` `<packageSources>`,
+//! Azure Artifacts, GitHub Packages, internal Artifactory) are out of scope (D4). A 404 or
+//! otherwise-unknown package must degrade to **no diagnostic, no inlay hint, no error
+//! marker** (S4) — this already falls out of `deps-lsp`'s generic error handling around
+//! `Registry::get_latest_matching` (a fetch error or `Ok(None)` both simply omit the
+//! package from `cached_versions`), so no special-casing is needed here.
+
+use std::any::Any;
+use std::sync::Arc;
+use tower_lsp_server::ls_types::{CompletionItem, Position, Uri};
+
+use deps_core::{
+    Ecosystem, ParseResult as ParseResultTrait, Registry, Result, lsp_helpers::EcosystemFormatter,
+};
+
+use crate::formatter::NuGetFormatter;
+use crate::lockfile::NuGetLockParser;
+use crate::registry::NuGetRegistry;
+use crate::types::NuGetParseResult;
+
+/// NuGet/.NET ecosystem implementation.
+///
+/// Provides LSP functionality for `.csproj`/`.fsproj`/`.vbproj`, `Directory.Packages.props`,
+/// and `packages.config` files, backed by the NuGet V3 registry API.
+pub struct NuGetEcosystem {
+    registry: Arc<NuGetRegistry>,
+    formatter: NuGetFormatter,
+    lockfile_provider: Arc<NuGetLockParser>,
+}
+
+impl NuGetEcosystem {
+    pub fn new(cache: Arc<deps_core::HttpCache>) -> Self {
+        Self {
+            registry: Arc::new(NuGetRegistry::new(cache)),
+            formatter: NuGetFormatter,
+            lockfile_provider: Arc::new(NuGetLockParser),
+        }
+    }
+
+    async fn complete_package_names(&self, prefix: &str) -> Vec<CompletionItem> {
+        deps_core::completion::complete_package_names_generic(self.registry.as_ref(), prefix, 20)
+            .await
+    }
+
+    async fn complete_versions(&self, package_name: &str, prefix: &str) -> Vec<CompletionItem> {
+        deps_core::completion::complete_versions_generic(
+            self.registry.as_ref(),
+            package_name,
+            prefix,
+            &[],
+        )
+        .await
+    }
+
+    /// Dispatches to the manifest-kind-specific parser based on the URI's basename.
+    /// `.csproj`/`.fsproj`/`.vbproj` (routed to this ecosystem via `manifest_extensions`)
+    /// all share the `PackageReference` MSBuild schema, so anything not matching one of the
+    /// two fixed filenames falls through to the project-file parser.
+    fn parse_by_filename(content: &str, uri: &Uri) -> crate::error::Result<NuGetParseResult> {
+        let path = uri.path().as_str();
+        let filename = path.rsplit('/').next().unwrap_or(path);
+
+        match filename.to_lowercase().as_str() {
+            "directory.packages.props" => {
+                crate::parser::parse_directory_packages_props(content, uri)
+            }
+            "packages.config" => crate::parser::parse_packages_config(content, uri),
+            _ => crate::parser::parse_project_file(content, uri),
+        }
+    }
+}
+
+impl deps_core::ecosystem::private::Sealed for NuGetEcosystem {}
+
+impl Ecosystem for NuGetEcosystem {
+    fn id(&self) -> &'static str {
+        "nuget"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "NuGet (.NET)"
+    }
+
+    fn manifest_filenames(&self) -> &[&'static str] {
+        &["Directory.Packages.props", "packages.config"]
+    }
+
+    fn manifest_extensions(&self) -> &[&'static str] {
+        &[".csproj", ".fsproj", ".vbproj"]
+    }
+
+    fn lockfile_filenames(&self) -> &[&'static str] {
+        &["packages.lock.json"]
+    }
+
+    fn parse_manifest<'a>(
+        &'a self,
+        content: &'a str,
+        uri: &'a Uri,
+    ) -> deps_core::ecosystem::BoxFuture<'a, Result<Box<dyn ParseResultTrait>>> {
+        Box::pin(async move {
+            let result =
+                Self::parse_by_filename(content, uri).map_err(deps_core::DepsError::from)?;
+            Ok(Box::new(result) as Box<dyn ParseResultTrait>)
+        })
+    }
+
+    fn registry(&self) -> Arc<dyn Registry> {
+        self.registry.clone() as Arc<dyn Registry>
+    }
+
+    fn lockfile_provider(&self) -> Option<Arc<dyn deps_core::lockfile::LockFileProvider>> {
+        Some(self.lockfile_provider.clone() as Arc<dyn deps_core::lockfile::LockFileProvider>)
+    }
+
+    fn formatter(&self) -> &dyn EcosystemFormatter {
+        &self.formatter
+    }
+
+    fn generate_completions<'a>(
+        &'a self,
+        parse_result: &'a dyn ParseResultTrait,
+        position: Position,
+        content: &'a str,
+    ) -> deps_core::ecosystem::BoxFuture<'a, Vec<CompletionItem>> {
+        Box::pin(async move {
+            use deps_core::completion::{CompletionContext, detect_completion_context};
+
+            match detect_completion_context(parse_result, position, content) {
+                CompletionContext::PackageName { prefix } => {
+                    self.complete_package_names(&prefix).await
+                }
+                CompletionContext::Version {
+                    package_name,
+                    prefix,
+                } => self.complete_versions(&package_name, &prefix).await,
+                CompletionContext::Feature { .. } | CompletionContext::None => vec![],
+            }
+        })
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ecosystem_id() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = NuGetEcosystem::new(cache);
+        assert_eq!(eco.id(), "nuget");
+    }
+
+    #[test]
+    fn test_ecosystem_display_name() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = NuGetEcosystem::new(cache);
+        assert_eq!(eco.display_name(), "NuGet (.NET)");
+    }
+
+    #[test]
+    fn test_manifest_filenames_and_extensions() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = NuGetEcosystem::new(cache);
+        assert_eq!(
+            eco.manifest_filenames(),
+            &["Directory.Packages.props", "packages.config"]
+        );
+        assert_eq!(
+            eco.manifest_extensions(),
+            &[".csproj", ".fsproj", ".vbproj"]
+        );
+    }
+
+    #[test]
+    fn test_lockfile_filenames() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = NuGetEcosystem::new(cache);
+        assert_eq!(eco.lockfile_filenames(), &["packages.lock.json"]);
+    }
+
+    #[test]
+    fn test_lockfile_provider_some() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = NuGetEcosystem::new(cache);
+        assert!(eco.lockfile_provider().is_some());
+    }
+
+    #[test]
+    fn test_as_any() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = NuGetEcosystem::new(cache);
+        assert!(eco.as_any().is::<NuGetEcosystem>());
+    }
+
+    #[tokio::test]
+    async fn test_parse_manifest_csproj() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = NuGetEcosystem::new(cache);
+        let uri = deps_core::test_util::test_uri("/test/App.csproj");
+        let content = r#"<Project><ItemGroup><PackageReference Include="Newtonsoft.Json" Version="13.0.3" /></ItemGroup></Project>"#;
+
+        let result = eco.parse_manifest(content, &uri).await.unwrap();
+        assert_eq!(result.dependencies().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_parse_manifest_fsproj_routes_as_project_file() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = NuGetEcosystem::new(cache);
+        let uri = deps_core::test_util::test_uri("/test/App.fsproj");
+        let content = r#"<Project><ItemGroup><PackageReference Include="Newtonsoft.Json" Version="13.0.3" /></ItemGroup></Project>"#;
+
+        let result = eco.parse_manifest(content, &uri).await.unwrap();
+        assert_eq!(result.dependencies().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_parse_manifest_directory_packages_props() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = NuGetEcosystem::new(cache);
+        let uri = deps_core::test_util::test_uri("/test/Directory.Packages.props");
+        let content = r#"<Project><ItemGroup><PackageVersion Include="Serilog" Version="3.1.1" /></ItemGroup></Project>"#;
+
+        let result = eco.parse_manifest(content, &uri).await.unwrap();
+        assert_eq!(result.dependencies().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_parse_manifest_packages_config() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = NuGetEcosystem::new(cache);
+        let uri = deps_core::test_util::test_uri("/test/packages.config");
+        let content = r#"<packages><package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" /></packages>"#;
+
+        let result = eco.parse_manifest(content, &uri).await.unwrap();
+        assert_eq!(result.dependencies().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_parse_manifest_invalid_xml_errors() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = NuGetEcosystem::new(cache);
+        let uri = deps_core::test_util::test_uri("/test/App.csproj");
+        let content = r#"<Project attr="unclosed></Project>"#;
+
+        let result = eco.parse_manifest(content, &uri).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_complete_package_names_min_prefix() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = NuGetEcosystem::new(cache);
+        assert!(eco.complete_package_names("").await.is_empty());
+    }
+}

--- a/crates/deps-nuget/src/error.rs
+++ b/crates/deps-nuget/src/error.rs
@@ -1,0 +1,189 @@
+//! Errors specific to NuGet/.NET project file handling.
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum NuGetError {
+    #[error("Failed to parse project file: {message}")]
+    ParseError { message: String },
+
+    #[error("Invalid version '{version}': {message}")]
+    InvalidVersion { version: String, message: String },
+
+    #[error("Package '{package}' not found on NuGet")]
+    PackageNotFound { package: String },
+
+    #[error("NuGet request failed for '{package}': {source}")]
+    RegistryError {
+        package: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[error("Failed to resolve NuGet service index: {source}")]
+    ServiceIndexError {
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[error("Failed to parse NuGet API response for '{package}': {source}")]
+    ApiResponseError {
+        package: String,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    #[error("Cache error: {0}")]
+    CacheError(String),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+pub type Result<T> = std::result::Result<T, NuGetError>;
+
+impl From<deps_core::DepsError> for NuGetError {
+    fn from(err: deps_core::DepsError) -> Self {
+        match err {
+            deps_core::DepsError::ParseError { source, .. } => Self::CacheError(source.to_string()),
+            deps_core::DepsError::CacheError(msg) => Self::CacheError(msg),
+            deps_core::DepsError::InvalidVersionReq(msg) => Self::InvalidVersion {
+                version: String::new(),
+                message: msg,
+            },
+            deps_core::DepsError::Io(e) => Self::Io(e),
+            deps_core::DepsError::Json(e) => Self::ApiResponseError {
+                package: String::new(),
+                source: e,
+            },
+            other => Self::CacheError(other.to_string()),
+        }
+    }
+}
+
+impl From<NuGetError> for deps_core::DepsError {
+    fn from(err: NuGetError) -> Self {
+        match err {
+            NuGetError::ParseError { message } => Self::ParseError {
+                file_type: "NuGet project file".into(),
+                source: Box::new(std::io::Error::other(message)),
+            },
+            NuGetError::InvalidVersion { message, .. } => Self::InvalidVersionReq(message),
+            NuGetError::PackageNotFound { package } => {
+                Self::CacheError(format!("Package '{package}' not found"))
+            }
+            NuGetError::RegistryError { package, source } => Self::ParseError {
+                file_type: format!("NuGet registry for {package}"),
+                source,
+            },
+            NuGetError::ServiceIndexError { source } => Self::ParseError {
+                file_type: "NuGet service index".into(),
+                source,
+            },
+            NuGetError::ApiResponseError { source, .. } => Self::Json(source),
+            NuGetError::CacheError(msg) => Self::CacheError(msg),
+            NuGetError::Io(e) => Self::Io(e),
+            NuGetError::Other(e) => Self::CacheError(e.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_display() {
+        let err = NuGetError::PackageNotFound {
+            package: "Newtonsoft.Json".into(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "Package 'Newtonsoft.Json' not found on NuGet"
+        );
+    }
+
+    #[test]
+    fn test_conversion_to_deps_error() {
+        let err = NuGetError::PackageNotFound {
+            package: "test-pkg".into(),
+        };
+        let deps_err: deps_core::DepsError = err.into();
+        assert!(deps_err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn test_parse_error_to_deps_error() {
+        let err = NuGetError::ParseError {
+            message: "syntax error".into(),
+        };
+        let deps_err: deps_core::DepsError = err.into();
+        assert!(matches!(deps_err, deps_core::DepsError::ParseError { .. }));
+    }
+
+    #[test]
+    fn test_invalid_version_to_deps_error() {
+        let err = NuGetError::InvalidVersion {
+            version: "bad".into(),
+            message: "invalid".into(),
+        };
+        let deps_err: deps_core::DepsError = err.into();
+        assert!(matches!(
+            deps_err,
+            deps_core::DepsError::InvalidVersionReq(_)
+        ));
+    }
+
+    #[test]
+    fn test_io_error_conversion() {
+        let io_err = std::io::Error::from(std::io::ErrorKind::NotFound);
+        let err: NuGetError = io_err.into();
+        assert!(matches!(err, NuGetError::Io(_)));
+
+        let deps_err: deps_core::DepsError = err.into();
+        assert!(matches!(deps_err, deps_core::DepsError::Io(_)));
+    }
+
+    #[test]
+    fn test_deps_error_to_nuget_error() {
+        let deps_err = deps_core::DepsError::CacheError("cache miss".into());
+        let nuget_err: NuGetError = deps_err.into();
+        assert!(matches!(nuget_err, NuGetError::CacheError(_)));
+
+        let deps_err = deps_core::DepsError::InvalidVersionReq("bad".into());
+        let nuget_err: NuGetError = deps_err.into();
+        assert!(matches!(nuget_err, NuGetError::InvalidVersion { .. }));
+    }
+
+    #[test]
+    fn test_service_index_error_to_deps_error() {
+        let err = NuGetError::ServiceIndexError {
+            source: Box::new(std::io::Error::other("index fetch failed")),
+        };
+        let deps_err: deps_core::DepsError = err.into();
+        assert!(matches!(deps_err, deps_core::DepsError::ParseError { .. }));
+    }
+
+    #[test]
+    fn test_api_response_error_to_deps_error() {
+        let json_err = serde_json::from_str::<serde_json::Value>("{invalid}").unwrap_err();
+        let err = NuGetError::ApiResponseError {
+            package: "test-pkg".into(),
+            source: json_err,
+        };
+        let deps_err: deps_core::DepsError = err.into();
+        assert!(matches!(deps_err, deps_core::DepsError::Json(_)));
+    }
+
+    #[test]
+    fn test_other_error_to_deps_error() {
+        let other: Box<dyn std::error::Error + Send + Sync> =
+            Box::new(std::io::Error::other("unknown"));
+        let err = NuGetError::Other(other);
+        let deps_err: deps_core::DepsError = err.into();
+        assert!(matches!(deps_err, deps_core::DepsError::CacheError(_)));
+    }
+}

--- a/crates/deps-nuget/src/formatter.rs
+++ b/crates/deps-nuget/src/formatter.rs
@@ -1,0 +1,81 @@
+//! Version formatting for the NuGet ecosystem.
+
+use deps_core::lsp_helpers::EcosystemFormatter;
+
+pub struct NuGetFormatter;
+
+impl EcosystemFormatter for NuGetFormatter {
+    fn format_version_for_text_edit(&self, version: &str) -> String {
+        // NuGet manifests store plain version text; no prefix/wrapping on insert.
+        version.to_string()
+    }
+
+    fn package_url(&self, name: &str) -> String {
+        crate::registry::package_url(name)
+    }
+
+    /// Overridden because the default npm caret/tilde semantics do not apply to NuGet's
+    /// interval-notation ranges (`[1.0,2.0)`) and floating patterns (`1.1.*`).
+    fn version_satisfies_requirement(&self, version: &str, requirement: &str) -> bool {
+        if requirement.contains('*') {
+            let versions = [version.to_string()];
+            return crate::version::resolve_float(&versions, requirement).is_some();
+        }
+        crate::version::satisfies(version, requirement)
+    }
+
+    /// NuGet package ids are case-insensitive and every V3 API path segment is lowercased.
+    fn normalize_package_name(&self, name: &str) -> String {
+        name.to_lowercase()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_version() {
+        let f = NuGetFormatter;
+        assert_eq!(f.format_version_for_text_edit("13.0.3"), "13.0.3");
+    }
+
+    #[test]
+    fn test_package_url() {
+        let f = NuGetFormatter;
+        assert_eq!(
+            f.package_url("Newtonsoft.Json"),
+            "https://www.nuget.org/packages/Newtonsoft.Json"
+        );
+    }
+
+    #[test]
+    fn test_version_satisfies_exact_pin() {
+        let f = NuGetFormatter;
+        assert!(f.version_satisfies_requirement("1.0.0", "[1.0.0]"));
+        assert!(!f.version_satisfies_requirement("1.0.1", "[1.0.0]"));
+    }
+
+    #[test]
+    fn test_version_satisfies_bare_floor() {
+        let f = NuGetFormatter;
+        assert!(f.version_satisfies_requirement("2.0.0", "1.0.0"));
+        assert!(!f.version_satisfies_requirement("0.9.0", "1.0.0"));
+    }
+
+    #[test]
+    fn test_version_satisfies_floating() {
+        let f = NuGetFormatter;
+        assert!(f.version_satisfies_requirement("1.1.5", "1.1.*"));
+        assert!(!f.version_satisfies_requirement("1.2.0", "1.1.*"));
+    }
+
+    #[test]
+    fn test_normalize_lowercases() {
+        let f = NuGetFormatter;
+        assert_eq!(
+            f.normalize_package_name("Newtonsoft.Json"),
+            "newtonsoft.json"
+        );
+    }
+}

--- a/crates/deps-nuget/src/lib.rs
+++ b/crates/deps-nuget/src/lib.rs
@@ -1,0 +1,22 @@
+//! NuGet/.NET project file parsing and registry integration.
+//!
+//! This crate provides NuGet ecosystem support for the deps-lsp server, including
+//! `.csproj`/`.fsproj`/`.vbproj`, `Directory.Packages.props`, and `packages.config`
+//! parsing, `packages.lock.json` lock file support, and NuGet V3 registry integration.
+
+pub mod ecosystem;
+pub mod error;
+pub mod formatter;
+pub mod lockfile;
+pub mod parser;
+pub mod registry;
+pub mod types;
+pub mod version;
+
+pub use ecosystem::NuGetEcosystem;
+pub use error::{NuGetError, Result};
+pub use formatter::NuGetFormatter;
+pub use lockfile::NuGetLockParser;
+pub use parser::{parse_directory_packages_props, parse_packages_config, parse_project_file};
+pub use registry::NuGetRegistry;
+pub use types::{NuGetDependency, NuGetParseResult, NuGetVersion, PackageInfo};

--- a/crates/deps-nuget/src/lockfile.rs
+++ b/crates/deps-nuget/src/lockfile.rs
@@ -1,0 +1,253 @@
+//! `packages.lock.json` parser.
+//!
+//! Every field except the package name is optional (S2): `"type": "Project"` and
+//! `"type": "CentralTransitive"` entries carry `requested` but no `resolved` at all — a
+//! required `resolved` field would abort deserialization of the *entire* file, which would
+//! only surface on multi-project solutions and not on the single-project fixture a test is
+//! most likely to use. Entries without `resolved` are simply skipped.
+//!
+//! `packages.<project_name>.lock.json` cannot be expressed here — `lockfile_filenames()` is
+//! an exact-name list with no glob support (D3, follow-up).
+// TODO(critic): multi-project lock file names (packages.<project>.lock.json) cannot be
+// expressed as exact names.
+
+use deps_core::error::{DepsError, Result};
+use deps_core::lockfile::{
+    LockFileProvider, ResolvedPackage, ResolvedPackages, ResolvedSource,
+    locate_lockfile_for_manifest,
+};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use tower_lsp_server::ls_types::Uri;
+
+const NUGET_ORG_URL: &str = "https://api.nuget.org/v3/index.json";
+
+pub struct NuGetLockParser;
+
+impl NuGetLockParser {
+    const LOCKFILE_NAMES: &'static [&'static str] = &["packages.lock.json"];
+}
+
+#[derive(Deserialize)]
+struct PackagesLock {
+    // The top-level "version" field (1 or 2) is intentionally not modeled: both schema
+    // versions are accepted without gating on its value, and serde ignores unknown fields
+    // by default, so there is nothing to read it for.
+    #[serde(default)]
+    dependencies: HashMap<String, HashMap<String, LockEntry>>,
+}
+
+#[derive(Deserialize)]
+struct LockEntry {
+    #[serde(default)]
+    resolved: Option<String>,
+    #[serde(default, rename = "contentHash")]
+    content_hash: Option<String>,
+}
+
+impl LockFileProvider for NuGetLockParser {
+    fn locate_lockfile(&self, manifest_uri: &Uri) -> Option<PathBuf> {
+        locate_lockfile_for_manifest(manifest_uri, Self::LOCKFILE_NAMES)
+    }
+
+    fn parse_lockfile<'a>(
+        &'a self,
+        lockfile_path: &'a Path,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ResolvedPackages>> + Send + 'a>>
+    {
+        Box::pin(async move {
+            tracing::debug!("Parsing packages.lock.json: {}", lockfile_path.display());
+
+            let content = tokio::fs::read_to_string(lockfile_path)
+                .await
+                .map_err(|e| DepsError::ParseError {
+                    file_type: format!("packages.lock.json at {}", lockfile_path.display()),
+                    source: Box::new(e),
+                })?;
+
+            let lock_data: PackagesLock =
+                serde_json::from_str(&content).map_err(|e| DepsError::ParseError {
+                    file_type: "packages.lock.json".into(),
+                    source: Box::new(e),
+                })?;
+
+            // Collect every TFM's resolved version per package name, then resolve the
+            // cross-TFM tie-break with the crate's own `compare_versions` (S6) instead of
+            // `deps_core::lockfile::best_package`, whose `semver::Version::parse` fallback
+            // always fails on NuGet's 4-component versions and degrades to string
+            // comparison (e.g. "1.10.0" < "1.9.0"). Only the single winner is ever handed
+            // to `ResolvedPackages`, so that broken comparator is never reached.
+            let mut candidates: HashMap<String, Vec<(String, Option<String>)>> = HashMap::new();
+            for packages in lock_data.dependencies.into_values() {
+                for (name, entry) in packages {
+                    // "type": "Project" / "CentralTransitive" entries carry no `resolved`
+                    // at all — skip rather than aborting the whole file (S2).
+                    if let Some(resolved) = entry.resolved {
+                        candidates
+                            .entry(name)
+                            .or_default()
+                            .push((resolved, entry.content_hash));
+                    }
+                }
+            }
+
+            let mut packages = ResolvedPackages::new();
+            for (name, versions) in candidates {
+                let best = versions
+                    .into_iter()
+                    .max_by(|a, b| crate::version::compare_versions(&a.0, &b.0));
+                if let Some((version, content_hash)) = best {
+                    packages.insert(ResolvedPackage {
+                        name,
+                        version,
+                        source: ResolvedSource::Registry {
+                            url: NUGET_ORG_URL.into(),
+                            checksum: content_hash.unwrap_or_default(),
+                        },
+                        dependencies: vec![],
+                    });
+                }
+            }
+
+            tracing::info!(
+                "Parsed packages.lock.json: {} packages from {}",
+                packages.len(),
+                lockfile_path.display()
+            );
+
+            Ok(packages)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_parse_single_tfm() {
+        let content = r#"{
+  "version": 1,
+  "dependencies": {
+    "net8.0": {
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.3, )",
+        "resolved": "13.0.3",
+        "contentHash": "abc123"
+      }
+    }
+  }
+}"#;
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("packages.lock.json");
+        tokio::fs::write(&path, content).await.unwrap();
+
+        let parser = NuGetLockParser;
+        let resolved = parser.parse_lockfile(&path).await.unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved.get_version("Newtonsoft.Json"), Some("13.0.3"));
+    }
+
+    #[tokio::test]
+    async fn test_project_reference_entry_skipped() {
+        let content = r#"{
+  "version": 2,
+  "dependencies": {
+    "net8.0": {
+      "MyCompany.Shared": { "type": "Project" },
+      "Newtonsoft.Json": { "type": "Direct", "resolved": "13.0.3" }
+    }
+  }
+}"#;
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("packages.lock.json");
+        tokio::fs::write(&path, content).await.unwrap();
+
+        let parser = NuGetLockParser;
+        let resolved = parser.parse_lockfile(&path).await.unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert!(resolved.get("MyCompany.Shared").is_none());
+        assert_eq!(resolved.get_version("Newtonsoft.Json"), Some("13.0.3"));
+    }
+
+    #[tokio::test]
+    async fn test_multi_tfm_tie_break_uses_nuget_comparator() {
+        // 4-component versions where "1.10.0.0" > "1.9.0.0" numerically but would sort the
+        // other way under a broken semver-then-string fallback.
+        let content = r#"{
+  "version": 1,
+  "dependencies": {
+    "net472": {
+      "Foo": { "type": "Direct", "resolved": "1.9.0.0" }
+    },
+    "net8.0": {
+      "Foo": { "type": "Direct", "resolved": "1.10.0.0" }
+    }
+  }
+}"#;
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("packages.lock.json");
+        tokio::fs::write(&path, content).await.unwrap();
+
+        let parser = NuGetLockParser;
+        let resolved = parser.parse_lockfile(&path).await.unwrap();
+        assert_eq!(resolved.get_version("Foo"), Some("1.10.0.0"));
+    }
+
+    #[tokio::test]
+    async fn test_missing_optional_fields() {
+        let content = r#"{
+  "dependencies": {
+    "net8.0": {
+      "Bare": { "resolved": "1.0.0" }
+    }
+  }
+}"#;
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("packages.lock.json");
+        tokio::fs::write(&path, content).await.unwrap();
+
+        let parser = NuGetLockParser;
+        let resolved = parser.parse_lockfile(&path).await.unwrap();
+        assert_eq!(resolved.get_version("Bare"), Some("1.0.0"));
+    }
+
+    #[tokio::test]
+    async fn test_invalid_json_returns_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("packages.lock.json");
+        tokio::fs::write(&path, b"not valid json").await.unwrap();
+
+        let parser = NuGetLockParser;
+        let result = parser.parse_lockfile(&path).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_empty_dependencies_returns_empty() {
+        let content = r#"{"version": 1, "dependencies": {}}"#;
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("packages.lock.json");
+        tokio::fs::write(&path, content).await.unwrap();
+
+        let parser = NuGetLockParser;
+        let resolved = parser.parse_lockfile(&path).await.unwrap();
+        assert_eq!(resolved.len(), 0);
+    }
+
+    #[test]
+    fn test_locate_lockfile() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let manifest_path = temp_dir.path().join("App.csproj");
+        let lock_path = temp_dir.path().join("packages.lock.json");
+        std::fs::write(&manifest_path, "<Project></Project>").unwrap();
+        std::fs::write(&lock_path, "{}").unwrap();
+
+        let manifest_uri = Uri::from_file_path(&manifest_path).unwrap();
+        let parser = NuGetLockParser;
+        let located = parser.locate_lockfile(&manifest_uri);
+        assert_eq!(located, Some(lock_path));
+    }
+}

--- a/crates/deps-nuget/src/parser.rs
+++ b/crates/deps-nuget/src/parser.rs
@@ -1,0 +1,563 @@
+//! Manifest parsers for `.csproj`/`.fsproj`/`.vbproj`, `Directory.Packages.props`, and
+//! `packages.config`, with byte-accurate LSP position tracking.
+//!
+//! # Attribute byte spans
+//!
+//! NuGet carries its values in XML *attributes* (`Include="..."`, `Version="..."`), and
+//! `quick-xml`'s `Attribute` exposes no span API. This module uses the borrowed-slice
+//! offset instead of a text scan: `Reader::from_str(content)` + `reader.read_event()`
+//! (mirroring `deps-maven`'s reader setup exactly, `crates/deps-maven/src/parser.rs:51,62`)
+//! yields `Event<'a>` borrowed from `content` itself, so an attribute's raw `Cow<'a, [u8]>`
+//! value is `Cow::Borrowed` pointing directly into `content`'s bytes. The byte offset is then
+//! simple pointer arithmetic:
+//!
+//! ```ignore
+//! let offset = value.as_ptr() as usize - content.as_ptr() as usize;
+//! ```
+//!
+//! This is O(1) and immune to the false-match a text scan would hit on an MSBuild
+//! `Condition` attribute whose *value* happens to contain the literal text `Version="`
+//! (see `test_condition_attribute_with_literal_version_text` below). Switching the reader
+//! to `Reader::from_reader` + `read_event_into(&mut buf)` would make attributes borrow from
+//! the scratch buffer instead of `content`, silently breaking this arithmetic — it would
+//! compile and produce garbage ranges. `test_attribute_byte_range_matches_source_bytes`
+//! guards against that regression.
+
+use crate::error::{NuGetError, Result};
+use crate::types::NuGetDependency;
+use deps_core::lsp_helpers::LineOffsetTable;
+use quick_xml::Reader;
+use quick_xml::events::{BytesStart, BytesText, Event};
+use tower_lsp_server::ls_types::{Range, Uri};
+
+use crate::types::NuGetParseResult;
+
+/// Parses a `.csproj`/`.fsproj`/`.vbproj` MSBuild project file, extracting `PackageReference` entries.
+///
+/// Supports both the attribute form (`Version="1.0"`) and the child-element metadata form
+/// (`<Version>1.0</Version>`). Central package management entries (no `Version` attribute
+/// or child) are emitted with `version_requirement: None` so hover/completion on the name
+/// still works.
+pub fn parse_project_file(content: &str, doc_uri: &Uri) -> Result<NuGetParseResult> {
+    parse_reference_elements(content, doc_uri, "PackageReference")
+}
+
+/// Parses a `Directory.Packages.props` central package management file, extracting
+/// `PackageVersion` entries.
+pub fn parse_directory_packages_props(content: &str, doc_uri: &Uri) -> Result<NuGetParseResult> {
+    parse_reference_elements(content, doc_uri, "PackageVersion")
+}
+
+/// Parses a legacy `packages.config` file, extracting `package` entries.
+///
+/// `packages.config` `version="..."` semantics are an **exact pin**, unlike the floor
+/// semantics of a bare `PackageReference` `Version="..."`. That difference is normalized at
+/// parse time into a bracketed exact range (`"1.0.0"` → `"[1.0.0]"`) so the existing interval
+/// parser (`crate::version::satisfies`) handles it with no new formatter state.
+pub fn parse_packages_config(content: &str, doc_uri: &Uri) -> Result<NuGetParseResult> {
+    let line_table = LineOffsetTable::new(content);
+    let mut reader = Reader::from_str(content);
+    reader.config_mut().trim_text(true);
+
+    let mut dependencies = Vec::new();
+
+    loop {
+        let event = reader.read_event().map_err(|e| NuGetError::ParseError {
+            message: e.to_string(),
+        })?;
+
+        match event {
+            Event::Empty(ref e) | Event::Start(ref e) if e.local_name().as_ref() == b"package" => {
+                if let Some(dep) = parse_package_element(content, &line_table, e) {
+                    dependencies.push(dep);
+                }
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+
+    Ok(NuGetParseResult {
+        dependencies,
+        uri: doc_uri.clone(),
+    })
+}
+
+fn parse_package_element(
+    content: &str,
+    line_table: &LineOffsetTable,
+    e: &BytesStart<'_>,
+) -> Option<NuGetDependency> {
+    let mut name = None;
+    let mut name_span = (0usize, 0usize);
+    let mut version = None;
+    let mut version_span = (0usize, 0usize);
+
+    for attr in e.attributes().flatten() {
+        match attr.key.local_name().as_ref() {
+            b"id" => {
+                name_span = attribute_byte_range(content, &attr.value);
+                name = Some(decode_attr_value(&attr.value));
+            }
+            b"version" => {
+                version_span = attribute_byte_range(content, &attr.value);
+                version = Some(decode_attr_value(&attr.value));
+            }
+            _ => {}
+        }
+    }
+
+    let name = name?;
+    let name_range = span_to_range(content, line_table, name_span);
+    let (version_requirement, version_range) = match version {
+        Some(v) if !v.contains("$(") => (
+            Some(format!("[{v}]")),
+            Some(span_to_range(content, line_table, version_span)),
+        ),
+        _ => (None, None),
+    };
+
+    Some(NuGetDependency {
+        name,
+        name_range,
+        version_requirement,
+        version_range,
+    })
+}
+
+/// Accumulator for a single `PackageReference`/`PackageVersion` entry being parsed.
+#[derive(Default)]
+struct DepAccum {
+    name: Option<String>,
+    name_span: (usize, usize),
+    version: Option<String>,
+    version_span: (usize, usize),
+}
+
+fn parse_reference_elements(
+    content: &str,
+    doc_uri: &Uri,
+    tag_name: &str,
+) -> Result<NuGetParseResult> {
+    let line_table = LineOffsetTable::new(content);
+    let mut reader = Reader::from_str(content);
+    reader.config_mut().trim_text(true);
+
+    let mut dependencies = Vec::new();
+    let mut current: Option<DepAccum> = None;
+    let mut in_version_child = false;
+
+    loop {
+        let text_pos = reader.buffer_position();
+        let event = reader.read_event().map_err(|e| NuGetError::ParseError {
+            message: e.to_string(),
+        })?;
+
+        match event {
+            Event::Empty(ref e) => {
+                if e.local_name().as_ref() == tag_name.as_bytes()
+                    && let Some(dep) =
+                        finalize_dep(content, &line_table, accum_from_attrs(content, e))
+                {
+                    dependencies.push(dep);
+                }
+            }
+            Event::Start(ref e) => {
+                if e.local_name().as_ref() == tag_name.as_bytes() {
+                    current = Some(accum_from_attrs(content, e));
+                } else if current.is_some() && e.local_name().as_ref() == b"Version" {
+                    in_version_child = true;
+                }
+            }
+            Event::Text(ref e) if in_version_child => {
+                if let Some(accum) = current.as_mut() {
+                    let text_end = reader.buffer_position();
+                    accum.version = Some(decode_text(e));
+                    accum.version_span = (text_pos as usize, text_end as usize);
+                }
+            }
+            Event::End(ref e) => {
+                let local = e.local_name();
+                if local.as_ref() == b"Version" && in_version_child {
+                    in_version_child = false;
+                } else if local.as_ref() == tag_name.as_bytes()
+                    && let Some(accum) = current.take()
+                    && let Some(dep) = finalize_dep(content, &line_table, accum)
+                {
+                    dependencies.push(dep);
+                }
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+
+    Ok(NuGetParseResult {
+        dependencies,
+        uri: doc_uri.clone(),
+    })
+}
+
+fn accum_from_attrs(content: &str, e: &BytesStart<'_>) -> DepAccum {
+    let mut accum = DepAccum::default();
+    for attr in e.attributes().flatten() {
+        match attr.key.local_name().as_ref() {
+            b"Include" => {
+                accum.name_span = attribute_byte_range(content, &attr.value);
+                accum.name = Some(decode_attr_value(&attr.value));
+            }
+            b"Version" => {
+                accum.version_span = attribute_byte_range(content, &attr.value);
+                accum.version = Some(decode_attr_value(&attr.value));
+            }
+            _ => {}
+        }
+    }
+    accum
+}
+
+fn finalize_dep(
+    content: &str,
+    line_table: &LineOffsetTable,
+    accum: DepAccum,
+) -> Option<NuGetDependency> {
+    let name = accum.name?;
+    let name_range = span_to_range(content, line_table, accum.name_span);
+    let (version_requirement, version_range) =
+        resolve_version_field(content, line_table, accum.version, accum.version_span);
+
+    Some(NuGetDependency {
+        name,
+        name_range,
+        version_requirement,
+        version_range,
+    })
+}
+
+/// Unresolvable MSBuild property expressions (`Version="$(SerilogVersion)"`) and central
+/// package management entries (no `Version` at all) both degrade to `version_requirement:
+/// None` rather than a bogus or unresolved-looking requirement (spec §3, deferred scope).
+fn resolve_version_field(
+    content: &str,
+    line_table: &LineOffsetTable,
+    version: Option<String>,
+    span: (usize, usize),
+) -> (Option<String>, Option<Range>) {
+    match version {
+        Some(v) if !v.contains("$(") => (Some(v), Some(span_to_range(content, line_table, span))),
+        _ => (None, None),
+    }
+}
+
+/// Computes the byte offset range of an attribute's raw value slice within `content`.
+///
+/// Sound only when `raw` borrows directly from `content` (`Cow::Borrowed`), which holds for
+/// `Reader::from_str` + `read_event()` per the module docs above. `checked_sub` guards
+/// against that invariant being violated by a future reader-setup regression: release
+/// builds have no overflow checks, so an unchecked subtraction would wrap silently into a
+/// garbage offset instead of failing loudly — falling back to an empty `(0, 0)` range is
+/// safe (worst case, a wrong/empty LSP range) where a wrapped `usize` is not.
+fn attribute_byte_range(content: &str, raw: &[u8]) -> (usize, usize) {
+    let Some(offset) = (raw.as_ptr() as usize).checked_sub(content.as_ptr() as usize) else {
+        return (0, 0);
+    };
+    (offset, offset + raw.len())
+}
+
+fn span_to_range(content: &str, line_table: &LineOffsetTable, span: (usize, usize)) -> Range {
+    Range::new(
+        line_table.byte_offset_to_position(content, span.0),
+        line_table.byte_offset_to_position(content, span.1),
+    )
+}
+
+fn decode_attr_value(raw: &[u8]) -> String {
+    std::str::from_utf8(raw)
+        .ok()
+        .and_then(|s| quick_xml::escape::unescape(s).ok())
+        .map(|c| c.into_owned())
+        .unwrap_or_else(|| String::from_utf8_lossy(raw).into_owned())
+}
+
+fn decode_text(e: &BytesText<'_>) -> String {
+    match e.decode() {
+        Ok(cow) => {
+            let s = cow.trim().to_string();
+            quick_xml::escape::unescape(&s)
+                .map(|c| c.into_owned())
+                .unwrap_or(s)
+        }
+        Err(_) => String::from_utf8_lossy(e.as_ref()).trim().to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_uri() -> Uri {
+        deps_core::test_util::test_uri("/test/App.csproj")
+    }
+
+    #[test]
+    fn test_parse_attribute_form() {
+        let xml = r#"<Project>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>"#;
+        let result = parse_project_file(xml, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name, "Newtonsoft.Json");
+        assert_eq!(dep.version_requirement, Some("13.0.3".into()));
+        assert!(dep.version_range.is_some());
+    }
+
+    #[test]
+    fn test_parse_child_element_form() {
+        let xml = r#"<Project>
+  <ItemGroup>
+    <PackageReference Include="Serilog"><Version>3.1.1</Version></PackageReference>
+  </ItemGroup>
+</Project>"#;
+        let result = parse_project_file(xml, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name, "Serilog");
+        assert_eq!(dep.version_requirement, Some("3.1.1".into()));
+    }
+
+    #[test]
+    fn test_parse_child_element_form_multiline_whitespace() {
+        // Whitespace-padded child-element form: `<Version>\n  3.1.1\n</Version>`.
+        // decode_text() trims the extracted value regardless of surrounding whitespace
+        // (matches deps-maven's identical text-node handling).
+        let xml = "<Project><ItemGroup><PackageReference Include=\"Serilog\"><Version>\n      3.1.1\n    </Version></PackageReference></ItemGroup></Project>";
+        let result = parse_project_file(xml, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(
+            result.dependencies[0].version_requirement,
+            Some("3.1.1".into())
+        );
+    }
+
+    #[test]
+    fn test_parse_central_package_management_no_version() {
+        let xml = r#"<Project>
+  <ItemGroup>
+    <PackageReference Include="Serilog" />
+  </ItemGroup>
+</Project>"#;
+        let result = parse_project_file(xml, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].name, "Serilog");
+        assert!(result.dependencies[0].version_requirement.is_none());
+        assert!(result.dependencies[0].version_range.is_none());
+    }
+
+    #[test]
+    fn test_parse_multiple_references() {
+        let xml = r#"<Project>
+  <ItemGroup>
+    <PackageReference Include="A" Version="1.0.0" />
+    <PackageReference Include="B" Version="2.0.0" />
+  </ItemGroup>
+</Project>"#;
+        let result = parse_project_file(xml, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 2);
+        assert_eq!(result.dependencies[0].name, "A");
+        assert_eq!(result.dependencies[1].name, "B");
+    }
+
+    #[test]
+    fn test_attribute_order_version_before_include() {
+        let xml = r#"<Project><ItemGroup><PackageReference Version="1.2.3" Include="Foo" /></ItemGroup></Project>"#;
+        let result = parse_project_file(xml, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].name, "Foo");
+        assert_eq!(
+            result.dependencies[0].version_requirement,
+            Some("1.2.3".into())
+        );
+    }
+
+    #[test]
+    fn test_single_and_double_quotes() {
+        let xml = r"<Project><ItemGroup><PackageReference Include='Foo' Version='1.0.0' /></ItemGroup></Project>";
+        let result = parse_project_file(xml, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].name, "Foo");
+        assert_eq!(
+            result.dependencies[0].version_requirement,
+            Some("1.0.0".into())
+        );
+    }
+
+    #[test]
+    fn test_whitespace_around_equals() {
+        let xml = r#"<Project><ItemGroup><PackageReference Include = "Foo" Version = "1.0.0" /></ItemGroup></Project>"#;
+        let result = parse_project_file(xml, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].name, "Foo");
+        assert_eq!(
+            result.dependencies[0].version_requirement,
+            Some("1.0.0".into())
+        );
+    }
+
+    #[test]
+    fn test_self_closing_vs_paired_tags() {
+        let self_closing = r#"<Project><ItemGroup><PackageReference Include="Foo" Version="1.0.0" /></ItemGroup></Project>"#;
+        let paired = r#"<Project><ItemGroup><PackageReference Include="Foo" Version="1.0.0"></PackageReference></ItemGroup></Project>"#;
+
+        let r1 = parse_project_file(self_closing, &test_uri()).unwrap();
+        let r2 = parse_project_file(paired, &test_uri()).unwrap();
+
+        assert_eq!(r1.dependencies.len(), 1);
+        assert_eq!(r2.dependencies.len(), 1);
+        assert_eq!(r1.dependencies[0].name, r2.dependencies[0].name);
+        assert_eq!(
+            r1.dependencies[0].version_requirement,
+            r2.dependencies[0].version_requirement
+        );
+    }
+
+    #[test]
+    fn test_condition_attribute_with_literal_version_text() {
+        // A `Condition` attribute value containing the literal text `Version="` would
+        // false-match a naive text scan. The attribute-key-based parser must not be fooled.
+        let xml = r#"<Project><ItemGroup><PackageReference Include="Foo" Condition="'$(Version)' == 'Version="9.9.9"'" Version="1.0.0" /></ItemGroup></Project>"#;
+        let result = parse_project_file(xml, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].name, "Foo");
+        assert_eq!(
+            result.dependencies[0].version_requirement,
+            Some("1.0.0".into())
+        );
+    }
+
+    #[test]
+    fn test_attribute_byte_range_matches_source_bytes() {
+        // Guards the reader-setup constraint: attribute values must borrow directly from
+        // `content` (Reader::from_str + read_event()), not a scratch buffer, or this
+        // pointer-arithmetic offset silently produces garbage ranges.
+        let xml = r#"<PackageReference Include="Foo" Version="1.2.3" />"#;
+        let mut reader = Reader::from_str(xml);
+        let event = reader.read_event().unwrap();
+        let Event::Empty(e) = event else {
+            panic!("expected Empty event");
+        };
+        let mut checked = false;
+        for attr in e.attributes().flatten() {
+            if attr.key.local_name().as_ref() == b"Version" {
+                let (start, end) = attribute_byte_range(xml, &attr.value);
+                assert_eq!(&xml.as_bytes()[start..end], attr.value.as_ref());
+                assert_eq!(&xml[start..end], "1.2.3");
+                checked = true;
+            }
+        }
+        assert!(
+            checked,
+            "Version attribute was never found — guarded assertions did not run"
+        );
+    }
+
+    #[test]
+    fn test_attribute_byte_range_checked_sub_fallback_on_invariant_violation() {
+        // Deterministically construct `raw` at a lower memory address than `content` by
+        // slicing the same backing buffer in reverse order — this violates the "raw
+        // borrows from content" invariant and must return the safe (0, 0) fallback instead
+        // of wrapping.
+        let buffer = "0123456789";
+        let content = &buffer[5..];
+        let raw = &buffer.as_bytes()[0..3];
+        assert_eq!(attribute_byte_range(content, raw), (0, 0));
+    }
+
+    #[test]
+    fn test_directory_packages_props() {
+        let xml = r#"<Project>
+  <ItemGroup>
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>"#;
+        let uri = deps_core::test_util::test_uri("/test/Directory.Packages.props");
+        let result = parse_directory_packages_props(xml, &uri).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].name, "Newtonsoft.Json");
+        assert_eq!(
+            result.dependencies[0].version_requirement,
+            Some("13.0.3".into())
+        );
+    }
+
+    #[test]
+    fn test_packages_config_normalizes_exact_pin() {
+        let xml = r#"<packages>
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
+</packages>"#;
+        let uri = deps_core::test_util::test_uri("/test/packages.config");
+        let result = parse_packages_config(xml, &uri).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].name, "Newtonsoft.Json");
+        assert_eq!(
+            result.dependencies[0].version_requirement,
+            Some("[13.0.3]".into())
+        );
+    }
+
+    #[test]
+    fn test_packages_config_multiple_packages() {
+        let xml = r#"<packages>
+  <package id="A" version="1.0.0" targetFramework="net48" />
+  <package id="B" version="2.0.0" targetFramework="net48" />
+</packages>"#;
+        let uri = deps_core::test_util::test_uri("/test/packages.config");
+        let result = parse_packages_config(xml, &uri).unwrap();
+        assert_eq!(result.dependencies.len(), 2);
+    }
+
+    #[test]
+    fn test_unresolved_msbuild_property_degrades_to_none() {
+        let xml = r#"<Project><ItemGroup><PackageReference Include="Serilog" Version="$(SerilogVersion)" /></ItemGroup></Project>"#;
+        let result = parse_project_file(xml, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].name, "Serilog");
+        assert!(result.dependencies[0].version_requirement.is_none());
+        assert!(result.dependencies[0].version_range.is_none());
+    }
+
+    #[test]
+    fn test_empty_project() {
+        let xml = "<Project></Project>";
+        let result = parse_project_file(xml, &test_uri()).unwrap();
+        assert!(result.dependencies.is_empty());
+    }
+
+    #[test]
+    fn test_invalid_xml_errors() {
+        let xml = r#"<Project attr="unclosed></Project>"#;
+        let result = parse_project_file(xml, &test_uri());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_result_trait() {
+        use deps_core::ParseResult;
+
+        let xml = r#"<Project><ItemGroup><PackageReference Include="Foo" Version="1.0.0" /></ItemGroup></Project>"#;
+        let result = parse_project_file(xml, &test_uri()).unwrap();
+        assert_eq!(result.dependencies().len(), 1);
+        assert!(result.workspace_root().is_none());
+        assert!(result.as_any().is::<NuGetParseResult>());
+    }
+
+    #[test]
+    fn test_position_tracking() {
+        let xml = "<Project>\n  <ItemGroup>\n    <PackageReference Include=\"Foo\" Version=\"1.0.0\" />\n  </ItemGroup>\n</Project>";
+        let result = parse_project_file(xml, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name_range.start.line, 2);
+    }
+}

--- a/crates/deps-nuget/src/registry.rs
+++ b/crates/deps-nuget/src/registry.rs
@@ -1,0 +1,563 @@
+//! NuGet V3 registry client.
+//!
+//! NuGet base URLs are not hardcodable: the service index
+//! (`https://api.nuget.org/v3/index.json`) must be resolved first, then consulted for the
+//! flat-container ("PackageBaseAddress"), search ("SearchQueryService"), and (future,
+//! see D1 below) registration ("RegistrationsBaseUrl") resource URLs.
+
+use crate::types::{NuGetVersion, PackageInfo};
+use crate::version::compare_versions;
+use deps_core::{HttpCache, Result};
+use serde::Deserialize;
+use std::any::Any;
+use std::sync::Arc;
+use tokio::sync::OnceCell;
+
+const SERVICE_INDEX_URL: &str = "https://api.nuget.org/v3/index.json";
+
+#[derive(Debug, Deserialize)]
+struct ServiceIndexResponse {
+    resources: Vec<ServiceResource>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ServiceResource {
+    #[serde(rename = "@id")]
+    id: String,
+    #[serde(rename = "@type")]
+    r#type: String,
+}
+
+/// Resolved base URLs from the NuGet service index.
+#[derive(Debug, Clone)]
+struct ServiceIndex {
+    /// `PackageBaseAddress/3.0.0` — flat-container version enumeration.
+    package_base_address: String,
+    /// `SearchQueryService/3.5.0` (preferred) or bare `SearchQueryService`.
+    search_query_service: String,
+}
+
+fn pick_resource(resources: &[ServiceResource], type_preference: &[&str]) -> Option<String> {
+    for want in type_preference {
+        if let Some(r) = resources.iter().find(|r| r.r#type == *want) {
+            return Some(r.id.trim_end_matches('/').to_string());
+        }
+    }
+    None
+}
+
+impl ServiceIndex {
+    fn resolve(response: &ServiceIndexResponse) -> Result<Self> {
+        let package_base_address =
+            pick_resource(&response.resources, &["PackageBaseAddress/3.0.0"]).ok_or_else(|| {
+                deps_core::DepsError::ParseError {
+                    file_type: "NuGet service index".into(),
+                    source: Box::new(std::io::Error::other(
+                        "missing PackageBaseAddress/3.0.0 resource",
+                    )),
+                }
+            })?;
+        let search_query_service = pick_resource(
+            &response.resources,
+            &["SearchQueryService/3.5.0", "SearchQueryService"],
+        )
+        .ok_or_else(|| deps_core::DepsError::ParseError {
+            file_type: "NuGet service index".into(),
+            source: Box::new(std::io::Error::other("missing SearchQueryService resource")),
+        })?;
+
+        Ok(Self {
+            package_base_address,
+            search_query_service,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct FlatContainerIndex {
+    #[serde(default)]
+    versions: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchResponse {
+    #[serde(default)]
+    data: Vec<SearchResultDoc>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchResultDoc {
+    id: String,
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default, rename = "projectUrl")]
+    project_url: Option<String>,
+}
+
+/// Returns the nuget.org package page URL for `name`.
+pub fn package_url(name: &str) -> String {
+    format!("https://www.nuget.org/packages/{name}")
+}
+
+#[derive(Clone)]
+pub struct NuGetRegistry {
+    cache: Arc<HttpCache>,
+    service_index_url: String,
+    service_index: Arc<OnceCell<ServiceIndex>>,
+}
+
+impl NuGetRegistry {
+    pub fn new(cache: Arc<HttpCache>) -> Self {
+        Self::with_service_index_url(cache, SERVICE_INDEX_URL.to_string())
+    }
+
+    fn with_service_index_url(cache: Arc<HttpCache>, service_index_url: String) -> Self {
+        Self {
+            cache,
+            service_index_url,
+            service_index: Arc::new(OnceCell::new()),
+        }
+    }
+
+    /// Resolves the service index once per process, retrying on the next call if
+    /// resolution failed. `get_or_try_init` (not `get_or_init`) is load-bearing: it leaves
+    /// the cell empty on `Err` so a transient failure does not permanently poison lookups,
+    /// and it serializes concurrent initializers so a cold start with many dependencies
+    /// does not stampede the index endpoint.
+    async fn service_index(&self) -> Result<&ServiceIndex> {
+        self.service_index
+            .get_or_try_init(|| async {
+                let data = self.cache.get_cached(&self.service_index_url).await?;
+                let response: ServiceIndexResponse = serde_json::from_slice(&data)?;
+                ServiceIndex::resolve(&response)
+            })
+            .await
+    }
+
+    /// Fetches all available versions for `name` from the flat-container endpoint,
+    /// sorted newest-first.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the service index cannot be resolved or the flat-container
+    /// request fails.
+    pub async fn get_versions_typed(&self, name: &str) -> Result<Vec<NuGetVersion>> {
+        let index = self.service_index().await?;
+        let url = flat_container_url(&index.package_base_address, name);
+
+        let data = self.cache.get_cached(&url).await?;
+        parse_flat_container(&data)
+    }
+
+    /// Finds the highest version of `name` matching `req` (exact pin, interval notation,
+    /// or floating pattern). Prerelease versions are excluded unless `req` itself is
+    /// prerelease-bearing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the service index cannot be resolved or the flat-container
+    /// request fails.
+    pub async fn get_latest_matching_typed(
+        &self,
+        name: &str,
+        req: &str,
+    ) -> Result<Option<NuGetVersion>> {
+        let versions = self.get_versions_typed(name).await?;
+        Ok(pick_latest_matching(versions, req))
+    }
+
+    /// Searches the NuGet `SearchQueryService` for `query`, returning up to `limit` results.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the service index cannot be resolved or the search request fails.
+    pub async fn search_typed(&self, query: &str, limit: usize) -> Result<Vec<PackageInfo>> {
+        let index = self.service_index().await?;
+        let url = search_url(&index.search_query_service, query, limit);
+
+        let data = self.cache.get_cached(&url).await?;
+        parse_search_response(&data, limit)
+    }
+}
+
+/// Builds the flat-container version-enumeration URL for `name`.
+///
+/// The package id is lowercased (NuGet ids are case-insensitive and every V3 API path
+/// segment is lowercased) and percent-encoded before being interpolated into the path.
+/// Encoding is load-bearing, not cosmetic: an unencoded id lets a crafted
+/// `PackageReference Include="..."` value inject path segments (`../../etc/passwd`
+/// collapses dot-segments) or truncate the path at `#`/`?`/control characters, making
+/// deps-lsp silently resolve and display a *different* real package's version data under
+/// an attacker-chosen name.
+pub fn flat_container_url(base: &str, name: &str) -> String {
+    let lower = name.to_lowercase();
+    format!("{base}/{}/index.json", urlencoding::encode(&lower))
+}
+
+/// Builds the `SearchQueryService` URL for `query`, limited to `limit` results.
+///
+/// `semVerLevel=2.0.0` is mandatory (spec §1) — omitting it silently hides every package
+/// whose latest version uses a dotted prerelease label.
+pub fn search_url(base: &str, query: &str, limit: usize) -> String {
+    format!(
+        "{base}?q={}&take={limit}&prerelease=false&semVerLevel=2.0.0",
+        urlencoding::encode(query),
+    )
+}
+
+/// Parses a flat-container `index.json` response into descending-sorted versions.
+pub fn parse_flat_container(data: &[u8]) -> Result<Vec<NuGetVersion>> {
+    let parsed: FlatContainerIndex = serde_json::from_slice(data)?;
+
+    let mut versions = parsed.versions;
+    // Sort locally, descending: the flat container's observed ascending order is not a
+    // documented contract, so relying on `.reverse()` would silently corrupt "latest" if
+    // the CDN/backend ever changes it (rev2, S3).
+    versions.sort_by(|a, b| compare_versions(b, a));
+
+    Ok(versions
+        .into_iter()
+        .map(|version| NuGetVersion { version })
+        .collect())
+}
+
+/// Picks the highest version matching `req` from an already-fetched, descending-sorted
+/// version list. `req` is treated as `"*"` when empty. Prerelease versions are excluded
+/// unless `req` itself is prerelease-bearing (contains `-`) or is a floating pattern whose
+/// own prerelease inclusion is handled by `crate::version::resolve_float`.
+fn pick_latest_matching(versions: Vec<NuGetVersion>, req: &str) -> Option<NuGetVersion> {
+    if versions.is_empty() {
+        return None;
+    }
+
+    let req = if req.is_empty() { "*" } else { req };
+
+    if req.contains('*') {
+        let strings: Vec<String> = versions.iter().map(|v| v.version.clone()).collect();
+        return crate::version::resolve_float(&strings, req).map(|v| NuGetVersion {
+            version: v.to_string(),
+        });
+    }
+
+    let req_is_prerelease_bearing = req.contains('-');
+    versions.into_iter().find(|v| {
+        crate::version::satisfies(&v.version, req)
+            && (req_is_prerelease_bearing || !crate::version::is_prerelease(&v.version))
+    })
+}
+
+fn parse_search_response(data: &[u8], limit: usize) -> Result<Vec<PackageInfo>> {
+    let response: SearchResponse = serde_json::from_slice(data)?;
+
+    Ok(response
+        .data
+        .into_iter()
+        .take(limit)
+        .map(|d| PackageInfo {
+            name: d.id,
+            description: d.description,
+            repository: d.project_url,
+            documentation: None,
+            latest_version: d.version.unwrap_or_default(),
+        })
+        .collect())
+}
+
+// TODO(critic): unlisted versions are reported as listed; enrich from
+// RegistrationsBaseUrl/3.6.0 on hover only (D1). The flat container used by get_versions
+// carries no `listed` flag, and paying the extra registration-hive hop on every dependency
+// in an open file is the wrong trade for the inlay-hint path.
+
+impl deps_core::Registry for NuGetRegistry {
+    fn get_versions<'a>(
+        &'a self,
+        name: &'a str,
+    ) -> deps_core::ecosystem::BoxFuture<'a, Result<Vec<Box<dyn deps_core::Version>>>> {
+        Box::pin(async move {
+            let versions = self.get_versions_typed(name).await?;
+            Ok(versions
+                .into_iter()
+                .map(|v| Box::new(v) as Box<dyn deps_core::Version>)
+                .collect())
+        })
+    }
+
+    fn get_latest_matching<'a>(
+        &'a self,
+        name: &'a str,
+        req: &'a str,
+    ) -> deps_core::ecosystem::BoxFuture<'a, Result<Option<Box<dyn deps_core::Version>>>> {
+        Box::pin(async move {
+            let version = self.get_latest_matching_typed(name, req).await?;
+            Ok(version.map(|v| Box::new(v) as Box<dyn deps_core::Version>))
+        })
+    }
+
+    fn search<'a>(
+        &'a self,
+        query: &'a str,
+        limit: usize,
+    ) -> deps_core::ecosystem::BoxFuture<'a, Result<Vec<Box<dyn deps_core::Metadata>>>> {
+        Box::pin(async move {
+            let results = self.search_typed(query, limit).await?;
+            Ok(results
+                .into_iter()
+                .map(|m| Box::new(m) as Box<dyn deps_core::Metadata>)
+                .collect())
+        })
+    }
+
+    fn package_url(&self, name: &str) -> String {
+        package_url(name)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn service_index_body(package_base_address: &str, search_query_service: &str) -> String {
+        format!(
+            r#"{{
+                "version": "3.0.0",
+                "resources": [
+                    {{"@id": "{package_base_address}", "@type": "PackageBaseAddress/3.0.0"}},
+                    {{"@id": "{search_query_service}", "@type": "SearchQueryService/3.5.0"}}
+                ]
+            }}"#
+        )
+    }
+
+    #[test]
+    fn test_package_url() {
+        assert_eq!(
+            package_url("Newtonsoft.Json"),
+            "https://www.nuget.org/packages/Newtonsoft.Json"
+        );
+    }
+
+    #[test]
+    fn test_flat_container_url_lowercases_and_encodes() {
+        assert_eq!(
+            flat_container_url("https://api.nuget.org/v3-flatcontainer", "Newtonsoft.Json"),
+            "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/index.json"
+        );
+    }
+
+    #[test]
+    fn test_flat_container_url_encodes_path_traversal_attempt() {
+        // A crafted `Include="../../../../etc/passwd"` must not produce raw dot-segments
+        // that a URL-parsing layer could collapse across path boundaries.
+        let url = flat_container_url(
+            "https://api.nuget.org/v3-flatcontainer",
+            "../../../../etc/passwd",
+        );
+        assert_eq!(
+            url,
+            "https://api.nuget.org/v3-flatcontainer/..%2F..%2F..%2F..%2Fetc%2Fpasswd/index.json"
+        );
+        assert!(
+            !url.contains("/../"),
+            "raw path traversal segment leaked into URL: {url}"
+        );
+    }
+
+    #[test]
+    fn test_flat_container_url_encodes_fragment_and_query_delimiters() {
+        // '#'/'?' must not be able to truncate the path and silently resolve as a
+        // different, shorter package name.
+        assert_eq!(
+            flat_container_url("https://api.nuget.org/v3-flatcontainer", "Foo#x"),
+            "https://api.nuget.org/v3-flatcontainer/foo%23x/index.json"
+        );
+        assert_eq!(
+            flat_container_url("https://api.nuget.org/v3-flatcontainer", "Foo?x=1"),
+            "https://api.nuget.org/v3-flatcontainer/foo%3Fx%3D1/index.json"
+        );
+    }
+
+    #[test]
+    fn test_flat_container_url_encodes_control_characters() {
+        let url = flat_container_url("https://api.nuget.org/v3-flatcontainer", "Foo\tBar");
+        assert_eq!(
+            url,
+            "https://api.nuget.org/v3-flatcontainer/foo%09bar/index.json"
+        );
+    }
+
+    #[test]
+    fn test_search_url_includes_mandatory_semver_level_and_prerelease_false() {
+        let url = search_url("https://azuresearch-usnc.nuget.org/query", "json", 10);
+        assert_eq!(
+            url,
+            "https://azuresearch-usnc.nuget.org/query?q=json&take=10&prerelease=false&semVerLevel=2.0.0"
+        );
+    }
+
+    #[test]
+    fn test_search_url_encodes_query() {
+        let url = search_url("https://azuresearch-usnc.nuget.org/query", "a b&c", 5);
+        assert!(url.contains("q=a%20b%26c"), "query not encoded: {url}");
+    }
+
+    #[test]
+    fn test_service_index_resolve_success() {
+        let response: ServiceIndexResponse = serde_json::from_str(&service_index_body(
+            "https://api.nuget.org/v3-flatcontainer/",
+            "https://azuresearch-usnc.nuget.org/query",
+        ))
+        .unwrap();
+        let index = ServiceIndex::resolve(&response).unwrap();
+        assert_eq!(
+            index.package_base_address,
+            "https://api.nuget.org/v3-flatcontainer"
+        );
+        assert_eq!(
+            index.search_query_service,
+            "https://azuresearch-usnc.nuget.org/query"
+        );
+    }
+
+    #[test]
+    fn test_service_index_resolve_missing_resource_errors() {
+        let response: ServiceIndexResponse = serde_json::from_str(
+            r#"{"version": "3.0.0", "resources": [{"@id": "https://x", "@type": "SomeOtherType"}]}"#,
+        )
+        .unwrap();
+        assert!(ServiceIndex::resolve(&response).is_err());
+    }
+
+    #[test]
+    fn test_service_index_search_query_service_fallback() {
+        let response: ServiceIndexResponse = serde_json::from_str(
+            r#"{"version": "3.0.0", "resources": [
+                {"@id": "https://flat/", "@type": "PackageBaseAddress/3.0.0"},
+                {"@id": "https://search/", "@type": "SearchQueryService"}
+            ]}"#,
+        )
+        .unwrap();
+        let index = ServiceIndex::resolve(&response).unwrap();
+        assert_eq!(index.search_query_service, "https://search");
+    }
+
+    #[test]
+    fn test_parse_flat_container_sorted_descending() {
+        let data = br#"{"versions": ["12.0.1", "13.0.3", "13.0.0-beta1"]}"#;
+        let versions = parse_flat_container(data).unwrap();
+        let strings: Vec<&str> = versions.iter().map(|v| v.version.as_str()).collect();
+        assert_eq!(strings, vec!["13.0.3", "13.0.0-beta1", "12.0.1"]);
+    }
+
+    #[test]
+    fn test_parse_flat_container_empty() {
+        let data = br#"{"versions": []}"#;
+        let versions = parse_flat_container(data).unwrap();
+        assert!(versions.is_empty());
+    }
+
+    #[test]
+    fn test_parse_flat_container_invalid_json_errors() {
+        assert!(parse_flat_container(b"not json").is_err());
+    }
+
+    #[test]
+    fn test_parse_search_response() {
+        let data = br#"{"totalHits": 1, "data": [{"id": "Newtonsoft.Json", "version": "13.0.3", "description": "JSON framework", "projectUrl": "https://example.com"}]}"#;
+        let results = parse_search_response(data, 10).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "Newtonsoft.Json");
+        assert_eq!(results[0].latest_version, "13.0.3");
+        assert_eq!(
+            results[0].repository.as_deref(),
+            Some("https://example.com")
+        );
+    }
+
+    #[test]
+    fn test_parse_search_response_respects_limit() {
+        let data = br#"{"totalHits": 2, "data": [
+            {"id": "A", "version": "1.0.0"},
+            {"id": "B", "version": "2.0.0"}
+        ]}"#;
+        let results = parse_search_response(data, 1).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "A");
+    }
+
+    fn v(s: &str) -> NuGetVersion {
+        NuGetVersion {
+            version: s.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_pick_latest_matching_wildcard_excludes_prerelease() {
+        let versions = vec![v("1.0.0"), v("1.1.0-rc.1")];
+        let latest = pick_latest_matching(versions, "*");
+        assert_eq!(latest.unwrap().version, "1.0.0");
+    }
+
+    #[test]
+    fn test_pick_latest_matching_empty_req_behaves_like_wildcard() {
+        let versions = vec![v("1.0.0"), v("1.1.0-rc.1")];
+        let latest = pick_latest_matching(versions, "");
+        assert_eq!(latest.unwrap().version, "1.0.0");
+    }
+
+    #[test]
+    fn test_pick_latest_matching_exact_pin() {
+        let versions = vec![v("1.0.1"), v("1.0.0")];
+        let matched = pick_latest_matching(versions, "[1.0.0]");
+        assert_eq!(matched.unwrap().version, "1.0.0");
+    }
+
+    #[test]
+    fn test_pick_latest_matching_floating_prefix() {
+        let versions = vec![v("1.2.0"), v("1.1.5"), v("1.1.0")];
+        let matched = pick_latest_matching(versions, "1.1.*");
+        assert_eq!(matched.unwrap().version, "1.1.5");
+    }
+
+    #[test]
+    fn test_pick_latest_matching_prerelease_bearing_requirement_allows_prerelease() {
+        let versions = vec![v("1.0.0-rc.2"), v("0.9.0")];
+        let matched = pick_latest_matching(versions, "[1.0.0-rc.2]");
+        assert_eq!(matched.unwrap().version, "1.0.0-rc.2");
+    }
+
+    #[test]
+    fn test_pick_latest_matching_empty_versions_returns_none() {
+        assert!(pick_latest_matching(vec![], "*").is_none());
+    }
+
+    #[test]
+    fn test_pick_latest_matching_no_match_returns_none() {
+        let versions = vec![v("2.0.0")];
+        assert!(pick_latest_matching(versions, "[1.0.0]").is_none());
+    }
+
+    #[test]
+    fn test_registry_creation_and_trait_impls() {
+        use deps_core::Registry;
+        let cache = Arc::new(HttpCache::new());
+        let registry = NuGetRegistry::new(cache);
+        assert_eq!(
+            registry.package_url("Newtonsoft.Json"),
+            "https://www.nuget.org/packages/Newtonsoft.Json"
+        );
+        assert!(registry.as_any().is::<NuGetRegistry>());
+    }
+
+    #[test]
+    fn test_with_service_index_url_used_by_new() {
+        let cache = Arc::new(HttpCache::new());
+        let registry = NuGetRegistry::new(cache);
+        assert_eq!(registry.service_index_url, SERVICE_INDEX_URL);
+    }
+}

--- a/crates/deps-nuget/src/types.rs
+++ b/crates/deps-nuget/src/types.rs
@@ -1,0 +1,206 @@
+//! Domain types for NuGet/.NET project dependencies.
+
+use std::any::Any;
+use tower_lsp_server::ls_types::{Range, Uri};
+
+/// A single `PackageReference` / `PackageVersion` / `package` entry from a manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NuGetDependency {
+    pub name: String,
+    pub name_range: Range,
+    /// Absent when the manifest omits an explicit version — central package management
+    /// entries and unresolvable MSBuild property expressions (`$(...)`) both degrade to
+    /// `None` rather than a bogus or unresolved-looking requirement.
+    pub version_requirement: Option<String>,
+    pub version_range: Option<Range>,
+}
+
+deps_core::impl_dependency!(NuGetDependency {
+    name: name,
+    name_range: name_range,
+    version: version_requirement,
+    version_range: version_range,
+});
+
+/// Parsed result of a single manifest file (`.csproj`, `Directory.Packages.props`,
+/// `packages.config`).
+#[derive(Debug)]
+pub struct NuGetParseResult {
+    pub dependencies: Vec<NuGetDependency>,
+    pub uri: Uri,
+}
+
+deps_core::impl_parse_result!(
+    NuGetParseResult,
+    NuGetDependency {
+        dependencies: dependencies,
+        uri: uri,
+    }
+);
+
+/// A single version of a package, as returned by the NuGet flat-container endpoint.
+///
+/// Deliberately a single field. `is_yanked` always reports `false` because the flat
+/// container carries no `listed` flag — unlisted detection requires the registration
+/// hive and is deferred (spec §1, follow-up D1) to hover-only enrichment.
+///
+/// Hand-writes `deps_core::Version` instead of using `impl_version!` because the macro's
+/// `is_prerelease` cannot be overridden and the shared default (a keyword sniff for
+/// `-alpha|-beta|-rc|-dev|-pre|-snapshot|-canary|-nightly`) does not recognize standard
+/// .NET prerelease labels (`-rtm`, `-servicing.23`, `-CI-*`, `-final`, ...). This follows
+/// the same precedent as `deps-maven`'s and `deps-go`'s hand-written `Version` impls for
+/// ecosystems with a structural (non-keyword) prerelease convention.
+#[derive(Debug, Clone)]
+pub struct NuGetVersion {
+    pub version: String,
+}
+
+impl deps_core::Version for NuGetVersion {
+    fn version_string(&self) -> &str {
+        &self.version
+    }
+
+    fn is_yanked(&self) -> bool {
+        false
+    }
+
+    fn is_prerelease(&self) -> bool {
+        crate::version::is_prerelease(&self.version)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Package metadata from a NuGet search result.
+#[derive(Debug, Clone)]
+pub struct PackageInfo {
+    pub name: String,
+    pub description: Option<String>,
+    pub repository: Option<String>,
+    pub documentation: Option<String>,
+    pub latest_version: String,
+}
+
+deps_core::impl_metadata!(PackageInfo {
+    name: name,
+    description: description,
+    repository: repository,
+    documentation: documentation,
+    latest_version: latest_version,
+});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_lsp_server::ls_types::Position;
+
+    fn test_dep() -> NuGetDependency {
+        NuGetDependency {
+            name: "Newtonsoft.Json".into(),
+            name_range: Range::new(Position::new(2, 4), Position::new(2, 20)),
+            version_requirement: Some("13.0.3".into()),
+            version_range: Some(Range::new(Position::new(2, 30), Position::new(2, 36))),
+        }
+    }
+
+    #[test]
+    fn test_dependency_trait() {
+        use deps_core::Dependency;
+
+        let dep = test_dep();
+        assert_eq!(dep.name(), "Newtonsoft.Json");
+        assert_eq!(dep.version_requirement(), Some("13.0.3"));
+        assert!(dep.features().is_empty());
+        assert!(dep.as_any().is::<NuGetDependency>());
+        assert!(matches!(
+            dep.source(),
+            deps_core::parser::DependencySource::Registry
+        ));
+    }
+
+    #[test]
+    fn test_dependency_without_version() {
+        use deps_core::Dependency;
+
+        let dep = NuGetDependency {
+            name: "MyCompany.Shared".into(),
+            name_range: Range::default(),
+            version_requirement: None,
+            version_range: None,
+        };
+        assert!(dep.version_requirement().is_none());
+        assert!(dep.version_range().is_none());
+    }
+
+    #[test]
+    fn test_parse_result_trait() {
+        use deps_core::ParseResult;
+
+        let result = NuGetParseResult {
+            dependencies: vec![test_dep()],
+            uri: deps_core::test_util::test_uri("/test/App.csproj"),
+        };
+
+        assert_eq!(result.dependencies().len(), 1);
+        assert!(result.workspace_root().is_none());
+        assert!(result.as_any().is::<NuGetParseResult>());
+    }
+
+    #[test]
+    fn test_version_trait() {
+        use deps_core::Version;
+
+        let ver = NuGetVersion {
+            version: "13.0.3".into(),
+        };
+        assert_eq!(ver.version_string(), "13.0.3");
+        assert!(!ver.is_yanked());
+        assert!(!ver.is_prerelease());
+        assert!(ver.as_any().is::<NuGetVersion>());
+    }
+
+    #[test]
+    fn test_version_prerelease_dotnet_label() {
+        use deps_core::Version;
+
+        // Real .NET label that the shared keyword-sniff default would misclassify as stable.
+        let ver = NuGetVersion {
+            version: "13.0.0-rtm".into(),
+        };
+        assert!(ver.is_prerelease());
+        assert!(!ver.is_stable());
+    }
+
+    #[test]
+    fn test_version_never_yanked() {
+        use deps_core::Version;
+
+        let ver = NuGetVersion {
+            version: "1.0.0".into(),
+        };
+        assert!(!ver.is_yanked());
+    }
+
+    #[test]
+    fn test_metadata_trait() {
+        use deps_core::Metadata;
+
+        let info = PackageInfo {
+            name: "Newtonsoft.Json".into(),
+            description: Some("Popular high-performance JSON framework".into()),
+            repository: None,
+            documentation: None,
+            latest_version: "13.0.3".into(),
+        };
+        assert_eq!(info.name(), "Newtonsoft.Json");
+        assert_eq!(
+            info.description(),
+            Some("Popular high-performance JSON framework")
+        );
+        assert_eq!(info.latest_version(), "13.0.3");
+        assert!(info.repository().is_none());
+        assert!(info.as_any().is::<PackageInfo>());
+    }
+}

--- a/crates/deps-nuget/src/version.rs
+++ b/crates/deps-nuget/src/version.rs
@@ -1,0 +1,603 @@
+//! NuGet version comparison, prerelease detection, and range/floating syntax.
+//!
+//! # Why this is hand-rolled
+//!
+//! No maintained Rust crate implements NuGet's versioning scheme. NuGet versions are
+//! `Major.Minor.Patch[.Revision]` (1–4 numeric components, `Major` required) with SemVer2
+//! prerelease precedence and case-insensitive prerelease label comparison; the workspace's
+//! `semver` crate rejects both `1.2.3.4` (too many components) and `1.2` (too few) outright, so
+//! it cannot parse the common NuGet forms. `deps-maven` set the precedent for a crate-local
+//! hand-rolled comparator under the same constraint (no maintained crate for Maven's scheme).
+
+use std::cmp::Ordering;
+
+/// A single dot-separated prerelease identifier, per SemVer2 precedence rules:
+/// numeric identifiers compare numerically and always sort below alphanumeric ones;
+/// alphanumeric identifiers compare lexically. NuGet's twist: alphanumeric identifiers
+/// compare case-insensitively (`1.0.0-Alpha == 1.0.0-alpha`), so they are lowercased at parse
+/// time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PrereleaseSegment {
+    Numeric(u64),
+    Alphanumeric(String),
+}
+
+impl PrereleaseSegment {
+    fn parse(s: &str) -> Self {
+        if !s.is_empty()
+            && s.bytes().all(|b| b.is_ascii_digit())
+            && let Ok(n) = s.parse::<u64>()
+        {
+            return Self::Numeric(n);
+        }
+        Self::Alphanumeric(s.to_lowercase())
+    }
+}
+
+impl Ord for PrereleaseSegment {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (Self::Numeric(a), Self::Numeric(b)) => a.cmp(b),
+            (Self::Alphanumeric(a), Self::Alphanumeric(b)) => a.cmp(b),
+            (Self::Numeric(_), Self::Alphanumeric(_)) => Ordering::Less,
+            (Self::Alphanumeric(_), Self::Numeric(_)) => Ordering::Greater,
+        }
+    }
+}
+
+impl PartialOrd for PrereleaseSegment {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// A parsed NuGet version: 4 numeric components (missing = 0) plus SemVer2 prerelease
+/// segments. Build metadata is stripped during parsing and never retained — it is never
+/// compared, and nothing in this crate round-trips a version string back from its parsed
+/// form.
+///
+/// Kept crate-private so it cannot collide with the registry-facing `NuGetVersion` in
+/// `types.rs` — this mirrors the `deps-maven` module split.
+#[derive(Debug, Clone)]
+pub(crate) struct ParsedVersion {
+    major: u64,
+    minor: u64,
+    patch: u64,
+    revision: u64,
+    pre: Vec<PrereleaseSegment>,
+}
+
+impl ParsedVersion {
+    pub(crate) fn parse(version: &str) -> Self {
+        let version = version.trim();
+        // Build metadata (after '+') is discarded — never compared, never retained.
+        let core_and_pre = version.split('+').next().unwrap_or(version);
+        let (core, pre) = match core_and_pre.split_once('-') {
+            Some((a, b)) => (a, Some(b)),
+            None => (core_and_pre, None),
+        };
+
+        let mut parts = core.split('.').map(|s| s.parse::<u64>().unwrap_or(0));
+        let major = parts.next().unwrap_or(0);
+        let minor = parts.next().unwrap_or(0);
+        let patch = parts.next().unwrap_or(0);
+        let revision = parts.next().unwrap_or(0);
+
+        let pre = pre
+            .map(|p| p.split('.').map(PrereleaseSegment::parse).collect())
+            .unwrap_or_default();
+
+        Self {
+            major,
+            minor,
+            patch,
+            revision,
+            pre,
+        }
+    }
+}
+
+fn compare_pre(a: &[PrereleaseSegment], b: &[PrereleaseSegment]) -> Ordering {
+    for (x, y) in a.iter().zip(b.iter()) {
+        let ord = x.cmp(y);
+        if ord != Ordering::Equal {
+            return ord;
+        }
+    }
+    // A larger set of prerelease fields has higher precedence when all preceding
+    // identifiers are equal (SemVer2 rule).
+    a.len().cmp(&b.len())
+}
+
+fn compare_parsed(a: &ParsedVersion, b: &ParsedVersion) -> Ordering {
+    a.major
+        .cmp(&b.major)
+        .then_with(|| a.minor.cmp(&b.minor))
+        .then_with(|| a.patch.cmp(&b.patch))
+        .then_with(|| a.revision.cmp(&b.revision))
+        .then_with(|| match (a.pre.is_empty(), b.pre.is_empty()) {
+            (true, true) => Ordering::Equal,
+            // No prerelease has higher precedence than any prerelease of the same core.
+            (true, false) => Ordering::Greater,
+            (false, true) => Ordering::Less,
+            (false, false) => compare_pre(&a.pre, &b.pre),
+        })
+}
+
+/// Compares two NuGet version strings.
+///
+/// 4 numeric components (missing components treated as 0), then SemVer2 prerelease
+/// precedence with case-insensitive prerelease label comparison. Build metadata is ignored.
+pub fn compare_versions(a: &str, b: &str) -> Ordering {
+    compare_parsed(&ParsedVersion::parse(a), &ParsedVersion::parse(b))
+}
+
+/// Detects whether a NuGet version string is a prerelease version.
+///
+/// NuGet's rule is **structural**, not keyword-based: any version with a `-` suffix after
+/// the numeric core is a prerelease, regardless of the label used. This must not be
+/// confused with `deps_core::registry::Version`'s defaulted keyword-sniff implementation,
+/// which recognizes only `-alpha|-beta|-rc|-dev|-pre|-snapshot|-canary|-nightly` — standard
+/// .NET labels like `-rtm`, `-servicing.23`, `-CI-*`, and `-final` all match none of those
+/// keywords and would be misreported as stable. See the `NuGetVersion` hand-written
+/// `Version` impl in `types.rs`, which delegates here instead of using `impl_version!`.
+pub fn is_prerelease(version: &str) -> bool {
+    let without_build = version.split('+').next().unwrap_or(version);
+    without_build.contains('-')
+}
+
+/// A parsed interval-notation version range (spec §2).
+enum VersionRange {
+    Exact(ParsedVersion),
+    Minimum {
+        version: ParsedVersion,
+        inclusive: bool,
+    },
+    Maximum {
+        version: ParsedVersion,
+        inclusive: bool,
+    },
+    Bounded {
+        min: ParsedVersion,
+        min_inclusive: bool,
+        max: ParsedVersion,
+        max_inclusive: bool,
+    },
+}
+
+fn parse_range(range: &str) -> Option<VersionRange> {
+    let range = range.trim();
+    if range.is_empty() {
+        return None;
+    }
+
+    let first = range.chars().next()?;
+    if first != '[' && first != '(' {
+        // Bare version is a floor (minimum, inclusive) under PackageReference.
+        return Some(VersionRange::Minimum {
+            version: ParsedVersion::parse(range),
+            inclusive: true,
+        });
+    }
+
+    let last = range.chars().next_back()?;
+    if last != ']' && last != ')' {
+        return None;
+    }
+
+    let min_inclusive = first == '[';
+    let max_inclusive = last == ']';
+    let inner = &range[first.len_utf8()..range.len() - last.len_utf8()];
+
+    if let Some((lo, hi)) = inner.split_once(',') {
+        let lo = lo.trim();
+        let hi = hi.trim();
+        let min = (!lo.is_empty()).then(|| ParsedVersion::parse(lo));
+        let max = (!hi.is_empty()).then(|| ParsedVersion::parse(hi));
+        match (min, max) {
+            (Some(min), Some(max)) => Some(VersionRange::Bounded {
+                min,
+                min_inclusive,
+                max,
+                max_inclusive,
+            }),
+            (Some(version), None) => Some(VersionRange::Minimum {
+                version,
+                inclusive: min_inclusive,
+            }),
+            (None, Some(version)) => Some(VersionRange::Maximum {
+                version,
+                inclusive: max_inclusive,
+            }),
+            (None, None) => None,
+        }
+    } else {
+        // No comma inside brackets: exact pin, e.g. "[1.0]" == 1.0.
+        Some(VersionRange::Exact(ParsedVersion::parse(inner.trim())))
+    }
+}
+
+fn satisfies_min(v: &ParsedVersion, min: &ParsedVersion, inclusive: bool) -> bool {
+    let ord = compare_parsed(v, min);
+    if inclusive {
+        ord != Ordering::Less
+    } else {
+        ord == Ordering::Greater
+    }
+}
+
+fn satisfies_max(v: &ParsedVersion, max: &ParsedVersion, inclusive: bool) -> bool {
+    let ord = compare_parsed(v, max);
+    if inclusive {
+        ord != Ordering::Greater
+    } else {
+        ord == Ordering::Less
+    }
+}
+
+/// Checks whether `version` satisfies a NuGet interval-notation `range` (spec §2).
+///
+/// Supports bare floors (`1.0`), exact pins (`[1.0]`), open/closed minimums and maximums
+/// (`[1.0,)`, `(,1.0]`, ...), and bounded intervals (`[1.0,2.0)`, ...). Returns `false` for
+/// unparseable ranges rather than panicking.
+pub fn satisfies(version: &str, range: &str) -> bool {
+    let Some(parsed_range) = parse_range(range) else {
+        return false;
+    };
+    let v = ParsedVersion::parse(version);
+
+    match parsed_range {
+        VersionRange::Exact(target) => compare_parsed(&v, &target) == Ordering::Equal,
+        VersionRange::Minimum { version, inclusive } => satisfies_min(&v, &version, inclusive),
+        VersionRange::Maximum { version, inclusive } => satisfies_max(&v, &version, inclusive),
+        VersionRange::Bounded {
+            min,
+            min_inclusive,
+            max,
+            max_inclusive,
+        } => satisfies_min(&v, &min, min_inclusive) && satisfies_max(&v, &max, max_inclusive),
+    }
+}
+
+/// A parsed floating-version pattern (spec §2).
+enum FloatPattern {
+    /// `*` (stable only) or `*-*` (including prerelease).
+    Any { include_prerelease: bool },
+    /// `1.1.*` (stable only) or `1.1.*-*` (including prerelease); `prefix` is the
+    /// dot-separated numeric prefix (e.g. `"1.1"`).
+    NumericPrefix {
+        prefix: String,
+        include_prerelease: bool,
+    },
+    /// `1.2.0-rc.*`: matches the stable version `1.2.0` itself, or any prerelease whose
+    /// numeric core is `1.2.0` and whose prerelease label starts with `rc`.
+    PrereleaseLabelPrefix {
+        stable_prefix: String,
+        label_prefix: String,
+    },
+}
+
+fn parse_float(pattern: &str) -> Option<FloatPattern> {
+    let pattern = pattern.trim();
+    if pattern == "*" {
+        return Some(FloatPattern::Any {
+            include_prerelease: false,
+        });
+    }
+    if pattern == "*-*" {
+        return Some(FloatPattern::Any {
+            include_prerelease: true,
+        });
+    }
+
+    if let Some(prefix) = pattern.strip_suffix(".*-*") {
+        return Some(FloatPattern::NumericPrefix {
+            prefix: prefix.to_string(),
+            include_prerelease: true,
+        });
+    }
+
+    if let Some(prefix) = pattern.strip_suffix(".*") {
+        if let Some((stable, label)) = prefix.split_once('-') {
+            return Some(FloatPattern::PrereleaseLabelPrefix {
+                stable_prefix: stable.to_string(),
+                label_prefix: label.to_string(),
+            });
+        }
+        return Some(FloatPattern::NumericPrefix {
+            prefix: prefix.to_string(),
+            include_prerelease: false,
+        });
+    }
+
+    None
+}
+
+/// Returns true if `version`'s numeric core has `prefix` as an exact dot-separated
+/// component prefix (e.g. `"1.1"` matches `"1.1.5"` but not `"1.10"`).
+fn numeric_prefix_matches(version: &str, prefix: &str) -> bool {
+    let core = version.split(['-', '+']).next().unwrap_or(version);
+    let core_parts: Vec<&str> = core.split('.').collect();
+    let prefix_parts: Vec<&str> = prefix.split('.').collect();
+    if prefix_parts.len() > core_parts.len() {
+        return false;
+    }
+    core_parts
+        .iter()
+        .zip(prefix_parts.iter())
+        .all(|(c, p)| c == p)
+}
+
+/// Returns true if `version`'s numeric core exactly equals `stable_prefix`'s numeric core.
+fn stable_core_matches(version: &str, stable_prefix: &str) -> bool {
+    let v = ParsedVersion::parse(version);
+    let s = ParsedVersion::parse(stable_prefix);
+    v.major == s.major && v.minor == s.minor && v.patch == s.patch && v.revision == s.revision
+}
+
+/// Returns true if `version`'s prerelease label starts with `label_prefix`, case-insensitively.
+fn prerelease_label_starts_with(version: &str, label_prefix: &str) -> bool {
+    let Some((_, pre)) = version.split_once('-') else {
+        return false;
+    };
+    let pre = pre.split('+').next().unwrap_or(pre);
+    pre.to_lowercase().starts_with(&label_prefix.to_lowercase())
+}
+
+/// Resolves a floating-version pattern (`*`, `1.1.*`, `*-*`, `1.2.0-rc.*`, ...) against a
+/// list of available versions, returning the highest matching version.
+///
+/// Prerelease versions are excluded unless the pattern is itself prerelease-bearing
+/// (`*-*`, `*.-*`) or the prerelease-label-prefix form is used. Returns `None` if the
+/// pattern cannot be parsed or no version matches.
+pub fn resolve_float<'a>(versions: &'a [String], pattern: &str) -> Option<&'a str> {
+    let float = parse_float(pattern)?;
+    let mut best: Option<(&'a str, ParsedVersion)> = None;
+
+    for v in versions {
+        let parsed = ParsedVersion::parse(v);
+        let matches = match &float {
+            FloatPattern::Any { include_prerelease } => {
+                *include_prerelease || parsed.pre.is_empty()
+            }
+            FloatPattern::NumericPrefix {
+                prefix,
+                include_prerelease,
+            } => {
+                (*include_prerelease || parsed.pre.is_empty()) && numeric_prefix_matches(v, prefix)
+            }
+            FloatPattern::PrereleaseLabelPrefix {
+                stable_prefix,
+                label_prefix,
+            } => {
+                stable_core_matches(v, stable_prefix)
+                    && (parsed.pre.is_empty() || prerelease_label_starts_with(v, label_prefix))
+            }
+        };
+        if !matches {
+            continue;
+        }
+
+        let is_better = best.as_ref().is_none_or(|(_, best_parsed)| {
+            compare_parsed(&parsed, best_parsed) == Ordering::Greater
+        });
+        if is_better {
+            best = Some((v.as_str(), parsed));
+        }
+    }
+
+    best.map(|(v, _)| v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compare_versions_basic() {
+        assert_eq!(compare_versions("1.0.0", "1.0.0"), Ordering::Equal);
+        assert_eq!(compare_versions("1.0.1", "1.0.0"), Ordering::Greater);
+        assert_eq!(compare_versions("1.0.0", "1.0.1"), Ordering::Less);
+        assert_eq!(compare_versions("2.0.0", "1.9.9"), Ordering::Greater);
+        assert_eq!(compare_versions("10.0.0", "9.0.0"), Ordering::Greater);
+    }
+
+    #[test]
+    fn test_compare_versions_missing_components_are_zero() {
+        assert_eq!(compare_versions("1.0", "1.0.0"), Ordering::Equal);
+        assert_eq!(compare_versions("1", "1.0.0.0"), Ordering::Equal);
+        assert_eq!(compare_versions("1.2", "1.2.0.1"), Ordering::Less);
+    }
+
+    #[test]
+    fn test_compare_versions_four_component() {
+        assert_eq!(compare_versions("1.0.0.1", "1.0.0.0"), Ordering::Greater);
+        assert_eq!(compare_versions("1.0.0.10", "1.0.0.9"), Ordering::Greater);
+    }
+
+    #[test]
+    fn test_compare_versions_stable_beats_prerelease() {
+        assert_eq!(compare_versions("1.0.0", "1.0.0-rc"), Ordering::Greater);
+        assert_eq!(compare_versions("1.0.0-rc", "1.0.0"), Ordering::Less);
+    }
+
+    #[test]
+    fn test_compare_versions_prerelease_case_insensitive() {
+        assert_eq!(
+            compare_versions("1.0.0-Alpha", "1.0.0-alpha"),
+            Ordering::Equal
+        );
+        assert_eq!(
+            compare_versions("1.0.0-RC.1", "1.0.0-rc.1"),
+            Ordering::Equal
+        );
+    }
+
+    #[test]
+    fn test_compare_versions_prerelease_numeric_vs_alphanumeric() {
+        // Numeric identifiers always have lower precedence than alphanumeric ones.
+        assert_eq!(compare_versions("1.0.0-1", "1.0.0-alpha"), Ordering::Less);
+    }
+
+    #[test]
+    fn test_compare_versions_prerelease_more_fields_higher_precedence() {
+        assert_eq!(
+            compare_versions("1.0.0-alpha.1", "1.0.0-alpha"),
+            Ordering::Greater
+        );
+    }
+
+    #[test]
+    fn test_compare_versions_build_metadata_ignored() {
+        assert_eq!(
+            compare_versions("1.0.0+build1", "1.0.0+build2"),
+            Ordering::Equal
+        );
+        assert_eq!(
+            compare_versions("1.0.0-rc+build1", "1.0.0-rc+build2"),
+            Ordering::Equal
+        );
+    }
+
+    #[test]
+    fn test_is_prerelease_dotnet_labels() {
+        // Real .NET prerelease labels that the shared keyword sniff in
+        // deps_core::registry::Version::is_prerelease (-alpha|-beta|-rc|-dev|-pre|-snapshot|
+        // -canary|-nightly) would all misclassify as stable.
+        assert!(is_prerelease("13.0.0-rtm"));
+        assert!(is_prerelease("8.0.0-servicing.23"));
+        assert!(is_prerelease("1.0.0-CI-20240101"));
+        assert!(is_prerelease("6.0.0-final"));
+        assert!(is_prerelease("7.0.0-preview.1"));
+    }
+
+    #[test]
+    fn test_is_prerelease_stable() {
+        assert!(!is_prerelease("1.0.0"));
+        assert!(!is_prerelease("13.0.0"));
+        assert!(!is_prerelease("1.0.0.5"));
+    }
+
+    #[test]
+    fn test_is_prerelease_ignores_build_metadata() {
+        assert!(!is_prerelease("1.0.0+build-with-dash"));
+        assert!(is_prerelease("1.0.0-rc+build"));
+    }
+
+    #[test]
+    fn test_satisfies_bare_is_minimum_inclusive() {
+        assert!(satisfies("1.0.0", "1.0"));
+        assert!(satisfies("2.0.0", "1.0"));
+        assert!(!satisfies("0.9.0", "1.0"));
+    }
+
+    #[test]
+    fn test_satisfies_exact_pin() {
+        assert!(satisfies("1.0.0", "[1.0]"));
+        assert!(satisfies("1.0", "[1.0.0]"));
+        assert!(!satisfies("1.0.1", "[1.0]"));
+    }
+
+    #[test]
+    fn test_satisfies_open_minimum() {
+        assert!(satisfies("1.0.0", "[1.0,)"));
+        assert!(satisfies("1.5.0", "[1.0,)"));
+        assert!(!satisfies("0.9.0", "[1.0,)"));
+
+        assert!(satisfies("1.0.1", "(1.0,)"));
+        assert!(!satisfies("1.0.0", "(1.0,)"));
+    }
+
+    #[test]
+    fn test_satisfies_open_maximum() {
+        assert!(satisfies("1.0.0", "(,1.0]"));
+        assert!(!satisfies("1.0.1", "(,1.0]"));
+
+        assert!(satisfies("0.9.0", "(,1.0)"));
+        assert!(!satisfies("1.0.0", "(,1.0)"));
+    }
+
+    #[test]
+    fn test_satisfies_bounded() {
+        assert!(satisfies("1.5.0", "[1.0,2.0]"));
+        assert!(satisfies("2.0.0", "[1.0,2.0]"));
+        assert!(!satisfies("2.0.0", "[1.0,2.0)"));
+        assert!(!satisfies("1.0.0", "(1.0,2.0)"));
+        assert!(satisfies("1.0.1", "(1.0,2.0)"));
+        assert!(!satisfies("1.0.0", "(1.0,2.0]"));
+        assert!(satisfies("1.0.1", "(1.0,2.0]"));
+    }
+
+    #[test]
+    fn test_satisfies_malformed_range_returns_false() {
+        assert!(!satisfies("1.0.0", ""));
+        assert!(!satisfies("1.0.0", "[1.0"));
+        assert!(!satisfies("1.0.0", "(,)"));
+    }
+
+    #[test]
+    fn test_resolve_float_any_stable_only() {
+        let versions: Vec<String> = ["1.0.0", "2.0.0-rc", "1.5.0"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        assert_eq!(resolve_float(&versions, "*"), Some("1.5.0"));
+    }
+
+    #[test]
+    fn test_resolve_float_any_including_prerelease() {
+        let versions: Vec<String> = ["1.0.0", "2.0.0-rc", "1.5.0"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        assert_eq!(resolve_float(&versions, "*-*"), Some("2.0.0-rc"));
+    }
+
+    #[test]
+    fn test_resolve_float_numeric_prefix_stable() {
+        let versions: Vec<String> = ["1.1.0", "1.1.5", "1.2.0", "1.1.9-beta"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        assert_eq!(resolve_float(&versions, "1.1.*"), Some("1.1.5"));
+    }
+
+    #[test]
+    fn test_resolve_float_numeric_prefix_including_prerelease() {
+        let versions: Vec<String> = ["1.1.0", "1.1.5", "1.1.9-beta"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        assert_eq!(resolve_float(&versions, "1.1.*-*"), Some("1.1.9-beta"));
+    }
+
+    #[test]
+    fn test_resolve_float_prerelease_label_prefix_stable_wins() {
+        let versions: Vec<String> = ["1.2.0-rc.1", "1.2.0-rc.2", "1.2.0"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        assert_eq!(resolve_float(&versions, "1.2.0-rc.*"), Some("1.2.0"));
+    }
+
+    #[test]
+    fn test_resolve_float_prerelease_label_prefix_no_stable() {
+        let versions: Vec<String> = ["1.2.0-rc.1", "1.2.0-rc.2", "1.2.0-beta"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        assert_eq!(resolve_float(&versions, "1.2.0-rc.*"), Some("1.2.0-rc.2"));
+    }
+
+    #[test]
+    fn test_resolve_float_no_match_returns_none() {
+        let versions: Vec<String> = vec!["2.0.0".to_string()];
+        assert_eq!(resolve_float(&versions, "1.1.*"), None);
+    }
+
+    #[test]
+    fn test_resolve_float_invalid_pattern_returns_none() {
+        let versions: Vec<String> = vec!["1.0.0".to_string()];
+        assert_eq!(resolve_float(&versions, "not-a-pattern"), None);
+    }
+}

--- a/crates/deps-nuget/tests/fixtures/Directory.Packages.props
+++ b/crates/deps-nuget/tests/fixtures/Directory.Packages.props
@@ -1,0 +1,13 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Serilog" Version="3.1.1" />
+    <PackageVersion Include="MyCompany.Shared" Version="2.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/crates/deps-nuget/tests/fixtures/central_package_management.csproj
+++ b/crates/deps-nuget/tests/fixtures/central_package_management.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Serilog" />
+  </ItemGroup>
+
+</Project>

--- a/crates/deps-nuget/tests/fixtures/child_element.csproj
+++ b/crates/deps-nuget/tests/fixtures/child_element.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog">
+      <Version>3.1.1</Version>
+    </PackageReference>
+    <PackageReference Include="Serilog.Sinks.Console">
+      <Version>5.0.1</Version>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/crates/deps-nuget/tests/fixtures/complex.csproj
+++ b/crates/deps-nuget/tests/fixtures/complex.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Attribute form -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+
+    <!-- Child-element metadata form -->
+    <PackageReference Include="Serilog">
+      <Version>3.1.1</Version>
+    </PackageReference>
+
+    <!-- Central package management: no Version at all -->
+    <PackageReference Include="MyCompany.Shared" />
+
+    <!-- Unresolvable MSBuild property expression -->
+    <PackageReference Include="AutoMapper" Version="$(AutoMapperVersion)" />
+
+    <!-- Condition attribute containing a literal 'Version="' trap -->
+    <PackageReference Include="System.Text.Json" Condition="'$(TargetFramework)' == 'net472' AND '$(Foo)' == 'Version=&quot;1.0.0&quot;'" Version="8.0.5" />
+
+    <!-- Single-quoted attributes -->
+    <PackageReference Include='Polly' Version='8.4.1' />
+  </ItemGroup>
+
+</Project>

--- a/crates/deps-nuget/tests/fixtures/malformed.csproj
+++ b/crates/deps-nuget/tests/fixtures/malformed.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3"
+  </ItemGroup>
+</Project>

--- a/crates/deps-nuget/tests/fixtures/packages.config
+++ b/crates/deps-nuget/tests/fixtures/packages.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
+  <package id="Serilog" version="3.1.1" targetFramework="net48" />
+  <package id="EntityFramework" version="6.4.4" targetFramework="net48" developmentDependency="true" />
+</packages>

--- a/crates/deps-nuget/tests/fixtures/packages.lock.json
+++ b/crates/deps-nuget/tests/fixtures/packages.lock.json
@@ -1,0 +1,30 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net8.0": {
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.3, )",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXBEziyloDdCoLBjs1uCOWMlt/0oaVjA3czqISVMi1u5D9tPtC1XSf+7A0ndowVI30Xj9tspZeVj+lPd0g=="
+      },
+      "Serilog": {
+        "type": "Direct",
+        "requested": "[3.1.1, )",
+        "resolved": "3.1.1",
+        "contentHash": "P6yxIe5BQKhPfrOMBBEz9zvT6yn/gBqSjxfQ9Ex+8Ilo0+KcRSY6P+iXqTNAvsdWkBaSPUJIAMg1kdgHUqvxKw=="
+      },
+      "MyCompany.Shared": {
+        "type": "Project"
+      }
+    },
+    "net472": {
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.3, )",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXBEziyloDdCoLBjs1uCOWMlt/0oaVjA3czqISVMi1u5D9tPtC1XSf+7A0ndowVI30Xj9tspZeVj+lPd0g=="
+      }
+    }
+  }
+}

--- a/crates/deps-nuget/tests/fixtures/simple.csproj
+++ b/crates/deps-nuget/tests/fixtures/simple.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+  </ItemGroup>
+
+</Project>

--- a/crates/deps-nuget/tests/integration_tests.rs
+++ b/crates/deps-nuget/tests/integration_tests.rs
@@ -1,0 +1,160 @@
+//! Integration tests using fixture files.
+
+use deps_core::lockfile::LockFileProvider;
+use deps_nuget::{
+    NuGetLockParser, parse_directory_packages_props, parse_packages_config, parse_project_file,
+};
+use tower_lsp_server::ls_types::Uri;
+
+fn fixture_uri(name: &str) -> Uri {
+    #[cfg(windows)]
+    let path = format!("C:/test/{name}");
+    #[cfg(not(windows))]
+    let path = format!("/test/{name}");
+    Uri::from_file_path(path).unwrap()
+}
+
+fn load_fixture(name: &str) -> String {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {name}: {e}"))
+}
+
+#[test]
+fn test_fixture_simple_csproj() {
+    let content = load_fixture("simple.csproj");
+    let result = parse_project_file(&content, &fixture_uri("simple.csproj")).unwrap();
+    assert_eq!(result.dependencies.len(), 2);
+    assert_eq!(result.dependencies[0].name, "Newtonsoft.Json");
+    assert_eq!(
+        result.dependencies[0].version_requirement,
+        Some("13.0.3".into())
+    );
+    assert_eq!(result.dependencies[1].name, "Serilog");
+    assert_eq!(
+        result.dependencies[1].version_requirement,
+        Some("3.1.1".into())
+    );
+}
+
+#[test]
+fn test_fixture_child_element_csproj() {
+    let content = load_fixture("child_element.csproj");
+    let result = parse_project_file(&content, &fixture_uri("child_element.csproj")).unwrap();
+    assert_eq!(result.dependencies.len(), 2);
+    assert_eq!(
+        result.dependencies[0].version_requirement,
+        Some("3.1.1".into())
+    );
+    assert_eq!(
+        result.dependencies[1].version_requirement,
+        Some("5.0.1".into())
+    );
+}
+
+#[test]
+fn test_fixture_central_package_management_csproj() {
+    let content = load_fixture("central_package_management.csproj");
+    let result =
+        parse_project_file(&content, &fixture_uri("central_package_management.csproj")).unwrap();
+    assert_eq!(result.dependencies.len(), 2);
+    for dep in &result.dependencies {
+        assert!(dep.version_requirement.is_none());
+        assert!(dep.version_range.is_none());
+    }
+}
+
+#[test]
+fn test_fixture_complex_csproj() {
+    let content = load_fixture("complex.csproj");
+    let result = parse_project_file(&content, &fixture_uri("complex.csproj")).unwrap();
+    assert_eq!(result.dependencies.len(), 6);
+
+    let by_name: std::collections::HashMap<&str, &deps_nuget::NuGetDependency> = result
+        .dependencies
+        .iter()
+        .map(|d| (d.name.as_str(), d))
+        .collect();
+
+    assert_eq!(
+        by_name["Newtonsoft.Json"].version_requirement,
+        Some("13.0.3".into())
+    );
+    assert_eq!(by_name["Serilog"].version_requirement, Some("3.1.1".into()));
+    // Central package management: no version at all.
+    assert!(by_name["MyCompany.Shared"].version_requirement.is_none());
+    // Unresolvable MSBuild property expression degrades to None.
+    assert!(by_name["AutoMapper"].version_requirement.is_none());
+    // Condition attribute containing a literal `Version="` must not confuse the parser.
+    assert_eq!(
+        by_name["System.Text.Json"].version_requirement,
+        Some("8.0.5".into())
+    );
+    // Single-quoted attributes.
+    assert_eq!(by_name["Polly"].version_requirement, Some("8.4.1".into()));
+}
+
+#[test]
+fn test_fixture_malformed_csproj_errors() {
+    let content = load_fixture("malformed.csproj");
+    let result = parse_project_file(&content, &fixture_uri("malformed.csproj"));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_fixture_directory_packages_props() {
+    let content = load_fixture("Directory.Packages.props");
+    let result =
+        parse_directory_packages_props(&content, &fixture_uri("Directory.Packages.props")).unwrap();
+    assert_eq!(result.dependencies.len(), 3);
+    assert_eq!(result.dependencies[0].name, "Newtonsoft.Json");
+    assert_eq!(
+        result.dependencies[0].version_requirement,
+        Some("13.0.3".into())
+    );
+}
+
+#[test]
+fn test_fixture_packages_config_normalizes_exact_pin() {
+    let content = load_fixture("packages.config");
+    let result = parse_packages_config(&content, &fixture_uri("packages.config")).unwrap();
+    assert_eq!(result.dependencies.len(), 3);
+    for dep in &result.dependencies {
+        let req = dep.version_requirement.as_deref().unwrap();
+        assert!(
+            req.starts_with('[') && req.ends_with(']'),
+            "expected bracketed exact pin for {}, got {req}",
+            dep.name
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_fixture_packages_lock_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    let content = load_fixture("packages.lock.json");
+    let lock_path = tmp.path().join("packages.lock.json");
+    tokio::fs::write(&lock_path, &content).await.unwrap();
+
+    let parser = NuGetLockParser;
+    let resolved = parser.parse_lockfile(&lock_path).await.unwrap();
+
+    // MyCompany.Shared ("type": "Project", no "resolved") must be skipped, not abort parsing.
+    assert_eq!(resolved.len(), 2);
+    assert_eq!(resolved.get_version("Newtonsoft.Json"), Some("13.0.3"));
+    assert_eq!(resolved.get_version("Serilog"), Some("3.1.1"));
+    assert!(resolved.get("MyCompany.Shared").is_none());
+}
+
+#[test]
+fn test_parse_result_trait() {
+    use deps_core::ParseResult;
+
+    let content = load_fixture("simple.csproj");
+    let result = parse_project_file(&content, &fixture_uri("simple.csproj")).unwrap();
+
+    assert_eq!(result.dependencies().len(), 2);
+    assert!(result.workspace_root().is_none());
+    assert!(result.as_any().is::<deps_nuget::NuGetParseResult>());
+}

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -677,6 +677,7 @@ See existing implementations for reference:
 - `crates/deps-dart/` - Dart/pubspec.yaml with pub.dev
 - `crates/deps-maven/` - Java/pom.xml with Maven Central
 - `crates/deps-gradle/` - Kotlin/Gradle version catalogs
+- `crates/deps-nuget/` - C#/.csproj with NuGet V3
 
 ## Key API Contracts
 


### PR DESCRIPTION
## Summary
- Adds `deps-nuget`, a new ecosystem crate providing NuGet/.NET support: `.csproj`/`.fsproj`/`.vbproj` (`PackageReference`, attribute and child-element form, with Central Package Management entries degrading to no version requirement), `Directory.Packages.props` (`PackageVersion`), legacy `packages.config` (normalized to an exact-pin range), and `packages.lock.json` lock files.
- Backed by the NuGet V3 registry API: service index resolution, flat-container version enumeration, and `SearchQueryService` search (with the mandatory `semVerLevel=2.0.0` parameter).
- Version comparison is hand-rolled (4-component `Major.Minor.Patch.Revision`, SemVer2 prerelease precedence with case-insensitive labels, interval and floating-version syntax), since no maintained crate supports NuGet's versioning scheme — following the precedent already set by `deps-maven`.
- `deps_core::Ecosystem` gains `manifest_extensions()`, a defaulted trait method (zero behavior change for the ten existing ecosystems) enabling extension-based routing fallback in `EcosystemRegistry::get_for_filename`, required because `.csproj`/`.fsproj`/`.vbproj` basenames are arbitrary and cannot be matched by the existing exact-filename dispatcher.
- Root `README.md` and `docs/ECOSYSTEM_GUIDE.md` updated to list NuGet alongside the other ecosystems.

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (1452 passed, 0 failed, 37 skipped)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --all-features`
- [x] `cargo test --doc --all-features -p deps-nuget -p deps-core -p deps-lsp`
- [x] `cargo deny check advisories`
- [x] 118 crate unit tests + 9 fixture-based integration tests for `deps-nuget`, plus 4 new regression tests for `deps-core`'s extension-based routing
- [x] Live-verified NuGet V3 registry facts (service index indirection, mandatory `semVerLevel=2.0.0`, flat-container response shape) against `api.nuget.org`
- [x] Security-reviewed: a live-confirmed medium-severity issue (unencoded package id enabling path traversal / package-identity spoofing in the flat-container URL) was found and fixed, with regression tests added