### PR TITLE
docs(deps-go,deps-core): document intentional DepsError::InvalidVersionReq sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **deps-bundler, deps-go**: removed private duplicate `LineOffsetTable` structs, both now use the shared `deps_core::lsp_helpers::LineOffsetTable` (resolves #389) (#395)
 - **deps-cargo, deps-npm, deps-composer, deps-dart, deps-deno, deps-go, deps-gradle, deps-maven, deps-nuget**: removed per-crate `{Ecosystem}Error` wrapper enums; call sites now construct `deps_core::DepsError` directly (resolves #388) (#398)
+- **deps-core, deps-go**: documented that `deps-go`'s module-path validation intentionally shares `DepsError::InvalidVersionReq` with version-string rejections, no new variant added (resolves #399) (#PR)
 
 ### Fixed
 - **deps-cargo**: invalid file URI during workspace-root discovery now reports `DepsError::InvalidUri`, matching every other ecosystem, instead of the previously divergent `DepsError::CacheError` (#398)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **deps-bundler, deps-go**: removed private duplicate `LineOffsetTable` structs, both now use the shared `deps_core::lsp_helpers::LineOffsetTable` (resolves #389) (#395)
 - **deps-cargo, deps-npm, deps-composer, deps-dart, deps-deno, deps-go, deps-gradle, deps-maven, deps-nuget**: removed per-crate `{Ecosystem}Error` wrapper enums; call sites now construct `deps_core::DepsError` directly (resolves #388) (#398)
-- **deps-core, deps-go**: documented that `deps-go`'s module-path validation intentionally shares `DepsError::InvalidVersionReq` with version-string rejections, no new variant added (resolves #399) (#PR)
+- **deps-core, deps-go**: documented that `deps-go`'s module-path validation intentionally shares `DepsError::InvalidVersionReq` with version-string rejections, no new variant added (resolves #399) (#401)
 
 ### Fixed
 - **deps-cargo**: invalid file URI during workspace-root discovery now reports `DepsError::InvalidUri`, matching every other ecosystem, instead of the previously divergent `DepsError::CacheError` (#398)

--- a/crates/deps-core/src/error.rs
+++ b/crates/deps-core/src/error.rs
@@ -76,6 +76,11 @@ pub enum DepsError {
     #[error("response body for {url} exceeds {limit} byte limit")]
     ResponseTooLarge { url: String, limit: usize },
 
+    /// Deliberately shared between two distinct rejection kinds: malformed version-requirement
+    /// strings (all ecosystems) and malformed Go module paths (`deps-go`, which has no separate
+    /// variant for the latter — see its `validate_module_path`). Nothing in the workspace
+    /// discriminates on this variant beyond rendering its message, so a consumer-specific split
+    /// was deferred (#399).
     #[error("invalid version requirement: {0}")]
     InvalidVersionReq(String),
 

--- a/crates/deps-go/src/registry.rs
+++ b/crates/deps-go/src/registry.rs
@@ -49,6 +49,9 @@ const MAX_VERSION_LENGTH: usize = 128;
 
 /// Validates a module path for length and basic format.
 ///
+/// Rejections intentionally render through the shared `DepsError::InvalidVersionReq` variant
+/// rather than a Go-specific one — see #399.
+///
 /// # Errors
 ///
 /// Returns error if:
@@ -363,7 +366,7 @@ struct VersionInfo {
 /// `find_latest_stable` returns the correct latest version.
 fn parse_version_list(data: &[u8]) -> Result<Vec<GoVersion>> {
     let content = std::str::from_utf8(data).map_err(|e| {
-        DepsError::InvalidVersionReq(format!("Invalid UTF-8 in version list response: {e}"))
+        DepsError::CacheError(format!("Invalid UTF-8 in version list response: {e}"))
     })?;
 
     // Parse versions with precomputed sort keys (Schwartzian transform)


### PR DESCRIPTION
## Summary
- Documents the deliberate design decision from #399: `deps-go`'s `validate_module_path` rejections intentionally share `DepsError::InvalidVersionReq` with genuine version-requirement-string rejections, rather than getting a Go-specific variant.
- Decision rationale: nothing in the workspace structurally matches on `InvalidVersionReq` (only `is_not_found()` matches on `PackageNotFound`/`HttpStatus{404}`), so a new variant would add a 4th spelling of "malformed package reference" to a 12-crate shared enum with zero current consumers needing the distinction.
- While verifying that decision, found and fixed a pre-existing mislabel: `parse_version_list`'s UTF-8 decode failure on a registry response body was routed through `InvalidVersionReq` (misreporting a transient/upstream issue as a user-input error) instead of `DepsError::CacheError`, which the sibling case (`get_go_mod_content`, same file) already uses for identical semantics. Fixing this also makes the new doc comment's "two distinct rejection kinds" claim accurate.

## Test plan
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` — 2908 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace` — clean
- [x] `cargo test --doc --workspace` — all pass
- [x] `test_parse_version_list_invalid_utf8` confirmed unaffected by the variant swap (asserts `is_err()` only)

Closes #399