### PR TITLE
ci: gate cargo-deny CI on yanked crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-cargo, deps-npm, deps-composer, deps-dart, deps-deno, deps-go, deps-gradle, deps-maven, deps-nuget**: removed per-crate `{Ecosystem}Error` wrapper enums; call sites now construct `deps_core::DepsError` directly (resolves #388) (#398)
 - **deps-core, deps-go**: documented that `deps-go`'s module-path validation intentionally shares `DepsError::InvalidVersionReq` with version-string rejections, no new variant added (resolves #399) (#401)
 - **deps-core**: resolved 5 open CodeQL code-scanning alerts (`rust/non-https-url`, `rust/cleartext-logging`) in `cache.rs` test code, none reachable from production paths (#409)
+- **ci**: `cargo deny check advisories` now fails on a yanked crate (`yanked = "deny"`) instead of only warning (resolves #415)
 
 ## [0.11.0] - 2026-08-24
 

--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,7 @@
 [advisories]
 version = 2
 ignore = []
+yanked = "deny"
 
 [licenses]
 version = 2


### PR DESCRIPTION
## Summary
- Set `yanked = "deny"` in `deny.toml` `[advisories]` so a yanked crate entering `Cargo.lock` fails `cargo deny check` in CI instead of only producing a warning.
- No workflow files changed — `.github/workflows/ci.yml` already runs `cargo deny check`, which now enforces this.

## Test plan
- [x] `cargo deny check advisories` passes locally (0 errors) — verified independently by both the implementer and the reviewer.
- [x] Confirmed `.github/workflows/ci.yml` already invokes `cargo deny check` without a subcommand filter, so the new gate takes effect without further CI changes.

Closes #415