### PR TITLE
fix: harden .gitignore against common secret-file patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,18 @@ target
 .local/
 .env
 .env.local
+
+# Secrets
+*.key
+*.pem
+*.p12
+*.pfx
+*.jks
+*.keystore
+id_rsa
+id_dsa
+id_ecdsa
+id_ed25519
+secrets/
+*.credentials
+credentials.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **.gitignore**: added globs for common secret files (SSH private keys, `*.key`/`*.pem`/`*.p12`/`*.pfx`/`*.jks`/`*.keystore`, `*.credentials`, `credentials.json`, `secrets/`) to prevent accidental commits (resolves #411)
+- **.gitignore**: added globs for common secret files (SSH private keys, `*.key`/`*.pem`/`*.p12`/`*.pfx`/`*.jks`/`*.keystore`, `*.credentials`, `credentials.json`, `secrets/`) to prevent accidental commits (resolves #411) (#412)
 - **deps-go, deps-bundler, deps-dart, deps-composer, deps-nuget, deps-swift**: structurally invalid package names/module paths now report "Invalid package name" instead of a misleading "Registry lookup failed" diagnostic (resolves #402) (#406)
 - **docs**: `ECOSYSTEM_GUIDE.md` and the ecosystem-crate template now teach the current direct-`DepsError`-construction convention instead of the per-crate error wrapper pattern removed in #398 (resolves #403) (#405)
 - **deps-core, deps-lsp**: duplicate dependency names within a manifest (e.g. the same crate under `[dependencies]`/`[dev-dependencies]` or multiple `[target.*.dependencies]` blocks) no longer collapse via name-only `HashMap` in the diff/yanked-probe/OSV-scan pipeline, so an edit to any occurrence is correctly diffed and neither yanked nor OSV findings leak between occurrences pinned to different versions (resolves #394)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **.gitignore**: added globs for common secret files (SSH private keys, `*.key`/`*.pem`/`*.p12`/`*.pfx`/`*.jks`/`*.keystore`, `*.credentials`, `credentials.json`, `secrets/`) to prevent accidental commits (resolves #411)
 - **deps-go, deps-bundler, deps-dart, deps-composer, deps-nuget, deps-swift**: structurally invalid package names/module paths now report "Invalid package name" instead of a misleading "Registry lookup failed" diagnostic (resolves #402) (#406)
 - **docs**: `ECOSYSTEM_GUIDE.md` and the ecosystem-crate template now teach the current direct-`DepsError`-construction convention instead of the per-crate error wrapper pattern removed in #398 (resolves #403) (#405)
 - **deps-core, deps-lsp**: duplicate dependency names within a manifest (e.g. the same crate under `[dependencies]`/`[dev-dependencies]` or multiple `[target.*.dependencies]` blocks) no longer collapse via name-only `HashMap` in the diff/yanked-probe/OSV-scan pipeline, so an edit to any occurrence is correctly diffed and neither yanked nor OSV findings leak between occurrences pinned to different versions (resolves #394)


### PR DESCRIPTION
## Summary

Adds `.gitignore` globs for common local-secret file patterns that were previously uncovered: SSH private key names (`id_rsa`, `id_dsa`, `id_ecdsa`, `id_ed25519`), PKCS#12/PFX certificates, Java keystores, credential config files, and a `secrets/` directory.

Preventive/defense-in-depth only — no secret file is currently tracked in the repo (per the linked issue's gitleaks scan of the working tree and full commit history).

## Changes

- `.gitignore`: new `# Secrets` section with `*.key`, `*.pem`, `*.p12`, `*.pfx`, `*.jks`, `*.keystore`, `id_rsa`, `id_dsa`, `id_ecdsa`, `id_ed25519`, `secrets/`, `*.credentials`, `credentials.json`
- `CHANGELOG.md`: one-line `[Unreleased] > Fixed` entry

## Test plan

- [x] `git diff` confirms only `.gitignore` and `CHANGELOG.md` changed
- [x] `git ls-files` confirms zero currently-tracked files match any new pattern (no `git rm --cached` needed)
- [x] `git check-ignore -v` confirms all new patterns match as intended
- [x] No `!negation` rules exist in `.gitignore`, so appending at end-of-file is conflict-free
- [x] Config-only change — no Rust source touched, so no fmt/clippy/nextest/rustdoc gate applies

Closes #411

https://claude.ai/code/session_014JCbNsQQP4t2oQu6NWopwm