### PR TITLE
fix(deps-lsp): supervise cold-start-limiter cleanup task's JoinHandle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **.gitignore**: added globs for common secret files (SSH private keys, `*.key`/`*.pem`/`*.p12`/`*.pfx`/`*.jks`/`*.keystore`, `*.credentials`, `credentials.json`, `secrets/`) to prevent accidental commits (resolves #411) (#412)
+- **deps-lsp**: background cold-start rate-limiter cleanup task no longer discards its `JoinHandle`, so a panic surfaces as an `error!` log instead of silently stopping cleanup forever (resolves #408)
 - **deps-go, deps-bundler, deps-dart, deps-composer, deps-nuget, deps-swift**: structurally invalid package names/module paths now report "Invalid package name" instead of a misleading "Registry lookup failed" diagnostic (resolves #402) (#406)
 - **docs**: `ECOSYSTEM_GUIDE.md` and the ecosystem-crate template now teach the current direct-`DepsError`-construction convention instead of the per-crate error wrapper pattern removed in #398 (resolves #403) (#405)
 - **deps-core, deps-lsp**: duplicate dependency names within a manifest (e.g. the same crate under `[dependencies]`/`[dev-dependencies]` or multiple `[target.*.dependencies]` blocks) no longer collapse via name-only `HashMap` in the diff/yanked-probe/OSV-scan pipeline, so an edit to any occurrence is correctly diffed and neither yanked nor OSV findings leak between occurrences pinned to different versions (resolves #394)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **.gitignore**: added globs for common secret files (SSH private keys, `*.key`/`*.pem`/`*.p12`/`*.pfx`/`*.jks`/`*.keystore`, `*.credentials`, `credentials.json`, `secrets/`) to prevent accidental commits (resolves #411) (#412)
-- **deps-lsp**: background cold-start rate-limiter cleanup task no longer discards its `JoinHandle`, so a panic surfaces as an `error!` log instead of silently stopping cleanup forever (resolves #408)
+- **deps-lsp**: background cold-start rate-limiter cleanup task no longer discards its `JoinHandle`, so a panic surfaces as an `error!` log instead of silently stopping cleanup forever (resolves #408) (#413)
 - **deps-go, deps-bundler, deps-dart, deps-composer, deps-nuget, deps-swift**: structurally invalid package names/module paths now report "Invalid package name" instead of a misleading "Registry lookup failed" diagnostic (resolves #402) (#406)
 - **docs**: `ECOSYSTEM_GUIDE.md` and the ecosystem-crate template now teach the current direct-`DepsError`-construction convention instead of the per-crate error wrapper pattern removed in #398 (resolves #403) (#405)
 - **deps-core, deps-lsp**: duplicate dependency names within a manifest (e.g. the same crate under `[dependencies]`/`[dev-dependencies]` or multiple `[target.*.dependencies]` blocks) no longer collapse via name-only `HashMap` in the diff/yanked-probe/OSV-scan pipeline, so an edit to any occurrence is correctly diffed and neither yanked nor OSV findings leak between occurrences pinned to different versions (resolves #394)

--- a/crates/deps-lsp/src/server.rs
+++ b/crates/deps-lsp/src/server.rs
@@ -389,9 +389,10 @@ impl LanguageServer for Backend {
             }
         }
 
-        // Spawn background cleanup task for cold start rate limiter
+        // Spawn background cleanup task for cold start rate limiter, supervised so a
+        // panic surfaces as an `error!` log instead of silently stopping cleanup forever.
         let state_clone = Arc::clone(&self.state);
-        tokio::spawn(async move {
+        let cleanup_task = tokio::spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_mins(1));
             loop {
                 interval.tick().await;
@@ -400,6 +401,11 @@ impl LanguageServer for Backend {
                     .cleanup_old_entries(std::time::Duration::from_mins(5));
                 tracing::trace!("Cleaned up old cold start rate limit entries");
             }
+        });
+        tokio::spawn(async move {
+            // Inner loop never returns (`JoinHandle<!>`), so `Ok` is unreachable and this pattern is irrefutable.
+            let Err(e) = cleanup_task.await;
+            tracing::error!("Cold start rate limiter cleanup task exited unexpectedly: {e}");
         });
     }
 


### PR DESCRIPTION
## Summary
- The background cleanup task for `cold_start_limiter` discarded its `JoinHandle`; a panic in the loop would silently and permanently stop cleanup with no diagnostic trail.
- Retain the handle and spawn a small supervisor task that awaits it and logs at `error!` level if it ever exits (panic), instead of storing the handle on `self` (avoids extra struct/lifecycle plumbing for this MVP-scoped fix).
- No behavior change to the cleanup cadence or logic itself.

## Test plan
- [x] `cargo build -p deps-lsp`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (2941 passed, 49 skipped)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Adversarial critique confirmed the supervisor pattern is sound (verified empirically against the multi-thread runtime's panic-propagation and shutdown behavior) and correctly scoped to the single fire-and-forget spawn named in the issue.

Closes #408