### PR TITLE
release: v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-08-20
+
 ### Removed
 - **Breaking (pre-1.0, internal API)**: deleted dead ecosystem-specific error variants, constructor helpers, and `DepsError`⇄ecosystem `From` conversions across all 11 registry-integrated crates. Evidence: none of these types were referenced by any consumer outside their own crate's `error.rs` (verified via workspace-wide `rg`), and registry code across the crates already returned `deps_core::DepsError` in 8 of 11 cases — the deleted variants existed only to be immediately round-tripped back into a `DepsError` with a lossier message, or were never constructed at all. Per-crate:
   - **deps-cargo**: `CargoError::{InvalidVersionSpecifier, PackageNotFound, RegistryError, ApiResponseError, InvalidStructure, MissingField, WorkspaceError, CacheError, Other}` and their constructor helpers; `impl From<DepsError> for CargoError`. Kept: `TomlParseError`, `InvalidUri`.
@@ -514,7 +516,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TLS enforced via rustls
 - cargo-deny configured for vulnerability scanning
 
-[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.10.1...HEAD
+[0.10.1]: https://github.com/bug-ops/deps-lsp/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/bug-ops/deps-lsp/compare/v0.9.5...v0.10.0
 [0.9.5]: https://github.com/bug-ops/deps-lsp/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/bug-ops/deps-lsp/compare/v0.9.3...v0.9.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "deps-bundler"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "criterion",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "deps-cargo"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "criterion",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "deps-composer"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "deps-core",
  "serde",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "deps-core"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "deps-dart"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "criterion",
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "deps-go"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "criterion",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "deps-gradle"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "deps-core",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "deps-lsp"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "criterion",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "deps-maven"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "deps-core",
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "deps-npm"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "criterion",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "deps-nuget"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "criterion",
  "deps-core",
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "deps-pypi"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "criterion",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "deps-swift"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "deps-core",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/deps-zed"]
 resolver = "3"
 
 [workspace.package]
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 rust-version = "1.91"
 authors = ["Andrei G"]
@@ -15,19 +15,19 @@ repository = "https://github.com/bug-ops/deps-lsp"
 async-trait = "0.1"
 criterion = "0.8"
 dashmap = "6.2"
-deps-core = { version = "0.10.0", path ="crates/deps-core" }
-deps-cargo = { version = "0.10.0", path ="crates/deps-cargo" }
-deps-npm = { version = "0.10.0", path ="crates/deps-npm" }
-deps-pypi = { version = "0.10.0", path ="crates/deps-pypi" }
-deps-go = { version = "0.10.0", path ="crates/deps-go" }
-deps-bundler = { version = "0.10.0", path ="crates/deps-bundler" }
-deps-dart = { version = "0.10.0", path ="crates/deps-dart" }
-deps-maven = { version = "0.10.0", path ="crates/deps-maven" }
-deps-nuget = { version = "0.10.0", path ="crates/deps-nuget" }
-deps-composer = { version = "0.10.0", path ="crates/deps-composer" }
-deps-gradle = { version = "0.10.0", path ="crates/deps-gradle" }
-deps-swift = { version = "0.10.0", path ="crates/deps-swift" }
-deps-lsp = { version = "0.10.0", path ="crates/deps-lsp" }
+deps-core = { version = "0.10.1", path ="crates/deps-core" }
+deps-cargo = { version = "0.10.1", path ="crates/deps-cargo" }
+deps-npm = { version = "0.10.1", path ="crates/deps-npm" }
+deps-pypi = { version = "0.10.1", path ="crates/deps-pypi" }
+deps-go = { version = "0.10.1", path ="crates/deps-go" }
+deps-bundler = { version = "0.10.1", path ="crates/deps-bundler" }
+deps-dart = { version = "0.10.1", path ="crates/deps-dart" }
+deps-maven = { version = "0.10.1", path ="crates/deps-maven" }
+deps-nuget = { version = "0.10.1", path ="crates/deps-nuget" }
+deps-composer = { version = "0.10.1", path ="crates/deps-composer" }
+deps-gradle = { version = "0.10.1", path ="crates/deps-gradle" }
+deps-swift = { version = "0.10.1", path ="crates/deps-swift" }
+deps-lsp = { version = "0.10.1", path ="crates/deps-lsp" }
 futures = "0.3"
 insta = "1.48"
 mockito = "1"


### PR DESCRIPTION
## Summary

- Bump version from 0.10.0 to 0.10.1
- Move Unreleased changelog content into a dated 0.10.1 section

## Checklist

- [x] Version updated in all manifests
- [x] CHANGELOG.md has release section with date
- [x] README reflects new version (no hardcoded version references needed updating)
- [x] All CI checks pass locally (fmt, clippy, nextest, rustdoc)
- [ ] Ready for tagging after merge