### PR TITLE
fix: wire structural package-name validation into validate_package_name for 6 ecosystems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **deps-go, deps-bundler, deps-dart, deps-composer, deps-nuget, deps-swift**: structurally invalid package names/module paths now report "Invalid package name" instead of a misleading "Registry lookup failed" diagnostic (resolves #402) (#406)
 - **docs**: `ECOSYSTEM_GUIDE.md` and the ecosystem-crate template now teach the current direct-`DepsError`-construction convention instead of the per-crate error wrapper pattern removed in #398 (resolves #403) (#405)
 - **deps-core, deps-lsp**: duplicate dependency names within a manifest (e.g. the same crate under `[dependencies]`/`[dev-dependencies]` or multiple `[target.*.dependencies]` blocks) no longer collapse via name-only `HashMap` in the diff/yanked-probe/OSV-scan pipeline, so an edit to any occurrence is correctly diffed and neither yanked nor OSV findings leak between occurrences pinned to different versions (resolves #394)
 - **deps-cargo**: dependencies declared under `[target.<cfg-expr-or-triple>.dependencies|dev-dependencies|build-dependencies]` are now parsed and visible to hover/diagnostics/completion, same as top-level ones (#396)

--- a/crates/deps-bundler/src/formatter.rs
+++ b/crates/deps-bundler/src/formatter.rs
@@ -1,9 +1,17 @@
 //! Version formatting for Bundler ecosystem.
 
 use crate::version::{compare_versions, is_valid_rubygems_version, version_matches_requirement};
+use deps_core::InvalidPackageName;
 use deps_core::PackageName;
 use deps_core::VersionReq;
 use deps_core::lsp_helpers::{EcosystemFormatter, RequirementMatcher, compile_requirement_unless};
+
+/// Whether every character of `name` is in RubyGems' gem-name charset
+/// (`Gem::Specification::VALID_NAME_PATTERN`): ASCII letters, digits, `.`, `-`, `_`.
+fn is_rubygems_name_charset(name: &str) -> bool {
+    name.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_'))
+}
 
 /// Extracts the version operand of `requirement` for the operators whose
 /// [`version_matches_requirement`] branch evaluates `false` against every candidate on a
@@ -121,6 +129,35 @@ impl EcosystemFormatter for BundlerFormatter {
 
     fn package_url(&self, name: &PackageName) -> String {
         crate::registry::gem_url(name.as_str())
+    }
+
+    /// Lints `name` against RubyGems' own gem-name rule (see `is_rubygems_name_charset` plus
+    /// its "must include at least one letter" check), so a structurally invalid gem name is
+    /// reported as "Invalid package name" instead of falling through to a registry lookup and
+    /// rendering the generic "Registry lookup failed" diagnostic (#402).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidPackageName`] if `name` is empty, contains a character outside
+    /// RubyGems' `[a-zA-Z0-9.\-_]` charset, or contains no letter. The charset check runs
+    /// before the letter check (#402 critique M4) so a name that fails both — e.g. a
+    /// non-ASCII name with no ASCII letter at all — reports the charset violation rather than
+    /// the less specific "no letter" message.
+    fn validate_package_name(&self, name: &str) -> Result<(), InvalidPackageName> {
+        if name.is_empty() {
+            return Err(InvalidPackageName::new("name cannot be empty"));
+        }
+        if !is_rubygems_name_charset(name) {
+            return Err(InvalidPackageName::new(
+                "name must contain only ASCII letters, digits, '.', '-', or '_'",
+            ));
+        }
+        if !name.chars().any(|c| c.is_ascii_alphabetic()) {
+            return Err(InvalidPackageName::new(
+                "name must include at least one letter",
+            ));
+        }
+        Ok(())
     }
 
     fn version_satisfies_requirement(&self, version: &str, requirement: &str) -> bool {
@@ -493,5 +530,49 @@ mod tests {
             &VersionReq::new("7.2.0"),
             &available,
         ));
+    }
+
+    #[test]
+    fn test_validate_package_name_accepts_valid_names() {
+        let formatter = BundlerFormatter;
+        for name in ["rails", "rspec-rails", "nokogiri", "activesupport.rb"] {
+            assert!(
+                formatter.validate_package_name(name).is_ok(),
+                "expected {name:?} to be accepted"
+            );
+        }
+    }
+
+    /// #402: a structurally invalid gem name must be reported as an invalid package name, not
+    /// forwarded to the registry lookup that produces the misleading generic diagnostic.
+    #[test]
+    fn test_validate_package_name_rejects_invalid_names() {
+        let formatter = BundlerFormatter;
+        for name in ["", "123", "rails util", "rails/util", "日本語"] {
+            assert!(
+                formatter.validate_package_name(name).is_err(),
+                "expected {name:?} to be rejected"
+            );
+        }
+    }
+
+    /// #402 critique M4: a name that fails both checks (no ASCII letter at all, and a
+    /// character outside the charset) must report the charset violation, since that is the
+    /// more specific and actionable diagnosis of the two.
+    #[test]
+    fn test_validate_package_name_prefers_charset_message_over_letter_message() {
+        let formatter = BundlerFormatter;
+        let err = formatter.validate_package_name("日本語").unwrap_err();
+        assert!(err.reason().contains("must contain only ASCII"));
+        assert!(!err.reason().contains("must include at least one letter"));
+    }
+
+    /// A name with valid charset but no letter (e.g. all digits) still reports the "must
+    /// include at least one letter" message — unaffected by the M4 check-order swap.
+    #[test]
+    fn test_validate_package_name_rejects_all_digits_with_letter_message() {
+        let formatter = BundlerFormatter;
+        let err = formatter.validate_package_name("123").unwrap_err();
+        assert!(err.reason().contains("letter"));
     }
 }

--- a/crates/deps-composer/src/formatter.rs
+++ b/crates/deps-composer/src/formatter.rs
@@ -1,8 +1,27 @@
 use deps_core::Dependency;
+use deps_core::InvalidPackageName;
 use deps_core::PackageName;
 use deps_core::VersionReq;
 use deps_core::lsp_helpers::{EcosystemFormatter, RequirementMatcher, compile_requirement_unless};
 use deps_core::normalize_operator_spacing;
+
+/// Whether `segment` matches Packagist's vendor/package name-segment charset: starts and ends
+/// with an ASCII alphanumeric character, with only `.`, `_`, `-` allowed in between (Composer's
+/// `composer.json` schema pattern, applied case-insensitively here — Composer itself lowercases
+/// dependency names, so a mixed-case `require` entry is not on its own a rejection reason).
+fn is_valid_composer_segment(segment: &str) -> bool {
+    segment
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphanumeric())
+        && segment
+            .chars()
+            .last()
+            .is_some_and(|c| c.is_ascii_alphanumeric())
+        && segment
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+}
 
 /// Composer requirement matcher, compiled once per dependency by
 /// [`ComposerFormatter::compile_requirement`]. Shares `version_satisfies_requirement`'s
@@ -35,6 +54,34 @@ impl EcosystemFormatter for ComposerFormatter {
 
     fn package_url(&self, name: &PackageName) -> String {
         crate::registry::package_url(name.as_str())
+    }
+
+    /// Lints `name` against Packagist's `vendor/package` coordinate shape (see
+    /// `is_valid_composer_segment`), so a structurally invalid name is reported as
+    /// "Invalid package name" instead of falling through to a registry lookup and rendering
+    /// the generic "Registry lookup failed" diagnostic (#402).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidPackageName`] if `name` is not exactly `vendor/package`, or either
+    /// segment is empty, starts/ends with a separator, or contains a character outside
+    /// Packagist's `[a-zA-Z0-9.\-_]` charset.
+    fn validate_package_name(&self, name: &str) -> Result<(), InvalidPackageName> {
+        let Some((vendor, package)) = name.split_once('/') else {
+            return Err(InvalidPackageName::new(
+                "name must be in 'vendor/package' form",
+            ));
+        };
+        if package.contains('/') {
+            return Err(InvalidPackageName::new("name must contain exactly one '/'"));
+        }
+        if !is_valid_composer_segment(vendor) {
+            return Err(InvalidPackageName::new("vendor segment is malformed"));
+        }
+        if !is_valid_composer_segment(package) {
+            return Err(InvalidPackageName::new("package segment is malformed"));
+        }
+        Ok(())
     }
 
     fn yanked_message(&self) -> &'static str {
@@ -601,5 +648,39 @@ mod tests {
         let f = ComposerFormatter;
         assert!(f.yanked_diagnostic_applies_to(&VersionReq::new("1.2.3")));
         assert!(!f.yanked_diagnostic_applies_to(&VersionReq::new("^1.2.3")));
+    }
+
+    #[test]
+    fn test_validate_package_name_accepts_valid_names() {
+        let f = ComposerFormatter;
+        for name in ["symfony/console", "vendor.name/pkg-name", "a/b"] {
+            assert!(
+                f.validate_package_name(name).is_ok(),
+                "expected {name:?} to be accepted"
+            );
+        }
+    }
+
+    /// #402: a structurally invalid Composer coordinate must be reported as an invalid
+    /// package name, not forwarded to the registry lookup that produces the misleading
+    /// generic diagnostic.
+    #[test]
+    fn test_validate_package_name_rejects_invalid_names() {
+        let f = ComposerFormatter;
+        for name in [
+            "",
+            "symfony",
+            "symfony/console/extra",
+            "/console",
+            "symfony/",
+            "-vendor/pkg",
+            "vendor/-pkg",
+            "vendor name/pkg",
+        ] {
+            assert!(
+                f.validate_package_name(name).is_err(),
+                "expected {name:?} to be rejected"
+            );
+        }
     }
 }

--- a/crates/deps-composer/src/parser.rs
+++ b/crates/deps-composer/src/parser.rs
@@ -74,11 +74,39 @@ impl deps_core::ParseResult for ComposerParseResult {
 /// Returns true if the package is a platform requirement (not a Packagist package).
 ///
 /// Platform packages include:
-/// - `php` — PHP version requirement
+/// - `php`, and its variants `php-64bit`, `php-ipv6`, `php-zts`, `php-debug` — PHP version
+///   requirements
+/// - `hhvm` — HHVM version requirement
+/// - `composer` — the Composer CLI version itself
 /// - `ext-*` — PHP extensions
 /// - `lib-*` — PHP libraries
+/// - `composer-plugin-api`, `composer-runtime-api` — Composer's own virtual packages
+///
+/// Mirrors Composer's `PlatformRepository` package set (#402 critique S1: an incomplete list
+/// here previously let a real platform requirement like `composer-plugin-api` — present in
+/// essentially every Composer plugin's `composer.json` — reach the Packagist-shaped
+/// `vendor/package` name validator and get flagged "Invalid package name"; M6: `composer`
+/// itself was still missing from the set).
+///
+/// Every platform package name is a single bare token with no `/` — a real Packagist package
+/// always has a `vendor/package` shape — so any name containing `/` returns `false`
+/// immediately, before the prefix checks below. Without this guard, `starts_with("php-")` (and
+/// `ext-`/`lib-`) would also match a real package merely because its *vendor* happens to start
+/// with that prefix (e.g. `php-di/php-di`, `php-amqplib/php-amqplib`, `ext-mongo/whatever`),
+/// silently dropping it from the dependency list entirely — no diagnostic, hover, inlay hint,
+/// or code lens — rather than validating it as a normal dependency (#402 critique C2).
 pub fn is_platform_package(name: &str) -> bool {
-    name == "php" || name.starts_with("ext-") || name.starts_with("lib-")
+    if name.contains('/') {
+        return false;
+    }
+    name == "php"
+        || name.starts_with("php-")
+        || name == "hhvm"
+        || name == "composer"
+        || name.starts_with("ext-")
+        || name.starts_with("lib-")
+        || name == "composer-plugin-api"
+        || name == "composer-runtime-api"
 }
 
 /// Parses a composer.json file and extracts all non-platform dependencies with positions.
@@ -319,6 +347,53 @@ mod tests {
         assert!(!is_platform_package("symfony/console"));
         assert!(!is_platform_package("monolog/monolog"));
         assert!(!is_platform_package("extended/package")); // not ext- prefix
+    }
+
+    /// #402 critique S1: the platform-package set previously covered only `php`/`ext-*`/
+    /// `lib-*`, so a real requirement like `composer-plugin-api` fell through to the
+    /// Packagist-shaped `vendor/package` name validator and was flagged "Invalid package
+    /// name" instead of being silently filtered like the other platform packages.
+    #[test]
+    fn test_is_platform_package_covers_full_composer_platform_set() {
+        for name in [
+            "php-64bit",
+            "php-ipv6",
+            "php-zts",
+            "php-debug",
+            "hhvm",
+            "composer",
+            "composer-plugin-api",
+            "composer-runtime-api",
+        ] {
+            assert!(
+                is_platform_package(name),
+                "expected {name:?} to be recognized as a platform package"
+            );
+        }
+    }
+
+    /// #402 critique C2: a real Packagist package under a vendor whose name happens to start
+    /// with a platform prefix (`php-di/php-di`, `php-amqplib/php-amqplib`,
+    /// `ext-mongo/whatever`, `lib-xml/whatever`) must not be misclassified as a platform
+    /// package — that would silently drop it from the dependency list entirely, with no
+    /// diagnostic, hover, inlay hint, or code lens, rather than validating it normally.
+    #[test]
+    fn test_is_platform_package_does_not_swallow_real_packages_with_platform_like_vendors() {
+        for name in [
+            "php-di/php-di",
+            "php-amqplib/php-amqplib",
+            "php-debugbar/php-debugbar",
+            "php-ffmpeg/php-ffmpeg",
+            "ext-mongo/whatever",
+            "lib-xml/whatever",
+            "hhvm/whatever",
+            "composer/whatever",
+        ] {
+            assert!(
+                !is_platform_package(name),
+                "expected {name:?} to NOT be recognized as a platform package"
+            );
+        }
     }
 
     #[test]

--- a/crates/deps-dart/src/formatter.rs
+++ b/crates/deps-dart/src/formatter.rs
@@ -1,10 +1,22 @@
 //! Version formatting for Dart ecosystem.
 
 use crate::version::{version_matches_constraint, version_matches_normalized_constraint};
+use deps_core::InvalidPackageName;
 use deps_core::PackageName;
 use deps_core::VersionReq;
 use deps_core::lsp_helpers::{EcosystemFormatter, RequirementMatcher};
 use deps_core::normalize_operator_spacing;
+
+/// Whether `name` is a valid Dart identifier: pub.dev requires every package name to be one,
+/// per <https://dart.dev/tools/pub/pubspec#name> — ASCII letters/digits/`_` only, starting
+/// with a letter or `_` (never a digit).
+fn is_valid_dart_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
 
 /// pub.dev constraint matcher, compiled once per dependency by
 /// [`DartFormatter::compile_requirement`]. Holds the requirement already run through
@@ -28,6 +40,27 @@ impl EcosystemFormatter for DartFormatter {
 
     fn package_url(&self, name: &PackageName) -> String {
         crate::registry::package_url(name.as_str())
+    }
+
+    /// Lints `name` against pub.dev's rule that every package name must be a valid Dart
+    /// identifier (see `is_valid_dart_identifier`), so a structurally invalid name is
+    /// reported as "Invalid package name" instead of falling through to a registry lookup
+    /// and rendering the generic "Registry lookup failed" diagnostic (#402).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidPackageName`] if `name` is empty, starts with a digit, or contains a
+    /// character other than an ASCII letter, digit, or `_`.
+    fn validate_package_name(&self, name: &str) -> Result<(), InvalidPackageName> {
+        if name.is_empty() {
+            return Err(InvalidPackageName::new("name cannot be empty"));
+        }
+        if !is_valid_dart_identifier(name) {
+            return Err(InvalidPackageName::new(
+                "name must be a valid Dart identifier: only ASCII letters, digits, and '_', not starting with a digit",
+            ));
+        }
+        Ok(())
     }
 
     fn version_satisfies_requirement(&self, version: &str, requirement: &str) -> bool {
@@ -100,5 +133,30 @@ mod tests {
         assert_eq!(matcher.matches("1.99.0"), Some(true));
         assert_eq!(matcher.matches("2.0.0"), Some(false));
         assert_eq!(matcher.matches("1.14.0"), Some(false));
+    }
+
+    #[test]
+    fn test_validate_package_name_accepts_valid_names() {
+        let f = DartFormatter;
+        for name in ["provider", "flutter_bloc", "_private", "path9"] {
+            assert!(
+                f.validate_package_name(name).is_ok(),
+                "expected {name:?} to be accepted"
+            );
+        }
+    }
+
+    /// #402: a structurally invalid Dart package name must be reported as an invalid package
+    /// name, not forwarded to the registry lookup that produces the misleading generic
+    /// diagnostic.
+    #[test]
+    fn test_validate_package_name_rejects_invalid_names() {
+        let f = DartFormatter;
+        for name in ["", "9path", "my-package", "my package", "日本語"] {
+            assert!(
+                f.validate_package_name(name).is_err(),
+                "expected {name:?} to be rejected"
+            );
+        }
     }
 }

--- a/crates/deps-go/src/formatter.rs
+++ b/crates/deps-go/src/formatter.rs
@@ -1,6 +1,6 @@
 use deps_core::VersionReq;
 use deps_core::lsp_helpers::{EcosystemFormatter, RequirementMatcher, compile_requirement_unless};
-use deps_core::{Dependency, PackageName};
+use deps_core::{Dependency, DepsError, InvalidPackageName, PackageName};
 
 use crate::types::{GoDependency, GoDirective};
 
@@ -58,6 +58,31 @@ impl EcosystemFormatter for GoFormatter {
 
     fn package_url(&self, name: &PackageName) -> String {
         crate::registry::package_url(name.as_str())
+    }
+
+    /// Reuses `crate::registry::validate_module_path` — the same structural rule that
+    /// gates every registry request — so a malformed module path (empty, too long, or
+    /// containing a `.`/`..` path segment) is reported as "Invalid package name" instead of
+    /// falling through to a registry lookup and rendering the generic "Registry lookup
+    /// failed" diagnostic (#402).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidPackageName`] carrying `validate_module_path`'s rejection reason.
+    fn validate_package_name(&self, name: &str) -> Result<(), InvalidPackageName> {
+        let Err(err) = crate::registry::validate_module_path(name) else {
+            return Ok(());
+        };
+        // `validate_module_path` only ever constructs `DepsError::InvalidVersionReq` (#399
+        // documents it as the shared "invalid input" carrier it deliberately reuses for this),
+        // so this is the only reachable arm — matched explicitly rather than a catch-all
+        // `.to_string()` fallback, both to avoid dead code per CLAUDE.md and because
+        // `DepsError`'s `Display` prefixes an unrelated "invalid version requirement: " label
+        // that would misrender the module-path reason here (#402 critique M3).
+        let DepsError::InvalidVersionReq(reason) = err else {
+            unreachable!("validate_module_path only ever returns DepsError::InvalidVersionReq")
+        };
+        Err(InvalidPackageName::new(reason))
     }
 
     fn version_satisfies_requirement(&self, version: &str, requirement: &str) -> bool {
@@ -358,5 +383,42 @@ mod tests {
             .compile_requirement(&VersionReq::new("v2.0.0+incompatible"))
             .expect("a +incompatible tag is not a pseudo-version");
         assert_eq!(matcher.matches("v2.0.0+incompatible"), Some(true));
+    }
+
+    #[test]
+    fn test_validate_package_name_accepts_valid_module_path() {
+        let formatter = GoFormatter;
+        assert!(
+            formatter
+                .validate_package_name("github.com/gin-gonic/gin")
+                .is_ok()
+        );
+        assert!(formatter.validate_package_name("golang.org/x/mod").is_ok());
+    }
+
+    #[test]
+    fn test_validate_package_name_rejects_empty() {
+        let formatter = GoFormatter;
+        assert!(formatter.validate_package_name("").is_err());
+    }
+
+    /// #402: a `.`/`..` module path segment must be reported as an invalid package name,
+    /// not forwarded to the registry lookup that produces the misleading generic diagnostic.
+    #[test]
+    fn test_validate_package_name_rejects_dot_segment() {
+        let formatter = GoFormatter;
+        assert!(
+            formatter
+                .validate_package_name("github.com/user/..")
+                .is_err()
+        );
+        assert!(formatter.validate_package_name("./evil").is_err());
+    }
+
+    #[test]
+    fn test_validate_package_name_rejects_too_long() {
+        let formatter = GoFormatter;
+        let too_long = "a".repeat(501);
+        assert!(formatter.validate_package_name(&too_long).is_err());
     }
 }

--- a/crates/deps-go/src/registry.rs
+++ b/crates/deps-go/src/registry.rs
@@ -58,7 +58,10 @@ const MAX_VERSION_LENGTH: usize = 128;
 /// - Path is empty
 /// - Path exceeds MAX_MODULE_PATH_LENGTH
 /// - Any `/`-separated segment is exactly `.`/`..`
-fn validate_module_path(module_path: &str) -> Result<()> {
+///
+/// `pub(crate)` (not private) so [`crate::formatter::GoFormatter::validate_package_name`] can
+/// reuse the same structural rule for its "Invalid package name" diagnostic lint (#402).
+pub(crate) fn validate_module_path(module_path: &str) -> Result<()> {
     if module_path.is_empty() {
         return Err(DepsError::InvalidVersionReq("module path is empty".into()));
     }

--- a/crates/deps-nuget/src/formatter.rs
+++ b/crates/deps-nuget/src/formatter.rs
@@ -1,7 +1,23 @@
 //! Version formatting for the NuGet ecosystem.
 
 use deps_core::lsp_helpers::{EcosystemFormatter, RequirementMatcher, compile_requirement_unless};
-use deps_core::{PackageName, VersionReq};
+use deps_core::{InvalidPackageName, PackageName, VersionReq};
+
+/// Maximum package ID length NuGet's client-side `PackageIdValidator` accepts.
+const MAX_PACKAGE_ID_LENGTH: usize = 100;
+
+/// Whether `name` matches NuGet's package ID rule (`PackageIdValidator.IdRegex` in
+/// NuGet.Client: `^\w+([_.-]\w+)*$`, `\w` restricted to ASCII here): one or more ASCII
+/// alphanumeric/`_` "words" separated by single `.` or `-` characters, with no leading,
+/// trailing, or consecutive `.`/`-`. `_` is itself a `\w` character in .NET regex, not a
+/// separator, so it is treated as ordinary word content — `_foo`/`foo__bar`/a bare `_` are
+/// all accepted by NuGet's real validator (confirmed live: `_` is a published package id,
+/// nuget.org id `_`, #402 critique M1) but were previously rejected here by splitting on `_`
+/// as if it were a separator too.
+fn is_valid_nuget_id(name: &str) -> bool {
+    name.split(['.', '-'])
+        .all(|word| !word.is_empty() && word.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'))
+}
 
 /// NuGet interval/floating-pattern matcher, compiled once per dependency by
 /// [`NuGetFormatter::compile_requirement`] — the range or floating pattern is parsed once
@@ -36,6 +52,42 @@ impl EcosystemFormatter for NuGetFormatter {
 
     fn package_url(&self, name: &PackageName) -> String {
         crate::registry::package_url(name.as_str())
+    }
+
+    /// Lints `name` against NuGet's own `PackageIdValidator` rule (see
+    /// `is_valid_nuget_id`), so a structurally invalid package ID is reported as "Invalid
+    /// package name" instead of falling through to a registry lookup and rendering the
+    /// generic "Registry lookup failed" diagnostic (#402).
+    ///
+    /// An unresolved MSBuild property reference (e.g. `<PackageReference
+    /// Include="$(MyPackageId)" />`) is checked first and always accepted — the same
+    /// unresolvable-variable treatment `requirement_is_unresolved` already gives a
+    /// `$(...)`-containing *version* string (#402 critique M2): `name` here is not a
+    /// concrete package id at all until MSBuild expands the property, so it has no shape to
+    /// validate.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidPackageName`] if `name` is empty, exceeds 100 characters, or contains
+    /// a character outside NuGet's `\w+([_.-]\w+)*` shape.
+    fn validate_package_name(&self, name: &str) -> Result<(), InvalidPackageName> {
+        if name.contains("$(") {
+            return Ok(());
+        }
+        if name.is_empty() {
+            return Err(InvalidPackageName::new("name cannot be empty"));
+        }
+        if name.chars().count() > MAX_PACKAGE_ID_LENGTH {
+            return Err(InvalidPackageName::new(format!(
+                "name cannot exceed {MAX_PACKAGE_ID_LENGTH} characters"
+            )));
+        }
+        if !is_valid_nuget_id(name) {
+            return Err(InvalidPackageName::new(
+                "name must be ASCII alphanumeric/'_' words separated by single '.' or '-' characters",
+            ));
+        }
+        Ok(())
     }
 
     /// Overridden because the default npm caret/tilde semantics do not apply to NuGet's
@@ -333,5 +385,60 @@ mod tests {
         let f = NuGetFormatter;
         assert!(!f.requirement_is_unresolved(&VersionReq::new("13.0.3")));
         assert!(!f.requirement_is_unresolved(&VersionReq::new("[1.0,2.0)")));
+    }
+
+    #[test]
+    fn test_validate_package_name_accepts_valid_names() {
+        let f = NuGetFormatter;
+        for name in ["Newtonsoft.Json", "Microsoft.Extensions.Logging", "moq"] {
+            assert!(
+                f.validate_package_name(name).is_ok(),
+                "expected {name:?} to be accepted"
+            );
+        }
+    }
+
+    /// #402: a structurally invalid NuGet package ID must be reported as an invalid package
+    /// name, not forwarded to the registry lookup that produces the misleading generic
+    /// diagnostic.
+    #[test]
+    fn test_validate_package_name_rejects_invalid_names() {
+        let f = NuGetFormatter;
+        for name in ["", ".Json", "Json.", "New..Json", "New Json", "日本語"] {
+            assert!(
+                f.validate_package_name(name).is_err(),
+                "expected {name:?} to be rejected"
+            );
+        }
+    }
+
+    /// #402 critique M1: `_` is a `\w` character in NuGet's real `PackageIdValidator.IdRegex`,
+    /// not a separator, so a leading/doubled/bare underscore is accepted (confirmed live:
+    /// nuget.org publishes a package with id `_`).
+    #[test]
+    fn test_validate_package_name_accepts_underscore_as_word_character() {
+        let f = NuGetFormatter;
+        for name in ["_foo", "foo__bar", "_", "foo_bar"] {
+            assert!(
+                f.validate_package_name(name).is_ok(),
+                "expected {name:?} to be accepted"
+            );
+        }
+    }
+
+    /// #402 critique M2: an unexpanded MSBuild property reference in `Include` (e.g.
+    /// `<PackageReference Include="$(MyPackageId)" />`) is not yet a concrete package id and
+    /// must not be flagged as an invalid package name.
+    #[test]
+    fn test_validate_package_name_accepts_unresolved_msbuild_property() {
+        let f = NuGetFormatter;
+        assert!(f.validate_package_name("$(MyPackageId)").is_ok());
+    }
+
+    #[test]
+    fn test_validate_package_name_rejects_too_long() {
+        let f = NuGetFormatter;
+        let too_long = "a".repeat(101);
+        assert!(f.validate_package_name(&too_long).is_err());
     }
 }

--- a/crates/deps-swift/src/formatter.rs
+++ b/crates/deps-swift/src/formatter.rs
@@ -1,8 +1,10 @@
 //! Swift ecosystem formatter.
 
 use deps_core::Dependency;
+use deps_core::InvalidPackageName;
 use deps_core::PackageName;
 use deps_core::VersionReq;
+use deps_core::is_dot_segment;
 use deps_core::lsp_helpers::{EcosystemFormatter, RequirementMatcher, warn_rejected_value};
 
 /// Precise semver `VersionReq` matcher, compiled once per dependency by
@@ -52,6 +54,38 @@ impl EcosystemFormatter for SwiftFormatter {
 
     fn normalize_package_name(&self, name: &PackageName) -> String {
         name.as_str().to_lowercase()
+    }
+
+    /// Accepts either `is_valid_owner_repo`'s `owner/repo` GitHub identifier shape (the same
+    /// one `package_url` and the registry's fetch-URL gate require), or a bare single-segment
+    /// name with no `/`.
+    ///
+    /// The bare-name case matters because `name` is not always a GitHub coordinate to begin
+    /// with: `deps_swift::parser`'s `.package(path:)` handling sets it to the target
+    /// directory's basename (`crates/deps-swift/src/parser.rs`, the `RE_PATH` arm) for a
+    /// `DependencySource::Path` dependency, which never contains a `/` and has no GitHub
+    /// identity at all. `validate_package_name` only sees the bare string, not the
+    /// dependency's source, so it cannot tell a local package's basename apart from a
+    /// registry-style name typo'd without its `owner/` prefix — per this trait's "err on the
+    /// side of accepting anything ambiguous" contract, the bare form is accepted rather than
+    /// flagged, which also fixes a false "Invalid package name" on every local Swift package
+    /// dependency (#402 critique C1). A multi-segment name (extra segment, disallowed
+    /// character, or a `.`/`..` segment) still fails the `owner/repo` check and is rejected,
+    /// same as before.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidPackageName`] when `name` is empty, is exactly `.`/`..`, or contains a
+    /// `/` without matching the `owner/repo` shape.
+    fn validate_package_name(&self, name: &str) -> Result<(), InvalidPackageName> {
+        let bare_name_ok = !name.contains('/') && !name.is_empty() && !is_dot_segment(name);
+        if is_valid_owner_repo(name) || bare_name_ok {
+            Ok(())
+        } else {
+            Err(InvalidPackageName::new(
+                "name must be a GitHub 'owner/repo' identifier",
+            ))
+        }
     }
 
     fn version_satisfies_requirement(&self, version: &str, requirement: &str) -> bool {
@@ -367,5 +401,48 @@ mod tests {
             .compile_requirement(&VersionReq::new(">=1.0.0"))
             .unwrap();
         assert_eq!(matcher.matches("not-a-version"), None);
+    }
+
+    #[test]
+    fn test_validate_package_name_accepts_owner_repo() {
+        let fmt = SwiftFormatter;
+        assert!(fmt.validate_package_name("apple/swift-nio").is_ok());
+    }
+
+    /// #402 critique C1: a `.package(path:)` dependency's name is the target directory's
+    /// basename (see `deps_swift::parser`'s `RE_PATH` arm), never an `owner/repo` GitHub
+    /// coordinate — it must not be flagged as an invalid package name.
+    #[test]
+    fn test_validate_package_name_accepts_bare_name_for_path_dependencies() {
+        let fmt = SwiftFormatter;
+        for name in ["MyLib", "my-package", "LocalPackage", "no-slash"] {
+            assert!(
+                fmt.validate_package_name(name).is_ok(),
+                "expected {name:?} to be accepted"
+            );
+        }
+    }
+
+    /// #402: a structurally invalid Swift package name must be reported as an invalid
+    /// package name, not forwarded to the registry lookup that produces the misleading
+    /// generic "Registry lookup failed" diagnostic. Only multi-segment shapes are still
+    /// checked against `owner/repo` — a bare name has no `/` to validate the shape of (see
+    /// `test_validate_package_name_accepts_bare_name_for_path_dependencies`).
+    #[test]
+    fn test_validate_package_name_rejects_malformed_names() {
+        let fmt = SwiftFormatter;
+        for name in [
+            "",
+            ".",
+            "..",
+            "owner/repo/extra",
+            "../../etc/passwd",
+            "apple/..",
+        ] {
+            assert!(
+                fmt.validate_package_name(name).is_err(),
+                "expected {name:?} to be rejected"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

`EcosystemFormatter::validate_package_name` had overrides only for cargo, npm, pypi, maven, gradle, and deno, letting `deps-core`'s diagnostics path short-circuit to an "Invalid package name" diagnostic before attempting a registry lookup. `go`, `bundler`, `dart`, `composer`, `nuget`, and `swift` lacked overrides, so a structurally invalid name fell through to a registry lookup and rendered the confusing "Registry lookup failed" diagnostic instead.

- **go, swift**: wired existing structural validators (`validate_module_path`, `is_valid_github_identity`/`is_valid_owner_repo`)
- **bundler, dart, composer, nuget**: added validators derived from each ecosystem's real naming rules (RubyGems `VALID_NAME_PATTERN`, Dart identifier rule, Packagist `vendor/package` schema, NuGet `PackageIdValidator` regex)
- **swift**: `.package(path:)` local dependencies get a bare directory-basename name, not a GitHub `owner/repo` coordinate — `validate_package_name` now accepts a bare no-slash name too, avoiding a false "Invalid package name" on every local Swift dependency
- **composer**: `is_platform_package` now rejects any name containing `/` before the prefix checks, so a real Packagist package under a `php-*`/`ext-*`/`lib-*` vendor (e.g. `php-di/php-di`, `php-amqplib/php-amqplib`) is no longer silently misclassified as a platform requirement and dropped from the dependency list; also extended the platform set (`hhvm`, `composer`, `composer-plugin-api`, `composer-runtime-api`, `php-*` variants) to match Composer's `PlatformRepository`

This went through two rounds of adversarial critique that each caught a real regression before merge: a Swift path-dependency false positive (fixed at the parser/formatter level rather than a broader deps-core gate, to avoid regressing an existing intentional contract for the original six ecosystems), and a Composer platform-package false negative that would have silently dropped real, widely-used packages.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` — 2941 passed, 49 skipped, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --all-features`
- [x] New unit tests per ecosystem covering valid/invalid names, plus regression tests for the Swift path-dependency and Composer platform-package edge cases

Closes #402