### PR TITLE
fix(deps-npm,deps-deno,deps-lsp,deps-maven): wildcard resolution correctness in diagnostics cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: extract `Version::is_prerelease()`'s default heuristic into a reusable `has_default_prerelease_marker` function (resolves #327) (#330)
 
 ### Fixed
+- **deps-npm, deps-deno**: npm/JSR packages whose every published version is deprecated or yanked are no longer misreported as "Unknown package" (resolves #338).
+- **deps-lsp**: release-cooldown diagnostic message now fires for npm, Deno, Maven, NuGet, and Swift, not just hover (resolves #339).
+- **deps-maven, deps-gradle**: diagnostics and quick-fix no longer recommend a prerelease as "latest" when a newer stable release exists (resolves #340).
 - **deps-lsp**: `handle_inlay_hints` no longer awaits the config `RwLock` read while holding a `DashMap` document `Ref`, closing the reproducible liveness hazard from #317 (the residual `Ref`-across-`generate_*()` hold is tracked separately) (#318).
 - **deps-bundler**: hover's "Recent versions" list no longer repeats the same version once per RubyGems platform variant; entries are now deduplicated by version number (resolves #311) (#321).
 - **deps-core**: hover's `(latest)` marker in "Recent versions" now matches the `**Latest**` header's stable-version pick instead of the raw highest-numbered entry, which could be a pre-release (resolves #313) (#321).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: extract `Version::is_prerelease()`'s default heuristic into a reusable `has_default_prerelease_marker` function (resolves #327) (#330)
 
 ### Fixed
-- **deps-npm, deps-deno**: npm/JSR packages whose every published version is deprecated or yanked are no longer misreported as "Unknown package" (resolves #338).
-- **deps-lsp**: release-cooldown diagnostic message now fires for npm, Deno, Maven, NuGet, and Swift, not just hover (resolves #339).
-- **deps-maven, deps-gradle**: diagnostics and quick-fix no longer recommend a prerelease as "latest" when a newer stable release exists (resolves #340).
+- **deps-npm, deps-deno**: npm/JSR packages whose every published version is deprecated or yanked are no longer misreported as "Unknown package" (resolves #338) (#352)
+- **deps-lsp**: release-cooldown diagnostic message now fires for npm, Deno, Maven, NuGet, and Swift, not just hover (resolves #339) (#352)
+- **deps-maven, deps-gradle**: diagnostics and quick-fix no longer recommend a prerelease as "latest" when a newer stable release exists (resolves #340) (#352)
 - **deps-lsp**: `handle_inlay_hints` no longer awaits the config `RwLock` read while holding a `DashMap` document `Ref`, closing the reproducible liveness hazard from #317 (the residual `Ref`-across-`generate_*()` hold is tracked separately) (#318).
 - **deps-bundler**: hover's "Recent versions" list no longer repeats the same version once per RubyGems platform variant; entries are now deduplicated by version number (resolves #311) (#321).
 - **deps-core**: hover's `(latest)` marker in "Recent versions" now matches the `**Latest**` header's stable-version pick instead of the raw highest-numbered entry, which could be a pre-release (resolves #313) (#321).

--- a/crates/deps-core/src/registry.rs
+++ b/crates/deps-core/src/registry.rs
@@ -115,8 +115,18 @@ pub trait Registry: Send + Sync {
 
     /// Finds the latest version matching a version requirement.
     ///
-    /// Only returns stable (non-yanked, non-deprecated) versions unless
-    /// explicitly requested in the version requirement.
+    /// Only returns stable (non-yanked, non-deprecated) versions unless explicitly
+    /// requested in the version requirement, with one documented exception: under a
+    /// wildcard/empty requirement (`"*"`/`""`), an implementation may treat this as an
+    /// *existence* check ("does this package exist / what is its newest version for
+    /// display purposes") rather than an upgrade recommendation, preferring a stable
+    /// version but falling back to a yanked/deprecated one rather than returning `None`
+    /// when no stable version exists — a yanked/deprecated package still exists. `deps-npm`
+    /// implements this fallback (mirrored by
+    /// [`select_latest_matching`](Self::select_latest_matching)'s wildcard branch on the
+    /// same registry, which every caller reaching this trait method through the shared
+    /// fetch loop actually goes through first); the exception never applies to a concrete
+    /// requirement.
     ///
     /// # Arguments
     ///

--- a/crates/deps-deno/src/registry.rs
+++ b/crates/deps-deno/src/registry.rs
@@ -514,7 +514,11 @@ impl Registry for DenoRegistry {
     ) -> Option<usize> {
         // Name-free and pure `node_semver`: correct for both JSR (which mandates semver)
         // and npm version strings, so npm's implementation covers both without a
-        // downcast.
+        // downcast. This deliberately includes npm's #338 wildcard fallback: an
+        // all-yanked JSR package (like an all-deprecated npm package) resolves to its
+        // newest yanked version rather than `None`/"Unknown package" — not a bug to
+        // "fix" by special-casing JSR here, since the alternative reintroduces #338
+        // for JSR specifically.
         self.npm.select_latest_matching(versions, req)
     }
 

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -691,6 +691,7 @@ async fn fetch_latest_versions_parallel(
     package_names: Vec<PackageName>,
     in_use: &HashMap<PackageName, String>,
     progress_sender: Option<ProgressSender>,
+    freshness: deps_core::freshness::FreshnessSettings,
     timeout_secs: u64,
     max_concurrent: usize,
 ) -> FetchResult {
@@ -717,8 +718,13 @@ async fn fetch_latest_versions_parallel(
                 // Single round trip: the full version list is fetched once, and "latest"
                 // is a pure in-memory pick over it (`Registry::select_latest_matching`) —
                 // no second registry call, so the retained full list costs nothing extra
-                // over the network (see `PackageVersions`).
-                let result = tokio::time::timeout(timeout, registry.get_versions(&name)).await;
+                // over the network (see `PackageVersions`). `get_versions_with` rather than
+                // `get_versions`: this populates `published_at` for registries that support
+                // it (#339), matching hover's existing freshness-aware call — registries with
+                // no override forward straight to `get_versions` at zero extra cost.
+                let result =
+                    tokio::time::timeout(timeout, registry.get_versions_with(&name, freshness))
+                        .await;
 
                 let mut yanked: Option<(PackageName, String)> = None;
                 let mut failed_name: Option<PackageName> = None;
@@ -1103,6 +1109,7 @@ pub async fn handle_document_open(
             dep_names,
             &in_use,
             progress_sender,
+            freshness_settings,
             cache_config.fetch_timeout_secs,
             cache_config.max_concurrent_fetches,
         )
@@ -1467,6 +1474,7 @@ pub async fn handle_document_change(
             deps_to_fetch,
             &in_use,
             progress_sender,
+            freshness_settings,
             cache_config.fetch_timeout_secs,
             cache_config.max_concurrent_fetches,
         )
@@ -1901,8 +1909,16 @@ mod tests {
         let packages = vec![PackageName::new("slow-package")];
 
         // Use 1 second timeout for test speed
-        let result =
-            fetch_latest_versions_parallel(registry, packages, &HashMap::new(), None, 1, 10).await;
+        let result = fetch_latest_versions_parallel(
+            registry,
+            packages,
+            &HashMap::new(),
+            None,
+            deps_core::freshness::FreshnessSettings::default(),
+            1,
+            10,
+        )
+        .await;
 
         // Should return empty (timeout, not success)
         assert!(result.versions.is_empty(), "Slow package should timeout");
@@ -1978,8 +1994,16 @@ mod tests {
         ];
 
         let start = std::time::Instant::now();
-        let result =
-            fetch_latest_versions_parallel(registry, packages, &HashMap::new(), None, 1, 10).await;
+        let result = fetch_latest_versions_parallel(
+            registry,
+            packages,
+            &HashMap::new(),
+            None,
+            deps_core::freshness::FreshnessSettings::default(),
+            1,
+            10,
+        )
+        .await;
         let elapsed = start.elapsed();
 
         // Should complete in ~1s (timeout), not 10s (slow package duration)
@@ -2086,7 +2110,16 @@ mod tests {
             .map(|i| PackageName::new(format!("package-{}", i)))
             .collect();
 
-        fetch_latest_versions_parallel(registry, packages, &HashMap::new(), None, 5, 20).await;
+        fetch_latest_versions_parallel(
+            registry,
+            packages,
+            &HashMap::new(),
+            None,
+            deps_core::freshness::FreshnessSettings::default(),
+            5,
+            20,
+        )
+        .await;
 
         // Max concurrent should not exceed limit (allow small margin for timing)
         let max = max_seen.load(Ordering::SeqCst);
@@ -2220,8 +2253,16 @@ mod tests {
         ];
 
         // Use 1 second timeout for test speed
-        let result =
-            fetch_latest_versions_parallel(registry, packages, &HashMap::new(), None, 1, 10).await;
+        let result = fetch_latest_versions_parallel(
+            registry,
+            packages,
+            &HashMap::new(),
+            None,
+            deps_core::freshness::FreshnessSettings::default(),
+            1,
+            10,
+        )
+        .await;
 
         // Only the fast package should be in results
         assert_eq!(
@@ -2330,8 +2371,16 @@ mod tests {
         let registry: Arc<dyn Registry> = Arc::new(YankedRegistry);
         let packages = vec![PackageName::new("serde")];
 
-        let result =
-            fetch_latest_versions_parallel(registry, packages, &HashMap::new(), None, 10, 10).await;
+        let result = fetch_latest_versions_parallel(
+            registry,
+            packages,
+            &HashMap::new(),
+            None,
+            deps_core::freshness::FreshnessSettings::default(),
+            10,
+            10,
+        )
+        .await;
 
         let serde = result
             .versions
@@ -2444,8 +2493,16 @@ mod tests {
         let registry: Arc<dyn Registry> = Arc::new(DatedRegistry);
         let packages = vec![PackageName::new("serde")];
 
-        let result =
-            fetch_latest_versions_parallel(registry, packages, &HashMap::new(), None, 10, 10).await;
+        let result = fetch_latest_versions_parallel(
+            registry,
+            packages,
+            &HashMap::new(),
+            None,
+            deps_core::freshness::FreshnessSettings::default(),
+            10,
+            10,
+        )
+        .await;
 
         let serde = result
             .versions
@@ -2456,6 +2513,129 @@ mod tests {
             serde.published_at,
             Some(PublishTime::from_unix_secs(2_000)),
             "published_at must be 1.0.214's own timestamp, not the yanked 1.0.213 entry's"
+        );
+    }
+
+    /// #339 regression guard: the bulk diagnostics-cache-population pass must call the
+    /// freshness-aware `Registry::get_versions_with`, not the freshness-blind `get_versions`,
+    /// for a registry that implements the override — otherwise `published_at` (and the
+    /// cooldown-context diagnostic message it drives) is silently always `None` in
+    /// production even though hover's separate call path gets it right.
+    #[tokio::test]
+    async fn test_fetch_latest_versions_parallel_uses_get_versions_with_for_freshness() {
+        use deps_core::freshness::{FreshnessSettings, PublishTime};
+        use deps_core::{Metadata, Registry, Version};
+        use std::any::Any;
+
+        #[derive(Debug)]
+        struct MockVersion {
+            version: String,
+            published_at: Option<PublishTime>,
+        }
+
+        impl Version for MockVersion {
+            fn version_string(&self) -> &str {
+                &self.version
+            }
+            fn is_yanked(&self) -> bool {
+                false
+            }
+            fn published_at(&self) -> Option<PublishTime> {
+                self.published_at
+            }
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        struct FreshnessAwareRegistry;
+
+        impl Registry for FreshnessAwareRegistry {
+            fn get_versions<'a>(
+                &'a self,
+                _name: &'a deps_core::PackageName,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Version>>>>
+            {
+                // Deliberately returns no `published_at` — if the fetch loop ever calls
+                // this instead of `get_versions_with`, the assertion below catches it.
+                Box::pin(async move {
+                    Ok(vec![Box::new(MockVersion {
+                        version: "1.0.0".to_string(),
+                        published_at: None,
+                    }) as Box<dyn Version>])
+                })
+            }
+
+            fn get_versions_with<'a>(
+                &'a self,
+                _name: &'a deps_core::PackageName,
+                freshness: FreshnessSettings,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Version>>>>
+            {
+                Box::pin(async move {
+                    Ok(vec![Box::new(MockVersion {
+                        version: "1.0.0".to_string(),
+                        published_at: freshness
+                            .enabled
+                            .then(|| PublishTime::from_unix_secs(5_000)),
+                    }) as Box<dyn Version>])
+                })
+            }
+
+            fn get_latest_matching<'a>(
+                &'a self,
+                _name: &'a deps_core::PackageName,
+                _req: &'a deps_core::VersionReq,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Option<Box<dyn Version>>>>
+            {
+                Box::pin(async move { Ok(None) })
+            }
+
+            fn search<'a>(
+                &'a self,
+                _query: &'a str,
+                _limit: usize,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Metadata>>>>
+            {
+                Box::pin(async move { Ok(vec![]) })
+            }
+
+            fn select_latest_matching(
+                &self,
+                versions: &[Box<dyn Version>],
+                _req: &deps_core::VersionReq,
+            ) -> Option<usize> {
+                if versions.is_empty() { None } else { Some(0) }
+            }
+
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        let registry: Arc<dyn Registry> = Arc::new(FreshnessAwareRegistry);
+        let packages = vec![PackageName::new("widget")];
+
+        let result = fetch_latest_versions_parallel(
+            registry,
+            packages,
+            &HashMap::new(),
+            None,
+            FreshnessSettings::default(),
+            10,
+            10,
+        )
+        .await;
+
+        let widget = result
+            .versions
+            .get("widget")
+            .expect("widget should be fetched");
+        assert_eq!(
+            widget.published_at,
+            Some(PublishTime::from_unix_secs(5_000)),
+            "published_at must come from get_versions_with, not the freshness-blind \
+             get_versions (#339)"
         );
     }
 
@@ -2532,8 +2712,16 @@ mod tests {
         let registry: Arc<dyn Registry> = Arc::new(UntaggedModuleRegistry);
         let packages = vec![PackageName::new("golang.org/x/exp")];
 
-        let result =
-            fetch_latest_versions_parallel(registry, packages, &HashMap::new(), None, 5, 10).await;
+        let result = fetch_latest_versions_parallel(
+            registry,
+            packages,
+            &HashMap::new(),
+            None,
+            deps_core::freshness::FreshnessSettings::default(),
+            5,
+            10,
+        )
+        .await;
 
         assert_eq!(
             result
@@ -2603,8 +2791,16 @@ mod tests {
         ];
 
         // Should not panic, just return empty result
-        let result =
-            fetch_latest_versions_parallel(registry, packages, &HashMap::new(), None, 5, 10).await;
+        let result = fetch_latest_versions_parallel(
+            registry,
+            packages,
+            &HashMap::new(),
+            None,
+            deps_core::freshness::FreshnessSettings::default(),
+            5,
+            10,
+        )
+        .await;
 
         // All packages failed, result should be empty
         assert!(
@@ -2688,8 +2884,16 @@ mod tests {
         let registry: Arc<dyn Registry> = Arc::new(NotFoundRegistry);
         let packages = vec![PackageName::new("typo-pkg")];
 
-        let result =
-            fetch_latest_versions_parallel(registry, packages, &HashMap::new(), None, 5, 10).await;
+        let result = fetch_latest_versions_parallel(
+            registry,
+            packages,
+            &HashMap::new(),
+            None,
+            deps_core::freshness::FreshnessSettings::default(),
+            5,
+            10,
+        )
+        .await;
 
         assert!(result.versions.is_empty());
         assert!(
@@ -2756,8 +2960,16 @@ mod tests {
         let registry: Arc<dyn Registry> = Arc::new(Http404Registry);
         let packages = vec![PackageName::new("typo-pkg")];
 
-        let result =
-            fetch_latest_versions_parallel(registry, packages, &HashMap::new(), None, 5, 10).await;
+        let result = fetch_latest_versions_parallel(
+            registry,
+            packages,
+            &HashMap::new(),
+            None,
+            deps_core::freshness::FreshnessSettings::default(),
+            5,
+            10,
+        )
+        .await;
 
         assert!(result.versions.is_empty());
         assert!(
@@ -2826,8 +3038,16 @@ mod tests {
         let registry: Arc<dyn Registry> = Arc::new(FallbackErrorRegistry);
         let packages = vec![PackageName::new("flaky"), PackageName::new("not-found")];
 
-        let result =
-            fetch_latest_versions_parallel(registry, packages, &HashMap::new(), None, 5, 10).await;
+        let result = fetch_latest_versions_parallel(
+            registry,
+            packages,
+            &HashMap::new(),
+            None,
+            deps_core::freshness::FreshnessSettings::default(),
+            5,
+            10,
+        )
+        .await;
 
         assert!(result.versions.is_empty());
         assert_eq!(
@@ -2892,8 +3112,16 @@ mod tests {
         let packages = vec![PackageName::new("slow-fallback")];
 
         // 1s timeout for test speed.
-        let result =
-            fetch_latest_versions_parallel(registry, packages, &HashMap::new(), None, 1, 10).await;
+        let result = fetch_latest_versions_parallel(
+            registry,
+            packages,
+            &HashMap::new(),
+            None,
+            deps_core::freshness::FreshnessSettings::default(),
+            1,
+            10,
+        )
+        .await;
 
         assert!(result.versions.is_empty());
         assert_eq!(
@@ -3479,8 +3707,16 @@ dependencies = ["requests>=2.0.0"]
             );
 
             let registry: Arc<dyn Registry> = Arc::new(MockYankedRegistry { pinned_version });
-            let fetch_result =
-                fetch_latest_versions_parallel(registry, dep_names, &in_use, None, 5, 10).await;
+            let fetch_result = fetch_latest_versions_parallel(
+                registry,
+                dep_names,
+                &in_use,
+                None,
+                deps_core::freshness::FreshnessSettings::default(),
+                5,
+                10,
+            )
+            .await;
 
             let yanked_versions: HashMap<String, String> = fetch_result
                 .yanked_versions
@@ -5264,6 +5500,7 @@ tokio = "1.0"
                 vec![PackageName::new("pkg")],
                 &in_use,
                 None,
+                deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
             )
@@ -5290,6 +5527,7 @@ tokio = "1.0"
                 vec![PackageName::new("pkg")],
                 &in_use,
                 None,
+                deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
             )
@@ -5314,6 +5552,7 @@ tokio = "1.0"
                 vec![PackageName::new("pkg")],
                 &HashMap::new(),
                 None,
+                deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
             )
@@ -5346,6 +5585,7 @@ tokio = "1.0"
                 vec![PackageName::new("pkg")],
                 &in_use,
                 None,
+                deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
             )
@@ -5378,6 +5618,7 @@ tokio = "1.0"
                 vec![PackageName::new("pkg")],
                 &in_use,
                 None,
+                deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
             )
@@ -5410,6 +5651,7 @@ tokio = "1.0"
                 vec![PackageName::new("pkg")],
                 &in_use,
                 None,
+                deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
             )
@@ -5444,6 +5686,7 @@ tokio = "1.0"
                 vec![PackageName::new("pkg")],
                 &in_use,
                 None,
+                deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
             )
@@ -5482,6 +5725,7 @@ tokio = "1.0"
                 vec![PackageName::new("pkg")],
                 &HashMap::new(),
                 None,
+                deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
             )
@@ -5514,6 +5758,7 @@ tokio = "1.0"
                 vec![PackageName::new("pkg")],
                 &HashMap::new(),
                 None,
+                deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
             )
@@ -5557,6 +5802,7 @@ tokio = "1.0"
                 vec![PackageName::new("pkg")],
                 &in_use,
                 None,
+                deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
             )
@@ -5585,6 +5831,7 @@ tokio = "1.0"
                 vec![PackageName::new("pkg")],
                 &in_use,
                 None,
+                deps_core::freshness::FreshnessSettings::default(),
                 1,
                 10,
             )

--- a/crates/deps-maven/src/registry.rs
+++ b/crates/deps-maven/src/registry.rs
@@ -183,27 +183,42 @@ fn move_release_to_front(versions: &mut Vec<MavenVersion>, release: Option<&str>
 /// Picks the "latest" version for a wildcard (`*`/empty) requirement from already-fetched
 /// `(versions, release)` metadata: prefers the `<release>`-designated entry — synthesizing a
 /// placeholder `MavenVersion` if `release` names something absent from `versions`, since
-/// `<release>` is still authoritative even when the metadata is otherwise inconsistent — else
-/// the first non-prerelease entry, else the first entry.
+/// `<release>` is still authoritative even when the metadata is otherwise inconsistent,
+/// *unless* `release` itself is a prerelease (#340 edge case — see below) — else the first
+/// non-prerelease entry, else the first entry.
 ///
 /// Shares its release-present/absent decision shape with [`move_release_to_front`], but
 /// differs in the one case that function structurally cannot handle: `release` naming an
 /// entry absent from `versions`. `move_release_to_front` must return an index into the
 /// existing slice (or no-op), so it can't invent an entry; this function returns an owned
 /// `MavenVersion` and has no such constraint, so it trusts `release` unconditionally instead
-/// — the same asymmetry `get_latest_matching_typed` had before this extraction.
+/// — the same asymmetry `get_latest_matching_typed` had before this extraction. The one
+/// exception: when `release` is absent from `versions` AND is itself a prerelease, this
+/// returns `None` rather than synthesizing it. This is the sole path through which this
+/// function is reachable in production (`Registry::get_latest_matching`'s only caller,
+/// `deps-lsp`'s bulk fetch loop, only falls back to it when
+/// `Registry::select_latest_matching`'s wildcard branch returned `None`, which for Maven
+/// only happens when `versions` is empty) — so without this guard, a
+/// `<release>`-names-a-prerelease-absent-from-an-empty-`<versions>`-list metadata shape
+/// (malformed but real: `parse_metadata_xml` parses `<release>` and `<versions>`
+/// independently) would reproduce #340 through this one narrow, otherwise-unscoped corner.
+/// Trade-off, not a free fix: `None` here surfaces as diagnostics' "Unknown package" for
+/// this narrow malformed shape — the inverse of #338's general "don't report a resolvable
+/// package as unknown" principle. Accepted deliberately (returning `None` rather than
+/// inventing a version is the safer failure mode for metadata this inconsistent), not
+/// something this function's normal contract silently absorbs.
 fn pick_wildcard_latest(versions: &[MavenVersion], release: Option<&str>) -> Option<MavenVersion> {
     if let Some(rel) = release {
-        return Some(
-            versions
-                .iter()
-                .find(|v| v.version == rel)
-                .cloned()
-                .unwrap_or(MavenVersion {
-                    version: rel.to_string(),
-                    published_at: None,
-                }),
-        );
+        if let Some(found) = versions.iter().find(|v| v.version == rel) {
+            return Some(found.clone());
+        }
+        if crate::version::is_prerelease(rel) {
+            return None;
+        }
+        return Some(MavenVersion {
+            version: rel.to_string(),
+            published_at: None,
+        });
     }
     versions
         .iter()
@@ -830,15 +845,36 @@ impl deps_core::Registry for MavenCentralRegistry {
         versions: &[Box<dyn deps_core::Version>],
         req: &deps_core::VersionReq,
     ) -> Option<usize> {
-        // `versions` is `get_versions`'s output, which already moved the
-        // maven-metadata.xml `<release>` entry to the front (`move_release_to_front`) — so
-        // index 0 *is* the authoritative "latest" here, not just a sort-order guess. This
-        // keeps `select_latest_matching` (no I/O, no side channel) in agreement with
-        // `get_latest_matching_typed`'s `<release>`-preferring pick without a second
-        // registry round trip.
+        // `versions` is `get_versions`'s output, which already moved the maven-metadata.xml
+        // `<release>` entry to the front (`move_release_to_front`). Unlike npm's curated
+        // `dist-tags.latest`, Maven Central's `<release>`/`<latest>` tags carry no
+        // prerelease semantics — they simply track the most recently *deployed* artifact,
+        // which can itself be a prerelease. So index 0 is trusted only when it isn't one;
+        // otherwise scan for the newest non-prerelease entry. When every version is a
+        // prerelease (#340), this does NOT fall back to raw index 0 either — see the
+        // version-comparison scan below (M1) — since `move_release_to_front` may have
+        // hoisted a `<release>`-tagged prerelease that isn't actually the newest deployed
+        // one. This keeps `select_latest_matching` (no I/O, no side channel) agreeing with
+        // hover's `is_stable()`-based pick whenever a stable version exists.
         let req_str = req.as_str();
         if req_str.is_empty() || req_str == "*" {
-            return if versions.is_empty() { None } else { Some(0) };
+            if versions.is_empty() {
+                return None;
+            }
+            if let Some(idx) = versions.iter().position(|v| !v.is_prerelease()) {
+                return Some(idx);
+            }
+            // FR-002: every version is a prerelease. Don't just trust index 0 here —
+            // `move_release_to_front` may have hoisted a `<release>`-tagged prerelease
+            // that isn't actually the newest deployed one (M1); scan by actual version
+            // comparison instead, same comparator `get_versions` already sorted by.
+            return versions
+                .iter()
+                .enumerate()
+                .max_by(|(_, a), (_, b)| {
+                    crate::version::compare_versions(a.version_string(), b.version_string())
+                })
+                .map(|(idx, _)| idx);
         }
         versions.iter().position(|v| v.version_string() == req_str)
     }
@@ -1562,6 +1598,29 @@ mod tests {
         assert_eq!(picked.version, "9.9.9");
     }
 
+    /// #340 residual edge case (found during validation, not the original spec): when
+    /// `release` names a prerelease absent from `versions` — the exact shape
+    /// `Registry::get_latest_matching`'s only production caller reaches this function
+    /// through, since `versions` is always empty there — `pick_wildcard_latest` must not
+    /// synthesize a placeholder for it. Doing so would reproduce #340 through this one
+    /// narrow corner even after the `select_latest_matching` fix.
+    #[test]
+    fn test_pick_wildcard_latest_release_prerelease_absent_from_list_returns_none() {
+        let versions: Vec<MavenVersion> = vec![];
+        let picked = pick_wildcard_latest(&versions, Some("8.0.0.Beta1"));
+        assert!(picked.is_none());
+    }
+
+    /// Companion to the above: a *stable* `release` absent from `versions` is unaffected
+    /// (unlikely to be a real issue in practice — this is the pre-existing, deliberately
+    /// documented synthesis behavior for a non-prerelease `<release>` tag).
+    #[test]
+    fn test_pick_wildcard_latest_release_stable_absent_from_empty_list_still_synthesizes() {
+        let versions: Vec<MavenVersion> = vec![];
+        let picked = pick_wildcard_latest(&versions, Some("1.2.3")).unwrap();
+        assert_eq!(picked.version, "1.2.3");
+    }
+
     #[test]
     fn test_pick_wildcard_latest_no_release_prefers_non_prerelease() {
         let versions = vec![
@@ -1579,10 +1638,16 @@ mod tests {
     }
 
     /// S8: `select_latest_matching` (via `move_release_to_front`) and
-    /// `get_latest_matching_typed` (via `pick_wildcard_latest`) must agree on the same
-    /// `(versions, release)` fixture across the three scenarios that previously diverged
-    /// (S3/S7): release present, release absent with a non-prerelease available, release
-    /// absent with only prereleases available.
+    /// `get_latest_matching_typed`'s own wildcard branch (via `pick_wildcard_latest`) must
+    /// agree on the same `(versions, release)` fixture when `<release>` names a stable
+    /// version or is absent (S3/S7). They deliberately no longer agree when `<release>`
+    /// itself names a prerelease *present in `versions`* (#340): `select_latest_matching`
+    /// now skips past it to the newest stable version, matching hover's
+    /// `is_stable()`-based pick, while `pick_wildcard_latest` still trusts a
+    /// `<release>` found in `versions` verbatim — see
+    /// `test_select_latest_matching_skips_prerelease_release_tag`. When `<release>` names a
+    /// prerelease *absent* from `versions` instead, `pick_wildcard_latest` no longer trusts
+    /// it either (see `test_pick_wildcard_latest_release_prerelease_absent_from_list_returns_none`).
     fn assert_select_latest_matching_agrees_with_pick_wildcard_latest(
         versions: Vec<MavenVersion>,
         release: Option<&str>,
@@ -1611,19 +1676,126 @@ mod tests {
     }
 
     #[test]
-    fn test_select_latest_matching_agrees_with_pick_wildcard_latest_release_present() {
+    fn test_select_latest_matching_agrees_with_pick_wildcard_latest_release_present_stable() {
         assert_select_latest_matching_agrees_with_pick_wildcard_latest(
             vec![
-                MavenVersion {
-                    version: "1.4.0".into(),
-                    published_at: None,
-                },
                 MavenVersion {
                     version: "1.5.0-M1".into(),
                     published_at: None,
                 },
+                MavenVersion {
+                    version: "1.4.0".into(),
+                    published_at: None,
+                },
             ],
-            Some("1.5.0-M1"),
+            Some("1.4.0"),
+        );
+    }
+
+    /// #340: `<release>` names a prerelease (`8.0.0.Beta1`-shaped scenario), but a stable
+    /// release also exists in the list. `select_latest_matching`'s wildcard fast path must
+    /// skip past the front-loaded prerelease and return the newest stable version instead
+    /// of blindly trusting index 0, matching hover's `is_stable()`-based pick (FR-001).
+    #[test]
+    fn test_select_latest_matching_skips_prerelease_release_tag() {
+        use deps_core::{Registry, VersionReq};
+
+        let mut versions = vec![
+            MavenVersion {
+                version: "1.4.0".into(),
+                published_at: None,
+            },
+            MavenVersion {
+                version: "1.5.0-M1".into(),
+                published_at: None,
+            },
+        ];
+        // `<release>` names the prerelease, so `move_release_to_front` puts it at index 0 —
+        // reproducing the real `maven-metadata.xml` shape this bug was found in.
+        move_release_to_front(&mut versions, Some("1.5.0-M1"));
+        assert_eq!(versions[0].version, "1.5.0-M1");
+
+        let boxed: Vec<Box<dyn deps_core::Version>> = versions
+            .into_iter()
+            .map(|v| Box::new(v) as Box<dyn deps_core::Version>)
+            .collect();
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = MavenCentralRegistry::new(cache);
+        let idx = registry
+            .select_latest_matching(&boxed, &VersionReq::new("*"))
+            .expect("non-empty list must select an index");
+
+        assert_eq!(boxed[idx].version_string(), "1.4.0");
+    }
+
+    /// FR-002: when every version in the list is a prerelease, the wildcard fast path
+    /// falls back to the newest version regardless of prerelease status.
+    #[test]
+    fn test_select_latest_matching_wildcard_all_prerelease_falls_back_to_newest() {
+        use deps_core::{Registry, VersionReq};
+
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(MavenVersion {
+                version: "2.0.0-alpha".into(),
+                published_at: None,
+            }),
+            Box::new(MavenVersion {
+                version: "1.0.0-beta".into(),
+                published_at: None,
+            }),
+        ];
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = MavenCentralRegistry::new(cache);
+        let idx = registry
+            .select_latest_matching(&versions, &VersionReq::new("*"))
+            .expect("non-empty list must select an index");
+
+        assert_eq!(versions[idx].version_string(), "2.0.0-alpha");
+    }
+
+    /// M1: when every version is a prerelease AND `<release>` hoisted an *older*
+    /// prerelease to index 0 (`move_release_to_front` trusts `<release>` unconditionally,
+    /// independent of whether it's actually the newest deployed artifact), the FR-002
+    /// fallback must scan by actual version comparison rather than blindly trusting
+    /// index 0 — otherwise a stale/inconsistent `<release>` tag reproduces #340 even in
+    /// this all-prerelease branch.
+    #[test]
+    fn test_select_latest_matching_wildcard_all_prerelease_ignores_stale_release_hoist() {
+        use deps_core::{Registry, VersionReq};
+
+        let mut versions = vec![
+            MavenVersion {
+                version: "2.0.0-beta".into(),
+                published_at: None,
+            },
+            MavenVersion {
+                version: "1.0.0-alpha".into(),
+                published_at: None,
+            },
+        ];
+        // `<release>` names the OLDER prerelease — `move_release_to_front` hoists it to
+        // index 0 regardless, reproducing the real shape a stale/inconsistent
+        // `maven-metadata.xml` could produce.
+        move_release_to_front(&mut versions, Some("1.0.0-alpha"));
+        assert_eq!(versions[0].version, "1.0.0-alpha");
+
+        let boxed: Vec<Box<dyn deps_core::Version>> = versions
+            .into_iter()
+            .map(|v| Box::new(v) as Box<dyn deps_core::Version>)
+            .collect();
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = MavenCentralRegistry::new(cache);
+        let idx = registry
+            .select_latest_matching(&boxed, &VersionReq::new("*"))
+            .expect("non-empty list must select an index");
+
+        assert_eq!(
+            boxed[idx].version_string(),
+            "2.0.0-beta",
+            "must scan for the actual newest prerelease, not trust the release-tag hoist"
         );
     }
 

--- a/crates/deps-npm/src/registry.rs
+++ b/crates/deps-npm/src/registry.rs
@@ -39,6 +39,31 @@ const PUBLISH_TIMES_TTL: Duration = Duration::from_hours(1);
 /// a small constant size.
 const PUBLISH_TIMES_MAX_ENTRIES: usize = 256;
 
+/// Per-request timeout for the full-packument fetch inside
+/// [`NpmRegistry::fetch_publish_times`].
+///
+/// Unlike the abbreviated packument `get_versions` uses, the full packument this fetches
+/// (for `published_at`/freshness) can be multi-MB and has no timeout of its own beyond
+/// `HttpCache`'s generic client timeout. Since #339 routes this through the bulk
+/// diagnostics-cache-population pass (`deps-lsp`'s `fetch_latest_versions_parallel`), a
+/// slow full-packument response now shares the same outer per-package
+/// `tokio::time::timeout` (10s default) as the abbreviated fetch it runs alongside —
+/// without a tighter inner cap, a hanging full-packument request could consume that
+/// entire outer budget and lose the package's whole version list ("Registry lookup
+/// failed") where it previously succeeded. Mirrors `deps-swift`'s
+/// `RELEASE_DATES_FETCH_TIMEOUT` pattern: elapsing this timeout is treated the same as
+/// any other fetch failure — an empty map, never propagated as an error.
+///
+/// This is a mitigation, not a structural bound: it is a fixed, independent cap, not
+/// derived from whatever outer budget remains after the abbreviated fetch that runs first
+/// in the same `get_versions_with` call. `fetch_timeout_secs` is user-configurable down to
+/// 1s (`deps-lsp`'s `default_fetch_timeout_secs`/config bounds), and even at the 10s
+/// default a slow-but-under-cap abbreviated fetch plus a full 5s of this timeout can still
+/// exceed the outer budget. Deriving this from the remaining outer time would close that
+/// gap but needs threading the outer deadline into this call — left as a known limitation
+/// rather than a blocking fix.
+const PUBLISH_TIMES_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Display name for the npm registry used in not-found and API-response
 /// error messages.
 pub const REGISTRY: &str = "npm";
@@ -275,14 +300,22 @@ impl NpmRegistry {
         known_versions: &[String],
     ) -> HashMap<String, PublishTime> {
         let url = versions_url(&self.registry_base, name);
-        let body = match self
-            .cache
-            .get_transport_only_with_headers(&url, &[(reqwest::header::ACCEPT, "application/json")])
-            .await
-        {
-            Ok(body) => body,
-            Err(e) => {
+        let fetch = self.cache.get_transport_only_with_headers(
+            &url,
+            &[(reqwest::header::ACCEPT, "application/json")],
+        );
+        let body = match tokio::time::timeout(PUBLISH_TIMES_FETCH_TIMEOUT, fetch).await {
+            Ok(Ok(body)) => body,
+            Ok(Err(e)) => {
                 tracing::debug!(package = %name, error = %e, "full packument fetch failed, publish times unavailable");
+                return HashMap::new();
+            }
+            Err(_) => {
+                tracing::debug!(
+                    package = %name,
+                    timeout_secs = PUBLISH_TIMES_FETCH_TIMEOUT.as_secs(),
+                    "full packument fetch timed out, publish times unavailable"
+                );
                 return HashMap::new();
             }
         };
@@ -311,7 +344,20 @@ impl NpmRegistry {
 
     /// Finds the latest version matching the given npm semver requirement.
     ///
-    /// Only returns non-deprecated versions.
+    /// Only returns non-deprecated, non-prerelease versions unless explicitly requested in
+    /// the version requirement (e.g. `^1.0.0-beta.1` legitimately matches and returns
+    /// `1.0.0-beta.2`), with one exception: under a wildcard/empty requirement
+    /// (`"*"`/`""`), which answers "does this package exist / what is its newest version"
+    /// for existence checks rather than "what should I recommend installing". That call
+    /// prefers the newest stable version, falls back to the newest non-deprecated version
+    /// (possibly a prerelease — including when every version is a prerelease and none is
+    /// deprecated, which resolves to that newest prerelease rather than `None`; hover's
+    /// separate `is_stable()`-based pick shows no `**Latest**` line in that case, so
+    /// diagnostics and hover intentionally diverge here) when no stable version exists, and
+    /// finally to the newest version overall when every version is deprecated (#338) — a
+    /// deprecated package still exists. Mirrors
+    /// [`Registry::select_latest_matching`](deps_core::Registry::select_latest_matching)'s
+    /// wildcard branch exactly, so the two never disagree on the same input.
     ///
     /// # Errors
     ///
@@ -340,6 +386,19 @@ impl NpmRegistry {
         req_str: &str,
     ) -> Result<Option<NpmVersion>> {
         let versions = self.get_versions(name).await?;
+
+        if req_str.is_empty() || req_str == "*" {
+            if versions.is_empty() {
+                return Ok(None);
+            }
+            use deps_core::Version as _;
+            let idx = versions
+                .iter()
+                .position(|v| v.is_stable())
+                .or_else(|| versions.iter().position(|v| !v.deprecated))
+                .unwrap_or(0);
+            return Ok(versions.into_iter().nth(idx));
+        }
 
         // Parse npm semver requirement
         let req = node_semver::Range::parse(req_str)
@@ -616,7 +675,36 @@ impl deps_core::Registry for NpmRegistry {
         versions: &[Box<dyn deps_core::Version>],
         req: &deps_core::VersionReq,
     ) -> Option<usize> {
-        let parsed_req = node_semver::Range::parse(req.as_str()).ok()?;
+        let req_str = req.as_str();
+        if req_str.is_empty() || req_str == "*" {
+            if versions.is_empty() {
+                return None;
+            }
+            // Existence/latest-for-display resolution (#338): prefer the newest
+            // stable (non-yanked, non-prerelease) version — matching
+            // `Version::is_stable()`, mirroring `get_latest_matching`'s identical
+            // wildcard branch above so the two never disagree — falling back to the
+            // newest non-yanked version (possibly a prerelease) when no stable
+            // version exists, and finally to the newest version overall when every
+            // version is yanked. A yanked/deprecated-but-existing package must never
+            // resolve to "no version found", but that must not surface an
+            // unrequested prerelease as "the latest" ahead of a stable release.
+            // Deliberate divergence from hover (W1): a package whose every version
+            // is a prerelease, with none deprecated, resolves here to that newest
+            // prerelease (diagnostics can say "Newer version available:
+            // 0.1.0-alpha.2"), while hover's separate `is_stable()`-based pick shows
+            // no `**Latest**` line at all for the same package — this is accepted as
+            // consistent with #338's own principle of not reporting "Unknown
+            // package"/"no latest" for a package that genuinely exists and resolves.
+            return Some(
+                versions
+                    .iter()
+                    .position(|v| v.is_stable())
+                    .or_else(|| versions.iter().position(|v| !v.is_yanked()))
+                    .unwrap_or(0),
+            );
+        }
+        let parsed_req = node_semver::Range::parse(req_str).ok()?;
         versions.iter().position(|v| {
             node_semver::Version::parse(v.version_string())
                 .is_ok_and(|ver| parsed_req.satisfies(&ver) && !v.is_yanked())
@@ -962,6 +1050,302 @@ mod tests {
         assert_eq!(registry.select_latest_matching(&versions, &req), Some(1));
     }
 
+    /// #338: every version is deprecated, but the wildcard existence/latest-for-display
+    /// resolution must still return the newest one rather than `None` — a deprecated
+    /// package still exists.
+    #[test]
+    fn test_select_latest_matching_wildcard_all_deprecated_returns_newest() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = NpmRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(NpmVersion {
+                version: "1.3.0".into(),
+                deprecated: true,
+                published_at: None,
+            }),
+            Box::new(NpmVersion {
+                version: "1.2.0".into(),
+                deprecated: true,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new("*");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
+    }
+
+    /// Same guarantee for the empty-requirement string, which `lifecycle.rs` treats
+    /// identically to `"*"`.
+    #[test]
+    fn test_select_latest_matching_empty_req_all_deprecated_returns_newest() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = NpmRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![Box::new(NpmVersion {
+            version: "1.0.0".into(),
+            deprecated: true,
+            published_at: None,
+        })];
+        let req = VersionReq::new("");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
+    }
+
+    /// B1 regression: the wildcard existence check must still skip a prerelease sitting
+    /// at index 0 (npm's abbreviated packument sorts newest-first regardless of
+    /// prerelease status — a package that publishes canary/beta builds routinely has one
+    /// at the front) and pick the newest *stable* version instead, matching pre-#338
+    /// behavior and hover's `is_stable()`-based pick. #338's deprecated-fallback must not
+    /// have loosened this.
+    #[test]
+    fn test_select_latest_matching_wildcard_skips_prerelease_at_front() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = NpmRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(NpmVersion {
+                version: "19.2.0-canary.1".into(),
+                deprecated: false,
+                published_at: None,
+            }),
+            Box::new(NpmVersion {
+                version: "19.1.0".into(),
+                deprecated: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new("*");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(1));
+    }
+
+    /// B1/FR-002-style fallback: when every version is a prerelease (no stable release
+    /// exists at all), the wildcard existence check still resolves to the newest version
+    /// rather than `None` — a prerelease-only package still exists.
+    #[test]
+    fn test_select_latest_matching_wildcard_all_prerelease_falls_back_to_newest() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = NpmRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(NpmVersion {
+                version: "2.0.0-alpha".into(),
+                deprecated: false,
+                published_at: None,
+            }),
+            Box::new(NpmVersion {
+                version: "1.0.0-beta".into(),
+                deprecated: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new("*");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
+    }
+
+    /// B2: `get_latest_matching`'s wildcard branch must agree with
+    /// `select_latest_matching`'s on the same prerelease-at-front shape.
+    #[tokio::test]
+    async fn test_get_latest_matching_wildcard_skips_prerelease_at_front() {
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let registry = NpmRegistry::with_registry_base(Arc::new(HttpCache::new()), base);
+
+        server
+            .mock("GET", "/react")
+            .match_header("accept", ABBREVIATED_ACCEPT)
+            .with_status(200)
+            .with_body(
+                r#"{"versions": {
+                    "19.2.0-canary.1": {},
+                    "19.1.0": {}
+                }}"#,
+            )
+            .create_async()
+            .await;
+
+        let latest = registry.get_latest_matching("react", "*").await.unwrap();
+
+        let version = latest.expect("react has a stable version");
+        assert_eq!(version.version, "19.1.0");
+    }
+
+    /// N4: `get_latest_matching` and `select_latest_matching` must agree under `"*"` on
+    /// the same version data, mirroring `deps-maven`'s S8 helper pattern. `entries` must
+    /// already be newest-first (matching `parse_package_metadata`'s sort), since that's
+    /// what both the mocked packument response and the directly-built `Vec` assume.
+    async fn assert_get_latest_matching_agrees_with_select_latest_matching(
+        name: &str,
+        entries: &[(&str, bool)],
+    ) {
+        use deps_core::{Registry, VersionReq};
+
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let registry = NpmRegistry::with_registry_base(Arc::new(HttpCache::new()), base);
+
+        let versions_json: Vec<String> = entries
+            .iter()
+            .map(|(version, deprecated)| {
+                if *deprecated {
+                    format!(r#""{version}": {{"deprecated": "old"}}"#)
+                } else {
+                    format!(r#""{version}": {{}}"#)
+                }
+            })
+            .collect();
+        server
+            .mock("GET", format!("/{name}").as_str())
+            .match_header("accept", ABBREVIATED_ACCEPT)
+            .with_status(200)
+            .with_body(format!(
+                r#"{{"versions": {{{}}}}}"#,
+                versions_json.join(",")
+            ))
+            .create_async()
+            .await;
+
+        let via_get_latest = registry
+            .get_latest_matching(name, "*")
+            .await
+            .unwrap()
+            .expect("fixture always has a pick");
+
+        let boxed: Vec<Box<dyn deps_core::Version>> = entries
+            .iter()
+            .map(|(version, deprecated)| {
+                Box::new(NpmVersion {
+                    version: (*version).to_string(),
+                    deprecated: *deprecated,
+                    published_at: None,
+                }) as Box<dyn deps_core::Version>
+            })
+            .collect();
+        let idx = registry
+            .select_latest_matching(&boxed, &VersionReq::new("*"))
+            .expect("fixture always has a pick");
+
+        assert_eq!(via_get_latest.version, boxed[idx].version_string());
+    }
+
+    #[tokio::test]
+    async fn test_wildcard_agreement_mixed_prerelease_and_stable() {
+        assert_get_latest_matching_agrees_with_select_latest_matching(
+            "react",
+            &[("19.2.0-canary.1", false), ("19.1.0", false)],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_wildcard_agreement_all_deprecated() {
+        assert_get_latest_matching_agrees_with_select_latest_matching(
+            "left-pad-agree",
+            &[("1.3.0", true), ("1.2.0", true)],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_wildcard_agreement_all_prerelease_none_deprecated() {
+        assert_get_latest_matching_agrees_with_select_latest_matching(
+            "canary-only",
+            &[("2.0.0-alpha", false), ("1.0.0-beta", false)],
+        )
+        .await;
+    }
+
+    /// N4 (tier 2): `get_latest_matching`'s all-prerelease/none-deprecated case (W1) —
+    /// the async path's own dedicated regression, alongside the shared-fixture agreement
+    /// test above.
+    #[tokio::test]
+    async fn test_get_latest_matching_wildcard_all_prerelease_none_deprecated_returns_newest() {
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let registry = NpmRegistry::with_registry_base(Arc::new(HttpCache::new()), base);
+
+        server
+            .mock("GET", "/canary-only-solo")
+            .match_header("accept", ABBREVIATED_ACCEPT)
+            .with_status(200)
+            .with_body(
+                r#"{"versions": {
+                    "2.0.0-alpha": {},
+                    "1.0.0-beta": {}
+                }}"#,
+            )
+            .create_async()
+            .await;
+
+        let latest = registry
+            .get_latest_matching("canary-only-solo", "*")
+            .await
+            .unwrap();
+
+        let version = latest.expect("a prerelease-only, non-deprecated package still exists");
+        assert_eq!(version.version, "2.0.0-alpha");
+        assert!(!version.deprecated);
+    }
+
+    /// #338 NFR-001: `get_latest_matching` under a wildcard requirement, mirroring the
+    /// `left-pad`-shaped real-world case (every published version deprecated), must return
+    /// the newest version rather than `None`.
+    #[tokio::test]
+    async fn test_get_latest_matching_wildcard_all_deprecated_returns_newest() {
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let registry = NpmRegistry::with_registry_base(Arc::new(HttpCache::new()), base);
+
+        server
+            .mock("GET", "/left-pad")
+            .match_header("accept", ABBREVIATED_ACCEPT)
+            .with_status(200)
+            .with_body(
+                r#"{"versions": {
+                    "1.3.0": {"deprecated": "use String.prototype.padStart()"},
+                    "1.2.0": {"deprecated": "use String.prototype.padStart()"}
+                }}"#,
+            )
+            .create_async()
+            .await;
+
+        let latest = registry.get_latest_matching("left-pad", "*").await.unwrap();
+
+        let version = latest.expect("an all-deprecated package must still resolve a latest");
+        assert_eq!(version.version, "1.3.0");
+        assert!(version.deprecated);
+    }
+
+    /// #338 NFR-002 (regression): a mix of deprecated and non-deprecated versions under a
+    /// wildcard requirement must still prefer the newest non-deprecated one, unchanged.
+    #[tokio::test]
+    async fn test_get_latest_matching_wildcard_prefers_non_deprecated_when_available() {
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let registry = NpmRegistry::with_registry_base(Arc::new(HttpCache::new()), base);
+
+        server
+            .mock("GET", "/widget")
+            .match_header("accept", ABBREVIATED_ACCEPT)
+            .with_status(200)
+            .with_body(
+                r#"{"versions": {
+                    "2.0.0": {"deprecated": "use widget-next"},
+                    "1.0.0": {}
+                }}"#,
+            )
+            .create_async()
+            .await;
+
+        let latest = registry.get_latest_matching("widget", "*").await.unwrap();
+
+        let version = latest.expect("widget has a non-deprecated version");
+        assert_eq!(version.version, "1.0.0");
+        assert!(!version.deprecated);
+    }
+
     fn npm_v(s: &str) -> NpmVersion {
         NpmVersion {
             version: s.to_string(),
@@ -1210,6 +1594,20 @@ mod tests {
             .await;
 
         assert!(Arc::ptr_eq(&result, &times));
+    }
+
+    /// H1: `fetch_publish_times`'s internal timeout must stay strictly tighter than the
+    /// bulk fetch loop's outer per-package timeout (10s default, `deps-lsp`'s
+    /// `default_fetch_timeout_secs`) — otherwise a hanging full-packument request could
+    /// consume the entire outer budget and lose the abbreviated fetch's own result too,
+    /// reproducing the "Registry lookup failed" regression #339 introduced by routing
+    /// this fetch through the bulk diagnostics-cache-population pass. A live
+    /// elapsed-timeout test is deliberately not included here (mockito has no built-in
+    /// response-delay primitive in this workspace, and sleeping for real seconds in a
+    /// unit test would slow the suite); this asserts the invariant the fix exists for.
+    #[test]
+    fn test_publish_times_fetch_timeout_is_tighter_than_default_outer_fetch_timeout() {
+        assert!(PUBLISH_TIMES_FETCH_TIMEOUT < Duration::from_secs(10));
     }
 
     // --- publish_times / get_versions_with: end-to-end via mockito (S3 — the mandatory


### PR DESCRIPTION
## Summary

Three P1 bugs, all rooted in the same theme: the bulk `"*"`-wildcard resolution pass that populates deps-lsp's diagnostics cache disagreed with the correct, prerelease/deprecation-aware resolution logic that hover already used.

- npm/JSR packages whose every published version is deprecated or yanked were misreported as "Unknown package". The wildcard existence/latest-for-display resolution now prefers the newest stable version, then the newest non-deprecated one, and only falls back to a deprecated version when nothing else exists.
- The release-cooldown diagnostic message never fired for npm, Deno, Maven, NuGet, or Swift because the bulk cache-population pass called the freshness-blind `get_versions` instead of `get_versions_with`, which hover already used.
- Maven's wildcard fast path trusted `maven-metadata.xml`'s `<release>` tag verbatim, recommending a prerelease as "latest" in both the diagnostic and the quick-fix whenever it was the most recently deployed artifact; `deps-gradle` inherits the fix via the shared `MavenCentralRegistry` type.

All three were live-verified against real registry data (registry.npmjs.org's `left-pad`/`react`, Maven Central's `spring-boot`/`hibernate-core`).

Closes #338
Closes #339
Closes #340

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (2757 passed, 0 failed)
- [x] rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`)
- [x] Live verification against real npm registry (`left-pad`, `react`) and Maven Central (`spring-boot`, `hibernate-core`)
- [x] New regression tests added for all three fixes, including the wildcard fallback edge cases