### PR TITLE
docs: add code lens to Deno row in ECOSYSTEM_GUIDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **docs**: `ECOSYSTEM_GUIDE.md`'s Deno row now lists code lens support, matching the shared `deps-core` default it already receives (resolves #410)
+- **docs**: `ECOSYSTEM_GUIDE.md`'s Deno row now lists code lens support, matching the shared `deps-core` default it already receives (resolves #410) (#416)
 - **.gitignore**: added globs for common secret files (SSH private keys, `*.key`/`*.pem`/`*.p12`/`*.pfx`/`*.jks`/`*.keystore`, `*.credentials`, `credentials.json`, `secrets/`) to prevent accidental commits (resolves #411) (#412)
 - **deps-lsp**: background cold-start rate-limiter cleanup task no longer discards its `JoinHandle`, so a panic surfaces as an `error!` log instead of silently stopping cleanup forever (resolves #408) (#413)
 - **deps-go, deps-bundler, deps-dart, deps-composer, deps-nuget, deps-swift**: structurally invalid package names/module paths now report "Invalid package name" instead of a misleading "Registry lookup failed" diagnostic (resolves #402) (#406)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **docs**: `ECOSYSTEM_GUIDE.md`'s Deno row now lists code lens support, matching the shared `deps-core` default it already receives (resolves #410)
 - **.gitignore**: added globs for common secret files (SSH private keys, `*.key`/`*.pem`/`*.p12`/`*.pfx`/`*.jks`/`*.keystore`, `*.credentials`, `credentials.json`, `secrets/`) to prevent accidental commits (resolves #411) (#412)
 - **deps-lsp**: background cold-start rate-limiter cleanup task no longer discards its `JoinHandle`, so a panic surfaces as an `error!` log instead of silently stopping cleanup forever (resolves #408) (#413)
 - **deps-go, deps-bundler, deps-dart, deps-composer, deps-nuget, deps-swift**: structurally invalid package names/module paths now report "Invalid package name" instead of a misleading "Registry lookup failed" diagnostic (resolves #402) (#406)

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -19,7 +19,7 @@ deps-lsp provides comprehensive LSP support for 12 package ecosystems:
 | **Composer** | PHP | `composer.json` | `composer.lock` | Hover, inlay hints, completion, code actions, diagnostics, code lens |
 | **Swift** | Swift | `Package.swift` | `Package.resolved` | Hover, inlay hints, completion, code actions, diagnostics, code lens (range-form dependencies not covered — see below), GitHub API support |
 | **NuGet** | .NET | `.csproj`, `.fsproj`, `.vbproj`, `Directory.Packages.props`, `packages.config` | `packages.lock.json` | Hover, inlay hints, completion, code actions, diagnostics, code lens, central package management support, SemVer2 prerelease handling |
-| **Deno** | JavaScript/TypeScript (Deno runtime) | `deno.json`, `deno.jsonc` | — (no `deno.lock` support yet) | Hover, inlay hints, completion, code actions, diagnostics — `jsr:` specifiers via the keyless JSR API, `npm:` specifiers delegate to the same registry client `npm` uses; `imports` map only, `scopes`/`importMap` not covered — see below |
+| **Deno** | JavaScript/TypeScript (Deno runtime) | `deno.json`, `deno.jsonc` | — (no `deno.lock` support yet) | Hover, inlay hints, completion, code actions, diagnostics, code lens — `jsr:` specifiers via the keyless JSR API, `npm:` specifiers delegate to the same registry client `npm` uses; `imports` map only, `scopes`/`importMap` not covered — see below |
 
 ### Yanked-Version Diagnostics
 


### PR DESCRIPTION
## Summary
- `docs/ECOSYSTEM_GUIDE.md`'s Deno row omitted "code lens" from its Features cell, even though `deps-deno`'s `Ecosystem` impl has no `generate_code_lenses` override and falls through to the shared `deps-core` default that every other ecosystem also uses (via the uniform dispatch in `crates/deps-lsp/src/handlers/code_lens.rs`).
- Added "code lens" to the Deno row so the feature matrix accurately reflects supported functionality.
- CHANGELOG.md updated under `[Unreleased]`.

## Test plan
- [x] Verified via code reading that `deps-deno` has no `generate_code_lenses` override (falls to `deps-core::ecosystem::Ecosystem::generate_code_lenses` default at `crates/deps-core/src/ecosystem.rs:543`)
- [x] Verified `crates/deps-lsp/src/handlers/code_lens.rs` dispatches uniformly with no per-ecosystem exclusion for Deno
- [x] `cargo check --workspace --all-features` passes
- [x] No other ECOSYSTEM_GUIDE.md section describes Deno's feature set separately

Closes #410