### PR TITLE
fix(deps-core): stop holding DashMap Ref across await in LockFileCache::get_or_parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: extract `Version::is_prerelease()`'s default heuristic into a reusable `has_default_prerelease_marker` function (resolves #327) (#330)
 
 ### Fixed
+- **deps-core**: `LockFileCache::get_or_parse` no longer holds a `DashMap` `Ref` across the `tokio::fs::metadata` staleness-check await, closing the last known hazard in this class after #333/#334 (resolves #350)
 - **deps-npm, deps-deno**: npm/JSR packages whose every published version is deprecated or yanked are no longer misreported as "Unknown package" (resolves #338) (#352)
 - **deps-lsp**: release-cooldown diagnostic message now fires for npm, Deno, Maven, NuGet, and Swift, not just hover (resolves #339) (#352)
 - **deps-maven, deps-gradle**: diagnostics and quick-fix no longer recommend a prerelease as "latest" when a newer stable release exists (resolves #340) (#352)

--- a/crates/deps-core/src/lockfile.rs
+++ b/crates/deps-core/src/lockfile.rs
@@ -424,23 +424,28 @@ impl LockFileCache {
     /// # Errors
     ///
     /// Returns error if file cannot be read or parsed
-    // TODO(#350): `cached` (a DashMap shard `Ref`) is held across the
-    // `tokio::fs::metadata(...).await` below — same hazard class as #333, tracked
-    // separately and out of scope here.
-    #[allow(clippy::await_holding_invalid_type)]
     pub async fn get_or_parse(
         &self,
         provider: &dyn LockFileProvider,
         lockfile_path: &Path,
     ) -> Result<ResolvedPackages> {
+        // Extract owned data from the cache entry before awaiting: the DashMap shard
+        // `Ref` returned by `entries.get` must not be held across `.await`, or a
+        // concurrent access to the same key blocks for the duration (#350, same hazard
+        // class as #333).
+        let cached = self
+            .entries
+            .get(lockfile_path)
+            .map(|entry| (entry.modified_at, entry.packages.clone()));
+
         // Check cache first
-        if let Some(cached) = self.entries.get(lockfile_path)
+        if let Some((cached_modified_at, cached_packages)) = cached
             && let Ok(metadata) = tokio::fs::metadata(lockfile_path).await
             && let Ok(mtime) = metadata.modified()
-            && mtime <= cached.modified_at
+            && mtime <= cached_modified_at
         {
             tracing::debug!("Lock file cache hit: {}", lockfile_path.display());
-            return Ok(cached.packages.clone());
+            return Ok(cached_packages);
         }
 
         // Cache miss - parse and store


### PR DESCRIPTION
## Summary
- `LockFileCache::get_or_parse` held a `dashmap::mapref::one::Ref` across the `tokio::fs::metadata(...).await` staleness check, the same liveness hazard class fixed in #333/#334 for `hover.rs`/`inlay_hints.rs`/`diagnostics.rs`/`code_lens.rs`
- Cache lookup now extracts `(modified_at, packages)` as an owned tuple before the await, dropping the DashMap guard beforehand; behavior is unchanged
- Removes the placeholder `#[allow(clippy::await_holding_invalid_type)]` left by #354; the workspace `clippy.toml` lint (added in #334) now passes clean on this file

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (2691 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`

Closes #350