### PR TITLE
docs: update ECOSYSTEM_GUIDE.md and error.rs.template to post-#398 convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **docs**: `ECOSYSTEM_GUIDE.md` and the ecosystem-crate template now teach the current direct-`DepsError`-construction convention instead of the per-crate error wrapper pattern removed in #398 (resolves #403)
+- **docs**: `ECOSYSTEM_GUIDE.md` and the ecosystem-crate template now teach the current direct-`DepsError`-construction convention instead of the per-crate error wrapper pattern removed in #398 (resolves #403) (#405)
 - **deps-core, deps-lsp**: duplicate dependency names within a manifest (e.g. the same crate under `[dependencies]`/`[dev-dependencies]` or multiple `[target.*.dependencies]` blocks) no longer collapse via name-only `HashMap` in the diff/yanked-probe/OSV-scan pipeline, so an edit to any occurrence is correctly diffed and neither yanked nor OSV findings leak between occurrences pinned to different versions (resolves #394)
 - **deps-cargo**: dependencies declared under `[target.<cfg-expr-or-triple>.dependencies|dev-dependencies|build-dependencies]` are now parsed and visible to hover/diagnostics/completion, same as top-level ones (#396)
 - **deps-cargo**: a git dependency's `tag`/`branch`/`rev` key is no longer dropped, populating `DependencySource::Git.rev` (#396)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **docs**: `ECOSYSTEM_GUIDE.md` and the ecosystem-crate template now teach the current direct-`DepsError`-construction convention instead of the per-crate error wrapper pattern removed in #398 (resolves #403)
 - **deps-core, deps-lsp**: duplicate dependency names within a manifest (e.g. the same crate under `[dependencies]`/`[dev-dependencies]` or multiple `[target.*.dependencies]` blocks) no longer collapse via name-only `HashMap` in the diff/yanked-probe/OSV-scan pipeline, so an edit to any occurrence is correctly diffed and neither yanked nor OSV findings leak between occurrences pinned to different versions (resolves #394)
 - **deps-cargo**: dependencies declared under `[target.<cfg-expr-or-triple>.dependencies|dev-dependencies|build-dependencies]` are now parsed and visible to hover/diagnostics/completion, same as top-level ones (#396)
 - **deps-cargo**: a git dependency's `tag`/`branch`/`rev` key is no longer dropped, populating `DependencySource::Git.rev` (#396)

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -476,79 +476,55 @@ members = [
 ]
 ```
 
-## Step 2: Define Error Types
+## Step 2: Handle Errors
 
-Create ecosystem-specific errors in `error.rs`:
+Construct `deps_core::DepsError` directly at call sites instead of using a local error wrapper. Use `deps_core::Result<T>` for function signatures:
 
 ```rust
-//! Errors specific to {Ecosystem} dependency handling.
+use deps_core::DepsError;
 
-use thiserror::Error;
-
-#[derive(Error, Debug)]
-pub enum {Ecosystem}Error {
-    /// Failed to parse manifest file
-    #[error("Failed to parse {manifest_file}: {source}")]
-    ParseError {
-        #[source]
-        source: Box<dyn std::error::Error + Send + Sync>,
-    },
-
-    /// Invalid version specifier
-    #[error("Invalid version specifier '{specifier}': {message}")]
-    InvalidVersionSpecifier {
-        specifier: String,
-        message: String,
-    },
-
-    /// Package not found
-    #[error("Package '{package}' not found")]
-    PackageNotFound { package: String },
-
-    /// Registry request failed
-    #[error("Registry request failed for '{package}': {source}")]
-    RegistryError {
-        package: String,
-        #[source]
-        source: Box<dyn std::error::Error + Send + Sync>,
-    },
-
-    /// Cache error
-    #[error("Cache error: {0}")]
-    CacheError(String),
-
-    /// I/O error
-    #[error("I/O error: {0}")]
-    Io(#[from] std::io::Error),
+/// Example: validation function
+fn validate_module_path(path: &str) -> deps_core::Result<()> {
+    if path.is_empty() {
+        return Err(DepsError::InvalidVersionReq("module path is empty".into()));
+    }
+    if path.contains("..") {
+        return Err(DepsError::InvalidVersionReq(
+            format!("invalid module path: {}", path)
+        ));
+    }
+    Ok(())
 }
 
-/// Result type alias for {Ecosystem} operations.
-pub type Result<T> = std::result::Result<T, {Ecosystem}Error>;
+/// Example: parsing function
+fn parse_manifest(content: &str, uri: &Uri) -> deps_core::Result<ParseResult> {
+    // Parse logic...
+    // On error: return Err(DepsError::ParseError { ... })
+    // On success: return Ok(ParseResult { ... })
+}
 
-// Implement conversions to/from deps_core::DepsError
-impl From<{Ecosystem}Error> for deps_core::DepsError {
-    fn from(err: {Ecosystem}Error) -> Self {
-        match err {
-            {Ecosystem}Error::ParseError { source } => deps_core::DepsError::ParseError {
-                file_type: "{manifest_file}".into(),
-                source,
-            },
-            {Ecosystem}Error::InvalidVersionSpecifier { message, .. } => {
-                deps_core::DepsError::InvalidVersionReq(message)
-            }
-            {Ecosystem}Error::PackageNotFound { package } => {
-                deps_core::DepsError::CacheError(format!("Package '{}' not found", package))
-            }
-            {Ecosystem}Error::RegistryError { package, source } => {
-                deps_core::DepsError::ParseError {
-                    file_type: format!("registry for {}", package),
-                    source,
-                }
-            }
-            {Ecosystem}Error::CacheError(msg) => deps_core::DepsError::CacheError(msg),
-            {Ecosystem}Error::Io(e) => deps_core::DepsError::Io(e),
-        }
+/// Example: registry function handling 404
+const REGISTRY: &str = "example-registry";
+
+fn fetch_versions(package: &str) -> deps_core::Result<Vec<Version>> {
+    let response = http_client.get(&url).send()
+        .map_err(|e| DepsError::CacheError(e.to_string()))?;
+    
+    if response.status() == 404 {
+        return Err(DepsError::PackageNotFound {
+            package: package.into(),
+            registry: REGISTRY,
+        });
     }
+    
+    let data: Vec<Version> = response.json()
+        .map_err(|e| DepsError::ApiResponse {
+            package: package.into(),
+            registry: REGISTRY,
+            source: e,
+        })?;
+    
+    Ok(data)
 }
 ```
 
@@ -709,9 +685,8 @@ Create registry client in `registry.rs`:
 ```rust
 //! {Registry} API client with HTTP caching.
 
-use crate::error::Result;
 use crate::types::{Ecosystem}Version;
-use deps_core::{HttpCache, ecosystem::BoxFuture};
+use deps_core::{DepsError, HttpCache, Result, ecosystem::BoxFuture};
 use std::any::Any;
 use std::sync::Arc;
 
@@ -734,7 +709,7 @@ impl {Ecosystem}Registry {
         let data = self.cache
             .get_cached(&url)
             .await
-            .map_err(|e| crate::error::{Ecosystem}Error::CacheError(e.to_string()))?;
+            .map_err(|e| DepsError::CacheError(e.to_string()))?;
 
         // TODO: Parse response and return versions
         Ok(vec![])
@@ -987,7 +962,6 @@ pub mod registry;
 pub mod types;
 
 pub use ecosystem::{Ecosystem}Ecosystem;
-pub use error::{Ecosystem}Error, Result;
 pub use parser::parse_{manifest};
 pub use registry::{Ecosystem}Registry;
 pub use types::{{Ecosystem}Dependency, {Ecosystem}Version};

--- a/templates/deps-ecosystem/src/error.rs.template
+++ b/templates/deps-ecosystem/src/error.rs.template
@@ -1,87 +1,39 @@
-//! Errors specific to {ECOSYSTEM_DISPLAY} dependency handling.
+//! Error handling for {ECOSYSTEM_DISPLAY} dependency operations.
+//!
+//! This module demonstrates how to construct `deps_core::DepsError` directly
+//! at call sites. There is no local error wrapper enum — all fallible functions
+//! return `deps_core::Result<T>`.
 
-use thiserror::Error;
+use deps_core::DepsError;
 
-/// Errors specific to {ECOSYSTEM_DISPLAY} dependency handling.
-#[derive(Error, Debug)]
-pub enum {ECOSYSTEM_PASCAL}Error {
-    /// Failed to parse manifest file
-    #[error("Failed to parse {MANIFEST_FILE}: {source}")]
-    ParseError {
-        #[source]
-        source: Box<dyn std::error::Error + Send + Sync>,
-    },
-
-    /// Invalid version specifier
-    #[error("Invalid version specifier '{specifier}': {message}")]
-    InvalidVersionSpecifier { specifier: String, message: String },
-
-    /// Package not found
-    #[error("Package '{package}' not found")]
-    PackageNotFound { package: String },
-
-    /// Registry request failed
-    #[error("Registry request failed for '{package}': {source}")]
-    RegistryError {
-        package: String,
-        #[source]
-        source: Box<dyn std::error::Error + Send + Sync>,
-    },
-
-    /// Cache error
-    #[error("Cache error: {0}")]
-    CacheError(String),
-
-    /// I/O error
-    #[error("I/O error: {0}")]
-    Io(#[from] std::io::Error),
+/// Validate a version specifier for {ECOSYSTEM_DISPLAY}.
+///
+/// # Errors
+///
+/// Returns `DepsError::InvalidVersionReq` if the version is invalid.
+pub fn validate_version(version: &str) -> deps_core::Result<()> {
+    if version.is_empty() {
+        return Err(DepsError::InvalidVersionReq(
+            "version string is empty".into(),
+        ));
+    }
+    // Add ecosystem-specific validation logic here
+    Ok(())
 }
 
-/// Result type alias for {ECOSYSTEM_DISPLAY} operations.
-pub type Result<T> = std::result::Result<T, {ECOSYSTEM_PASCAL}Error>;
-
-impl {ECOSYSTEM_PASCAL}Error {
-    pub fn registry_error(
-        package: impl Into<String>,
-        error: impl std::error::Error + Send + Sync + 'static,
-    ) -> Self {
-        Self::RegistryError {
-            package: package.into(),
-            source: Box::new(error),
-        }
+/// Validate a package name for {ECOSYSTEM_DISPLAY}.
+///
+/// # Errors
+///
+/// Returns `DepsError::InvalidVersionReq` if the package name is invalid.
+pub fn validate_package_name(name: &str) -> deps_core::Result<()> {
+    if name.is_empty() {
+        return Err(DepsError::InvalidVersionReq(
+            "package name is empty".into(),
+        ));
     }
-
-    pub fn invalid_version(specifier: impl Into<String>, message: impl Into<String>) -> Self {
-        Self::InvalidVersionSpecifier {
-            specifier: specifier.into(),
-            message: message.into(),
-        }
-    }
-}
-
-impl From<{ECOSYSTEM_PASCAL}Error> for deps_core::DepsError {
-    fn from(err: {ECOSYSTEM_PASCAL}Error) -> Self {
-        match err {
-            {ECOSYSTEM_PASCAL}Error::ParseError { source } => deps_core::DepsError::ParseError {
-                file_type: "{MANIFEST_FILE}".into(),
-                source,
-            },
-            {ECOSYSTEM_PASCAL}Error::InvalidVersionSpecifier { message, .. } => {
-                deps_core::DepsError::InvalidVersionReq(message)
-            }
-            {ECOSYSTEM_PASCAL}Error::PackageNotFound { package } => {
-                deps_core::DepsError::CacheError(format!("Package '{}' not found", package))
-            }
-            {ECOSYSTEM_PASCAL}Error::RegistryError { package, source } => {
-                deps_core::DepsError::ParseError {
-                    file_type: format!("registry for {}", package),
-                    source,
-                }
-            }
-            {ECOSYSTEM_PASCAL}Error::CacheError(msg) => deps_core::DepsError::CacheError(msg),
-            {ECOSYSTEM_PASCAL}Error::Io(e) => deps_core::DepsError::Io(e),
-        }
-    }
+    // Add ecosystem-specific validation logic here
+    Ok(())
 }
 
 #[cfg(test)]
@@ -89,18 +41,36 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_error_display() {
-        let err = {ECOSYSTEM_PASCAL}Error::PackageNotFound {
-            package: "test-pkg".into(),
-        };
-        assert!(err.to_string().contains("test-pkg"));
+    fn test_validate_version_empty() {
+        let result = validate_version("");
+        assert!(result.is_err());
+        match result {
+            Err(DepsError::InvalidVersionReq(msg)) => {
+                assert!(msg.contains("empty"));
+            }
+            _ => panic!("Expected InvalidVersionReq"),
+        }
     }
 
     #[test]
-    fn test_conversion_to_deps_error() {
-        let err = {ECOSYSTEM_PASCAL}Error::PackageNotFound {
-            package: "test".into(),
-        };
-        let _: deps_core::DepsError = err.into();
+    fn test_validate_version_valid() {
+        assert!(validate_version("1.0.0").is_ok());
+    }
+
+    #[test]
+    fn test_validate_package_name_empty() {
+        let result = validate_package_name("");
+        assert!(result.is_err());
+        match result {
+            Err(DepsError::InvalidVersionReq(msg)) => {
+                assert!(msg.contains("empty"));
+            }
+            _ => panic!("Expected InvalidVersionReq"),
+        }
+    }
+
+    #[test]
+    fn test_validate_package_name_valid() {
+        assert!(validate_package_name("my-package").is_ok());
     }
 }


### PR DESCRIPTION
## Summary
- `docs/ECOSYSTEM_GUIDE.md` and `templates/deps-ecosystem/src/error.rs.template` still taught the per-crate `{Ecosystem}Error` wrapper enum + `From<{Ecosystem}Error> for DepsError` pattern that PR #398 removed workspace-wide.
- Both docs now describe/generate the current convention: ecosystem crates construct `deps_core::DepsError` directly at call sites, matching every existing crate (verified against `deps-go` and `deps-cargo`).

## Changes
- `docs/ECOSYSTEM_GUIDE.md`: replaced the "Define Error Types" step with "Handle Errors", showing direct `DepsError` construction examples; updated the registry-client example and removed the stale local error re-export from the `lib.rs` snippet.
- `templates/deps-ecosystem/src/error.rs.template`: removed the local error enum/`From` impl scaffold, replaced with validation-function examples using `deps_core::DepsError` directly.
- `CHANGELOG.md`: added an entry under `[Unreleased]`.

## Test plan
- [x] `cargo check --workspace --all-features` (docs-only change, sanity build after rebase)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace` (verified clean during review)
- [x] Reviewed by rust-code-reviewer agent (two rounds — initial pass found two field-mismatch bugs in the `fetch_versions` example against the real `DepsError` enum, fixed and re-reviewed as approved)

Closes #403