### PR TITLE
fix(deps-lsp): duplicate dependency names within a section collapse via HashMap last-wins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **deps-lsp**: duplicate dependency names within a manifest (e.g. the same crate under `[dependencies]`/`[dev-dependencies]` or multiple `[target.*.dependencies]` blocks) no longer collapse via name-only `HashMap`, so an edit to any occurrence is correctly diffed and probed for yanked status (resolves #394)
+- **deps-cargo**: dependencies declared under `[target.<cfg-expr-or-triple>.dependencies|dev-dependencies|build-dependencies]` are now parsed and visible to hover/diagnostics/completion, same as top-level ones (#396)
+- **deps-cargo**: a git dependency's `tag`/`branch`/`rev` key is no longer dropped, populating `DependencySource::Git.rev` (#396)
+- **deps-cargo**: invalid file URI during workspace-root discovery now reports `DepsError::InvalidUri`, matching every other ecosystem, instead of the previously divergent `DepsError::CacheError` (#398)
+- **deps-pypi, deps-lsp**: package-name completion now works for PEP 621 `dependencies`/`optional-dependencies` arrays in `pyproject.toml`, which previously always returned zero results (resolves #390) (#397)
+
 ### Changed
 - **deps-bundler, deps-go**: removed private duplicate `LineOffsetTable` structs, both now use the shared `deps_core::lsp_helpers::LineOffsetTable` (resolves #389) (#395)
 - **deps-cargo, deps-npm, deps-composer, deps-dart, deps-deno, deps-go, deps-gradle, deps-maven, deps-nuget**: removed per-crate `{Ecosystem}Error` wrapper enums; call sites now construct `deps_core::DepsError` directly (resolves #388) (#398)
 - **deps-core, deps-go**: documented that `deps-go`'s module-path validation intentionally shares `DepsError::InvalidVersionReq` with version-string rejections, no new variant added (resolves #399) (#401)
-
-### Fixed
-- **deps-cargo**: invalid file URI during workspace-root discovery now reports `DepsError::InvalidUri`, matching every other ecosystem, instead of the previously divergent `DepsError::CacheError` (#398)
-- **deps-pypi, deps-lsp**: package-name completion now works for PEP 621 `dependencies`/`optional-dependencies` arrays in `pyproject.toml`, which previously always returned zero results (resolves #390) (#397)
-- **deps-cargo**: dependencies declared under `[target.<cfg-expr-or-triple>.dependencies|dev-dependencies|build-dependencies]` are now parsed and visible to hover/diagnostics/completion, same as top-level ones (#396)
-- **deps-cargo**: a git dependency's `tag`/`branch`/`rev` key is no longer dropped, populating `DependencySource::Git.rev` (#396)
 
 ## [0.11.0] - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **deps-lsp**: duplicate dependency names within a manifest (e.g. the same crate under `[dependencies]`/`[dev-dependencies]` or multiple `[target.*.dependencies]` blocks) no longer collapse via name-only `HashMap`, so an edit to any occurrence is correctly diffed and probed for yanked status (resolves #394)
+- **deps-core, deps-lsp**: duplicate dependency names within a manifest (e.g. the same crate under `[dependencies]`/`[dev-dependencies]` or multiple `[target.*.dependencies]` blocks) no longer collapse via name-only `HashMap` in the diff/yanked-probe/OSV-scan pipeline, so an edit to any occurrence is correctly diffed and neither yanked nor OSV findings leak between occurrences pinned to different versions (resolves #394)
 - **deps-cargo**: dependencies declared under `[target.<cfg-expr-or-triple>.dependencies|dev-dependencies|build-dependencies]` are now parsed and visible to hover/diagnostics/completion, same as top-level ones (#396)
 - **deps-cargo**: a git dependency's `tag`/`branch`/`rev` key is no longer dropped, populating `DependencySource::Git.rev` (#396)
 - **deps-cargo**: invalid file URI during workspace-root discovery now reports `DepsError::InvalidUri`, matching every other ecosystem, instead of the previously divergent `DepsError::CacheError` (#398)

--- a/crates/deps-core/src/lsp_helpers/code_actions.rs
+++ b/crates/deps-core/src/lsp_helpers/code_actions.rs
@@ -37,6 +37,7 @@ struct VulnerabilityFixAction {
 /// still reconcile the result against a successful registry fetch when one
 /// is available — see the yank check in [`generate_code_actions`].
 fn build_vulnerability_fix_action(
+    parse_result: &dyn ParseResult,
     dep: &dyn Dependency,
     uri: &Uri,
     version_range: Range,
@@ -45,8 +46,18 @@ fn build_vulnerability_fix_action(
     formatter: &dyn EcosystemFormatter,
 ) -> Option<VulnerabilityFixAction> {
     let normalized_name = formatter.normalize_package_name(dep.name());
+    // #394 S2: prefer the version-qualified key so a fix action for one
+    // occurrence of a duplicated name is never built from another
+    // occurrence's OSV result. See `crate::osv::vulnerability_keys`.
+    let vuln_key = versions.ecosystem.and_then(|ecosystem| {
+        crate::osv::vulnerability_keys(parse_result, versions.resolved, formatter, ecosystem)
+            .remove(&dep.name_range())
+    });
     let outcome = versions.vulnerabilities.and_then(|m| {
-        m.get(&normalized_name)
+        vuln_key
+            .as_deref()
+            .and_then(|key| m.get(key))
+            .or_else(|| m.get(&normalized_name))
             .or_else(|| m.get(dep.name().as_str()))
     })?;
     let ScanOutcome::Vulnerable(dv) = outcome else {
@@ -389,6 +400,7 @@ pub async fn generate_code_actions<R: Registry + ?Sized>(
     // Both fix actions are built before the registry fetch below so a registry outage
     // never suppresses an OSV-derived fix (FR-007) or a known-unsatisfiable one.
     let fix = build_vulnerability_fix_action(
+        parse_result,
         dep,
         uri,
         version_range,

--- a/crates/deps-core/src/lsp_helpers/code_actions.rs
+++ b/crates/deps-core/src/lsp_helpers/code_actions.rs
@@ -1016,6 +1016,122 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_generate_code_actions_vulnerability_fix_not_offered_on_patched_duplicate_occurrence()
+     {
+        // #394 S2 (critic addendum, security-relevant): the vulnerability
+        // quickfix *mutates the manifest*, so offering it on the wrong
+        // occurrence of a duplicated name is worse than a cosmetic bug.
+        // `log4j-core` appears twice with different pins — one vulnerable,
+        // one already patched. The quickfix must appear only at the
+        // vulnerable occurrence's position, never at the patched one's,
+        // regardless of which occurrence's OSV result happened to be
+        // inserted into the shared map last.
+        use crate::osv::{Advisory, DependencyVulnerabilities, UpgradeStatus, VulnSeverity};
+        use tower_lsp_server::ls_types::{Position, Range};
+
+        let vulnerable_line = "log4j-core = \"=2.14.1\"";
+        let patched_line = "log4j-core = \"=2.17.1\"";
+        let content = format!("{vulnerable_line}\n{patched_line}\n");
+
+        let name_start = 0u32;
+        let name_end = "log4j-core".len() as u32;
+        let version_start = "log4j-core = \"".len() as u32;
+
+        let vulnerable_dep = MockDep {
+            name: pkg("log4j-core"),
+            version_req: VersionReq::new("=2.14.1"),
+            version_range: Range::new(
+                Position::new(0, version_start),
+                Position::new(0, version_start + "=2.14.1".len() as u32),
+            ),
+            name_range: Range::new(Position::new(0, name_start), Position::new(0, name_end)),
+        };
+        let patched_dep = MockDep {
+            name: pkg("log4j-core"),
+            version_req: VersionReq::new("=2.17.1"),
+            version_range: Range::new(
+                Position::new(1, version_start),
+                Position::new(1, version_start + "=2.17.1".len() as u32),
+            ),
+            name_range: Range::new(Position::new(1, name_start), Position::new(1, name_end)),
+        };
+        let parse_result = MockParseResult {
+            deps: vec![vulnerable_dep, patched_dep],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+
+        let cached = HashMap::new();
+        let resolved = HashMap::new();
+
+        let keys = crate::osv::vulnerability_keys(
+            &parse_result,
+            &resolved,
+            &IdentityFormatter,
+            crate::EcosystemId::Cargo,
+        );
+        let deps = parse_result.dependencies();
+        let vulnerable_key = keys.get(&deps[0].name_range()).unwrap().clone();
+        let patched_key = keys.get(&deps[1].name_range()).unwrap().clone();
+        assert_ne!(vulnerable_key, patched_key);
+
+        let mut vulnerabilities = crate::osv::VulnerabilityMap::new();
+        vulnerabilities.insert(
+            vulnerable_key,
+            ScanOutcome::Vulnerable(DependencyVulnerabilities {
+                advisories: vec![std::sync::Arc::new(Advisory {
+                    id: "GHSA-log4j".to_string(),
+                    modified: "2023-01-01T00:00:00Z".to_string(),
+                    summary: None,
+                    aliases: vec![],
+                    severity: VulnSeverity::Critical,
+                    cvss_vector: None,
+                    fixed_versions: vec!["2.17.1".to_string()],
+                    url: String::new(),
+                })],
+                total_known: 1,
+                upgrade_status: UpgradeStatus::NotChecked,
+            }),
+        );
+        vulnerabilities.insert(patched_key, ScanOutcome::Clean);
+
+        let versions = VersionData::new(&cached, &resolved)
+            .with_vulnerabilities(&vulnerabilities)
+            .with_ecosystem(crate::EcosystemId::Cargo);
+
+        let actions_on_vulnerable = generate_code_actions(
+            &parse_result,
+            Position::new(0, version_start),
+            parse_result.uri(),
+            versions,
+            &content,
+            &MockRegistry,
+            &IdentityFormatter,
+        )
+        .await;
+        assert!(
+            !quickfix_titles(&actions_on_vulnerable).is_empty(),
+            "the vulnerable occurrence must get a fix quickfix"
+        );
+
+        let actions_on_patched = generate_code_actions(
+            &parse_result,
+            Position::new(1, version_start),
+            parse_result.uri(),
+            versions,
+            &content,
+            &MockRegistry,
+            &IdentityFormatter,
+        )
+        .await;
+        assert!(
+            quickfix_titles(&actions_on_patched).is_empty(),
+            "the already-patched occurrence must NOT get a fix quickfix, \
+             even though it shares a name with the vulnerable one: {:?}",
+            quickfix_titles(&actions_on_patched)
+        );
+    }
+
+    #[tokio::test]
     async fn test_generate_code_actions_refactor_loop_dedups_item_matching_fix_text_by_different_raw_version()
      {
         // Regression for #242 (gap 1): the old guard compared `item.version` against

--- a/crates/deps-core/src/lsp_helpers/diagnostics.rs
+++ b/crates/deps-core/src/lsp_helpers/diagnostics.rs
@@ -387,6 +387,15 @@ pub fn generate_diagnostics_from_cache(
     let deps = parse_result.dependencies();
     let mut diagnostics = Vec::with_capacity(deps.len());
 
+    // #394 S2: version-qualified OSV lookup keys, so two occurrences of one
+    // name pinned to different versions never share a `Vulnerable`/`Clean`
+    // result. `None` when this `VersionData` carries no ecosystem (most test
+    // fixtures) — the per-dep lookup below then falls back to the plain
+    // name, unaffected.
+    let vuln_keys = versions.ecosystem.map(|ecosystem| {
+        crate::osv::vulnerability_keys(parse_result, versions.resolved, formatter, ecosystem)
+    });
+
     for dep in deps {
         let normalized_name = formatter.normalize_package_name(dep.name());
 
@@ -394,8 +403,11 @@ pub fn generate_diagnostics_from_cache(
         // no version range) so a registry failure never suppresses an OSV
         // finding — the two are independent data sources (FR-007/US-004).
         if let Some(vulnerabilities) = versions.vulnerabilities
-            && let Some(ScanOutcome::Vulnerable(dv)) = vulnerabilities
-                .get(&normalized_name)
+            && let Some(ScanOutcome::Vulnerable(dv)) = vuln_keys
+                .as_ref()
+                .and_then(|keys| keys.get(&dep.name_range()))
+                .and_then(|key| vulnerabilities.get(key))
+                .or_else(|| vulnerabilities.get(&normalized_name))
                 .or_else(|| vulnerabilities.get(dep.name().as_str()))
         {
             push_vulnerability_diagnostics(&mut diagnostics, dep, dv);
@@ -427,19 +439,40 @@ pub fn generate_diagnostics_from_cache(
         // `test_yanked_only_match_suppresses_outdated_diagnostic`). Each policy was
         // independently reviewed and tested before this merge; harmonizing them is out
         // of scope here.
-        let yanked_diagnostic_pushed =
-            if let Some(yanked_version) = versions.yanked.and_then(|y| y.get(&normalized_name)) {
-                diagnostics.push(Diagnostic {
-                    range: dep.version_range().unwrap_or_else(|| dep.name_range()),
-                    severity: Some(severities.yanked),
-                    message: format!("{} ({})", formatter.yanked_message(), yanked_version),
-                    source: Some("deps-lsp".into()),
-                    ..Default::default()
-                });
-                true
-            } else {
-                false
-            };
+        // #394 S1: when multiple occurrences share `normalized_name`, the
+        // finding recorded under it may belong to a *different* occurrence
+        // (e.g. `[dependencies] time = "=0.1.43"`, yanked, and
+        // `[dev-dependencies] time = "=0.1.44"`, not yanked — both name-keyed
+        // to the same `yanked_version`). Emitting unconditionally would push
+        // a false-positive "yanked" diagnostic onto the safe occurrence, for
+        // a version string that does not even appear on that line. Gated on
+        // `versions.ecosystem` being set (production always sets it; the
+        // check is skipped, matching pre-#394 behavior, for the test
+        // fixtures that do not).
+        let yanked_diagnostic_pushed = if let Some(yanked_version) =
+            versions.yanked.and_then(|y| y.get(&normalized_name))
+            && versions.ecosystem.is_none_or(|ecosystem| {
+                super::in_use_version(
+                    dep,
+                    &normalized_name,
+                    versions.resolved,
+                    formatter,
+                    ecosystem,
+                )
+                .as_deref()
+                    == Some(yanked_version.as_str())
+            }) {
+            diagnostics.push(Diagnostic {
+                range: dep.version_range().unwrap_or_else(|| dep.name_range()),
+                severity: Some(severities.yanked),
+                message: format!("{} ({})", formatter.yanked_message(), yanked_version),
+                source: Some("deps-lsp".into()),
+                ..Default::default()
+            });
+            true
+        } else {
+            false
+        };
 
         let package_versions = versions
             .cached
@@ -1761,6 +1794,123 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_diagnostics_from_cache_yanked_not_shared_across_duplicate_name_occurrences() {
+        // #394 S1: two occurrences of `time` (e.g. under `[dependencies]` and
+        // `[dev-dependencies]`) pinned to different exact versions, only one
+        // of which is actually yanked. `yanked` is name-keyed (single value),
+        // recording only "0.1.43" — the occurrence pinned to "0.1.44" must
+        // NOT also render "yanked (0.1.43)" just because it shares the name;
+        // that version string doesn't even appear on its line.
+        use std::collections::HashMap;
+        use tower_lsp_server::ls_types::{Position, Range};
+
+        let formatter = MockFormatter;
+
+        let parse_result = MockParseResult {
+            deps: vec![
+                MockDep {
+                    name: "time".into(),
+                    version_req: "=0.1.43".into(),
+                    version_range: Range::new(Position::new(0, 10), Position::new(0, 20)),
+                    name_range: Range::new(Position::new(0, 0), Position::new(0, 5)),
+                },
+                MockDep {
+                    name: "time".into(),
+                    version_req: "=0.1.44".into(),
+                    version_range: Range::new(Position::new(3, 10), Position::new(3, 20)),
+                    name_range: Range::new(Position::new(3, 0), Position::new(3, 5)),
+                },
+            ],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+
+        let cached_versions = HashMap::new();
+        let resolved_versions = HashMap::new();
+        let mut yanked = HashMap::new();
+        yanked.insert("time".to_string(), "0.1.43".to_string());
+
+        let diagnostics = generate_diagnostics_from_cache(
+            &parse_result,
+            VersionData::new(&cached_versions, &resolved_versions)
+                .with_yanked(&yanked)
+                .with_ecosystem(crate::EcosystemId::Cargo),
+            &formatter,
+            crate::freshness::FreshnessSettings::default(),
+            DiagnosticSeverities::default(),
+            PublishTime::now(),
+        );
+
+        let yanked_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.starts_with(formatter.yanked_message()))
+            .collect();
+        assert_eq!(
+            yanked_diags.len(),
+            1,
+            "exactly one occurrence must get the yanked diagnostic, got: {diagnostics:?}"
+        );
+        assert_eq!(
+            yanked_diags[0].range.start.line, 0,
+            "must land on the yanked occurrence's own line"
+        );
+        assert!(yanked_diags[0].message.contains("0.1.43"));
+    }
+
+    #[test]
+    fn test_generate_diagnostics_from_cache_yanked_no_ecosystem_keeps_pre_394_behavior() {
+        // Without `with_ecosystem` (most test fixtures, and any caller that
+        // predates #394), the consistency check is skipped entirely and both
+        // occurrences render the shared name-keyed finding — the exact
+        // pre-#394 behavior, preserved deliberately for backward
+        // compatibility rather than silently tightened.
+        use std::collections::HashMap;
+        use tower_lsp_server::ls_types::{Position, Range};
+
+        let formatter = MockFormatter;
+
+        let parse_result = MockParseResult {
+            deps: vec![
+                MockDep {
+                    name: "time".into(),
+                    version_req: "=0.1.43".into(),
+                    version_range: Range::new(Position::new(0, 10), Position::new(0, 20)),
+                    name_range: Range::new(Position::new(0, 0), Position::new(0, 5)),
+                },
+                MockDep {
+                    name: "time".into(),
+                    version_req: "=0.1.44".into(),
+                    version_range: Range::new(Position::new(3, 10), Position::new(3, 20)),
+                    name_range: Range::new(Position::new(3, 0), Position::new(3, 5)),
+                },
+            ],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+
+        let cached_versions = HashMap::new();
+        let resolved_versions = HashMap::new();
+        let mut yanked = HashMap::new();
+        yanked.insert("time".to_string(), "0.1.43".to_string());
+
+        let diagnostics = generate_diagnostics_from_cache(
+            &parse_result,
+            VersionData::new(&cached_versions, &resolved_versions).with_yanked(&yanked),
+            &formatter,
+            crate::freshness::FreshnessSettings::default(),
+            DiagnosticSeverities::default(),
+            PublishTime::now(),
+        );
+
+        let yanked_diags = diagnostics
+            .iter()
+            .filter(|d| d.message.starts_with(formatter.yanked_message()))
+            .count();
+        assert_eq!(
+            yanked_diags, 2,
+            "no `ecosystem` set: both occurrences share the finding as before #394"
+        );
+    }
+
+    #[test]
     fn test_generate_diagnostics_unsatisfiable_enriched_with_matching_prerelease() {
         let cached_versions = {
             let mut m = HashMap::new();
@@ -2170,6 +2320,93 @@ mod tests {
             more_diag.message.contains("+35"),
             "got: {}",
             more_diag.message
+        );
+    }
+
+    #[test]
+    fn test_generate_diagnostics_vulnerability_not_shared_across_duplicate_name_occurrences() {
+        // #394 S2: two occurrences of `pkg` (e.g. under `[dependencies]` and
+        // `[dev-dependencies]`) pinned to different versions — one vulnerable,
+        // one patched. Built via `vulnerability_keys` the same way
+        // `deps-lsp`'s `build_scan_targets` would, so each occurrence's OSV
+        // result lands under its own key instead of colliding on the plain
+        // name. The patched occurrence must render no advisory diagnostic.
+        use crate::osv::{
+            DependencyVulnerabilities, ScanOutcome, UpgradeStatus, VulnSeverity, VulnerabilityMap,
+            vulnerability_keys,
+        };
+        use tower_lsp_server::ls_types::{Position, Range};
+
+        let formatter = MockFormatter;
+
+        let vulnerable_dep = MockDep {
+            name: "pkg".into(),
+            version_req: "=1.0.0".into(),
+            version_range: Range::new(Position::new(0, 10), Position::new(0, 20)),
+            name_range: Range::new(Position::new(0, 0), Position::new(0, 5)),
+        };
+        let patched_dep = MockDep {
+            name: "pkg".into(),
+            version_req: "=2.0.0".into(),
+            version_range: Range::new(Position::new(3, 10), Position::new(3, 20)),
+            name_range: Range::new(Position::new(3, 0), Position::new(3, 5)),
+        };
+        let parse_result = MockParseResult {
+            deps: vec![vulnerable_dep, patched_dep],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+
+        let cached_versions = HashMap::new();
+        let resolved_versions = HashMap::new();
+
+        let keys = vulnerability_keys(
+            &parse_result,
+            &resolved_versions,
+            &formatter,
+            crate::EcosystemId::Cargo,
+        );
+        let deps = parse_result.dependencies();
+        let vulnerable_key = keys.get(&deps[0].name_range()).unwrap().clone();
+        let patched_key = keys.get(&deps[1].name_range()).unwrap().clone();
+        assert_ne!(
+            vulnerable_key, patched_key,
+            "differently-versioned occurrences of one name must get distinct keys"
+        );
+
+        let mut vulns: VulnerabilityMap = VulnerabilityMap::new();
+        vulns.insert(
+            vulnerable_key,
+            ScanOutcome::Vulnerable(DependencyVulnerabilities {
+                advisories: vec![sample_advisory("RUSTSEC-2020-0071", VulnSeverity::High)],
+                total_known: 1,
+                upgrade_status: UpgradeStatus::NotChecked,
+            }),
+        );
+        vulns.insert(patched_key, ScanOutcome::Clean);
+
+        let diagnostics = generate_diagnostics_from_cache(
+            &parse_result,
+            VersionData::new(&cached_versions, &resolved_versions)
+                .with_vulnerabilities(&vulns)
+                .with_ecosystem(crate::EcosystemId::Cargo),
+            &formatter,
+            crate::FreshnessSettings::default(),
+            DiagnosticSeverities::default(),
+            PublishTime::now(),
+        );
+
+        let advisory_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("RUSTSEC-2020-0071"))
+            .collect();
+        assert_eq!(
+            advisory_diags.len(),
+            1,
+            "exactly one occurrence must get the advisory diagnostic, got: {diagnostics:?}"
+        );
+        assert_eq!(
+            advisory_diags[0].range.start.line, 0,
+            "must land on the vulnerable occurrence's own line, not the patched one"
         );
     }
 

--- a/crates/deps-core/src/lsp_helpers/hover.rs
+++ b/crates/deps-core/src/lsp_helpers/hover.rs
@@ -1938,6 +1938,98 @@ mod tests {
         assert!(content.value.contains("also affected"));
     }
 
+    #[tokio::test]
+    async fn test_generate_hover_vulnerability_not_shared_across_duplicate_name_occurrences() {
+        // #394 S2: `pkg` declared twice with different pins — one vulnerable,
+        // one patched. Hover on the patched occurrence must not show the
+        // vulnerable occurrence's advisory just because they share a name.
+        use crate::osv::{
+            DependencyVulnerabilities, ScanOutcome, UpgradeStatus, VulnSeverity, VulnerabilityMap,
+        };
+
+        let vulnerable_dep = MockDep {
+            name: "pkg".into(),
+            version_req: "=1.0.0".into(),
+            version_range: Range::new(Position::new(0, 10), Position::new(0, 20)),
+            name_range: Range::new(Position::new(0, 0), Position::new(0, 5)),
+        };
+        let patched_dep = MockDep {
+            name: "pkg".into(),
+            version_req: "=2.0.0".into(),
+            version_range: Range::new(Position::new(3, 10), Position::new(3, 20)),
+            name_range: Range::new(Position::new(3, 0), Position::new(3, 5)),
+        };
+        let parse_result = MockParseResult {
+            deps: vec![vulnerable_dep, patched_dep],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+        let cached_versions = HashMap::new();
+        let resolved_versions = HashMap::new();
+
+        let keys = crate::osv::vulnerability_keys(
+            &parse_result,
+            &resolved_versions,
+            &MockFormatter,
+            crate::EcosystemId::Cargo,
+        );
+        let deps = parse_result.dependencies();
+        let vulnerable_key = keys.get(&deps[0].name_range()).unwrap().clone();
+        let patched_key = keys.get(&deps[1].name_range()).unwrap().clone();
+        assert_ne!(vulnerable_key, patched_key);
+
+        let mut vulns: VulnerabilityMap = VulnerabilityMap::new();
+        vulns.insert(
+            vulnerable_key,
+            ScanOutcome::Vulnerable(DependencyVulnerabilities {
+                advisories: vec![sample_advisory("RUSTSEC-2020-0071", VulnSeverity::Critical)],
+                total_known: 1,
+                upgrade_status: UpgradeStatus::NotChecked,
+            }),
+        );
+        vulns.insert(patched_key, ScanOutcome::Clean);
+
+        let versions = VersionData::new(&cached_versions, &resolved_versions)
+            .with_vulnerabilities(&vulns)
+            .with_ecosystem(crate::EcosystemId::Cargo);
+
+        let hover_on_patched = generate_hover(
+            &parse_result,
+            Position::new(3, 2),
+            versions,
+            &MockRegistry,
+            &MockFormatter,
+            crate::FreshnessSettings::default(),
+            PublishTime::now(),
+        )
+        .await
+        .expect("hover should be generated");
+        let HoverContents::Markup(patched_content) = hover_on_patched.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(
+            !patched_content.value.contains("RUSTSEC-2020-0071"),
+            "the patched occurrence must not show the other occurrence's advisory: {}",
+            patched_content.value
+        );
+        assert!(patched_content.value.contains("No known vulnerabilities"));
+
+        let hover_on_vulnerable = generate_hover(
+            &parse_result,
+            Position::new(0, 2),
+            versions,
+            &MockRegistry,
+            &MockFormatter,
+            crate::FreshnessSettings::default(),
+            PublishTime::now(),
+        )
+        .await
+        .expect("hover should be generated");
+        let HoverContents::Markup(vulnerable_content) = hover_on_vulnerable.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(vulnerable_content.value.contains("RUSTSEC-2020-0071"));
+    }
+
     /// #366: a registry error classified as `PackageNotFound` (e.g. `deps-maven`'s
     /// `metadata_urls` rejecting a dot-segment coordinate like `com.example:..`, mirrored
     /// here by [`NotFoundRegistry`]) must make hover return `None` via this function's own

--- a/crates/deps-core/src/lsp_helpers/hover.rs
+++ b/crates/deps-core/src/lsp_helpers/hover.rs
@@ -262,8 +262,18 @@ pub async fn generate_hover<R: Registry + ?Sized>(
         }
     }
 
+    // #394 S2: prefer the version-qualified key so a hover on one occurrence
+    // of a duplicated name never shows another occurrence's OSV result. See
+    // `crate::osv::vulnerability_keys` for when qualification kicks in.
+    let vuln_key = versions.ecosystem.and_then(|ecosystem| {
+        crate::osv::vulnerability_keys(parse_result, versions.resolved, formatter, ecosystem)
+            .remove(&dep.name_range())
+    });
     let vuln_outcome = versions.vulnerabilities.and_then(|m| {
-        m.get(&normalized_name)
+        vuln_key
+            .as_deref()
+            .and_then(|key| m.get(key))
+            .or_else(|| m.get(&normalized_name))
             .or_else(|| m.get(dep.name().as_str()))
     });
     push_vulnerability_hover_section(&mut markdown, vuln_outcome);

--- a/crates/deps-core/src/lsp_helpers/in_use_version.rs
+++ b/crates/deps-core/src/lsp_helpers/in_use_version.rs
@@ -71,6 +71,28 @@ fn looks_like_a_single_version(s: &str) -> bool {
 /// *bare* requirement (no marker) is returned verbatim, and is accepted only
 /// for ecosystems where a bare version is not itself a range by default
 /// (critique C2) — see `bare_version_is_a_range`.
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::EcosystemId;
+/// use deps_core::lsp_helpers::concrete_pin_version;
+///
+/// // An explicit pin marker is stripped, for any ecosystem.
+/// assert_eq!(
+///     concrete_pin_version("=1.2.3", EcosystemId::Cargo),
+///     Some("1.2.3")
+/// );
+///
+/// // Cargo's bare version is a caret range by default, not a pin.
+/// assert_eq!(concrete_pin_version("1.2.3", EcosystemId::Cargo), None);
+///
+/// // Maven has no implicit range operator, so a bare version is exact.
+/// assert_eq!(
+///     concrete_pin_version("2.14.1", EcosystemId::Maven),
+///     Some("2.14.1")
+/// );
+/// ```
 pub fn concrete_pin_version(requirement: &str, ecosystem: EcosystemId) -> Option<&str> {
     let trimmed = requirement.trim();
     if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("latest") {
@@ -118,6 +140,65 @@ fn is_concrete_version(requirement: &str, ecosystem: EcosystemId) -> bool {
 /// (#394 S1) — all three need "what version does the user actually have"
 /// for the same reason: querying a fabricated version produces a silent
 /// false negative.
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::lsp_helpers::{EcosystemFormatter, in_use_version};
+/// use deps_core::{Dependency, EcosystemId, PackageName, VersionReq};
+/// use std::any::Any;
+/// use std::collections::HashMap;
+/// use tower_lsp_server::ls_types::Range;
+///
+/// struct SimpleDep {
+///     name: PackageName,
+///     version_req: Option<VersionReq>,
+/// }
+///
+/// impl Dependency for SimpleDep {
+///     fn name(&self) -> &PackageName {
+///         &self.name
+///     }
+///     fn name_range(&self) -> Range {
+///         Range::default()
+///     }
+///     fn version_requirement(&self) -> Option<&VersionReq> {
+///         self.version_req.as_ref()
+///     }
+///     fn version_range(&self) -> Option<Range> {
+///         None
+///     }
+///     fn source(&self) -> deps_core::parser::DependencySource {
+///         deps_core::parser::DependencySource::Registry
+///     }
+///     fn as_any(&self) -> &dyn Any {
+///         self
+///     }
+/// }
+///
+/// struct SimpleFormatter;
+/// impl EcosystemFormatter for SimpleFormatter {
+///     fn format_version_for_text_edit(&self, version: &str) -> String {
+///         version.to_string()
+///     }
+///     fn package_url(&self, name: &PackageName) -> String {
+///         name.to_string()
+///     }
+/// }
+///
+/// let dep = SimpleDep {
+///     name: PackageName::new("time"),
+///     version_req: Some(VersionReq::new("=0.1.43")),
+/// };
+/// let resolved_versions = HashMap::new();
+///
+/// // No lock file, but the requirement is already an exact pin — falls
+/// // back to it, stripped of its `=` marker.
+/// assert_eq!(
+///     in_use_version(&dep, "time", &resolved_versions, &SimpleFormatter, EcosystemId::Cargo),
+///     Some("0.1.43".to_string())
+/// );
+/// ```
 pub fn in_use_version(
     dep: &dyn Dependency,
     normalized_name: &str,

--- a/crates/deps-core/src/lsp_helpers/in_use_version.rs
+++ b/crates/deps-core/src/lsp_helpers/in_use_version.rs
@@ -1,0 +1,283 @@
+//! "What version does this dependency occurrence actually have" — shared by
+//! `deps-lsp`'s registry-fetch/OSV-target pipeline and, for #394's S1 fix,
+//! the yanked-diagnostic consistency check in [`super::diagnostics`].
+
+use std::collections::HashMap;
+
+use crate::lsp_helpers::EcosystemFormatter;
+use crate::{Dependency, EcosystemId, PackageName};
+
+/// Ecosystems whose *bare* (no explicit pin marker) version requirement is a
+/// range under that ecosystem's own default semantics — Cargo's implicit
+/// caret, npm/Composer's implicit caret. For these, [`is_concrete_version`]
+/// requires an explicit `=`/`==` (or an exact-bracket wrap) before treating a
+/// requirement as concrete; a bare `"1.2.3"` alone is not enough evidence
+/// (critique C2).
+///
+/// Deno reuses npm's exact grammar for both its `jsr:` and `npm:` specifiers
+/// (`DenoFormatter::compile_requirement` compiles both through the same
+/// `node_semver::Range` npm itself uses), so it gets the same treatment here.
+///
+/// Gradle is deliberately excluded: a bare Gradle coordinate version (e.g.
+/// `"2.14.1"`) is an exact match under `GradleFormatter`'s own
+/// `version_satisfies_requirement` unless it uses the `+` dynamic-version
+/// suffix, which [`looks_like_a_single_version`] already rejects via its
+/// reject-char set — Gradle has no implicit-caret default the way
+/// Cargo/npm/Composer do.
+const fn bare_version_is_a_range(ecosystem: EcosystemId) -> bool {
+    matches!(
+        ecosystem,
+        EcosystemId::Cargo | EcosystemId::Npm | EcosystemId::Composer | EcosystemId::Deno
+    )
+}
+
+/// Returns `true` if `s` (already stripped of any pin marker) has the shape
+/// of a single concrete version: non-empty, no wildcard/range-operator
+/// character, and starting with a digit (after an optional `v`/`V` prefix,
+/// e.g. Go's `v1.9.1`).
+///
+/// Deliberately conservative — see [`is_concrete_version`]'s doc for why a
+/// false positive here is worse than a false negative.
+fn looks_like_a_single_version(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    if s.contains([
+        '^', '~', '*', '<', '>', ',', '|', '(', ')', '[', ']', ' ', '\t', ':', '+', 'x', 'X',
+    ]) {
+        return false;
+    }
+    let core = s.strip_prefix(['v', 'V']).unwrap_or(s);
+    core.chars().next().is_some_and(|c| c.is_ascii_digit())
+}
+
+/// Returns the concrete version text `requirement` denotes, or `None` if
+/// `requirement` is not the shape of a single concrete version.
+///
+/// Any pin marker (`=`/`==`, or a single-value bracket wrap like NuGet's
+/// `[1.0.0]`) is stripped off. The only shape safe to query OSV with
+/// directly, and, for #233, the only shape safe to compare against a real
+/// registry version string in the yanked-version probe. A wrong answer here
+/// is invisible in testing (OSV silently returns `{}` for a fabricated
+/// version; the yanked probe silently finds no match), so getting this
+/// right matters more than covering every ecosystem's full range grammar.
+///
+/// An explicit pin marker is always accepted, and its marker is stripped
+/// from the returned text — required because PyPI's parser retains the
+/// pep440 comparator in `Dependency::version_requirement()` (an exact pin
+/// parses to `"==4.9.0"`, not `"4.9.0"`; confirmed by
+/// `deps-pypi`'s `test_basic_pinned`), so comparing the *unstripped* text
+/// against a real registry version string (`"4.9.0"`) would never match. A
+/// *bare* requirement (no marker) is returned verbatim, and is accepted only
+/// for ecosystems where a bare version is not itself a range by default
+/// (critique C2) — see `bare_version_is_a_range`.
+pub fn concrete_pin_version(requirement: &str, ecosystem: EcosystemId) -> Option<&str> {
+    let trimmed = requirement.trim();
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("latest") {
+        return None;
+    }
+
+    let pinned = trimmed
+        .strip_prefix("==")
+        .or_else(|| trimmed.strip_prefix('='));
+    let bracket_pinned = trimmed
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .filter(|inner| !inner.contains(','));
+
+    match pinned.or(bracket_pinned) {
+        Some(body) => looks_like_a_single_version(body).then_some(body),
+        None if bare_version_is_a_range(ecosystem) => None,
+        None => looks_like_a_single_version(trimmed).then_some(trimmed),
+    }
+}
+
+/// Returns `true` if `requirement` denotes a single concrete version. See
+/// [`concrete_pin_version`], whose boolean projection this is, for the
+/// acceptance rules. Test-only: production code needs the stripped text
+/// from `concrete_pin_version` itself, not just the boolean.
+#[cfg(test)]
+fn is_concrete_version(requirement: &str, ecosystem: EcosystemId) -> bool {
+    concrete_pin_version(requirement, ecosystem).is_some()
+}
+
+/// The version of `dep` this project treats as actually in use.
+///
+/// The lock-file-resolved version, else the declared requirement when it is
+/// already concrete ([`concrete_pin_version`]). `None` when neither applies.
+///
+/// A dependency whose manifest requirement is itself the resolved version
+/// ([`EcosystemFormatter::manifest_requirement_is_resolved_version`] — a Go
+/// `require`-directive dependency) skips the lockfile step entirely, going
+/// straight to the declared requirement (go.sum is unreliable there — a
+/// checksum ledger that `go get`/`go build` only ever append to, so its
+/// last-occurrence-wins parse can surface a version still recorded in the
+/// file but no longer selected by Go's MVS). Shared by `deps-lsp`'s OSV
+/// target selection, its yanked-version check, and the yanked-diagnostic
+/// consistency check in [`super::diagnostics::generate_diagnostics_from_cache`]
+/// (#394 S1) — all three need "what version does the user actually have"
+/// for the same reason: querying a fabricated version produces a silent
+/// false negative.
+pub fn in_use_version(
+    dep: &dyn Dependency,
+    normalized_name: &str,
+    resolved_versions: &HashMap<PackageName, String>,
+    formatter: &dyn EcosystemFormatter,
+    ecosystem: EcosystemId,
+) -> Option<String> {
+    if formatter.manifest_requirement_is_resolved_version(dep) {
+        dep.version_requirement()
+            .and_then(|req| concrete_pin_version(req.as_str(), ecosystem))
+            .map(str::to_string)
+    } else {
+        resolved_versions
+            .get(normalized_name)
+            .or_else(|| resolved_versions.get(dep.name()))
+            .cloned()
+            .or_else(|| {
+                dep.version_requirement()
+                    .and_then(|req| concrete_pin_version(req.as_str(), ecosystem))
+                    .map(str::to_string)
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_concrete_version_accepts_explicit_pins_in_any_ecosystem() {
+        for eco in [EcosystemId::Cargo, EcosystemId::Npm, EcosystemId::Go] {
+            assert!(is_concrete_version("=1.2.3", eco), "{eco:?}");
+        }
+        // Go's go.mod bare `v1.9.1` style: Go is not in the
+        // range-default set, so the bare form (with its `v` prefix) is
+        // accepted without needing an explicit `=`.
+        assert!(is_concrete_version("v1.9.1", EcosystemId::Go));
+    }
+
+    #[test]
+    fn is_concrete_version_pep440_double_equals_is_a_pin() {
+        // Critique C2: `strip_prefix('=')` alone turns PEP 440 `"==2.28.0"`
+        // into `"=2.28.0"`, whose first char then fails the digit check.
+        assert!(is_concrete_version("==2.28.0", EcosystemId::Pypi));
+    }
+
+    #[test]
+    fn is_concrete_version_bare_digit_accepted_for_non_range_default_ecosystems() {
+        // Maven/Go/Bundler/Dart/Gradle/NuGet: a bare version is already
+        // exact (or, for NuGet's PackageReference floor, resolves to
+        // exactly that version in practice). Gradle in particular has no
+        // implicit-caret default for a plain coordinate version like
+        // `"2.14.1"` — only the `+` dynamic-version suffix is a range,
+        // and that's rejected separately by `looks_like_a_single_version`.
+        for eco in [
+            EcosystemId::Maven,
+            EcosystemId::Go,
+            EcosystemId::Bundler,
+            EcosystemId::Dart,
+            EcosystemId::Gradle,
+            EcosystemId::NuGet,
+        ] {
+            assert!(is_concrete_version("2.14.1", eco), "{eco:?}");
+        }
+    }
+
+    #[test]
+    fn is_concrete_version_bare_digit_rejected_for_range_default_ecosystems() {
+        // Critique C2: Cargo's bare "1.2.3" is a caret range under
+        // Cargo's own default operator, not a pin — same for npm and
+        // Composer's implicit range notations. Deno reuses npm's exact
+        // grammar for both `jsr:` and `npm:` requirements, so it gets the
+        // same treatment (`bare_version_is_a_range`'s doc comment).
+        for eco in [
+            EcosystemId::Cargo,
+            EcosystemId::Npm,
+            EcosystemId::Composer,
+            EcosystemId::Deno,
+        ] {
+            assert!(!is_concrete_version("1.2.3", eco), "{eco:?}");
+            // ...but an explicit pin is still accepted.
+            assert!(is_concrete_version("=1.2.3", eco), "{eco:?}");
+        }
+    }
+
+    #[test]
+    fn is_concrete_version_rejects_partials_and_wildcards() {
+        // Critique C2: npm/Composer "1.x"/"1.2.x" and bare partials like
+        // "1.2" are ranges, and Gradle's "1.+" is a dynamic version —
+        // none of these contained a previously-rejected character.
+        for eco in [EcosystemId::Npm, EcosystemId::Composer] {
+            assert!(!is_concrete_version("1.x", eco), "{eco:?}");
+            assert!(!is_concrete_version("1.2.x", eco), "{eco:?}");
+            assert!(!is_concrete_version("1.2", eco), "{eco:?}");
+        }
+        assert!(!is_concrete_version("1.+", EcosystemId::Gradle));
+    }
+
+    #[test]
+    fn is_concrete_version_rejects_ranges_and_wildcards() {
+        for eco in [EcosystemId::Maven, EcosystemId::Go] {
+            assert!(!is_concrete_version("^1.0", eco));
+            assert!(!is_concrete_version("~1.2", eco));
+            assert!(!is_concrete_version("*", eco));
+            assert!(!is_concrete_version(">=1.0", eco));
+            assert!(!is_concrete_version(">=1.0 <2.0", eco));
+            assert!(!is_concrete_version("1.0.*", eco));
+            assert!(!is_concrete_version("", eco));
+        }
+    }
+
+    #[test]
+    fn is_concrete_version_rejects_non_version_schemes() {
+        let eco = EcosystemId::Go;
+        assert!(!is_concrete_version("latest", eco));
+        assert!(!is_concrete_version("github:user/repo", eco));
+        assert!(!is_concrete_version("file:../x", eco));
+        assert!(!is_concrete_version("main", eco));
+    }
+
+    #[test]
+    fn concrete_pin_version_strips_pep440_double_equals_comparator() {
+        // Regression guard: PyPI's parser retains the pep440 comparator
+        // in `version_requirement().as_str()` (`"==4.9.0"`, not
+        // `"4.9.0"` — confirmed by deps-pypi's `test_basic_pinned`). The
+        // verbatim string was silently unusable against real registry
+        // version strings in the yanked probe; `concrete_pin_version`
+        // must strip it.
+        assert_eq!(
+            concrete_pin_version("==4.9.0", EcosystemId::Pypi),
+            Some("4.9.0")
+        );
+    }
+
+    #[test]
+    fn concrete_pin_version_strips_single_equals_and_bracket_pins() {
+        assert_eq!(
+            concrete_pin_version("=1.2.3", EcosystemId::Cargo),
+            Some("1.2.3")
+        );
+        assert_eq!(
+            concrete_pin_version("[1.0.0]", EcosystemId::NuGet),
+            Some("1.0.0")
+        );
+    }
+
+    #[test]
+    fn concrete_pin_version_bare_version_returned_verbatim() {
+        // No operator to strip: Maven/Go/Bundler/Dart/Gradle/NuGet treat
+        // a bare version as already exact.
+        assert_eq!(
+            concrete_pin_version("2.14.1", EcosystemId::Maven),
+            Some("2.14.1")
+        );
+    }
+
+    #[test]
+    fn concrete_pin_version_rejects_ranges_and_partials() {
+        assert_eq!(concrete_pin_version("^1.0", EcosystemId::Cargo), None);
+        assert_eq!(concrete_pin_version("1.2.3", EcosystemId::Cargo), None);
+        assert_eq!(concrete_pin_version(">=1.0,<2.0", EcosystemId::Pypi), None);
+    }
+}

--- a/crates/deps-core/src/lsp_helpers/mod.rs
+++ b/crates/deps-core/src/lsp_helpers/mod.rs
@@ -5,12 +5,13 @@ use std::sync::Arc;
 use tower_lsp_server::ls_types::{Position, Range, TextEdit, Uri};
 
 use crate::osv::VulnerabilityMap;
-use crate::{Dependency, InvalidPackageName, PackageName, VersionReq};
+use crate::{Dependency, EcosystemId, InvalidPackageName, PackageName, VersionReq};
 
 mod code_actions;
 mod code_lenses;
 mod diagnostics;
 mod hover;
+mod in_use_version;
 mod inlay_hints;
 #[cfg(test)]
 mod test_support;
@@ -22,6 +23,7 @@ pub use diagnostics::{
     generate_diagnostics, generate_diagnostics_from_cache, requirement_is_unsatisfiable,
 };
 pub use hover::generate_hover;
+pub use in_use_version::{concrete_pin_version, in_use_version};
 pub use inlay_hints::generate_inlay_hints;
 
 /// Maximum number of recent versions hover's "Recent versions" section renders.
@@ -180,6 +182,21 @@ pub struct VersionData<'a> {
     /// a misleading "Unknown package" diagnostic. `None` when no fetch has
     /// run yet, same convention as [`Self::yanked`].
     pub fetch_failed: Option<&'a HashSet<String>>,
+    /// This document's ecosystem, when the caller has one to give. `None` in
+    /// most test fixtures and a handful of ecosystem-crate self-tests that
+    /// predate this field.
+    ///
+    /// Enables two occurrence-aware refinements added for #394 (duplicate
+    /// dependency names no longer collapsing into one shared finding):
+    /// [`generate_diagnostics_from_cache`] only emits a yanked-version
+    /// diagnostic on the occurrence whose own in-use version actually
+    /// matches the recorded finding (S1), and the vulnerability lookups in
+    /// `generate_diagnostics_from_cache`, [`generate_hover`], and
+    /// `generate_code_actions` prefer a version-qualified
+    /// [`crate::osv::VulnerabilityMap`] key over the plain name when more
+    /// than one occurrence of a name has a distinct in-use version (S2).
+    /// When `None`, both fall back to their pre-#394 name-only behavior.
+    pub ecosystem: Option<EcosystemId>,
 }
 
 impl<'a> VersionData<'a> {
@@ -210,6 +227,7 @@ impl<'a> VersionData<'a> {
             vulnerabilities: None,
             yanked: None,
             fetch_failed: None,
+            ecosystem: None,
         }
     }
 
@@ -272,6 +290,26 @@ impl<'a> VersionData<'a> {
     #[must_use]
     pub fn with_fetch_failed(mut self, fetch_failed: &'a HashSet<String>) -> Self {
         self.fetch_failed = Some(fetch_failed);
+        self
+    }
+
+    /// Attaches this document's ecosystem, enabling the occurrence-aware
+    /// refinements described on [`Self::ecosystem`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use deps_core::{EcosystemId, VersionData};
+    /// use std::collections::HashMap;
+    ///
+    /// let cached = HashMap::new();
+    /// let resolved = HashMap::new();
+    /// let versions = VersionData::new(&cached, &resolved).with_ecosystem(EcosystemId::Cargo);
+    /// assert_eq!(versions.ecosystem, Some(EcosystemId::Cargo));
+    /// ```
+    #[must_use]
+    pub const fn with_ecosystem(mut self, ecosystem: EcosystemId) -> Self {
+        self.ecosystem = Some(ecosystem);
         self
     }
 }

--- a/crates/deps-core/src/osv/mod.rs
+++ b/crates/deps-core/src/osv/mod.rs
@@ -26,7 +26,7 @@ use dashmap::DashMap;
 pub use severity::to_diagnostic_severity as diagnostic_severity_for;
 pub use types::{
     Advisory, DependencyVulnerabilities, FixRecommendation, ScanOutcome, ScanTarget, SkipReason,
-    UpgradeStatus, VulnSeverity, VulnerabilityMap,
+    UpgradeStatus, VulnSeverity, VulnerabilityMap, vulnerability_keys,
 };
 use types::{
     OsvBatchRequest, OsvBatchResponse, OsvPackage, OsvQuery, OsvSingleQueryResponse, OsvVulnRecord,

--- a/crates/deps-core/src/osv/types.rs
+++ b/crates/deps-core/src/osv/types.rs
@@ -386,6 +386,98 @@ pub type VulnerabilityMap = HashMap<String, ScanOutcome>;
 /// give (most test fixtures) skips this and falls back to the plain
 /// normalized name, which still finds any entry a test inserted under that
 /// name directly.
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::lsp_helpers::EcosystemFormatter;
+/// use deps_core::osv::vulnerability_keys;
+/// use deps_core::{Dependency, EcosystemId, PackageName, ParseResult, VersionReq};
+/// use std::any::Any;
+/// use std::collections::HashMap;
+/// use tower_lsp_server::ls_types::{Position, Range, Uri};
+///
+/// struct SimpleDep {
+///     name: PackageName,
+///     version_req: Option<VersionReq>,
+///     name_range: Range,
+/// }
+///
+/// impl Dependency for SimpleDep {
+///     fn name(&self) -> &PackageName {
+///         &self.name
+///     }
+///     fn name_range(&self) -> Range {
+///         self.name_range
+///     }
+///     fn version_requirement(&self) -> Option<&VersionReq> {
+///         self.version_req.as_ref()
+///     }
+///     fn version_range(&self) -> Option<Range> {
+///         None
+///     }
+///     fn source(&self) -> deps_core::parser::DependencySource {
+///         deps_core::parser::DependencySource::Registry
+///     }
+///     fn as_any(&self) -> &dyn Any {
+///         self
+///     }
+/// }
+///
+/// struct SimpleParseResult {
+///     deps: Vec<SimpleDep>,
+///     uri: Uri,
+/// }
+///
+/// impl ParseResult for SimpleParseResult {
+///     fn dependencies(&self) -> Vec<&dyn Dependency> {
+///         self.deps.iter().map(|d| d as &dyn Dependency).collect()
+///     }
+///     fn workspace_root(&self) -> Option<&std::path::Path> {
+///         None
+///     }
+///     fn uri(&self) -> &Uri {
+///         &self.uri
+///     }
+///     fn as_any(&self) -> &dyn Any {
+///         self
+///     }
+/// }
+///
+/// struct SimpleFormatter;
+/// impl EcosystemFormatter for SimpleFormatter {
+///     fn format_version_for_text_edit(&self, version: &str) -> String {
+///         version.to_string()
+///     }
+///     fn package_url(&self, name: &PackageName) -> String {
+///         name.to_string()
+///     }
+/// }
+///
+/// // `time` declared twice, pinned to two different versions.
+/// let parse_result = SimpleParseResult {
+///     deps: vec![
+///         SimpleDep {
+///             name: PackageName::new("time"),
+///             version_req: Some(VersionReq::new("=0.1.43")),
+///             name_range: Range::new(Position::new(0, 0), Position::new(0, 4)),
+///         },
+///         SimpleDep {
+///             name: PackageName::new("time"),
+///             version_req: Some(VersionReq::new("=0.1.44")),
+///             name_range: Range::new(Position::new(3, 0), Position::new(3, 4)),
+///         },
+///     ],
+///     uri: deps_core::test_util::test_uri("/test/Cargo.toml"),
+/// };
+/// let resolved = HashMap::new();
+///
+/// let keys = vulnerability_keys(&parse_result, &resolved, &SimpleFormatter, EcosystemId::Cargo);
+/// let deps = parse_result.dependencies();
+/// let key0 = keys.get(&deps[0].name_range()).unwrap();
+/// let key1 = keys.get(&deps[1].name_range()).unwrap();
+/// assert_ne!(key0, key1, "differently-pinned occurrences of one name get distinct keys");
+/// ```
 pub fn vulnerability_keys(
     parse_result: &dyn crate::ParseResult,
     resolved: &HashMap<crate::PackageName, String>,

--- a/crates/deps-core/src/osv/types.rs
+++ b/crates/deps-core/src/osv/types.rs
@@ -347,13 +347,101 @@ pub enum ScanOutcome {
     Vulnerable(DependencyVulnerabilities),
 }
 
-/// Per-scan result map, keyed by the normalized dependency name.
+/// Per-scan result map.
 ///
-/// The key is `EcosystemFormatter::normalize_package_name` — the same key
+/// Normally keyed by the normalized dependency name
+/// (`EcosystemFormatter::normalize_package_name` — the same key
 /// [`crate::lsp_helpers::generate_diagnostics_from_cache`] and
 /// [`crate::lsp_helpers::generate_hover`] already use to look up
-/// `cached`/`resolved` versions.
+/// `cached`/`resolved` versions), but see [`vulnerability_keys`] for the
+/// version-qualified form a duplicated dependency name's occurrences use.
 pub type VulnerabilityMap = HashMap<String, ScanOutcome>;
+
+/// Computes the [`VulnerabilityMap`] key each occurrence in `parse_result`
+/// should be scanned/looked-up under.
+///
+/// Keyed by [`Dependency::name_range`](crate::Dependency::name_range) —
+/// unique per occurrence within one document, so callers holding a specific
+/// `dep` (not just its name) can look their own key up directly.
+///
+/// Normally an occurrence's key is just its normalized name (the common
+/// case, and the only form most `VulnerabilityMap` test fixtures use). When
+/// two or more occurrences of the *same* name resolve to different signatures
+/// — e.g. the same crate under `[dependencies]` and `[dev-dependencies]`, or
+/// multiple `[target.'cfg(...)'.dependencies]` blocks (#394), pinned to
+/// different versions, or mixing a registry source with a git/path fork —
+/// each such occurrence's key is instead qualified with a signature specific
+/// to it, so their OSV results can never collide in the shared map.
+/// Occurrences that share both a name and an identical signature
+/// (registry-source, same in-use version) intentionally keep the plain,
+/// shared key and get scanned once: the OSV result would be identical
+/// either way, so collapsing them is a dedup, not a gap.
+///
+/// Every caller that builds or looks up a `VulnerabilityMap` entry for a
+/// *specific* dependency occurrence — `deps-lsp`'s `build_scan_targets`,
+/// and the vulnerability lookups in `generate_diagnostics_from_cache`,
+/// `generate_hover`, and `generate_code_actions` — must go through this
+/// function so key construction never drifts out of sync between producer
+/// and consumer. A caller with no [`EcosystemId`](crate::EcosystemId) to
+/// give (most test fixtures) skips this and falls back to the plain
+/// normalized name, which still finds any entry a test inserted under that
+/// name directly.
+pub fn vulnerability_keys(
+    parse_result: &dyn crate::ParseResult,
+    resolved: &HashMap<crate::PackageName, String>,
+    formatter: &dyn crate::lsp_helpers::EcosystemFormatter,
+    ecosystem: crate::EcosystemId,
+) -> HashMap<tower_lsp_server::ls_types::Range, String> {
+    use crate::lsp_helpers::in_use_version;
+    use crate::parser::DependencySource;
+
+    let deps = parse_result.dependencies();
+
+    // One signature per occurrence: registry-source deps carry their own
+    // in-use version (or "u" when none is determinable — a range
+    // requirement with no lock file); non-registry deps (git/path forks)
+    // always carry "n", since their `ScanOutcome` is always
+    // `Skipped(NonRegistrySource)` regardless of any declared version.
+    let signatures: Vec<(String, String)> = deps
+        .iter()
+        .map(|dep| {
+            let name = formatter.normalize_package_name(dep.name());
+            let signature = if dep.source() == DependencySource::Registry {
+                match in_use_version(*dep, &name, resolved, formatter, ecosystem) {
+                    Some(v) => format!("v:{v}"),
+                    None => "u".to_string(),
+                }
+            } else {
+                "n".to_string()
+            };
+            (name, signature)
+        })
+        .collect();
+
+    let mut distinct_signatures_by_name: HashMap<&str, std::collections::HashSet<&str>> =
+        HashMap::new();
+    for (name, signature) in &signatures {
+        distinct_signatures_by_name
+            .entry(name.as_str())
+            .or_default()
+            .insert(signature.as_str());
+    }
+
+    deps.iter()
+        .zip(&signatures)
+        .map(|(dep, (name, signature))| {
+            let ambiguous = distinct_signatures_by_name
+                .get(name.as_str())
+                .is_some_and(|s| s.len() > 1);
+            let key = if ambiguous {
+                format!("{name}\u{0}{signature}")
+            } else {
+                name.clone()
+            };
+            (dep.name_range(), key)
+        })
+        .collect()
+}
 
 // ---- OSV wire types (private) -------------------------------------------
 

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -233,33 +233,42 @@ fn in_use_version(
     }
 }
 
-/// Builds `dep_name -> in_use_version` (§4.5/§4.6) for every dependency with
-/// a known in-use version, for the yanked-check probe in
+/// Builds `dep_name -> [in_use_version, ...]` (§4.5/§4.6) for every
+/// dependency with a known in-use version, for the yanked-check probe in
 /// `fetch_latest_versions_parallel`. Skips non-registry dependencies
 /// (git/path forks, step 0 of [`build_scan_targets`]'s ladder) so a patched
 /// fork is never flagged for a registry version it does not contain.
+///
+/// One entry per *occurrence* of a name, not a single collapsed value: the
+/// same dependency name can appear more than once in a manifest (duplicate
+/// keys, or the same crate under `[dependencies]`/`[dev-dependencies]` or
+/// multiple `[target.'cfg(...)'.dependencies]` blocks — #394). A HashMap
+/// keyed by name alone would silently drop all but the last occurrence's
+/// in-use version from the yanked probe below.
 fn collect_in_use_versions(
     parse_result: &dyn deps_core::ParseResult,
     resolved_versions: &HashMap<PackageName, String>,
     formatter: &dyn deps_core::lsp_helpers::EcosystemFormatter,
     ecosystem: EcosystemId,
-) -> HashMap<PackageName, String> {
-    parse_result
+) -> HashMap<PackageName, Vec<String>> {
+    let mut map: HashMap<PackageName, Vec<String>> = HashMap::new();
+    for dep in parse_result
         .dependencies()
         .into_iter()
         .filter(|dep| dep.source() == deps_core::parser::DependencySource::Registry)
-        .filter_map(|dep| {
-            let normalized_name = formatter.normalize_package_name(dep.name());
-            in_use_version(
-                dep,
-                &normalized_name,
-                resolved_versions,
-                formatter,
-                ecosystem,
-            )
-            .map(|v| (dep.name().clone(), v))
-        })
-        .collect()
+    {
+        let normalized_name = formatter.normalize_package_name(dep.name());
+        if let Some(v) = in_use_version(
+            dep,
+            &normalized_name,
+            resolved_versions,
+            formatter,
+            ecosystem,
+        ) {
+            map.entry(dep.name().clone()).or_default().push(v);
+        }
+    }
+    map
 }
 
 /// Builds the OSV scan targets for one manifest's dependencies, applying the
@@ -559,11 +568,20 @@ struct DependencyDiff {
 }
 
 impl DependencyDiff {
-    /// `old`/`new` map each dependency name to its declared version
-    /// requirement (`Dependency::version_requirement()`) at parse time.
+    /// `old`/`new` map each dependency name to the declared version
+    /// requirements (`Dependency::version_requirement()`) of *every*
+    /// occurrence of that name at parse time, in document order — not a
+    /// single collapsed value. A name can appear more than once within a
+    /// manifest (accidental duplicate keys, or the same crate declared under
+    /// both `[dependencies]`/`[dev-dependencies]` or under two different
+    /// `[target.'cfg(...)'.dependencies]` blocks — see #394). Comparing the
+    /// full per-name `Vec` rather than a name-keyed single requirement
+    /// ensures an edit to *any* occurrence changes the value the diff
+    /// compares, instead of silently no-opping when a HashMap collapse would
+    /// have kept the "winning" occurrence's requirement unchanged.
     fn compute(
-        old: &HashMap<PackageName, Option<VersionReq>>,
-        new: &HashMap<PackageName, Option<VersionReq>>,
+        old: &HashMap<PackageName, Vec<Option<VersionReq>>>,
+        new: &HashMap<PackageName, Vec<Option<VersionReq>>>,
     ) -> Self {
         let old_names: HashSet<&PackageName> = old.keys().collect();
         let new_names: HashSet<&PackageName> = new.keys().collect();
@@ -612,15 +630,21 @@ impl DependencyDiff {
     }
 }
 
-/// Builds `name -> version_requirement` for every dependency in `pr`, the
-/// shape [`DependencyDiff::compute`] needs.
+/// Builds `name -> [version_requirement, ...]` for every dependency in `pr`,
+/// one entry per occurrence in document order, the shape
+/// [`DependencyDiff::compute`] needs. A `HashMap<PackageName, Option<VersionReq>>`
+/// (single value per name) would silently collapse a duplicate name to its
+/// last occurrence, losing any edit made to an earlier one (#394).
 fn dependency_version_map(
     pr: &dyn deps_core::ParseResult,
-) -> HashMap<PackageName, Option<VersionReq>> {
-    pr.dependencies()
-        .into_iter()
-        .map(|d| (d.name().clone(), d.version_requirement().cloned()))
-        .collect()
+) -> HashMap<PackageName, Vec<Option<VersionReq>>> {
+    let mut map: HashMap<PackageName, Vec<Option<VersionReq>>> = HashMap::new();
+    for d in pr.dependencies() {
+        map.entry(d.name().clone())
+            .or_default()
+            .push(d.version_requirement().cloned());
+    }
+    map
 }
 
 /// Result of parallel version fetching.
@@ -667,9 +691,10 @@ struct FetchResult {
 ///
 /// * `registry` - Package registry to fetch from
 /// * `package_names` - List of package names to fetch
-/// * `in_use` - Raw dependency name -> the version this project actually
-///   has (lockfile-resolved or a concrete pin), checked against the fetched
-///   version list for yank status
+/// * `in_use` - Raw dependency name -> the version(s) this project actually
+///   has (lockfile-resolved or a concrete pin) for every occurrence of that
+///   name in the manifest, checked against the fetched version list for
+///   yank status
 /// * `progress` - Optional progress tracker (will be updated after each fetch)
 /// * `timeout_secs` - Timeout for each individual package fetch (default: 10s)
 /// * `max_concurrent` - Maximum concurrent fetches (default: 20)
@@ -689,7 +714,7 @@ struct FetchResult {
 async fn fetch_latest_versions_parallel(
     registry: Arc<dyn Registry>,
     package_names: Vec<PackageName>,
-    in_use: &HashMap<PackageName, String>,
+    in_use: &HashMap<PackageName, Vec<String>>,
     progress_sender: Option<ProgressSender>,
     freshness: deps_core::freshness::FreshnessSettings,
     timeout_secs: u64,
@@ -713,7 +738,7 @@ async fn fetch_latest_versions_parallel(
             let first_error = Arc::clone(&first_error);
             let progress_sender = progress_sender.clone();
             let wildcard_req = &wildcard_req;
-            let in_use_version = in_use.get(&name).cloned();
+            let in_use_versions = in_use.get(&name).cloned().unwrap_or_default();
             async move {
                 // Single round trip: the full version list is fetched once, and "latest"
                 // is a pure in-memory pick over it (`Registry::select_latest_matching`) —
@@ -850,12 +875,21 @@ async fn fetch_latest_versions_parallel(
                             // yanked in-use version wins over an already
                             // -recorded yanked `latest` — it's the version
                             // the user actually has.
-                            if let Some(iv) = in_use_version.as_deref()
-                                && let Some(found) =
-                                    versions.iter().find(|v| v.version_string() == iv)
-                                && found.removal_status().is_flagged()
-                            {
-                                yanked = Some((name.clone(), iv.to_string()));
+                            //
+                            // Multiple occurrences of the same name (#394,
+                            // e.g. under both `[dependencies]` and
+                            // `[target.*.dependencies]`) can carry different
+                            // in-use versions — every one is checked so a
+                            // yanked pin on any occurrence is never missed
+                            // just because another occurrence happens to
+                            // share the registry lookup.
+                            if let Some(iv) = in_use_versions.iter().find(|iv| {
+                                versions.iter().any(|v| {
+                                    v.version_string() == iv.as_str()
+                                        && v.removal_status().is_flagged()
+                                })
+                            }) {
+                                yanked = Some((name.clone(), iv.clone()));
                             }
                         }
 
@@ -1054,7 +1088,7 @@ pub async fn handle_document_open(
 
         // Collect dependency names and the in-use-version map (§4.6) in one
         // pass while holding the reference (can't hold across await).
-        let (dep_names, in_use): (Vec<PackageName>, HashMap<PackageName, String>) = {
+        let (dep_names, in_use): (Vec<PackageName>, HashMap<PackageName, Vec<String>>) = {
             let doc = match state_clone.get_document(&uri_clone) {
                 Some(d) => d,
                 None => {
@@ -1250,7 +1284,7 @@ pub async fn handle_document_change(
 
     // Extract old dependency name -> version_requirement map before parsing
     // (for diff computation)
-    let old_deps: HashMap<PackageName, Option<VersionReq>> =
+    let old_deps: HashMap<PackageName, Vec<Option<VersionReq>>> =
         state.get_document(&uri).map_or_else(HashMap::new, |doc| {
             doc.parse_result()
                 .map(dependency_version_map)
@@ -1261,7 +1295,7 @@ pub async fn handle_document_change(
     let parse_result = ecosystem.parse_manifest(&content, &uri).await.ok();
 
     // Extract new dependency name -> version_requirement map for diff
-    let new_deps: HashMap<PackageName, Option<VersionReq>> = parse_result
+    let new_deps: HashMap<PackageName, Vec<Option<VersionReq>>> = parse_result
         .as_ref()
         .map(|pr| dependency_version_map(pr.as_ref()))
         .unwrap_or_default();
@@ -1458,7 +1492,7 @@ pub async fn handle_document_change(
 
         // Build the in-use-version map (§4.6) from the freshly-committed parse
         // result and the resolved versions just loaded above.
-        let in_use: HashMap<PackageName, String> = match state_clone.get_document(&uri_clone) {
+        let in_use: HashMap<PackageName, Vec<String>> = match state_clone.get_document(&uri_clone) {
             Some(doc) => match doc.parse_result() {
                 Some(pr) => collect_in_use_versions(
                     pr,
@@ -3701,7 +3735,7 @@ dependencies = ["requests>=2.0.0"]
             // `==` comparator must already be stripped here.
             assert_eq!(
                 in_use.get(&PackageName::new(raw_name)),
-                Some(&pinned_version.to_string())
+                Some(&vec![pinned_version.to_string()])
             );
 
             let registry: Arc<dyn Registry> = Arc::new(MockYankedRegistry { pinned_version });
@@ -4125,13 +4159,13 @@ time = "0.1.43"
             let content2 = r#"[dependencies]
 serde = "1.0"
 "#;
-            let old_deps: HashMap<PackageName, Option<VersionReq>> =
+            let old_deps: HashMap<PackageName, Vec<Option<VersionReq>>> =
                 [("serde", None), ("time", None)]
                     .into_iter()
-                    .map(|(n, r)| (PackageName::new(n), r))
+                    .map(|(n, r)| (PackageName::new(n), vec![r]))
                     .collect();
-            let new_deps: HashMap<PackageName, Option<VersionReq>> =
-                std::iter::once((PackageName::new("serde"), None)).collect();
+            let new_deps: HashMap<PackageName, Vec<Option<VersionReq>>> =
+                std::iter::once((PackageName::new("serde"), vec![None])).collect();
             let diff = DependencyDiff::compute(&old_deps, &new_deps);
             assert_eq!(diff.removed, vec![PackageName::new("time")]);
 
@@ -4274,13 +4308,13 @@ time = "0.1.43"
             let content2 = r#"[dependencies]
 serde = "1.0"
 "#;
-            let old_deps: HashMap<PackageName, Option<VersionReq>> =
+            let old_deps: HashMap<PackageName, Vec<Option<VersionReq>>> =
                 [("serde", None), ("time", None)]
                     .into_iter()
-                    .map(|(n, r)| (PackageName::new(n), r))
+                    .map(|(n, r)| (PackageName::new(n), vec![r]))
                     .collect();
-            let new_deps: HashMap<PackageName, Option<VersionReq>> =
-                std::iter::once((PackageName::new("serde"), None)).collect();
+            let new_deps: HashMap<PackageName, Vec<Option<VersionReq>>> =
+                std::iter::once((PackageName::new("serde"), vec![None])).collect();
             let diff = DependencyDiff::compute(&old_deps, &new_deps);
             assert_eq!(diff.removed, vec![PackageName::new("time")]);
 
@@ -4491,10 +4525,12 @@ serde = "1.0"
             );
         }
 
-        fn versions(pairs: &[(&str, Option<&str>)]) -> HashMap<PackageName, Option<VersionReq>> {
+        fn versions(
+            pairs: &[(&str, Option<&str>)],
+        ) -> HashMap<PackageName, Vec<Option<VersionReq>>> {
             pairs
                 .iter()
-                .map(|(name, req)| (PackageName::new(*name), req.map(VersionReq::new)))
+                .map(|(name, req)| (PackageName::new(*name), vec![req.map(VersionReq::new)]))
                 .collect()
         }
 
@@ -4550,7 +4586,7 @@ serde = "1.0"
 
         #[test]
         fn test_dependency_diff_empty_to_new() {
-            let old: HashMap<PackageName, Option<VersionReq>> = HashMap::new();
+            let old: HashMap<PackageName, Vec<Option<VersionReq>>> = HashMap::new();
             let new = versions(&[("serde", Some("1.0")), ("tokio", Some("1.0"))]);
 
             let diff = DependencyDiff::compute(&old, &new);
@@ -4581,6 +4617,148 @@ serde = "1.0"
                 diff.needs_osv_rescan(),
                 "a version-only edit must still trigger an OSV rescan"
             );
+        }
+
+        #[tokio::test]
+        async fn test_dependency_version_map_tracks_both_occurrences_of_duplicate_name() {
+            // Regression guard for #394: `time` appears under both
+            // `[dependencies]` and `[dev-dependencies]` with different
+            // requirements. A name-keyed `HashMap<PackageName, Option<VersionReq>>`
+            // would silently collapse this to one entry (whichever section's
+            // entry iterates last); `dependency_version_map` must instead
+            // keep one requirement per occurrence.
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+            let ecosystem = state.ecosystem_registry.get("cargo").unwrap();
+
+            let content = r#"[dependencies]
+time = "0.1.43"
+
+[dev-dependencies]
+time = "0.1.44"
+"#;
+            let parse_result = ecosystem.parse_manifest(content, &uri).await.unwrap();
+            assert_eq!(
+                parse_result.dependencies().len(),
+                2,
+                "both `[dependencies]` and `[dev-dependencies]` occurrences of `time` must parse"
+            );
+
+            let deps = dependency_version_map(parse_result.as_ref());
+            let time_reqs = deps
+                .get(&PackageName::new("time"))
+                .expect("duplicated name must still be present in the map");
+            assert_eq!(
+                time_reqs,
+                &vec![
+                    Some(VersionReq::new("0.1.43")),
+                    Some(VersionReq::new("0.1.44")),
+                ],
+                "both occurrences' version requirements must be tracked, not just the last one"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_dependency_diff_detects_edit_to_first_occurrence_of_duplicate_name() {
+            // Regression guard for #394: editing the *first* (`[dependencies]`)
+            // occurrence of a duplicated name, while the second
+            // (`[dev-dependencies]`) occurrence stays unchanged, must still
+            // produce a non-empty diff. Under the pre-fix name-only HashMap,
+            // the unchanged second occurrence "won" the collapse in both the
+            // old and new maps, so this edit was silently invisible to
+            // `DependencyDiff` — the registry fetch and OSV rescan never ran.
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+            let ecosystem = state.ecosystem_registry.get("cargo").unwrap();
+
+            let content1 = r#"[dependencies]
+time = "0.1.43"
+
+[dev-dependencies]
+time = "0.1.44"
+"#;
+            let old_deps = dependency_version_map(
+                ecosystem
+                    .parse_manifest(content1, &uri)
+                    .await
+                    .unwrap()
+                    .as_ref(),
+            );
+
+            let content2 = r#"[dependencies]
+time = "0.1.50"
+
+[dev-dependencies]
+time = "0.1.44"
+"#;
+            let new_deps = dependency_version_map(
+                ecosystem
+                    .parse_manifest(content2, &uri)
+                    .await
+                    .unwrap()
+                    .as_ref(),
+            );
+
+            let diff = DependencyDiff::compute(&old_deps, &new_deps);
+            assert!(diff.added.is_empty());
+            assert!(diff.removed.is_empty());
+            assert_eq!(
+                diff.version_changed,
+                vec![PackageName::new("time")],
+                "editing the losing (first) occurrence of a duplicated name must be detected"
+            );
+            assert!(diff.needs_fetch());
+            assert!(diff.needs_osv_rescan());
+        }
+
+        #[tokio::test]
+        async fn test_dependency_diff_detects_edit_to_second_occurrence_of_duplicate_name() {
+            // Mirrors the previous test in the opposite direction: editing
+            // the *second* (`[dev-dependencies]`) occurrence, with the first
+            // (`[dependencies]`) occurrence unchanged, must also be detected
+            // — confirming the fix is not merely order-dependent.
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+            let ecosystem = state.ecosystem_registry.get("cargo").unwrap();
+
+            let content1 = r#"[dependencies]
+time = "0.1.43"
+
+[dev-dependencies]
+time = "0.1.44"
+"#;
+            let old_deps = dependency_version_map(
+                ecosystem
+                    .parse_manifest(content1, &uri)
+                    .await
+                    .unwrap()
+                    .as_ref(),
+            );
+
+            let content2 = r#"[dependencies]
+time = "0.1.43"
+
+[dev-dependencies]
+time = "0.1.60"
+"#;
+            let new_deps = dependency_version_map(
+                ecosystem
+                    .parse_manifest(content2, &uri)
+                    .await
+                    .unwrap()
+                    .as_ref(),
+            );
+
+            let diff = DependencyDiff::compute(&old_deps, &new_deps);
+            assert!(diff.added.is_empty());
+            assert!(diff.removed.is_empty());
+            assert_eq!(
+                diff.version_changed,
+                vec![PackageName::new("time")],
+                "editing the winning (second) occurrence of a duplicated name must be detected"
+            );
+            assert!(diff.needs_fetch());
+            assert!(diff.needs_osv_rescan());
         }
 
         #[tokio::test]
@@ -4628,13 +4806,14 @@ tokio = "1.0"
 "#;
 
             // Compute diff and apply cache pruning
-            let old_deps: HashMap<PackageName, Option<VersionReq>> = ["serde", "tokio", "anyhow"]
+            let old_deps: HashMap<PackageName, Vec<Option<VersionReq>>> =
+                ["serde", "tokio", "anyhow"]
+                    .iter()
+                    .map(|s| (PackageName::new(*s), vec![None]))
+                    .collect();
+            let new_deps: HashMap<PackageName, Vec<Option<VersionReq>>> = ["serde", "tokio"]
                 .iter()
-                .map(|s| (PackageName::new(*s), None))
-                .collect();
-            let new_deps: HashMap<PackageName, Option<VersionReq>> = ["serde", "tokio"]
-                .iter()
-                .map(|s| (PackageName::new(*s), None))
+                .map(|s| (PackageName::new(*s), vec![None]))
                 .collect();
             let diff = DependencyDiff::compute(&old_deps, &new_deps);
 
@@ -5206,7 +5385,7 @@ tokio = "1.0"
             );
             assert_eq!(
                 in_use.get(&PackageName::new("serde")),
-                Some(&"1.0.195".to_string())
+                Some(&vec!["1.0.195".to_string()])
             );
         }
 
@@ -5231,7 +5410,7 @@ tokio = "1.0"
             );
             assert_eq!(
                 in_use.get(&PackageName::new("log4j-core")),
-                Some(&"2.14.1".to_string())
+                Some(&vec!["2.14.1".to_string()])
             );
         }
 
@@ -5301,7 +5480,7 @@ tokio = "1.0"
             );
             assert_eq!(
                 in_use.get(&PackageName::new("typing_extensions")),
-                Some(&"4.9.0".to_string()),
+                Some(&vec!["4.9.0".to_string()]),
                 "pep440 '==' comparator must be stripped, not carried into the in-use version"
             );
         }
@@ -5350,6 +5529,44 @@ tokio = "1.0"
                 EcosystemId::Cargo,
             );
             assert!(in_use.is_empty());
+        }
+
+        #[test]
+        fn collect_in_use_versions_tracks_all_occurrences_of_duplicate_name() {
+            // Regression guard for #394: two occurrences of the same
+            // dependency name (e.g. under different
+            // `[target.*.dependencies]` blocks, or `[dependencies]` +
+            // `[dev-dependencies]`) with different concrete pins and no lock
+            // file must both surface an in-use version for the yanked probe
+            // — a name-keyed `HashMap<PackageName, String>` would silently
+            // drop all but the last occurrence's pin.
+            let parse_result = MockParseResult {
+                deps: vec![
+                    MockDep {
+                        name: PackageName::new("time"),
+                        version_req: Some(VersionReq::new("=0.1.43")),
+                        source: DependencySource::Registry,
+                    },
+                    MockDep {
+                        name: PackageName::new("time"),
+                        version_req: Some(VersionReq::new("=0.1.44")),
+                        source: DependencySource::Registry,
+                    },
+                ],
+            };
+            let resolved = HashMap::new();
+
+            let in_use = collect_in_use_versions(
+                &parse_result,
+                &resolved,
+                &MockFormatter,
+                EcosystemId::Cargo,
+            );
+            assert_eq!(
+                in_use.get(&PackageName::new("time")),
+                Some(&vec!["0.1.43".to_string(), "0.1.44".to_string()]),
+                "both occurrences' in-use versions must be tracked, not just the last one"
+            );
         }
     }
 
@@ -5493,7 +5710,7 @@ tokio = "1.0"
                 fetch_calls: Arc::clone(&fetch_calls),
             });
             let mut in_use = HashMap::new();
-            in_use.insert(PackageName::new("pkg"), "1.0.0".to_string());
+            in_use.insert(PackageName::new("pkg"), vec!["1.0.0".to_string()]);
 
             let result = fetch_latest_versions_parallel(
                 registry,
@@ -5520,7 +5737,7 @@ tokio = "1.0"
                 fetch_calls: Arc::clone(&fetch_calls),
             });
             let mut in_use = HashMap::new();
-            in_use.insert(PackageName::new("pkg"), "1.0.0".to_string());
+            in_use.insert(PackageName::new("pkg"), vec!["1.0.0".to_string()]);
 
             let result = fetch_latest_versions_parallel(
                 registry,
@@ -5578,7 +5795,7 @@ tokio = "1.0"
                 fetch_calls: Arc::clone(&fetch_calls),
             });
             let mut in_use = HashMap::new();
-            in_use.insert(PackageName::new("pkg"), "1.0.0".to_string());
+            in_use.insert(PackageName::new("pkg"), vec!["1.0.0".to_string()]);
 
             let result = fetch_latest_versions_parallel(
                 registry,
@@ -5611,7 +5828,7 @@ tokio = "1.0"
                 fetch_calls: Arc::clone(&fetch_calls),
             });
             let mut in_use = HashMap::new();
-            in_use.insert(PackageName::new("pkg"), "1.0.0".to_string());
+            in_use.insert(PackageName::new("pkg"), vec!["1.0.0".to_string()]);
 
             let result = fetch_latest_versions_parallel(
                 registry,
@@ -5644,7 +5861,7 @@ tokio = "1.0"
                 fetch_calls: Arc::clone(&fetch_calls),
             });
             let mut in_use = HashMap::new();
-            in_use.insert(PackageName::new("pkg"), "1.0.0".to_string());
+            in_use.insert(PackageName::new("pkg"), vec!["1.0.0".to_string()]);
 
             let result = fetch_latest_versions_parallel(
                 registry,
@@ -5679,7 +5896,7 @@ tokio = "1.0"
                 fetch_calls: Arc::clone(&fetch_calls),
             });
             let mut in_use = HashMap::new();
-            in_use.insert(PackageName::new("pkg"), "1.0.0".to_string());
+            in_use.insert(PackageName::new("pkg"), vec!["1.0.0".to_string()]);
 
             let result = fetch_latest_versions_parallel(
                 registry,
@@ -5703,6 +5920,51 @@ tokio = "1.0"
             assert_eq!(
                 result.yanked_versions.get(&PackageName::new("pkg")),
                 Some(&"1.0.0".to_string())
+            );
+        }
+
+        #[tokio::test]
+        async fn in_use_checks_every_occurrence_of_a_duplicate_name() {
+            // Regression guard for #394: a package can appear more than once
+            // in a manifest under the same name (e.g. `[dependencies]` +
+            // `[dev-dependencies]`), each pinned to a different in-use
+            // version. Only one occurrence ("2.0.0") is yanked; the other
+            // ("3.0.0", not fetched here, not yanked) must not shadow it.
+            let registry: Arc<dyn Registry> = Arc::new(MockRegistry {
+                reports_yanked: true,
+                versions: HashMap::from([(
+                    "pkg",
+                    FetchOutcome::Versions(vec![
+                        ("3.0.0", false),
+                        ("2.0.0", true),
+                        ("1.0.0", false),
+                    ]),
+                )]),
+                latest_fallback: HashMap::new(),
+                fetch_calls: Arc::new(AtomicUsize::new(0)),
+            });
+            let mut in_use = HashMap::new();
+            in_use.insert(
+                PackageName::new("pkg"),
+                vec!["1.0.0".to_string(), "2.0.0".to_string()],
+            );
+
+            let result = fetch_latest_versions_parallel(
+                registry,
+                vec![PackageName::new("pkg")],
+                &in_use,
+                None,
+                deps_core::freshness::FreshnessSettings::default(),
+                5,
+                10,
+            )
+            .await;
+
+            assert_eq!(
+                result.yanked_versions.get(&PackageName::new("pkg")),
+                Some(&"2.0.0".to_string()),
+                "the yanked occurrence must be found even though a name-keyed \
+                 single-value map could have kept only the non-yanked \"1.0.0\" pin"
             );
         }
 
@@ -5795,7 +6057,7 @@ tokio = "1.0"
                 fetch_calls: Arc::new(AtomicUsize::new(0)),
             });
             let mut in_use = HashMap::new();
-            in_use.insert(PackageName::new("pkg"), "1.0.0".to_string());
+            in_use.insert(PackageName::new("pkg"), vec!["1.0.0".to_string()]);
 
             let result = fetch_latest_versions_parallel(
                 registry,
@@ -5823,7 +6085,7 @@ tokio = "1.0"
                 fetch_calls: Arc::new(AtomicUsize::new(0)),
             });
             let mut in_use = HashMap::new();
-            in_use.insert(PackageName::new("pkg"), "1.0.0".to_string());
+            in_use.insert(PackageName::new("pkg"), vec!["1.0.0".to_string()]);
 
             // 1 second timeout for test speed.
             let result = fetch_latest_versions_parallel(

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -8,7 +8,6 @@ use super::state::{DocumentState, ServerState};
 use crate::config::DepsConfig;
 use crate::handlers::diagnostics;
 use crate::progress::{ProgressSender, RegistryProgress};
-use deps_core::Dependency;
 use deps_core::Ecosystem;
 use deps_core::EcosystemId;
 use deps_core::PackageName;
@@ -16,6 +15,7 @@ use deps_core::PackageVersions;
 use deps_core::Registry;
 use deps_core::Result;
 use deps_core::VersionReq;
+use deps_core::lsp_helpers::in_use_version;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
@@ -103,136 +103,6 @@ fn preserve_cache(new_state: &mut DocumentState, old_state: &DocumentState) {
 /// per-phase timeout longer than that would never actually bind.
 const OSV_SCAN_TIMEOUT_CEILING_SECS: u64 = 30;
 
-/// Ecosystems whose *bare* (no explicit pin marker) version requirement is a
-/// range under that ecosystem's own default semantics — Cargo's implicit
-/// caret, npm/Composer's implicit caret. For these, [`is_concrete_version`]
-/// requires an explicit `=`/`==` (or an exact-bracket wrap) before treating a
-/// requirement as concrete; a bare `"1.2.3"` alone is not enough evidence
-/// (critique C2).
-///
-/// Deno reuses npm's exact grammar for both its `jsr:` and `npm:` specifiers
-/// (`DenoFormatter::compile_requirement` compiles both through the same
-/// `node_semver::Range` npm itself uses), so it gets the same treatment here.
-///
-/// Gradle is deliberately excluded: a bare Gradle coordinate version (e.g.
-/// `"2.14.1"`) is an exact match under `GradleFormatter`'s own
-/// `version_satisfies_requirement` unless it uses the `+` dynamic-version
-/// suffix, which [`looks_like_a_single_version`] already rejects via its
-/// reject-char set — Gradle has no implicit-caret default the way
-/// Cargo/npm/Composer do.
-const fn bare_version_is_a_range(ecosystem: EcosystemId) -> bool {
-    matches!(
-        ecosystem,
-        EcosystemId::Cargo | EcosystemId::Npm | EcosystemId::Composer | EcosystemId::Deno
-    )
-}
-
-/// Returns `true` if `s` (already stripped of any pin marker) has the shape
-/// of a single concrete version: non-empty, no wildcard/range-operator
-/// character, and starting with a digit (after an optional `v`/`V` prefix,
-/// e.g. Go's `v1.9.1`).
-///
-/// Deliberately conservative — see [`is_concrete_version`]'s doc for why a
-/// false positive here is worse than a false negative.
-fn looks_like_a_single_version(s: &str) -> bool {
-    if s.is_empty() {
-        return false;
-    }
-    if s.contains([
-        '^', '~', '*', '<', '>', ',', '|', '(', ')', '[', ']', ' ', '\t', ':', '+', 'x', 'X',
-    ]) {
-        return false;
-    }
-    let core = s.strip_prefix(['v', 'V']).unwrap_or(s);
-    core.chars().next().is_some_and(|c| c.is_ascii_digit())
-}
-
-/// Returns the concrete version text `requirement` denotes — with any pin
-/// marker (`=`/`==`, or a single-value bracket wrap like NuGet's `[1.0.0]`)
-/// stripped off — or `None` if `requirement` is not the shape of a single
-/// concrete version. The only shape safe to query OSV with directly (§3
-/// step 2), and, for #233, the only shape safe to compare against a real
-/// registry version string in the yanked-version probe. A wrong answer here
-/// is invisible in testing (OSV silently returns `{}` for a fabricated
-/// version; the yanked probe silently finds no match), so getting this
-/// right matters more than covering every ecosystem's full range grammar.
-///
-/// An explicit pin marker is always accepted, and its marker is stripped
-/// from the returned text — required because PyPI's parser retains the
-/// pep440 comparator in `Dependency::version_requirement()` (an exact pin
-/// parses to `"==4.9.0"`, not `"4.9.0"`; confirmed by
-/// `deps-pypi`'s `test_basic_pinned`), so comparing the *unstripped* text
-/// against a real registry version string (`"4.9.0"`) would never match. A
-/// *bare* requirement (no marker) is returned verbatim, and is accepted only
-/// for ecosystems where a bare version is not itself a range by default
-/// (critique C2) — see [`bare_version_is_a_range`].
-fn concrete_pin_version(requirement: &str, ecosystem: EcosystemId) -> Option<&str> {
-    let trimmed = requirement.trim();
-    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("latest") {
-        return None;
-    }
-
-    let pinned = trimmed
-        .strip_prefix("==")
-        .or_else(|| trimmed.strip_prefix('='));
-    let bracket_pinned = trimmed
-        .strip_prefix('[')
-        .and_then(|s| s.strip_suffix(']'))
-        .filter(|inner| !inner.contains(','));
-
-    match pinned.or(bracket_pinned) {
-        Some(body) => looks_like_a_single_version(body).then_some(body),
-        None if bare_version_is_a_range(ecosystem) => None,
-        None => looks_like_a_single_version(trimmed).then_some(trimmed),
-    }
-}
-
-/// Returns `true` if `requirement` denotes a single concrete version. See
-/// [`concrete_pin_version`], whose boolean projection this is, for the
-/// acceptance rules. Test-only: production code needs the stripped text
-/// from `concrete_pin_version` itself, not just the boolean.
-#[cfg(test)]
-fn is_concrete_version(requirement: &str, ecosystem: EcosystemId) -> bool {
-    concrete_pin_version(requirement, ecosystem).is_some()
-}
-
-/// The version of `dep` this project treats as actually in use: the
-/// lock-file-resolved version, else the declared requirement when it is
-/// already concrete ([`concrete_pin_version`]). `None` when neither applies.
-///
-/// A dependency whose manifest requirement is itself the resolved version
-/// ([`deps_core::lsp_helpers::EcosystemFormatter::manifest_requirement_is_resolved_version`]
-/// — a Go `require`-directive dependency) skips the lockfile step entirely,
-/// going straight to the declared requirement — see [`build_scan_targets`]
-/// for why go.sum is unreliable here. Shared by `build_scan_targets` (OSV
-/// targets) and the yanked-version check (`fetch_latest_versions_parallel`),
-/// both of which need "what version does the user actually have" for the
-/// same reason: querying a fabricated version produces a silent false
-/// negative.
-fn in_use_version(
-    dep: &dyn Dependency,
-    normalized_name: &str,
-    resolved_versions: &HashMap<PackageName, String>,
-    formatter: &dyn deps_core::lsp_helpers::EcosystemFormatter,
-    ecosystem: EcosystemId,
-) -> Option<String> {
-    if formatter.manifest_requirement_is_resolved_version(dep) {
-        dep.version_requirement()
-            .and_then(|req| concrete_pin_version(req.as_str(), ecosystem))
-            .map(str::to_string)
-    } else {
-        resolved_versions
-            .get(normalized_name)
-            .or_else(|| resolved_versions.get(dep.name()))
-            .cloned()
-            .or_else(|| {
-                dep.version_requirement()
-                    .and_then(|req| concrete_pin_version(req.as_str(), ecosystem))
-                    .map(str::to_string)
-            })
-    }
-}
-
 /// Builds `dep_name -> [in_use_version, ...]` (§4.5/§4.6) for every
 /// dependency with a known in-use version, for the yanked-check probe in
 /// `fetch_latest_versions_parallel`. Skips non-registry dependencies
@@ -240,11 +110,11 @@ fn in_use_version(
 /// fork is never flagged for a registry version it does not contain.
 ///
 /// One entry per *occurrence* of a name, not a single collapsed value: the
-/// same dependency name can appear more than once in a manifest (duplicate
-/// keys, or the same crate under `[dependencies]`/`[dev-dependencies]` or
-/// multiple `[target.'cfg(...)'.dependencies]` blocks — #394). A HashMap
-/// keyed by name alone would silently drop all but the last occurrence's
-/// in-use version from the yanked probe below.
+/// same dependency name can appear more than once in a manifest (the same
+/// crate under `[dependencies]`/`[dev-dependencies]` or multiple
+/// `[target.'cfg(...)'.dependencies]` blocks — #394). A HashMap keyed by
+/// name alone would silently drop all but the last occurrence's in-use
+/// version from the yanked probe below.
 fn collect_in_use_versions(
     parse_result: &dyn deps_core::ParseResult,
     resolved_versions: &HashMap<PackageName, String>,
@@ -303,6 +173,16 @@ fn collect_in_use_versions(
 /// returned map instead of silently vanishing (critique C1) — absence from
 /// [`deps_core::osv::VulnerabilityMap`] must never happen for an input this
 /// function considered.
+///
+/// Each dependency's map/target key comes from
+/// [`deps_core::osv::vulnerability_keys`] rather than a bare
+/// `formatter.normalize_package_name(dep.name())` (#394 S2): when two
+/// occurrences of one name resolve to different in-use versions (or mix a
+/// registry source with a git/path fork), their keys are disambiguated so
+/// one occurrence's OSV result never overwrites another's in the shared
+/// [`deps_core::osv::VulnerabilityMap`]. Occurrences that share both a name
+/// and an identical in-use version keep the plain key and are scanned once —
+/// a dedup, not a gap, since the OSV result would be identical either way.
 fn build_scan_targets(
     parse_result: &dyn deps_core::ParseResult,
     resolved_versions: &HashMap<PackageName, String>,
@@ -316,9 +196,15 @@ fn build_scan_targets(
 
     let mut targets = Vec::new();
     let mut skipped = deps_core::osv::VulnerabilityMap::new();
+    let keys =
+        deps_core::osv::vulnerability_keys(parse_result, resolved_versions, formatter, ecosystem);
 
     for dep in parse_result.dependencies() {
-        let key = formatter.normalize_package_name(dep.name());
+        let normalized_name = formatter.normalize_package_name(dep.name());
+        let key = keys
+            .get(&dep.name_range())
+            .cloned()
+            .unwrap_or_else(|| normalized_name.clone());
 
         if dep.source() != deps_core::parser::DependencySource::Registry {
             skipped.insert(key, ScanOutcome::Skipped(SkipReason::NonRegistrySource));
@@ -335,7 +221,13 @@ fn build_scan_targets(
         // to OSV (excludes/replaces fall through to the lockfile lookup below
         // like any other ecosystem, since their `version_requirement()` is
         // not an in-use version — see `manifest_requirement_is_resolved_version`).
-        let version = in_use_version(dep, &key, resolved_versions, formatter, ecosystem);
+        let version = in_use_version(
+            dep,
+            &normalized_name,
+            resolved_versions,
+            formatter,
+            ecosystem,
+        );
 
         let Some(version) = version else {
             skipped.insert(key, ScanOutcome::Skipped(SkipReason::NoConcreteVersion));
@@ -423,14 +315,25 @@ async fn run_osv_scan_phase_a(
             ecosystem.formatter(),
             ecosystem_id,
         );
+        // Keyed the same way `targets`/`skipped` are (#394 S2: possibly
+        // version-qualified, not just the plain normalized name) so phase B's
+        // `raw_name_by_key.get(key)` fallback below still finds this
+        // occurrence's raw name when its key was disambiguated.
+        let vuln_keys = deps_core::osv::vulnerability_keys(
+            parse_result,
+            &doc.resolved_versions,
+            ecosystem.formatter(),
+            ecosystem_id,
+        );
         let raw_name_by_key: HashMap<String, String> = parse_result
             .dependencies()
             .into_iter()
             .map(|d| {
-                (
-                    ecosystem.formatter().normalize_package_name(d.name()),
-                    d.name().to_string(),
-                )
+                let key = vuln_keys
+                    .get(&d.name_range())
+                    .cloned()
+                    .unwrap_or_else(|| ecosystem.formatter().normalize_package_name(d.name()));
+                (key, d.name().to_string())
             })
             .collect();
         (doc.content.clone(), targets, skipped, raw_name_by_key)
@@ -570,15 +473,24 @@ struct DependencyDiff {
 impl DependencyDiff {
     /// `old`/`new` map each dependency name to the declared version
     /// requirements (`Dependency::version_requirement()`) of *every*
-    /// occurrence of that name at parse time, in document order — not a
-    /// single collapsed value. A name can appear more than once within a
-    /// manifest (accidental duplicate keys, or the same crate declared under
-    /// both `[dependencies]`/`[dev-dependencies]` or under two different
-    /// `[target.'cfg(...)'.dependencies]` blocks — see #394). Comparing the
-    /// full per-name `Vec` rather than a name-keyed single requirement
-    /// ensures an edit to *any* occurrence changes the value the diff
-    /// compares, instead of silently no-opping when a HashMap collapse would
-    /// have kept the "winning" occurrence's requirement unchanged.
+    /// occurrence of that name at parse time — not a single collapsed value.
+    /// A name can appear more than once within a manifest: the same crate
+    /// declared under both `[dependencies]`/`[dev-dependencies]`, or under
+    /// two different `[target.'cfg(...)'.dependencies]` blocks (see #394).
+    /// Comparing the full per-name `Vec` rather than a name-keyed single
+    /// requirement ensures an edit to *any* occurrence changes the value the
+    /// diff compares, instead of silently no-opping when a HashMap collapse
+    /// would have kept the "winning" occurrence's requirement unchanged.
+    ///
+    /// Occurrence order within a `Vec` is deterministic per parser but is
+    /// **not** necessarily document/source order — e.g. `deps-cargo` walks
+    /// `toml_span::Table`, a `BTreeMap` ordered by key, so multiple
+    /// `[target.*]` blocks come out sorted by their cfg-expression string,
+    /// not by which one appears first in the file. This only affects which
+    /// index an occurrence lands at (never which name it's grouped under),
+    /// so it cannot cause a missed or misattributed diff — see
+    /// [`dependency_version_map`]'s doc for the consequence of reordering
+    /// across an edit.
     fn compute(
         old: &HashMap<PackageName, Vec<Option<VersionReq>>>,
         new: &HashMap<PackageName, Vec<Option<VersionReq>>>,
@@ -631,10 +543,20 @@ impl DependencyDiff {
 }
 
 /// Builds `name -> [version_requirement, ...]` for every dependency in `pr`,
-/// one entry per occurrence in document order, the shape
-/// [`DependencyDiff::compute`] needs. A `HashMap<PackageName, Option<VersionReq>>`
-/// (single value per name) would silently collapse a duplicate name to its
-/// last occurrence, losing any edit made to an earlier one (#394).
+/// one entry per occurrence, the shape [`DependencyDiff::compute`] needs. A
+/// `HashMap<PackageName, Option<VersionReq>>` (single value per name) would
+/// silently collapse a duplicate name to its last occurrence, losing any
+/// edit made to an earlier one (#394).
+///
+/// Occurrence order is whatever `pr.dependencies()` returns, which for
+/// `deps-cargo` is *not* document order for multiple `[target.*]` blocks
+/// (see [`DependencyDiff::compute`]'s doc). A consequence worth knowing: if
+/// an edit only renames a `[target.'cfg(...)'.dependencies]` expression
+/// (no version change), that occurrence can sort into a different position
+/// in the new `Vec` than the old one, so `old.get(name) != new.get(name)`
+/// trips even though every individual version requirement is unchanged —
+/// a spurious but harmless `version_changed` (one extra registry
+/// refetch/OSV rescan for that name, never a missed or misattributed one).
 fn dependency_version_map(
     pr: &dyn deps_core::ParseResult,
 ) -> HashMap<PackageName, Vec<Option<VersionReq>>> {
@@ -1103,10 +1025,17 @@ pub async fn handle_document_open(
                     return;
                 }
             };
+            // Deduped by name (critique M3): a duplicated name shares one
+            // registry fetch across all its occurrences — the result is
+            // name-keyed anyway (`FetchResult::versions`), so fetching it
+            // more than once would only issue wasted extra registry calls
+            // and inflate `RegistryProgress`'s total.
+            let mut seen_names = HashSet::new();
             let dep_names = parse_result
                 .dependencies()
                 .into_iter()
                 .map(|d| d.name().clone())
+                .filter(|name| seen_names.insert(name.clone()))
                 .collect();
             let in_use = collect_in_use_versions(
                 parse_result,
@@ -4762,6 +4691,70 @@ time = "0.1.60"
         }
 
         #[tokio::test]
+        async fn test_dependency_diff_detects_edit_to_duplicate_name_across_target_blocks() {
+            // #394's own headline reproduction: `time` declared under two
+            // different `[target.'cfg(...)'.dependencies]` blocks (reachable
+            // since #396's target-table parsing fix), pinned to different
+            // versions. Also the only scenario that exercises the ordering
+            // nuance noted on `dependency_version_map`'s doc: `deps-cargo`
+            // walks a `BTreeMap`, so `cfg(unix)` (declared second, below)
+            // sorts *before* `cfg(windows)` (declared first, above) in
+            // `pr.dependencies()` — the fix must not depend on occurrences
+            // appearing in source order to detect the edit correctly.
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+            let ecosystem = state.ecosystem_registry.get("cargo").unwrap();
+
+            let content1 = r#"[target.'cfg(windows)'.dependencies]
+time = "0.1.44"
+
+[target.'cfg(unix)'.dependencies]
+time = "0.1.43"
+"#;
+            let parse_result1 = ecosystem.parse_manifest(content1, &uri).await.unwrap();
+            assert_eq!(
+                parse_result1.dependencies().len(),
+                2,
+                "both target-block occurrences of `time` must parse"
+            );
+            let old_deps = dependency_version_map(parse_result1.as_ref());
+            assert_eq!(
+                old_deps.get(&PackageName::new("time")).map(Vec::len),
+                Some(2),
+                "duplicate-name occurrences under different target blocks must be tracked \
+                 per-occurrence, not collapsed to one entry"
+            );
+
+            // Edit only the `cfg(unix)` occurrence's version.
+            let content2 = r#"[target.'cfg(windows)'.dependencies]
+time = "0.1.44"
+
+[target.'cfg(unix)'.dependencies]
+time = "0.1.50"
+"#;
+            let new_deps = dependency_version_map(
+                ecosystem
+                    .parse_manifest(content2, &uri)
+                    .await
+                    .unwrap()
+                    .as_ref(),
+            );
+
+            let diff = DependencyDiff::compute(&old_deps, &new_deps);
+            assert!(diff.added.is_empty());
+            assert!(diff.removed.is_empty());
+            assert_eq!(
+                diff.version_changed,
+                vec![PackageName::new("time")],
+                "editing one target-block occurrence of a duplicated name must still \
+                 produce a non-empty diff, even though the other occurrence's \
+                 requirement (\"0.1.44\") is unchanged"
+            );
+            assert!(diff.needs_fetch());
+            assert!(diff.needs_osv_rescan());
+        }
+
+        #[tokio::test]
         async fn test_cache_pruned_on_dependency_removal() {
             let state = Arc::new(ServerState::new());
             let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
@@ -4877,7 +4870,14 @@ tokio = "1.0"
                 &self.name
             }
             fn name_range(&self) -> Range {
-                Range::new(Position::new(0, 0), Position::new(0, 1))
+                // Distinct per instance (not a fixed constant): `vulnerability_keys`
+                // (#394 S2) keys a `HashMap<Range, String>` by `name_range()`,
+                // requiring it to uniquely identify each occurrence the way a
+                // real parser's source-derived range always does. A hardcoded
+                // range here would make every `MockDep` in a test collide on
+                // one map entry.
+                let addr = std::ptr::from_ref(self) as u32;
+                Range::new(Position::new(0, addr), Position::new(0, addr + 1))
             }
             fn version_requirement(&self) -> Option<&VersionReq> {
                 self.version_req.as_ref()
@@ -4915,97 +4915,9 @@ tokio = "1.0"
 
         use deps_core::osv::{ScanOutcome, SkipReason};
 
-        #[test]
-        fn is_concrete_version_accepts_explicit_pins_in_any_ecosystem() {
-            for eco in [EcosystemId::Cargo, EcosystemId::Npm, EcosystemId::Go] {
-                assert!(is_concrete_version("=1.2.3", eco), "{eco:?}");
-            }
-            // Go's go.mod bare `v1.9.1` style: Go is not in the
-            // range-default set, so the bare form (with its `v` prefix) is
-            // accepted without needing an explicit `=`.
-            assert!(is_concrete_version("v1.9.1", EcosystemId::Go));
-        }
-
-        #[test]
-        fn is_concrete_version_pep440_double_equals_is_a_pin() {
-            // Critique C2: `strip_prefix('=')` alone turns PEP 440 `"==2.28.0"`
-            // into `"=2.28.0"`, whose first char then fails the digit check.
-            assert!(is_concrete_version("==2.28.0", EcosystemId::Pypi));
-        }
-
-        #[test]
-        fn is_concrete_version_bare_digit_accepted_for_non_range_default_ecosystems() {
-            // Maven/Go/Bundler/Dart/Gradle/NuGet: a bare version is already
-            // exact (or, for NuGet's PackageReference floor, resolves to
-            // exactly that version in practice). Gradle in particular has no
-            // implicit-caret default for a plain coordinate version like
-            // `"2.14.1"` — only the `+` dynamic-version suffix is a range,
-            // and that's rejected separately by `looks_like_a_single_version`.
-            for eco in [
-                EcosystemId::Maven,
-                EcosystemId::Go,
-                EcosystemId::Bundler,
-                EcosystemId::Dart,
-                EcosystemId::Gradle,
-                EcosystemId::NuGet,
-            ] {
-                assert!(is_concrete_version("2.14.1", eco), "{eco:?}");
-            }
-        }
-
-        #[test]
-        fn is_concrete_version_bare_digit_rejected_for_range_default_ecosystems() {
-            // Critique C2: Cargo's bare "1.2.3" is a caret range under
-            // Cargo's own default operator, not a pin — same for npm and
-            // Composer's implicit range notations. Deno reuses npm's exact
-            // grammar for both `jsr:` and `npm:` requirements, so it gets the
-            // same treatment (`bare_version_is_a_range`'s doc comment).
-            for eco in [
-                EcosystemId::Cargo,
-                EcosystemId::Npm,
-                EcosystemId::Composer,
-                EcosystemId::Deno,
-            ] {
-                assert!(!is_concrete_version("1.2.3", eco), "{eco:?}");
-                // ...but an explicit pin is still accepted.
-                assert!(is_concrete_version("=1.2.3", eco), "{eco:?}");
-            }
-        }
-
-        #[test]
-        fn is_concrete_version_rejects_partials_and_wildcards() {
-            // Critique C2: npm/Composer "1.x"/"1.2.x" and bare partials like
-            // "1.2" are ranges, and Gradle's "1.+" is a dynamic version —
-            // none of these contained a previously-rejected character.
-            for eco in [EcosystemId::Npm, EcosystemId::Composer] {
-                assert!(!is_concrete_version("1.x", eco), "{eco:?}");
-                assert!(!is_concrete_version("1.2.x", eco), "{eco:?}");
-                assert!(!is_concrete_version("1.2", eco), "{eco:?}");
-            }
-            assert!(!is_concrete_version("1.+", EcosystemId::Gradle));
-        }
-
-        #[test]
-        fn is_concrete_version_rejects_ranges_and_wildcards() {
-            for eco in [EcosystemId::Maven, EcosystemId::Go] {
-                assert!(!is_concrete_version("^1.0", eco));
-                assert!(!is_concrete_version("~1.2", eco));
-                assert!(!is_concrete_version("*", eco));
-                assert!(!is_concrete_version(">=1.0", eco));
-                assert!(!is_concrete_version(">=1.0 <2.0", eco));
-                assert!(!is_concrete_version("1.0.*", eco));
-                assert!(!is_concrete_version("", eco));
-            }
-        }
-
-        #[test]
-        fn is_concrete_version_rejects_non_version_schemes() {
-            let eco = EcosystemId::Go;
-            assert!(!is_concrete_version("latest", eco));
-            assert!(!is_concrete_version("github:user/repo", eco));
-            assert!(!is_concrete_version("file:../x", eco));
-            assert!(!is_concrete_version("main", eco));
-        }
+        // `is_concrete_version`/`concrete_pin_version` unit tests moved to
+        // `deps-core`'s `lsp_helpers::in_use_version` module alongside the
+        // functions themselves (#394).
 
         #[test]
         fn build_scan_targets_step0_skips_non_registry_source_even_with_lockfile_version() {
@@ -5412,49 +5324,6 @@ tokio = "1.0"
                 in_use.get(&PackageName::new("log4j-core")),
                 Some(&vec!["2.14.1".to_string()])
             );
-        }
-
-        #[test]
-        fn concrete_pin_version_strips_pep440_double_equals_comparator() {
-            // Regression guard: PyPI's parser retains the pep440 comparator
-            // in `version_requirement().as_str()` (`"==4.9.0"`, not
-            // `"4.9.0"` — confirmed by deps-pypi's `test_basic_pinned`). The
-            // verbatim string was silently unusable against real registry
-            // version strings in the yanked probe; `concrete_pin_version`
-            // must strip it.
-            assert_eq!(
-                concrete_pin_version("==4.9.0", EcosystemId::Pypi),
-                Some("4.9.0")
-            );
-        }
-
-        #[test]
-        fn concrete_pin_version_strips_single_equals_and_bracket_pins() {
-            assert_eq!(
-                concrete_pin_version("=1.2.3", EcosystemId::Cargo),
-                Some("1.2.3")
-            );
-            assert_eq!(
-                concrete_pin_version("[1.0.0]", EcosystemId::NuGet),
-                Some("1.0.0")
-            );
-        }
-
-        #[test]
-        fn concrete_pin_version_bare_version_returned_verbatim() {
-            // No operator to strip: Maven/Go/Bundler/Dart/Gradle/NuGet treat
-            // a bare version as already exact.
-            assert_eq!(
-                concrete_pin_version("2.14.1", EcosystemId::Maven),
-                Some("2.14.1")
-            );
-        }
-
-        #[test]
-        fn concrete_pin_version_rejects_ranges_and_partials() {
-            assert_eq!(concrete_pin_version("^1.0", EcosystemId::Cargo), None);
-            assert_eq!(concrete_pin_version("1.2.3", EcosystemId::Cargo), None);
-            assert_eq!(concrete_pin_version(">=1.0,<2.0", EcosystemId::Pypi), None);
         }
 
         #[test]

--- a/crates/deps-lsp/src/handlers/code_actions.rs
+++ b/crates/deps-lsp/src/handlers/code_actions.rs
@@ -44,16 +44,9 @@ pub async fn handle_code_actions(
         .with_document(uri, |doc| {
             let ecosystem = state.ecosystem_registry.get(doc.ecosystem_id())?;
             let parse_result = doc.parse_result_arc()?;
-            // `doc.ecosystem_id()` always originates from a statically
-            // registered ecosystem, so parsing it back can only fail on an
-            // internal registration bug, not on user input.
-            let ecosystem_id: deps_core::EcosystemId = doc
-                .ecosystem_id()
-                .parse()
-                .expect("doc.ecosystem_id() must be a registered EcosystemId");
             Some((
                 ecosystem,
-                ecosystem_id,
+                doc.ecosystem,
                 parse_result,
                 doc.cached_versions.clone(),
                 doc.resolved_versions.clone(),

--- a/crates/deps-lsp/src/handlers/code_actions.rs
+++ b/crates/deps-lsp/src/handlers/code_actions.rs
@@ -34,6 +34,7 @@ pub async fn handle_code_actions(
     // `with_document` makes this structural rather than a convention to remember (#333).
     let Some((
         ecosystem,
+        ecosystem_id,
         parse_result,
         cached_versions,
         resolved_versions,
@@ -43,8 +44,16 @@ pub async fn handle_code_actions(
         .with_document(uri, |doc| {
             let ecosystem = state.ecosystem_registry.get(doc.ecosystem_id())?;
             let parse_result = doc.parse_result_arc()?;
+            // `doc.ecosystem_id()` always originates from a statically
+            // registered ecosystem, so parsing it back can only fail on an
+            // internal registration bug, not on user input.
+            let ecosystem_id: deps_core::EcosystemId = doc
+                .ecosystem_id()
+                .parse()
+                .expect("doc.ecosystem_id() must be a registered EcosystemId");
             Some((
                 ecosystem,
+                ecosystem_id,
                 parse_result,
                 doc.cached_versions.clone(),
                 doc.resolved_versions.clone(),
@@ -63,7 +72,8 @@ pub async fn handle_code_actions(
             position,
             uri,
             VersionData::new(&cached_versions, &resolved_versions)
-                .with_vulnerabilities(&vulnerabilities),
+                .with_vulnerabilities(&vulnerabilities)
+                .with_ecosystem(ecosystem_id),
             &content,
         )
         .await;

--- a/crates/deps-lsp/src/handlers/diagnostics.rs
+++ b/crates/deps-lsp/src/handlers/diagnostics.rs
@@ -57,16 +57,9 @@ pub(crate) async fn generate_diagnostics_internal(
         }
 
         let parse_result = doc.parse_result_arc()?;
-        // `doc.ecosystem_id()` always originates from a statically
-        // registered ecosystem, so parsing it back can only fail on an
-        // internal registration bug, not on user input.
-        let ecosystem_id: deps_core::EcosystemId = doc
-            .ecosystem_id()
-            .parse()
-            .expect("doc.ecosystem_id() must be a registered EcosystemId");
         Some((
             ecosystem,
-            ecosystem_id,
+            doc.ecosystem,
             parse_result,
             doc.cached_versions.clone(),
             doc.resolved_versions.clone(),

--- a/crates/deps-lsp/src/handlers/diagnostics.rs
+++ b/crates/deps-lsp/src/handlers/diagnostics.rs
@@ -57,8 +57,16 @@ pub(crate) async fn generate_diagnostics_internal(
         }
 
         let parse_result = doc.parse_result_arc()?;
+        // `doc.ecosystem_id()` always originates from a statically
+        // registered ecosystem, so parsing it back can only fail on an
+        // internal registration bug, not on user input.
+        let ecosystem_id: deps_core::EcosystemId = doc
+            .ecosystem_id()
+            .parse()
+            .expect("doc.ecosystem_id() must be a registered EcosystemId");
         Some((
             ecosystem,
+            ecosystem_id,
             parse_result,
             doc.cached_versions.clone(),
             doc.resolved_versions.clone(),
@@ -73,6 +81,7 @@ pub(crate) async fn generate_diagnostics_internal(
 
     let Some((
         ecosystem,
+        ecosystem_id,
         parse_result,
         cached_versions,
         resolved_versions,
@@ -90,7 +99,8 @@ pub(crate) async fn generate_diagnostics_internal(
             VersionData::new(&cached_versions, &resolved_versions)
                 .with_vulnerabilities(&vulnerabilities)
                 .with_yanked(&yanked_versions)
-                .with_fetch_failed(&fetch_failed),
+                .with_fetch_failed(&fetch_failed)
+                .with_ecosystem(ecosystem_id),
             uri,
             freshness,
             severities,

--- a/crates/deps-lsp/src/handlers/hover.rs
+++ b/crates/deps-lsp/src/handlers/hover.rs
@@ -44,16 +44,9 @@ pub async fn handle_hover(
         .with_document(uri, |doc| {
             let ecosystem = state.ecosystem_registry.get(doc.ecosystem_id())?;
             let parse_result = doc.parse_result_arc()?;
-            // `doc.ecosystem_id()` always originates from a statically
-            // registered ecosystem, so parsing it back can only fail on
-            // an internal registration bug, not on user input.
-            let ecosystem_id: deps_core::EcosystemId = doc
-                .ecosystem_id()
-                .parse()
-                .expect("doc.ecosystem_id() must be a registered EcosystemId");
             Some((
                 ecosystem,
-                ecosystem_id,
+                doc.ecosystem,
                 parse_result,
                 doc.cached_versions.clone(),
                 doc.resolved_versions.clone(),

--- a/crates/deps-lsp/src/handlers/hover.rs
+++ b/crates/deps-lsp/src/handlers/hover.rs
@@ -33,12 +33,27 @@ pub async fn handle_hover(
     // (`Registry::get_versions_with`), so holding the guard across that await would
     // block a concurrent `documents.get_mut` on the same shard for the duration (#319).
     // `with_document` makes this structural rather than a convention to remember (#333).
-    let (ecosystem, parse_result, cached_versions, resolved_versions, vulnerabilities) = state
+    let (
+        ecosystem,
+        ecosystem_id,
+        parse_result,
+        cached_versions,
+        resolved_versions,
+        vulnerabilities,
+    ) = state
         .with_document(uri, |doc| {
             let ecosystem = state.ecosystem_registry.get(doc.ecosystem_id())?;
             let parse_result = doc.parse_result_arc()?;
+            // `doc.ecosystem_id()` always originates from a statically
+            // registered ecosystem, so parsing it back can only fail on
+            // an internal registration bug, not on user input.
+            let ecosystem_id: deps_core::EcosystemId = doc
+                .ecosystem_id()
+                .parse()
+                .expect("doc.ecosystem_id() must be a registered EcosystemId");
             Some((
                 ecosystem,
+                ecosystem_id,
                 parse_result,
                 doc.cached_versions.clone(),
                 doc.resolved_versions.clone(),
@@ -52,7 +67,8 @@ pub async fn handle_hover(
             parse_result.as_ref(),
             position,
             VersionData::new(&cached_versions, &resolved_versions)
-                .with_vulnerabilities(&vulnerabilities),
+                .with_vulnerabilities(&vulnerabilities)
+                .with_ecosystem(ecosystem_id),
             freshness,
         )
         .await


### PR DESCRIPTION
## Summary

Fixes duplicate dependency names within a manifest section silently collapsing via name-only `HashMap` keys, which dropped the losing occurrence from diagnostics/hover and produced stale or misattributed findings on edit.

- `dependency_version_map`/`collect_in_use_versions` in `crates/deps-lsp/src/document/lifecycle.rs` now track dependencies per-occurrence (`HashMap<PackageName, Vec<...>>`) instead of collapsing duplicate names, so an edit to any occurrence correctly produces a diff and is probed for yanked status.
- Yanked-version diagnostics no longer leak a finding from one occurrence onto every occurrence of the same name.
- The OSV vulnerability scan/lookup path (diagnostics, hover, and the manifest-editing quick-fix code action) is qualified per-occurrence when occurrences of a name differ (pinned version or source), so an advisory can no longer be misattributed to the wrong occurrence — including a security-relevant case where a quick-fix could have offered to "upgrade" an already-patched occurrence while withholding it from a vulnerable one.
- Deduped background registry fetches for repeated dependency names.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (2919 passed, 49 skipped)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New regression tests: duplicate name across `[target.'cfg(...)'.dependencies]` blocks, yanked-diagnostic isolation, OSV vulnerability isolation (diagnostics, hover, code actions)

Closes #394