### PR TITLE
fix(deps-lsp): stop holding DashMap Ref across config RwLock await in inlay_hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-cargo, deps-npm, deps-swift**: unsatisfiable-requirement WARNING now mentions a matching pre-release when one exists for Cargo/npm/Swift's strict-SemVer requirements, follow-up to #206 (resolves #299) (#305)
 
 ### Fixed
+- **deps-lsp**: `handle_inlay_hints` no longer awaits the config `RwLock` read while holding a `DashMap` document `Ref`, closing the reproducible liveness hazard from #317 (the residual `Ref`-across-`generate_*()` hold is tracked separately).
 - **deps-lsp**: `RegistryProgress::start` no longer sends `window/workDoneProgress/create` to a client that never advertised `window.workDoneProgress` support, an LSP 3.17 spec violation (resolves #290) (#296).
 - **deps-lsp** (tests): `LspClient::read_response`'s 10s hang-detection timeout is now covered by a fast unit test instead of being unexercised (resolves #291) (#296).
 - **deps-bundler**: fix Bundler yanked-diagnostic path incorrectly trusting missing RubyGems yank data (resolves #298) (#301).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-cargo, deps-npm, deps-swift**: unsatisfiable-requirement WARNING now mentions a matching pre-release when one exists for Cargo/npm/Swift's strict-SemVer requirements, follow-up to #206 (resolves #299) (#305)
 
 ### Fixed
-- **deps-lsp**: `handle_inlay_hints` no longer awaits the config `RwLock` read while holding a `DashMap` document `Ref`, closing the reproducible liveness hazard from #317 (the residual `Ref`-across-`generate_*()` hold is tracked separately).
+- **deps-lsp**: `handle_inlay_hints` no longer awaits the config `RwLock` read while holding a `DashMap` document `Ref`, closing the reproducible liveness hazard from #317 (the residual `Ref`-across-`generate_*()` hold is tracked separately) (#318).
 - **deps-lsp**: `RegistryProgress::start` no longer sends `window/workDoneProgress/create` to a client that never advertised `window.workDoneProgress` support, an LSP 3.17 spec violation (resolves #290) (#296).
 - **deps-lsp** (tests): `LspClient::read_response`'s 10s hang-detection timeout is now covered by a fast unit test instead of being unexercised (resolves #291) (#296).
 - **deps-bundler**: fix Bundler yanked-diagnostic path incorrectly trusting missing RubyGems yank data (resolves #298) (#301).

--- a/crates/deps-core/src/ecosystem.rs
+++ b/crates/deps-core/src/ecosystem.rs
@@ -403,7 +403,7 @@ pub trait Ecosystem: Send + Sync + private::Sealed {
     ///
     /// Default implementation delegates to `lsp_helpers::generate_inlay_hints`
     /// using `self.formatter()`. Override only if custom behavior is needed.
-    // TODO(#317-followup): callers hold a DashMap Ref across this future — overrides must not await I/O until the Ref-across-generate follow-up lands.
+    // TODO(#319): callers hold a DashMap Ref across this future — overrides must not await I/O until #319 lands.
     fn generate_inlay_hints<'a>(
         &'a self,
         parse_result: &'a dyn ParseResult,
@@ -485,7 +485,7 @@ pub trait Ecosystem: Send + Sync + private::Sealed {
     ///
     /// Default implementation delegates to `lsp_helpers::generate_diagnostics_from_cache`
     /// using `self.formatter()`.
-    // TODO(#317-followup): callers hold a DashMap Ref across this future — overrides must not await I/O until the Ref-across-generate follow-up lands.
+    // TODO(#319): callers hold a DashMap Ref across this future — overrides must not await I/O until #319 lands.
     fn generate_diagnostics<'a>(
         &'a self,
         parse_result: &'a dyn ParseResult,

--- a/crates/deps-core/src/ecosystem.rs
+++ b/crates/deps-core/src/ecosystem.rs
@@ -403,6 +403,7 @@ pub trait Ecosystem: Send + Sync + private::Sealed {
     ///
     /// Default implementation delegates to `lsp_helpers::generate_inlay_hints`
     /// using `self.formatter()`. Override only if custom behavior is needed.
+    // TODO(#317-followup): callers hold a DashMap Ref across this future — overrides must not await I/O until the Ref-across-generate follow-up lands.
     fn generate_inlay_hints<'a>(
         &'a self,
         parse_result: &'a dyn ParseResult,
@@ -484,6 +485,7 @@ pub trait Ecosystem: Send + Sync + private::Sealed {
     ///
     /// Default implementation delegates to `lsp_helpers::generate_diagnostics_from_cache`
     /// using `self.formatter()`.
+    // TODO(#317-followup): callers hold a DashMap Ref across this future — overrides must not await I/O until the Ref-across-generate follow-up lands.
     fn generate_diagnostics<'a>(
         &'a self,
         parse_result: &'a dyn ParseResult,

--- a/crates/deps-lsp/src/handlers/inlay_hints.rs
+++ b/crates/deps-lsp/src/handlers/inlay_hints.rs
@@ -34,6 +34,9 @@ pub async fn handle_inlay_hints(
         return vec![];
     }
 
+    // Snapshot config before the document lookup (Copy value, no lock held across the call)
+    let loading_config = { full_config.read().await.loading_indicator.clone() };
+
     // Single document lookup: extract all needed data at once
     let doc = match state.get_document(uri) {
         Some(d) => d,
@@ -55,9 +58,6 @@ pub async fn handle_inlay_hints(
         Some(p) => p,
         None => return vec![],
     };
-
-    // Get loading indicator config
-    let loading_config = { full_config.read().await.loading_indicator.clone() };
 
     let ecosystem_config = EcosystemConfig {
         show_up_to_date_hints: true,


### PR DESCRIPTION
## Summary

- `handle_inlay_hints` awaited `full_config.read().await` while holding the document's DashMap shard `Ref` obtained from `state.get_document(uri)` — a liveness hazard flagged by #227's security audit. Snapshot the config before the document lookup instead, matching `hover.rs`'s existing convention.
- `diagnostics.rs` needed no change: it already snapshots config before the document lookup (landed incidentally in #219, not #316 as the issue attributed).

## Deviation from the issue's literal proposal

#317 prescribed swapping `get_document` for `get_document_clone`. That does not work: `DocumentState::Clone` deliberately drops `parse_result` ("Don't clone trait object"), and both handlers need `parse_result` for the `generate_*` call — verified empirically (8 failing diagnostics tests) before reverting to the reordering approach used here.

## What is intentionally not fixed here

A second, distinct `Ref`-hold remains in both handlers: `parse_result` is borrowed from the `Ref` across the final `generate_*(...).await` call itself. This is currently inert — the `deps-core` default trait impls never actually yield (`Box::pin(async move { sync_fn() })`) — but adversarial review found the same pattern is a *live* hazard elsewhere: `hover.rs`, `completion.rs`, and `code_actions.rs` really do await real I/O (a registry fetch, and in `completion.rs`'s case a DashMap guard held across up to a 2-second search timeout) while holding a `Ref`. That is a distinct, larger-scope problem tracked in a separate follow-up issue — not this PR.

Two `TODO(#317-followup)` markers were added on the two default trait methods this PR relies on staying inert, so a future override that adds I/O doesn't silently reintroduce the hazard.

## Test plan

- [x] `cargo build -p deps-lsp -p deps-core`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (2624 passed, 49 skipped, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --all-features`