### PR TITLE
fix(deps-lsp): bound didOpen/didChange content size, derive ecosystem_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **deps-lsp**: `DocumentState::ecosystem_id: &'static str` is now a method (`ecosystem_id()`) instead of a stored field, since it was always fully derived from `ecosystem: EcosystemId` — removes the possibility of the two falling out of sync. `handlers::completion::fallback_completion` now takes the already-typed `EcosystemId` instead of re-parsing it from the `&str` id (resolves #155).
+- **deps-go, deps-pypi, deps-lsp**: resolved a pre-existing `clippy::unused_async_trait_impl` failure (`deps-go::GoEcosystem::{complete_package_names, complete_features}`, `deps-pypi::PypiRegistry::search`, `deps-lsp::Backend::shutdown`) by dropping `async` from these trait/inherent methods with no `.await` in their body and returning `std::future::ready(..)` instead; behavior is unchanged since no branch of any of these functions ever awaited anything.
 
 ## [0.10.1] - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **deps-lsp**: content received via `textDocument/didOpen`/`didChange` had no size bound before reaching `ecosystem.parse_manifest`, unlike disk-loaded documents (cold start), which were already capped at `MAX_FILE_SIZE` (10MB) in `document::loader`. `document::lifecycle::{handle_document_open, handle_document_change}` now reject content over the same 10MB limit before parsing; the rejected content is never stored or parsed. Both `Backend::handle_open` and `Backend::handle_change` (`server.rs`) now surface the rejection to the client via `window/logMessage` (previously `handle_change`'s error arm only logged server-side via `tracing::error!`, so a rejected `didChange` left the client editing against a stale server-side document with no client-visible signal that the edit was never applied) (resolves #161).
+
+### Changed
+- **deps-lsp**: `DocumentState::ecosystem_id: &'static str` is now a method (`ecosystem_id()`) instead of a stored field, since it was always fully derived from `ecosystem: EcosystemId` — removes the possibility of the two falling out of sync. `handlers::completion::fallback_completion` now takes the already-typed `EcosystemId` instead of re-parsing it from the `&str` id (resolves #155).
+
 ## [0.10.1] - 2026-08-20
 
 ### Removed

--- a/crates/deps-go/src/ecosystem.rs
+++ b/crates/deps-go/src/ecosystem.rs
@@ -47,10 +47,10 @@ impl GoEcosystem {
     /// - Popular packages database
     /// - Local workspace module paths
     /// - Integration with go.sum for recently used modules
-    async fn complete_package_names(&self, _prefix: &str) -> Vec<CompletionItem> {
+    fn complete_package_names(&self, _prefix: &str) -> impl Future<Output = Vec<CompletionItem>> {
         // Go modules don't have a centralized search API
         // Users typically know the full module path
-        vec![]
+        std::future::ready(vec![])
     }
 
     async fn complete_versions(&self, package_name: &str, prefix: &str) -> Vec<CompletionItem> {
@@ -67,9 +67,13 @@ impl GoEcosystem {
     ///
     /// Go modules don't have a feature flag system like Cargo.
     /// Returns empty results.
-    async fn complete_features(&self, _package_name: &str, _prefix: &str) -> Vec<CompletionItem> {
+    fn complete_features(
+        &self,
+        _package_name: &str,
+        _prefix: &str,
+    ) -> impl Future<Output = Vec<CompletionItem>> {
         // Go modules don't have feature flags
-        vec![]
+        std::future::ready(vec![])
     }
 }
 

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -3,7 +3,7 @@
 //! This module provides unified open/change/close handlers that work with
 //! the ecosystem trait architecture, eliminating per-ecosystem duplication.
 
-use super::loader::load_document_from_disk;
+use super::loader::{MAX_FILE_SIZE, load_document_from_disk};
 use super::state::{DocumentState, ServerState};
 use crate::config::DepsConfig;
 use crate::handlers::diagnostics;
@@ -29,6 +29,33 @@ fn resolve_ecosystem_id(ecosystem: &dyn Ecosystem) -> EcosystemId {
         .id()
         .parse()
         .expect("ecosystem.id() must be a registered EcosystemId")
+}
+
+/// Rejects document content larger than [`MAX_FILE_SIZE`].
+///
+/// Content from `textDocument/didOpen`/`didChange` reaches this crate directly
+/// over the LSP protocol, with no filesystem `metadata()` size check to gate on
+/// beforehand (unlike [`load_document_from_disk`], which checks before reading).
+/// This applies the same bound so an oversized payload is rejected before it
+/// ever reaches `ecosystem.parse_manifest`.
+///
+/// # Errors
+///
+/// Returns `Err(DepsError::CacheError)` if `content` exceeds `MAX_FILE_SIZE`.
+fn check_content_size(content: &str, uri: &Uri) -> Result<()> {
+    let size = content.len() as u64;
+    if size > MAX_FILE_SIZE {
+        tracing::error!(
+            "Document content exceeds maximum size: {} bytes (limit: {} bytes) for {:?}",
+            size,
+            MAX_FILE_SIZE,
+            uri
+        );
+        return Err(deps_core::error::DepsError::CacheError(format!(
+            "document too large: {size} bytes (max: {MAX_FILE_SIZE} bytes)"
+        )));
+    }
+    Ok(())
 }
 
 /// Preserves cached version data from old document state to new state.
@@ -198,6 +225,8 @@ pub async fn handle_document_open(
             )));
         }
     };
+
+    check_content_size(&content, &uri)?;
 
     tracing::info!(
         "Opening {:?} with ecosystem: {}",
@@ -372,6 +401,8 @@ pub async fn handle_document_change(
             )));
         }
     };
+
+    check_content_size(&content, &uri)?;
 
     // Extract old dependency names before parsing (for diff computation)
     let old_dep_names: HashSet<String> =
@@ -731,6 +762,26 @@ mod tests {
         let state = ServerState::new();
         let unknown_uri = deps_core::test_util::test_uri("/test/unknown.txt");
         assert!(state.ecosystem_registry.get_for_uri(&unknown_uri).is_none());
+    }
+
+    #[test]
+    fn test_check_content_size_accepts_content_within_limit() {
+        let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+        let content = "a".repeat(MAX_FILE_SIZE as usize);
+        assert!(check_content_size(&content, &uri).is_ok());
+    }
+
+    #[test]
+    fn test_check_content_size_rejects_content_over_limit() {
+        let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+        let content = "a".repeat(MAX_FILE_SIZE as usize + 1);
+        let result = check_content_size(&content, &uri);
+        match result {
+            Err(deps_core::error::DepsError::CacheError(msg)) => {
+                assert!(msg.contains("too large"), "unexpected message: {msg}");
+            }
+            other => panic!("Expected CacheError, got {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -1259,7 +1310,7 @@ serde = "1.0"
 
             assert_eq!(state.document_count(), 1);
             let doc = state.get_document(&uri).unwrap();
-            assert_eq!(doc.ecosystem_id, "cargo");
+            assert_eq!(doc.ecosystem_id(), "cargo");
         }
 
         #[tokio::test]
@@ -1300,7 +1351,7 @@ serde = "1.0"
             );
 
             let doc = doc.unwrap();
-            assert_eq!(doc.ecosystem_id, "cargo");
+            assert_eq!(doc.ecosystem_id(), "cargo");
             assert_eq!(doc.content, content);
             assert!(
                 doc.parse_result().is_none(),
@@ -1417,6 +1468,147 @@ serde = "1.0""#;
                 "Should still have only 1 document"
             );
         }
+
+        #[tokio::test]
+        async fn test_handle_document_open_rejects_oversized_content() {
+            use crate::test_utils::test_helpers::create_test_client_and_config;
+
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+            let oversized_content = "a".repeat(MAX_FILE_SIZE as usize + 1);
+            let (client, config) = create_test_client_and_config();
+
+            let result = handle_document_open(
+                uri.clone(),
+                oversized_content,
+                state.clone(),
+                client,
+                config,
+            )
+            .await;
+
+            assert!(result.is_err(), "Oversized content should be rejected");
+            match result {
+                Err(deps_core::error::DepsError::CacheError(msg)) => {
+                    assert!(
+                        msg.contains("too large"),
+                        "Error message should indicate size issue: {msg}"
+                    );
+                }
+                other => panic!("Expected CacheError for oversized content, got {other:?}"),
+            }
+            assert_eq!(
+                state.document_count(),
+                0,
+                "Oversized content must not be stored/parsed"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_handle_document_open_accepts_normal_sized_content() {
+            use crate::test_utils::test_helpers::create_test_client_and_config;
+
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+            let content = r#"[dependencies]
+serde = "1.0"
+"#
+            .to_string();
+            let (client, config) = create_test_client_and_config();
+
+            let result =
+                handle_document_open(uri.clone(), content, state.clone(), client, config).await;
+
+            assert!(result.is_ok(), "Normal-sized content should be accepted");
+            assert_eq!(state.document_count(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_handle_document_change_rejects_oversized_content() {
+            use crate::test_utils::test_helpers::create_test_client_and_config;
+
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+            let oversized_content = "a".repeat(MAX_FILE_SIZE as usize + 1);
+            let (client, config) = create_test_client_and_config();
+
+            let result = handle_document_change(
+                uri.clone(),
+                oversized_content,
+                state.clone(),
+                client,
+                config,
+            )
+            .await;
+
+            assert!(result.is_err(), "Oversized content should be rejected");
+            match result {
+                Err(deps_core::error::DepsError::CacheError(msg)) => {
+                    assert!(
+                        msg.contains("too large"),
+                        "Error message should indicate size issue: {msg}"
+                    );
+                }
+                other => panic!("Expected CacheError for oversized content, got {other:?}"),
+            }
+            assert_eq!(
+                state.document_count(),
+                0,
+                "Oversized content must not be stored/parsed"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_handle_document_change_rejects_oversized_content_preserves_existing_document()
+        {
+            use crate::test_utils::test_helpers::create_test_client_and_config;
+
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+            let original_content = r#"[dependencies]
+serde = "1.0"
+"#
+            .to_string();
+
+            // Open a valid document first (mirrors an already-open editor buffer).
+            let (client, config) = create_test_client_and_config();
+            handle_document_open(
+                uri.clone(),
+                original_content.clone(),
+                state.clone(),
+                client,
+                config,
+            )
+            .await
+            .expect("initial open should succeed");
+            assert_eq!(state.document_count(), 1);
+
+            // An oversized didChange must be rejected without touching the stored document.
+            let oversized_content = "a".repeat(MAX_FILE_SIZE as usize + 1);
+            let (client, config) = create_test_client_and_config();
+            let result = handle_document_change(
+                uri.clone(),
+                oversized_content,
+                state.clone(),
+                client,
+                config,
+            )
+            .await;
+
+            assert!(result.is_err(), "Oversized change should be rejected");
+            assert_eq!(
+                state.document_count(),
+                1,
+                "The previously stored document must survive a rejected change"
+            );
+            let doc = state
+                .get_document(&uri)
+                .expect("original document should still be present");
+            assert_eq!(
+                doc.content, original_content,
+                "Document content must be unchanged by the rejected change"
+            );
+        }
     }
 
     // npm-specific tests
@@ -1453,7 +1645,7 @@ serde = "1.0""#;
             state.update_document(uri.clone(), doc_state);
 
             let doc = state.get_document(&uri).unwrap();
-            assert_eq!(doc.ecosystem_id, "npm");
+            assert_eq!(doc.ecosystem_id(), "npm");
         }
     }
 
@@ -1493,7 +1685,7 @@ dependencies = ["requests>=2.0.0"]
             state.update_document(uri.clone(), doc_state);
 
             let doc = state.get_document(&uri).unwrap();
-            assert_eq!(doc.ecosystem_id, "pypi");
+            assert_eq!(doc.ecosystem_id(), "pypi");
         }
     }
 
@@ -1536,7 +1728,7 @@ require github.com/gorilla/mux v1.8.0
             state.update_document(uri.clone(), doc_state);
 
             let doc = state.get_document(&uri).unwrap();
-            assert_eq!(doc.ecosystem_id, "go");
+            assert_eq!(doc.ecosystem_id(), "go");
         }
     }
 

--- a/crates/deps-lsp/src/document/loader.rs
+++ b/crates/deps-lsp/src/document/loader.rs
@@ -32,12 +32,17 @@
 use deps_core::error::{DepsError, Result};
 use tower_lsp_server::ls_types::Uri;
 
-/// Maximum allowed file size in bytes (10MB).
+/// Maximum allowed file/document size in bytes (10MB).
 ///
 /// Files larger than this limit will be rejected to prevent excessive memory usage
 /// and performance degradation. This is a hard limit - files exceeding it cannot be loaded.
 /// Typical manifest files are <100KB, so 10MB provides ample headroom.
-const MAX_FILE_SIZE: u64 = 10_000_000; // 10MB
+///
+/// `pub(crate)` since [`super::lifecycle`] applies the same bound to content
+/// received directly over the LSP protocol (`textDocument/didOpen` /
+/// `textDocument/didChange`), which has no filesystem `metadata()` call to
+/// gate on before it reaches this crate.
+pub(crate) const MAX_FILE_SIZE: u64 = 10_000_000; // 10MB
 
 /// Large file warning threshold (1MB).
 ///

--- a/crates/deps-lsp/src/document/state.rs
+++ b/crates/deps-lsp/src/document/state.rs
@@ -35,10 +35,6 @@ pub use deps_core::LoadingState;
 pub struct DocumentState {
     /// Package ecosystem identifier, exhaustively typed.
     pub ecosystem: EcosystemId,
-    /// Ecosystem identifier as a `&'static str` (matches `ecosystem.id()`), kept
-    /// alongside `ecosystem` since registry lookups (`EcosystemRegistry::get`) are
-    /// keyed by string.
-    pub ecosystem_id: &'static str,
     /// Original document content
     pub content: String,
     /// Parsed result as trait object (new architecture)
@@ -61,7 +57,6 @@ impl Clone for DocumentState {
     fn clone(&self) -> Self {
         Self {
             ecosystem: self.ecosystem,
-            ecosystem_id: self.ecosystem_id,
             content: self.content.clone(),
             parse_result: None, // Don't clone trait object
             cached_versions: self.cached_versions.clone(),
@@ -157,7 +152,7 @@ impl std::fmt::Debug for DocumentState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DocumentState")
             .field("ecosystem", &self.ecosystem)
-            .field("ecosystem_id", &self.ecosystem_id)
+            .field("ecosystem_id", &self.ecosystem_id())
             .field("content_len", &self.content.len())
             .field("has_parse_result", &self.parse_result.is_some())
             .field("cached_versions_count", &self.cached_versions.len())
@@ -178,11 +173,8 @@ impl DocumentState {
         content: String,
         parse_result: Box<dyn ParseResult>,
     ) -> Self {
-        let ecosystem_id = ecosystem.id();
-
         Self {
             ecosystem,
-            ecosystem_id,
             content,
             parse_result: Some(parse_result),
             cached_versions: HashMap::new(),
@@ -198,11 +190,8 @@ impl DocumentState {
     /// Used when parsing fails but the document should still be stored
     /// to enable fallback completion and other LSP features.
     pub fn new_without_parse_result(ecosystem: EcosystemId, content: String) -> Self {
-        let ecosystem_id = ecosystem.id();
-
         Self {
             ecosystem,
-            ecosystem_id,
             content,
             parse_result: None,
             cached_versions: HashMap::new(),
@@ -211,6 +200,13 @@ impl DocumentState {
             loading_state: LoadingState::Idle,
             loading_started_at: None,
         }
+    }
+
+    /// Returns the ecosystem identifier as a `&'static str`, derived from
+    /// [`DocumentState::ecosystem`]. Registry lookups (`EcosystemRegistry::get`)
+    /// are keyed by string, so this mirrors `ecosystem.id()`.
+    pub fn ecosystem_id(&self) -> &'static str {
+        self.ecosystem.id()
     }
 
     /// Gets a reference to the parse result if available.
@@ -908,7 +904,7 @@ mod tests {
 
             let doc = DocumentState::new_without_parse_result(expected, String::new());
             assert_eq!(doc.ecosystem, expected);
-            assert_eq!(doc.ecosystem_id, id);
+            assert_eq!(doc.ecosystem_id(), id);
         }
     }
 
@@ -944,7 +940,7 @@ mod tests {
             .expect("maven must resolve to an EcosystemId");
         let doc_state = DocumentState::new_from_parse_result(ecosystem_id, content, parse_result);
 
-        assert_eq!(doc_state.ecosystem_id, "maven");
+        assert_eq!(doc_state.ecosystem_id(), "maven");
         assert_eq!(doc_state.ecosystem, EcosystemId::Maven);
     }
 
@@ -1003,7 +999,7 @@ mod tests {
                 parse_result,
             );
 
-            assert_eq!(doc_state.ecosystem_id, "cargo");
+            assert_eq!(doc_state.ecosystem_id(), "cargo");
             assert_eq!(doc_state.content, content);
             assert!(doc_state.parse_result.is_some());
         }
@@ -1013,7 +1009,7 @@ mod tests {
             let content = "[dependencies]\nserde = \"1.0\"\n".to_string();
             let doc_state = DocumentState::new_without_parse_result(EcosystemId::Cargo, content);
 
-            assert_eq!(doc_state.ecosystem_id, "cargo");
+            assert_eq!(doc_state.ecosystem_id(), "cargo");
             assert_eq!(doc_state.ecosystem, EcosystemId::Cargo);
             assert!(doc_state.parse_result.is_none());
         }
@@ -1084,7 +1080,7 @@ mod tests {
             let content = r#"{"dependencies": {"express": "^4.18.0"}}"#.to_string();
             let doc_state = DocumentState::new_without_parse_result(EcosystemId::Npm, content);
 
-            assert_eq!(doc_state.ecosystem_id, "npm");
+            assert_eq!(doc_state.ecosystem_id(), "npm");
             assert_eq!(doc_state.ecosystem, EcosystemId::Npm);
             assert!(doc_state.parse_result.is_none());
         }
@@ -1103,7 +1099,7 @@ mod tests {
             let content = "[project]\ndependencies = [\"requests>=2.0.0\"]\n".to_string();
             let doc_state = DocumentState::new_without_parse_result(EcosystemId::Pypi, content);
 
-            assert_eq!(doc_state.ecosystem_id, "pypi");
+            assert_eq!(doc_state.ecosystem_id(), "pypi");
             assert_eq!(doc_state.ecosystem, EcosystemId::Pypi);
             assert!(doc_state.parse_result.is_none());
         }
@@ -1124,7 +1120,7 @@ mod tests {
                     .to_string();
             let doc_state = DocumentState::new_without_parse_result(EcosystemId::Go, content);
 
-            assert_eq!(doc_state.ecosystem_id, "go");
+            assert_eq!(doc_state.ecosystem_id(), "go");
             assert_eq!(doc_state.ecosystem, EcosystemId::Go);
             assert!(doc_state.parse_result.is_none());
         }
@@ -1149,7 +1145,7 @@ mod tests {
                 parse_result,
             );
 
-            assert_eq!(doc_state.ecosystem_id, "go");
+            assert_eq!(doc_state.ecosystem_id(), "go");
             assert!(doc_state.parse_result.is_some());
         }
     }

--- a/crates/deps-lsp/src/handlers/code_actions.rs
+++ b/crates/deps-lsp/src/handlers/code_actions.rs
@@ -29,7 +29,7 @@ pub async fn handle_code_actions(
         None => return vec![],
     };
 
-    let ecosystem = match state.ecosystem_registry.get(doc.ecosystem_id) {
+    let ecosystem = match state.ecosystem_registry.get(doc.ecosystem_id()) {
         Some(e) => e,
         None => return vec![],
     };

--- a/crates/deps-lsp/src/handlers/completion.rs
+++ b/crates/deps-lsp/src/handlers/completion.rs
@@ -70,7 +70,8 @@ pub async fn handle_completion(
             return None;
         }
     };
-    let ecosystem_id = doc.ecosystem_id;
+    let ecosystem_id = doc.ecosystem_id();
+    let ecosystem_kind = doc.ecosystem;
     let content = doc.content.clone();
     let has_parse_result = doc.parse_result().is_some();
     drop(doc);
@@ -99,7 +100,7 @@ pub async fn handle_completion(
             // case where the user is typing a NEW package name.
             Ok(completions) if completions.is_empty() => {
                 tracing::info!("completion: ecosystem returned empty, trying fallback");
-                fallback_completion(&state, ecosystem_id, position, &content).await
+                fallback_completion(&state, ecosystem_kind, position, &content).await
             }
             Ok(completions) => completions,
             // Timed out, not genuinely empty: the registry is slow right now, so a
@@ -115,7 +116,7 @@ pub async fn handle_completion(
         }
     } else {
         // Fallback: detect context from raw text
-        fallback_completion(&state, ecosystem_id, position, &content).await
+        fallback_completion(&state, ecosystem_kind, position, &content).await
     };
 
     tracing::info!("completion: returning {} items", items.len());
@@ -132,13 +133,13 @@ pub async fn handle_completion(
 /// Detects dependencies sections from raw text and provides package name suggestions.
 async fn fallback_completion(
     state: &ServerState,
-    ecosystem_id: &str,
+    ecosystem_kind: EcosystemId,
     position: tower_lsp_server::ls_types::Position,
     content: &str,
 ) -> Vec<CompletionItem> {
     tracing::info!(
         "fallback_completion: starting for ecosystem={}",
-        ecosystem_id
+        ecosystem_kind
     );
 
     // Get the current line
@@ -152,13 +153,6 @@ async fn fallback_completion(
 
     tracing::info!("fallback_completion: line content = {:?}", line);
 
-    // Check if we're in a dependencies section. An ecosystem id that doesn't parse is
-    // not registered, so there is no fallback to offer (mirrors the `ecosystem_registry
-    // .get` lookup below, which fails the same way for the same reason).
-    let Ok(ecosystem_kind) = ecosystem_id.parse::<EcosystemId>() else {
-        tracing::warn!("fallback_completion: unknown ecosystem id {ecosystem_id:?}");
-        return vec![];
-    };
     if !is_in_dependencies_section(content, position.line as usize, ecosystem_kind) {
         tracing::info!("fallback_completion: not in dependencies section");
         return vec![];
@@ -176,7 +170,7 @@ async fn fallback_completion(
     }
 
     // Get ecosystem and search for packages
-    let ecosystem = match state.ecosystem_registry.get(ecosystem_id) {
+    let ecosystem = match state.ecosystem_registry.get(ecosystem_kind.id()) {
         Some(e) => e,
         None => return vec![],
     };
@@ -1087,15 +1081,6 @@ ser"
         // Just verify it doesn't panic - actual results depend on registry availability
         // In a real scenario with mocked registry, we'd verify it returns search results
         drop(result);
-    }
-
-    #[tokio::test]
-    async fn test_fallback_completion_unknown_ecosystem_id_returns_empty() {
-        let state = ServerState::new();
-        let content = "[dependencies]\nserde\n".to_string();
-
-        let items = fallback_completion(&state, "unknown", Position::new(1, 5), &content).await;
-        assert!(items.is_empty());
     }
 
     #[test]

--- a/crates/deps-lsp/src/handlers/diagnostics.rs
+++ b/crates/deps-lsp/src/handlers/diagnostics.rs
@@ -41,10 +41,13 @@ pub(crate) async fn generate_diagnostics_internal(
         }
     };
 
-    let ecosystem = match state.ecosystem_registry.get(doc.ecosystem_id) {
+    let ecosystem = match state.ecosystem_registry.get(doc.ecosystem_id()) {
         Some(e) => e,
         None => {
-            tracing::warn!("Ecosystem not found for diagnostics: {}", doc.ecosystem_id);
+            tracing::warn!(
+                "Ecosystem not found for diagnostics: {}",
+                doc.ecosystem_id()
+            );
             return vec![];
         }
     };

--- a/crates/deps-lsp/src/handlers/hover.rs
+++ b/crates/deps-lsp/src/handlers/hover.rs
@@ -26,7 +26,7 @@ pub async fn handle_hover(
 
     // Single document lookup: extract all needed data at once
     let doc = state.get_document(uri)?;
-    let ecosystem = state.ecosystem_registry.get(doc.ecosystem_id)?;
+    let ecosystem = state.ecosystem_registry.get(doc.ecosystem_id())?;
     let parse_result = doc.parse_result()?;
 
     // Generate hover while holding the lock

--- a/crates/deps-lsp/src/handlers/inlay_hints.rs
+++ b/crates/deps-lsp/src/handlers/inlay_hints.rs
@@ -43,10 +43,10 @@ pub async fn handle_inlay_hints(
         }
     };
 
-    let ecosystem = match state.ecosystem_registry.get(doc.ecosystem_id) {
+    let ecosystem = match state.ecosystem_registry.get(doc.ecosystem_id()) {
         Some(e) => e,
         None => {
-            tracing::warn!("Ecosystem not found: {}", doc.ecosystem_id);
+            tracing::warn!("Ecosystem not found: {}", doc.ecosystem_id());
             return vec![];
         }
     };

--- a/crates/deps-lsp/src/server.rs
+++ b/crates/deps-lsp/src/server.rs
@@ -86,6 +86,12 @@ impl Backend {
             }
             Err(e) => {
                 tracing::error!("failed to process document change {:?}: {}", uri, e);
+                // Without this, a rejected change (e.g. oversized content) leaves the
+                // client editing against a stale server-side DocumentState with no
+                // indication the edit was never applied.
+                self.client
+                    .log_message(MessageType::ERROR, format!("Change rejected: {e}"))
+                    .await;
             }
         }
     }
@@ -109,7 +115,7 @@ impl Backend {
             .filter_map(|entry| {
                 let uri = entry.key();
                 let doc = entry.value();
-                if doc.ecosystem_id != ecosystem_id {
+                if doc.ecosystem_id() != ecosystem_id {
                     return None;
                 }
                 let doc_lockfile = lock_provider.locate_lockfile(uri)?;

--- a/crates/deps-lsp/src/server.rs
+++ b/crates/deps-lsp/src/server.rs
@@ -288,9 +288,9 @@ impl LanguageServer for Backend {
         });
     }
 
-    async fn shutdown(&self) -> Result<()> {
+    fn shutdown(&self) -> impl Future<Output = Result<()>> {
         tracing::info!("shutting down deps-lsp server");
-        Ok(())
+        std::future::ready(Ok(()))
     }
 
     async fn did_open(&self, params: DidOpenTextDocumentParams) {

--- a/crates/deps-lsp/tests/common/mod.rs
+++ b/crates/deps-lsp/tests/common/mod.rs
@@ -247,6 +247,24 @@ impl LspClient {
         }));
     }
 
+    /// Sends a full-document change (matches the server's negotiated `FULL` sync kind).
+    #[allow(dead_code)] // Used in size-bound integration tests
+    pub(crate) fn did_change(&mut self, uri: &str, version: i64, text: &str) {
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+                "textDocument": {
+                    "uri": uri,
+                    "version": version
+                },
+                "contentChanges": [
+                    { "text": text }
+                ]
+            }
+        }));
+    }
+
     /// Request hover information.
     #[allow(dead_code)] // Not used in all tests
     pub(crate) fn hover(&mut self, id: i64, uri: &str, line: u32, character: u32) -> Value {

--- a/crates/deps-lsp/tests/lsp_integration.rs
+++ b/crates/deps-lsp/tests/lsp_integration.rs
@@ -294,6 +294,59 @@ fn test_malformed_document_content() {
     );
 }
 
+#[cfg(feature = "cargo")]
+#[test]
+fn test_oversized_did_change_notifies_client_and_keeps_stale_document() {
+    let mut client = LspClient::spawn();
+    client.initialize();
+
+    let uri = "file:///test/Cargo.toml";
+    let valid_content = r#"[package]
+name = "test-package"
+version = "0.1.0"
+
+[dependencies]
+serde = "1.0"
+"#;
+    client.did_open(uri, "toml", valid_content);
+    thread::sleep(Duration::from_millis(100));
+    // Drain (via flush) then discard notifications so far — this includes the
+    // startup `window/logMessage` sent from `initialized`, which would otherwise
+    // shadow the rejection message searched for below.
+    client.flush_notifications();
+    client.clear_notifications();
+
+    // Content over the 10MB manifest size bound (issue #161) must be rejected
+    // rather than replacing the previously stored document.
+    let oversized_content = "a".repeat(10_000_001);
+    client.did_change(uri, 2, &oversized_content);
+    client.flush_notifications();
+
+    let rejection = client
+        .get_notifications()
+        .into_iter()
+        .find(|n| {
+            n.method == "window/logMessage"
+                && n.params["message"]
+                    .as_str()
+                    .is_some_and(|m| m.contains("Change rejected"))
+        })
+        .expect("Server should notify the client that the change was rejected");
+    let message = rejection.params["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("Change rejected"),
+        "Unexpected window/logMessage content: {message:?}"
+    );
+
+    // The server must keep serving the last known-good (pre-rejection) document
+    // rather than crashing or dropping it silently.
+    let hints = client.inlay_hints(60, uri);
+    assert!(
+        hints.get("error").is_none(),
+        "Server should still serve the stale-but-valid document after a rejected change"
+    );
+}
+
 #[test]
 fn test_multiple_documents() {
     let mut client = LspClient::spawn();

--- a/crates/deps-pypi/src/registry.rs
+++ b/crates/deps-pypi/src/registry.rs
@@ -240,10 +240,14 @@ impl PypiRegistry {
     /// // Currently returns empty, to be implemented
     /// # }
     /// ```
-    pub async fn search(&self, _query: &str, _limit: usize) -> Result<Vec<PypiPackage>> {
+    pub fn search(
+        &self,
+        _query: &str,
+        _limit: usize,
+    ) -> impl Future<Output = Result<Vec<PypiPackage>>> {
         // TODO: Implement search using third-party API or scraping
         // PyPI deprecated their XML-RPC search API
-        Ok(Vec::new())
+        std::future::ready(Ok(Vec::new()))
     }
 
     /// Fetches package metadata including description and project URLs.


### PR DESCRIPTION
## Summary

- Closes #161: `textDocument/didOpen`/`didChange` content had no size ceiling before reaching `ecosystem.parse_manifest`, unlike disk-loaded documents (already capped at `MAX_FILE_SIZE`, 10MB, in `document::loader`). Both handlers now reject oversized content before parsing/storage, and the client is notified via `window/logMessage` on rejection (previously `handle_change`'s error path only logged server-side, leaving the client editing against a stale document with no signal the edit was rejected).
- Closes #155: `DocumentState::ecosystem_id` is no longer a stored `&'static str` field — it's a method deriving from the already-typed `ecosystem: EcosystemId` field, removing the possibility of the two disagreeing and eliminating a redundant str->EcosystemId reparse in `completion::fallback_completion`. ~15 call sites migrated from field access to method call.

## Scope boundaries

- **Peak-allocation vector only partially closed (#161).** `check_content_size` runs before `ecosystem.parse_manifest`, but after `tower-lsp-server`'s codec has already buffered the full `Content-Length` payload and `serde_json` has deserialized it into a `String`. This bounds parse-amplification and unbounded long-term retention in `state.documents` — exactly what #161's Remediation section asked for — but does not bound the transient memory spike from reading one very large frame before the check runs. Closing that residual vector would need a codec-level frame-size ceiling, out of scope here.
- **YAML flow-collection nesting depth deferred.** #161's Remediation section also suggested bounding YAML flow-collection nesting as defense in depth. Intentionally deferred, not attempted in this PR.

## Unrelated CI blocker (fixed in this PR)

The workspace `check` job (`cargo clippy --workspace --all-targets --all-features -- -D warnings`) was failing on `clippy::unused_async_trait_impl` at `crates/deps-go/src/ecosystem.rs:50`/`:70`, `crates/deps-pypi/src/registry.rs:243`, and (once those were fixed) `crates/deps-lsp/src/server.rs:291` (`Backend::shutdown`) — all `async fn` trait/inherent methods with no `.await` in their body. This was pre-existing on `origin/main` and unrelated to #159 (which is about an unused `async-trait` *crate dependency*, not this lint; no issue tracked the lint itself). Since it blocked this PR's own CI, fixed here alongside #161/#155 by dropping `async` and returning `std::future::ready(..)` per clippy's own suggested fix — no behavior change. Workspace-wide `cargo clippy --workspace --all-targets --all-features -- -D warnings` is now clean.

## Other deferred items (noted, not fixed — out of scope for #161/#155)

- `deps_core::lockfile::read_lockfile_content` (`crates/deps-core/src/lockfile.rs:43-50`) does a bare `read_to_string` with no size bound; lockfiles are routinely larger than manifests. Same class of issue as #161 but a different subsystem/entry point.
- No bound on the *number* of distinct open documents (`state.documents` is an unbounded `DashMap`). Same hostile-client threat model as #161, not addressed.
- `DepsError::CacheError` is semantically imprecise for a size-rejection error, but consistent with the existing precedent in `document/loader.rs`'s oversized-file path — left as-is rather than diverging the two call sites.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean, workspace-wide)
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (1633/1633)
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`)
- [x] New regression tests: oversized/boundary/normal-size payloads for both `didOpen` and `didChange`; stale-document-preserved assertion; full subprocess LSP integration test asserting the client receives the rejection notification
