### PR TITLE
fix(deps-core): resolve CodeQL cache.rs test alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-bundler, deps-go**: removed private duplicate `LineOffsetTable` structs, both now use the shared `deps_core::lsp_helpers::LineOffsetTable` (resolves #389) (#395)
 - **deps-cargo, deps-npm, deps-composer, deps-dart, deps-deno, deps-go, deps-gradle, deps-maven, deps-nuget**: removed per-crate `{Ecosystem}Error` wrapper enums; call sites now construct `deps_core::DepsError` directly (resolves #388) (#398)
 - **deps-core, deps-go**: documented that `deps-go`'s module-path validation intentionally shares `DepsError::InvalidVersionReq` with version-string rejections, no new variant added (resolves #399) (#401)
-- **deps-core**: resolved 5 open CodeQL code-scanning alerts (`rust/non-https-url`, `rust/cleartext-logging`) in `cache.rs` test code, none reachable from production paths
+- **deps-core**: resolved 5 open CodeQL code-scanning alerts (`rust/non-https-url`, `rust/cleartext-logging`) in `cache.rs` test code, none reachable from production paths (#409)
 
 ## [0.11.0] - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-bundler, deps-go**: removed private duplicate `LineOffsetTable` structs, both now use the shared `deps_core::lsp_helpers::LineOffsetTable` (resolves #389) (#395)
 - **deps-cargo, deps-npm, deps-composer, deps-dart, deps-deno, deps-go, deps-gradle, deps-maven, deps-nuget**: removed per-crate `{Ecosystem}Error` wrapper enums; call sites now construct `deps_core::DepsError` directly (resolves #388) (#398)
 - **deps-core, deps-go**: documented that `deps-go`'s module-path validation intentionally shares `DepsError::InvalidVersionReq` with version-string rejections, no new variant added (resolves #399) (#401)
+- **deps-core**: resolved 5 open CodeQL code-scanning alerts (`rust/non-https-url`, `rust/cleartext-logging`) in `cache.rs` test code, none reachable from production paths
 
 ## [0.11.0] - 2026-08-24
 

--- a/crates/deps-core/src/cache.rs
+++ b/crates/deps-core/src/cache.rs
@@ -946,10 +946,13 @@ mod tests {
 
         // The stopped redirect surfaces as the 302 response itself, handled like any
         // other non-2xx status - not as a distinct "redirect blocked" error variant.
-        match result {
-            Err(DepsError::HttpStatus { status, .. }) => assert_eq!(status, 302),
-            other => panic!("expected HttpStatus(302), got {other:?}"),
-        }
+        // Assert via `matches!` rather than debug-formatting `result` in a panic message:
+        // on the `Ok` arm that value is the raw response body, which would otherwise be
+        // written to the test log by the panic machinery.
+        assert!(
+            matches!(result, Err(DepsError::HttpStatus { status: 302, .. })),
+            "expected HttpStatus(302)"
+        );
 
         // Proves the security property itself (the escape origin was never contacted),
         // not just the symptom (the result is a 302) - a client that followed the
@@ -1023,10 +1026,13 @@ mod tests {
             .get_cached_trusted_origin(&source_url, &trusted_origin)
             .await;
 
-        match result {
-            Err(DepsError::HttpStatus { status, .. }) => assert_eq!(status, 302),
-            other => panic!("expected HttpStatus(302), got {other:?}"),
-        }
+        // Assert via `matches!` rather than debug-formatting `result` in a panic message:
+        // on the `Ok` arm that value is the raw response body, which would otherwise be
+        // written to the test log by the panic machinery.
+        assert!(
+            matches!(result, Err(DepsError::HttpStatus { status: 302, .. })),
+            "expected HttpStatus(302)"
+        );
         escape.assert_async().await;
     }
 
@@ -1058,10 +1064,13 @@ mod tests {
             .get_cached_trusted_origin(&source_url, &trusted_origin)
             .await;
 
-        match result {
-            Err(DepsError::HttpStatus { status, .. }) => assert_eq!(status, 302),
-            other => panic!("expected HttpStatus(302), got {other:?}"),
-        }
+        // Assert via `matches!` rather than debug-formatting `result` in a panic message:
+        // on the `Ok` arm that value is the raw response body, which would otherwise be
+        // written to the test log by the panic machinery.
+        assert!(
+            matches!(result, Err(DepsError::HttpStatus { status: 302, .. })),
+            "expected HttpStatus(302)"
+        );
         escape.assert_async().await;
     }
 
@@ -1311,7 +1320,9 @@ mod tests {
     #[tokio::test]
     async fn test_get_cached_network_error_fallback() {
         let cache = HttpCache::new();
-        let url = "http://invalid.localhost.test/data";
+        // https:// (not http://) so this exercises DNS-resolution failure, not the
+        // HTTPS-only policy enforced by `ensure_https`.
+        let url = "https://invalid.localhost.test/data";
 
         cache.entries.insert(
             url.to_string(),


### PR DESCRIPTION
## Summary
- Three redirect-policy tests in `crates/deps-core/src/cache.rs` debug-formatted the full `get_cached_trusted_origin` `Result` into a `panic!` message; on the unmatched `Ok` arm that includes the raw response body, which CodeQL's `rust/cleartext-logging` query flags as writing a sensitive value to a log. Replaced with `matches!`-based `assert!` calls that never touch the payload.
- `test_get_cached_network_error_fallback` used a hardcoded `http://` literal URL purely to trigger a DNS-resolution failure; CodeQL's `rust/non-https-url` query flags any literal `http://` URL reaching the network client, regardless of intent. Switched the literal to `https://` since the test exercises connection failure, not the HTTPS-only policy enforced by `ensure_https`.
- Closes all 5 currently open code-scanning alerts (#14-#18), none of which were reachable from production code paths — all three sinks are inside `#[cfg(test)]`.

## Test plan
- [x] `cargo nextest run -p deps-core --all-features` (630 passed)
- [x] `cargo nextest run --workspace --all-features --lib --bins` (2869 passed)
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`