### PR TITLE
fix(deps-lsp): stop holding DashMap Ref across registry-bound await in hover/completion/code_actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-lsp**: `handle_inlay_hints` no longer awaits the config `RwLock` read while holding a `DashMap` document `Ref`, closing the reproducible liveness hazard from #317 (the residual `Ref`-across-`generate_*()` hold is tracked separately) (#318).
 - **deps-bundler**: hover's "Recent versions" list no longer repeats the same version once per RubyGems platform variant; entries are now deduplicated by version number (resolves #311) (#321).
 - **deps-core**: hover's `(latest)` marker in "Recent versions" now matches the `**Latest**` header's stable-version pick instead of the raw highest-numbered entry, which could be a pre-release (resolves #313) (#321).
+- **deps-lsp**: stop holding DashMap document `Ref` across registry-bound await in hover/completion/code_actions handlers (resolves #319).
 - **deps-lsp**: `RegistryProgress::start` no longer sends `window/workDoneProgress/create` to a client that never advertised `window.workDoneProgress` support, an LSP 3.17 spec violation (resolves #290) (#296).
 - **deps-lsp** (tests): `LspClient::read_response`'s 10s hang-detection timeout is now covered by a fast unit test instead of being unexercised (resolves #291) (#296).
 - **deps-bundler**: fix Bundler yanked-diagnostic path incorrectly trusting missing RubyGems yank data (resolves #298) (#301).

--- a/crates/deps-core/src/ecosystem.rs
+++ b/crates/deps-core/src/ecosystem.rs
@@ -403,7 +403,15 @@ pub trait Ecosystem: Send + Sync + private::Sealed {
     ///
     /// Default implementation delegates to `lsp_helpers::generate_inlay_hints`
     /// using `self.formatter()`. Override only if custom behavior is needed.
-    // TODO(#319): callers hold a DashMap Ref across this future — overrides must not await I/O until #319 lands.
+    // TODO: `handlers::inlay_hints` holds a DashMap shard `Ref` across this future.
+    // An override must never start awaiting real I/O here — it is safe today only
+    // because the default impl (a sync fn wrapped in `Box::pin(async move {...})`)
+    // never actually yields. #319 fixed the identical hazard in
+    // generate_hover/generate_completions/generate_code_actions by having the caller
+    // own the parse result (`DocumentState::parse_result_arc`) and drop the `Ref`
+    // before awaiting; inlay_hints/diagnostics/code_lenses were deliberately left
+    // holding the `Ref` because their defaults never yield, not because the hazard
+    // doesn't apply — apply the same fix pattern here if that ever changes.
     fn generate_inlay_hints<'a>(
         &'a self,
         parse_result: &'a dyn ParseResult,
@@ -485,7 +493,9 @@ pub trait Ecosystem: Send + Sync + private::Sealed {
     ///
     /// Default implementation delegates to `lsp_helpers::generate_diagnostics_from_cache`
     /// using `self.formatter()`.
-    // TODO(#319): callers hold a DashMap Ref across this future — overrides must not await I/O until #319 lands.
+    // TODO: `handlers::diagnostics` holds a DashMap shard `Ref` across this future —
+    // same caveat as `generate_inlay_hints` above: an override must never start
+    // awaiting real I/O here, safe today only because the default never yields.
     fn generate_diagnostics<'a>(
         &'a self,
         parse_result: &'a dyn ParseResult,
@@ -510,6 +520,9 @@ pub trait Ecosystem: Send + Sync + private::Sealed {
     ///
     /// Default implementation delegates to `lsp_helpers::generate_code_lenses` using
     /// `self.formatter()`. Override only if custom behavior is needed.
+    // TODO: `handlers::code_lens` holds a DashMap shard `Ref` across this future —
+    // same caveat as `generate_inlay_hints` above: an override must never start
+    // awaiting real I/O here, safe today only because the default never yields.
     fn generate_code_lenses<'a>(
         &'a self,
         parse_result: &'a dyn ParseResult,

--- a/crates/deps-lsp/src/document/state.rs
+++ b/crates/deps-lsp/src/document/state.rs
@@ -39,10 +39,11 @@ pub struct DocumentState {
     pub ecosystem: EcosystemId,
     /// Original document content
     pub content: String,
-    /// Parsed result as trait object (new architecture)
-    /// Note: This is not cloned when DocumentState is cloned
-    #[allow(dead_code)]
-    parse_result: Option<Box<dyn ParseResult>>,
+    /// Parsed result as trait object, wrapped in `Arc` (rather than `Box`) so
+    /// [`Self::parse_result_arc`] can hand a caller a cheap owned clone — letting it
+    /// release the DashMap shard `Ref` before an `.await` on a registry-bound
+    /// `generate_*` call without deep-cloning ecosystem-specific parse data (#319).
+    parse_result: Option<Arc<dyn ParseResult>>,
     /// Latest known version and full version list per package, fetched together in a
     /// single registry round trip (see [`PackageVersions`]).
     pub cached_versions: HashMap<PackageName, PackageVersions>,
@@ -90,7 +91,8 @@ impl Clone for DocumentState {
         Self {
             ecosystem: self.ecosystem,
             content: self.content.clone(),
-            parse_result: None, // Don't clone trait object
+            // Cheap: `Arc::clone`, not a deep copy of the parse result.
+            parse_result: self.parse_result.clone(),
             cached_versions: self.cached_versions.clone(),
             resolved_versions: self.resolved_versions.clone(),
             vulnerabilities: self.vulnerabilities.clone(),
@@ -216,7 +218,7 @@ impl DocumentState {
         Self {
             ecosystem,
             content,
-            parse_result: Some(parse_result),
+            parse_result: Some(Arc::from(parse_result)),
             cached_versions: HashMap::new(),
             resolved_versions: HashMap::new(),
             vulnerabilities: VulnerabilityMap::new(),
@@ -259,7 +261,17 @@ impl DocumentState {
 
     /// Gets a reference to the parse result if available.
     pub fn parse_result(&self) -> Option<&dyn ParseResult> {
-        self.parse_result.as_ref().map(std::convert::AsRef::as_ref)
+        self.parse_result.as_deref()
+    }
+
+    /// Returns a cheap `Arc` clone of the parse result, if available.
+    ///
+    /// Lets a caller (e.g. a `handlers::{hover,completion,code_actions}` handler) own
+    /// the parse result and release the DashMap shard `Ref` before awaiting a
+    /// registry-bound `Ecosystem::generate_*` call, without deep-cloning
+    /// ecosystem-specific parse data on every request (#319).
+    pub fn parse_result_arc(&self) -> Option<Arc<dyn ParseResult>> {
+        self.parse_result.clone()
     }
 
     /// Updates the cached registry version data (new architecture).
@@ -519,9 +531,9 @@ impl ServerState {
     ///
     /// # Performance
     ///
-    /// Cloning `DocumentState` is relatively cheap as it only clones
-    /// `String` and `HashMap` metadata, not the underlying parse result
-    /// trait object.
+    /// Cloning `DocumentState` is relatively cheap: `String`/`HashMap` metadata is
+    /// deep-cloned, but the parse result is an `Arc` clone (a refcount bump), not a
+    /// deep copy of the underlying ecosystem-specific parse data.
     ///
     /// # Examples
     ///
@@ -1247,6 +1259,33 @@ mod tests {
             assert_eq!(cloned.ecosystem, state.ecosystem);
             assert_eq!(cloned.content, state.content);
             assert!(cloned.parse_result.is_none());
+        }
+
+        /// `parse_result` is stored as `Arc<dyn ParseResult>` (#319), so — unlike the
+        /// old `Box`-backed field, which `Clone` had to silently drop — a clone now
+        /// carries a cheap `Arc` clone of the *same* parse result rather than losing it.
+        #[test]
+        fn test_document_state_clone_preserves_parse_result() {
+            let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+            let ecosystem = ServerState::new().ecosystem_registry.get("cargo").unwrap();
+            let content = "[dependencies]\nserde = \"1.0\"\n".to_string();
+            let parse_result = tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(ecosystem.parse_manifest(&content, &uri))
+                .unwrap();
+
+            let state =
+                DocumentState::new_from_parse_result(EcosystemId::Cargo, content, parse_result);
+            let cloned = state.clone();
+
+            assert!(
+                cloned.parse_result_arc().is_some(),
+                "clone must still carry the parse result"
+            );
+            assert!(std::sync::Arc::ptr_eq(
+                &state.parse_result_arc().unwrap(),
+                &cloned.parse_result_arc().unwrap()
+            ));
         }
 
         #[test]

--- a/crates/deps-lsp/src/handlers/code_actions.rs
+++ b/crates/deps-lsp/src/handlers/code_actions.rs
@@ -27,31 +27,42 @@ pub async fn handle_code_actions(
         return vec![];
     }
 
-    // Single document lookup: extract all needed data at once
-    let doc = match state.get_document(uri) {
-        Some(d) => d,
-        None => return vec![],
+    // Own everything `generate_code_actions` needs and release the DashMap shard
+    // `Ref` before awaiting it: the default impl awaits a real registry fetch, so
+    // holding the guard across that await would block a concurrent
+    // `documents.get_mut` on the same shard for the duration (#319).
+    let (ecosystem, parse_result, cached_versions, resolved_versions, vulnerabilities, content) = {
+        let doc = match state.get_document(uri) {
+            Some(d) => d,
+            None => return vec![],
+        };
+
+        let Some(ecosystem) = state.ecosystem_registry.get(doc.ecosystem_id()) else {
+            return vec![];
+        };
+
+        let Some(parse_result) = doc.parse_result_arc() else {
+            return vec![];
+        };
+
+        (
+            ecosystem,
+            parse_result,
+            doc.cached_versions.clone(),
+            doc.resolved_versions.clone(),
+            doc.vulnerabilities.clone(),
+            doc.content.clone(),
+        )
     };
 
-    let ecosystem = match state.ecosystem_registry.get(doc.ecosystem_id()) {
-        Some(e) => e,
-        None => return vec![],
-    };
-
-    let parse_result = match doc.parse_result() {
-        Some(p) => p,
-        None => return vec![],
-    };
-
-    // Generate code actions while holding the lock
     let mut actions = ecosystem
         .generate_code_actions(
-            parse_result,
+            parse_result.as_ref(),
             position,
             uri,
-            VersionData::new(&doc.cached_versions, &doc.resolved_versions)
-                .with_vulnerabilities(&doc.vulnerabilities),
-            &doc.content,
+            VersionData::new(&cached_versions, &resolved_versions)
+                .with_vulnerabilities(&vulnerabilities),
+            &content,
         )
         .await;
 

--- a/crates/deps-lsp/src/handlers/completion.rs
+++ b/crates/deps-lsp/src/handlers/completion.rs
@@ -72,38 +72,47 @@ pub async fn handle_completion(
         }
     }
 
-    // Get document and extract needed data
-    let doc = match state.get_document(uri) {
-        Some(d) => d,
-        None => {
-            tracing::warn!("completion: document not found: {:?}", uri);
-            return None;
-        }
+    // Own everything needed from the document in a single shard acquisition, then
+    // release the `Ref` immediately: two separate acquisitions (one for `content`, a
+    // later one for `parse_result`) would let a concurrent `didChange` land in
+    // between, pairing a `parse_result` with `content` from a different document
+    // revision — `generate_completions` correlates the two (e.g. `extract_prefix`
+    // slicing `content` at a range taken from `parse_result`), so a torn pair risks
+    // wrong or out-of-bounds-guarded-empty completions (#319 review).
+    let (ecosystem_id, ecosystem_kind, content, parse_result) = {
+        let doc = match state.get_document(uri) {
+            Some(d) => d,
+            None => {
+                tracing::warn!("completion: document not found: {:?}", uri);
+                return None;
+            }
+        };
+        (
+            doc.ecosystem_id(),
+            doc.ecosystem,
+            doc.content.clone(),
+            doc.parse_result_arc(),
+        )
     };
-    let ecosystem_id = doc.ecosystem_id();
-    let ecosystem_kind = doc.ecosystem;
-    let content = doc.content.clone();
-    let has_parse_result = doc.parse_result().is_some();
-    drop(doc);
 
     tracing::info!(
         "completion: ecosystem={}, has_parse_result={}",
         ecosystem_id,
-        has_parse_result
+        parse_result.is_some()
     );
 
     // Try parse_result first, fallback to text-based detection
-    let items = if has_parse_result {
-        // Re-acquire document to get parse_result
-        let doc = state.get_document(uri)?;
-        let parse_result = doc.parse_result()?;
+    let items = if let Some(parse_result) = parse_result {
         let ecosystem = state.ecosystem_registry.get(ecosystem_id)?;
+        // The DashMap shard `Ref` was already dropped above, before this
+        // timeout-bound await: the search can run for up to
+        // `COMPLETION_SEARCH_TIMEOUT`, and holding the guard that long would block a
+        // concurrent `documents.get_mut` on the same shard for the duration (#319).
         let completion_result = tokio::time::timeout(
             COMPLETION_SEARCH_TIMEOUT,
-            ecosystem.generate_completions(parse_result, position, &content, freshness),
+            ecosystem.generate_completions(parse_result.as_ref(), position, &content, freshness),
         )
         .await;
-        drop(doc);
 
         match completion_result {
             // Ecosystem returned no completions: try fallback, since this handles the
@@ -859,6 +868,206 @@ mod tests {
         let (client, config) = create_test_client_and_config();
         let _result = handle_completion(state, params, client, config).await;
         // Just verify it doesn't panic - actual completion logic is in ecosystem
+    }
+
+    /// #319 liveness regression: `handle_completion` must release the DashMap shard
+    /// `Ref` on the document *before* entering the `COMPLETION_SEARCH_TIMEOUT`-bounded
+    /// await, so a concurrent `documents.get_mut` on the same URI (e.g. a `didChange`)
+    /// is never blocked behind an in-flight (or stuck) registry-backed search.
+    ///
+    /// `BlockingEcosystem::generate_completions` waits on a `Barrier` before blocking
+    /// forever (`std::future::pending`), standing in for a registry call that never
+    /// returns — the worst case for a shard `Ref` held across the search. The test
+    /// only proceeds to race the writer once that future has demonstrably started
+    /// executing (via the barrier), which — pre-fix — would still be *after* the old
+    /// code's `let doc = state.get_document(uri)?;` acquisition but *before* its
+    /// `drop(doc)`, since that drop ran only once the whole timeout resolved. A
+    /// concurrent write racing here would previously deadlock against the `parking_lot`
+    /// shard guard for the life of the (never-resolving) search; post-fix it must
+    /// complete almost immediately, since the `Ref` was already dropped before the
+    /// search was ever awaited.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_concurrent_document_write_not_blocked_by_in_flight_completion_search() {
+        use deps_core::ecosystem::private::Sealed;
+        use deps_core::{
+            Dependency, Ecosystem, EcosystemFormatter, Metadata, ParseResult, Registry, Version,
+        };
+        use std::any::Any;
+        use std::path::Path;
+        use tokio::sync::Barrier;
+        use tower_lsp_server::ls_types::Uri;
+
+        struct NoopRegistry;
+        impl Registry for NoopRegistry {
+            fn get_versions<'a>(
+                &'a self,
+                _name: &'a deps_core::PackageName,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Version>>>>
+            {
+                Box::pin(async move { Ok(vec![]) })
+            }
+            fn get_latest_matching<'a>(
+                &'a self,
+                _name: &'a deps_core::PackageName,
+                _req: &'a deps_core::VersionReq,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Option<Box<dyn Version>>>>
+            {
+                Box::pin(async move { Ok(None) })
+            }
+            fn search<'a>(
+                &'a self,
+                _query: &'a str,
+                _limit: usize,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Metadata>>>>
+            {
+                Box::pin(async move { Ok(vec![]) })
+            }
+            fn package_url(&self, name: &deps_core::PackageName) -> String {
+                format!("https://example.com/{name}")
+            }
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        struct NoopFormatter;
+        impl EcosystemFormatter for NoopFormatter {
+            fn format_version_for_text_edit(&self, version: &str) -> String {
+                version.to_string()
+            }
+            fn package_url(&self, name: &deps_core::PackageName) -> String {
+                format!("https://example.com/{name}")
+            }
+        }
+
+        struct BlockingEcosystem {
+            started: Arc<Barrier>,
+        }
+        impl Sealed for BlockingEcosystem {}
+        impl Ecosystem for BlockingEcosystem {
+            fn id(&self) -> &'static str {
+                "cargo"
+            }
+            fn display_name(&self) -> &'static str {
+                "cargo"
+            }
+            fn manifest_filenames(&self) -> &[&'static str] {
+                &["Cargo.toml"]
+            }
+            fn parse_manifest<'a>(
+                &'a self,
+                _content: &'a str,
+                _uri: &'a Uri,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Box<dyn ParseResult>>>
+            {
+                Box::pin(async move { unimplemented!() })
+            }
+            fn registry(&self) -> Arc<dyn Registry> {
+                Arc::new(NoopRegistry)
+            }
+            fn formatter(&self) -> &dyn EcosystemFormatter {
+                &NoopFormatter
+            }
+            fn generate_completions<'a>(
+                &'a self,
+                _parse_result: &'a dyn ParseResult,
+                _position: tower_lsp_server::ls_types::Position,
+                _content: &'a str,
+                _freshness: deps_core::FreshnessSettings,
+            ) -> deps_core::ecosystem::BoxFuture<'a, Vec<CompletionItem>> {
+                Box::pin(async move {
+                    self.started.wait().await;
+                    std::future::pending::<()>().await;
+                    unreachable!("test aborts the completion task before this future resolves")
+                })
+            }
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        struct MockParseResult {
+            uri: Uri,
+        }
+        impl ParseResult for MockParseResult {
+            fn dependencies(&self) -> Vec<&dyn Dependency> {
+                vec![]
+            }
+            fn workspace_root(&self) -> Option<&Path> {
+                None
+            }
+            fn uri(&self) -> &Uri {
+                &self.uri
+            }
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        let state = Arc::new(ServerState::new());
+        let started = Arc::new(Barrier::new(2));
+        state
+            .ecosystem_registry
+            .register(Arc::new(BlockingEcosystem {
+                started: Arc::clone(&started),
+            }));
+
+        let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+        let content = "[dependencies]\nserde = \"1.0\"\n".to_string();
+        let parse_result: Box<dyn ParseResult> = Box::new(MockParseResult { uri: uri.clone() });
+        let doc = DocumentState::new_from_parse_result(EcosystemId::Cargo, content, parse_result);
+        state.update_document(uri.clone(), doc);
+
+        let (client, config) = create_test_client_and_config();
+
+        let completion_task = tokio::spawn({
+            let state = Arc::clone(&state);
+            let uri = uri.clone();
+            async move {
+                let params = CompletionParams {
+                    text_document_position: TextDocumentPositionParams {
+                        text_document: TextDocumentIdentifier { uri },
+                        position: Position::new(1, 9),
+                    },
+                    work_done_progress_params: Default::default(),
+                    partial_result_params: Default::default(),
+                    context: None,
+                };
+                handle_completion(state, params, client, config).await
+            }
+        });
+
+        // Block until `generate_completions` has actually started executing — i.e.
+        // `handle_completion` has reached (and is now inside) the
+        // `COMPLETION_SEARCH_TIMEOUT`-bounded await — before racing the writer below.
+        started.wait().await;
+
+        // Spawned onto its own task (rather than awaited inline) deliberately:
+        // `DashMap::get_mut` blocks the OS thread synchronously on a `parking_lot`
+        // lock, with no `.await` point of its own. Wrapping that blocking call
+        // directly in `tokio::time::timeout` would not work — a `Future::poll` that
+        // never returns can't be preempted by a sibling timer that only fires between
+        // polls. Spawning it gives the *join* a real async yield point, so the
+        // `timeout` below can race against it and fire even while the spawned task
+        // sits blocked on the shard lock.
+        let write_task = tokio::spawn({
+            let state = Arc::clone(&state);
+            let uri = uri.clone();
+            async move {
+                state.documents.get_mut(&uri).unwrap().set_loading();
+            }
+        });
+        let write_result =
+            tokio::time::timeout(std::time::Duration::from_millis(500), write_task).await;
+
+        completion_task.abort();
+
+        assert!(
+            write_result.is_ok(),
+            "#319 regression: a concurrent documents.get_mut on the same URI must not \
+             block on an in-flight completion search — the DashMap shard Ref must be \
+             dropped before the COMPLETION_SEARCH_TIMEOUT-bounded await, not after it"
+        );
     }
 
     /// Issue #227 tester gap: `build_version_completion`'s `label_details`

--- a/crates/deps-lsp/src/handlers/hover.rs
+++ b/crates/deps-lsp/src/handlers/hover.rs
@@ -28,17 +28,29 @@ pub async fn handle_hover(
     // acquires the config RwLock before the DashMap shard guard, never the reverse.
     let freshness = { config.read().await.freshness.to_settings() };
 
-    // Single document lookup: extract all needed data at once
-    let doc = state.get_document(uri)?;
-    let ecosystem = state.ecosystem_registry.get(doc.ecosystem_id())?;
-    let parse_result = doc.parse_result()?;
+    // Own everything `generate_hover` needs and release the DashMap shard `Ref`
+    // before awaiting it: the default impl awaits a real registry fetch
+    // (`Registry::get_versions_with`), so holding the guard across that await would
+    // block a concurrent `documents.get_mut` on the same shard for the duration (#319).
+    let (ecosystem, parse_result, cached_versions, resolved_versions, vulnerabilities) = {
+        let doc = state.get_document(uri)?;
+        let ecosystem = state.ecosystem_registry.get(doc.ecosystem_id())?;
+        let parse_result = doc.parse_result_arc()?;
+        (
+            ecosystem,
+            parse_result,
+            doc.cached_versions.clone(),
+            doc.resolved_versions.clone(),
+            doc.vulnerabilities.clone(),
+        )
+    };
 
     ecosystem
         .generate_hover(
-            parse_result,
+            parse_result.as_ref(),
             position,
-            VersionData::new(&doc.cached_versions, &doc.resolved_versions)
-                .with_vulnerabilities(&doc.vulnerabilities),
+            VersionData::new(&cached_versions, &resolved_versions)
+                .with_vulnerabilities(&vulnerabilities),
             freshness,
         )
         .await


### PR DESCRIPTION
## Summary

Follow-up to #318. That PR fixed the concrete, reproducible liveness hazard in `inlay_hints.rs`/`diagnostics.rs` but left a residual pattern in `hover.rs`, `code_actions.rs`, and `completion.rs`: a DashMap document `Ref` held across a real await point in the corresponding `generate_*` call.

- `hover.rs` held the `Ref` across `generate_hover`'s network-bound `registry.get_versions_with(...)` fetch.
- `code_actions.rs` — same pattern, via `generate_code_actions`.
- `completion.rs` was the worst case: the `Ref` was held across `tokio::time::timeout(COMPLETION_SEARCH_TIMEOUT, ...)`, up to 2 seconds of a blocking `parking_lot` guard pinned on a tokio worker thread — a concurrent `documents.get_mut` on the same shard (e.g. `update_resolved_versions`) would block outright, not just delay a task.

`diagnostics.rs`/`code_lens.rs`/`inlay_hints.rs` are untouched — their default impls never yield, so they remain benign; their `TODO` markers are reworded to state that invariant unconditionally instead of "until #319 lands" (and the same marker is added to `generate_code_lenses`, which had none).

## Approach

`DocumentState.parse_result` changes from `Box<dyn ParseResult>` to `Arc<dyn ParseResult>`. Each handler now clones the Arc (a refcount bump, not a deep clone) plus the small pieces of version/vulnerability/content data it needs, inside a scoped block that ends — dropping the `Ref` — before the network/timeout-bound await. This was chosen over an earlier `ParseResult::clone_box()` trait-method design (which would have rippled into every ecosystem's `ParseResult` implementor) since `parse_result` is write-once/read-only for the lifetime of a `DocumentState`, making `Arc` strictly cheaper and smaller in footprint.

`completion.rs` additionally had a torn-snapshot bug: it acquired the document twice (once for `content`, separately for `parse_result`), so a concurrent edit between the two acquisitions could pair mismatched data. Both are now extracted from a single acquisition. A document with no parse result now correctly falls through to `fallback_completion` instead of returning `None` outright.

`Clone for DocumentState` previously silently dropped `parse_result`; it now preserves it via a cheap `Arc::clone`.

## Testing

- New `test_concurrent_document_write_not_blocked_by_in_flight_completion_search` regression test (modeled on the existing `test_no_deadlock_between_config_write_and_concurrent_hover_and_diagnostics` pattern): asserts a concurrent document write is not blocked by an in-flight completion search. Verified bidirectionally — reintroducing the original bug makes the new test fail (528ms, timeout) and it passes (~20ms) on the fix.
- New `test_document_state_clone_preserves_parse_result` covers the `Clone` fix.
- Full check suite green: `cargo +nightly fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo nextest run --workspace --all-features --no-fail-fast` (2643 passed, 0 failed), `cargo test --workspace --doc --all-features`, rustdoc gate.

## Test plan

- [x] Full pre-commit check suite passes
- [x] Regression test verified bidirectionally against the original bug
- [x] Reviewed by a second pass confirming Ref-drop-before-await in all three handlers by reading the actual code

Resolves #319