### PR TITLE
fix(deps-dart,deps-composer): correct prerelease-truncating compare_versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-cargo**: invalid file URI during workspace-root discovery now reports `DepsError::InvalidUri`, matching every other ecosystem, instead of the previously divergent `DepsError::CacheError` (#398)
 - **deps-pypi, deps-lsp**: package-name completion now works for PEP 621 `dependencies`/`optional-dependencies` arrays in `pyproject.toml`, which previously always returned zero results (resolves #390) (#397)
 - **workspace**: bumped the transitively-pinned `chacha20` from the yanked `0.10.1` to `0.10.2` in `Cargo.lock`, reachable via `reqwest`'s optional HTTP/3 stack (resolves #407) (#414)
+- **deps-dart, deps-composer**: `compare_versions` no longer truncates prerelease/qualifier suffixes, so a prerelease no longer compares equal to its stable counterpart (resolves #418)
 
 ### Changed
 - **deps-bundler, deps-go**: removed private duplicate `LineOffsetTable` structs, both now use the shared `deps_core::lsp_helpers::LineOffsetTable` (resolves #389) (#395)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-cargo**: invalid file URI during workspace-root discovery now reports `DepsError::InvalidUri`, matching every other ecosystem, instead of the previously divergent `DepsError::CacheError` (#398)
 - **deps-pypi, deps-lsp**: package-name completion now works for PEP 621 `dependencies`/`optional-dependencies` arrays in `pyproject.toml`, which previously always returned zero results (resolves #390) (#397)
 - **workspace**: bumped the transitively-pinned `chacha20` from the yanked `0.10.1` to `0.10.2` in `Cargo.lock`, reachable via `reqwest`'s optional HTTP/3 stack (resolves #407) (#414)
-- **deps-dart, deps-composer**: `compare_versions` no longer truncates prerelease/qualifier suffixes, so a prerelease no longer compares equal to its stable counterpart (resolves #418)
+- **deps-dart, deps-composer**: `compare_versions` no longer truncates prerelease/qualifier suffixes, so a prerelease no longer compares equal to its stable counterpart (resolves #418) (#420)
 
 ### Changed
 - **deps-bundler, deps-go**: removed private duplicate `LineOffsetTable` structs, both now use the shared `deps_core::lsp_helpers::LineOffsetTable` (resolves #389) (#395)

--- a/crates/deps-composer/src/formatter.rs
+++ b/crates/deps-composer/src/formatter.rs
@@ -162,24 +162,38 @@ impl EcosystemFormatter for ComposerFormatter {
             return satisfies_tilde_composer(version, req);
         }
 
-        // Comparison operators
+        // Comparison operators. `req` may itself be `v`-prefixed (e.g. ">=v1.0.0"); strip it
+        // the same way the caret/tilde branches above do, so it does not fall into
+        // `split_composer_core_and_suffix`'s qualifier-suffix branch and compare as core `0`.
         if let Some(req) = requirement.strip_prefix(">=") {
-            return compare_versions(version, req.trim()) >= 0;
+            let req = req.trim();
+            let req = req.strip_prefix('v').unwrap_or(req);
+            return compare_versions(version, req) >= 0;
         }
         if let Some(req) = requirement.strip_prefix("<=") {
-            return compare_versions(version, req.trim()) <= 0;
+            let req = req.trim();
+            let req = req.strip_prefix('v').unwrap_or(req);
+            return compare_versions(version, req) <= 0;
         }
         if let Some(req) = requirement.strip_prefix('>') {
-            return compare_versions(version, req.trim()) > 0;
+            let req = req.trim();
+            let req = req.strip_prefix('v').unwrap_or(req);
+            return compare_versions(version, req) > 0;
         }
         if let Some(req) = requirement.strip_prefix('<') {
-            return compare_versions(version, req.trim()) < 0;
+            let req = req.trim();
+            let req = req.strip_prefix('v').unwrap_or(req);
+            return compare_versions(version, req) < 0;
         }
         if let Some(req) = requirement.strip_prefix('=') {
-            return compare_versions(version, req.trim()) == 0;
+            let req = req.trim();
+            let req = req.strip_prefix('v').unwrap_or(req);
+            return compare_versions(version, req) == 0;
         }
         if let Some(req) = requirement.strip_prefix("!=") {
-            return compare_versions(version, req.trim()) != 0;
+            let req = req.trim();
+            let req = req.strip_prefix('v').unwrap_or(req);
+            return compare_versions(version, req) != 0;
         }
 
         // Wildcard: "1.0.*" means >=1.0.0 <1.1.0
@@ -335,22 +349,80 @@ fn satisfies_caret(version: &str, req: &str) -> bool {
     true
 }
 
+/// Rank of a Composer stability keyword in `dev < alpha < beta < RC < stable` (matching
+/// Composer's `VersionParser` keyword aliases `a`/`b` for alpha/beta), matched
+/// case-insensitively. An empty word (no qualifier at all) ranks as `stable`, the top of the
+/// scale, and so does any unrecognized suffix word — this happens to agree with Composer for
+/// its own `stable`/`patch`/`pl`/`p` aliases (all release-equivalent), but is not a general
+/// unknown-qualifier rule: a truly unrecognized word is not otherwise a valid Composer
+/// stability suffix.
+const COMPOSER_STABLE_RANK: u8 = 4;
+
+fn composer_stability_rank(word: &str) -> u8 {
+    match word.to_ascii_lowercase().as_str() {
+        "dev" => 0,
+        "alpha" | "a" => 1,
+        "beta" | "b" => 2,
+        "rc" => 3,
+        _ => COMPOSER_STABLE_RANK,
+    }
+}
+
+/// A parsed Composer stability qualifier: a stability rank plus every numeric group in its
+/// suffix (Composer's modifier regex allows any number of them, e.g. `alpha1.5`), compared
+/// group by group so `beta10` outranks `beta2` and `alpha1.5` outranks `alpha1.2`.
+struct ComposerQualifier {
+    rank: u8,
+    numeric: Vec<u64>,
+}
+
+/// Parses a qualifier suffix (already stripped of its leading separator, e.g. `"beta1"`,
+/// `"RC.2"`, `"dev"`, `"alpha1.5"`) into its stability rank and every digit run that follows
+/// the keyword, in order.
+fn parse_composer_qualifier(suffix: &str) -> ComposerQualifier {
+    let alpha_len = suffix.bytes().take_while(u8::is_ascii_alphabetic).count();
+    let (word, rest) = suffix.split_at(alpha_len);
+    let numeric = rest
+        .split(|c: char| !c.is_ascii_digit())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.parse().unwrap_or(0))
+        .collect();
+    ComposerQualifier {
+        rank: composer_stability_rank(word),
+        numeric,
+    }
+}
+
+/// Splits `version` into its bare numeric-dot core and, if present, its raw stability
+/// qualifier suffix (leading `-`/`_`/`.` separator stripped). Build metadata (after `+`) is
+/// discarded first.
+fn split_composer_core_and_suffix(version: &str) -> (&str, Option<&str>) {
+    let without_build = version.split('+').next().unwrap_or(version);
+    let split_at = without_build
+        .find(|c: char| !c.is_ascii_digit() && c != '.')
+        .unwrap_or(without_build.len());
+    let core = &without_build[..split_at];
+    let rest = without_build[split_at..].trim_start_matches(['-', '_', '.']);
+    if rest.is_empty() {
+        (core, None)
+    } else {
+        (core, Some(rest))
+    }
+}
+
 /// Simple semantic version comparison returning -1, 0, or 1.
 ///
-/// Compares version strings by splitting on '.' and comparing each numeric segment.
+/// Compares the numeric-dot core segment by segment, then applies Composer's stability
+/// precedence to any qualifier suffix (`dev < alpha < beta < RC < stable`, see
+/// [`composer_stability_rank`]) — a qualified version always sorts below its unqualified
+/// counterpart, and two qualifiers of the same stability compare by their numeric suffix
+/// (e.g. `beta2` < `beta10`).
 fn compare_versions(a: &str, b: &str) -> i32 {
-    fn parse_segment(s: &str) -> u64 {
-        let digits: String = s
-            .chars()
-            .skip_while(|c| !c.is_ascii_digit())
-            .take_while(|c| c.is_ascii_digit())
-            .collect();
-        digits.parse().unwrap_or(0)
-    }
-    let a_trimmed = a.trim_start_matches(|c: char| !c.is_ascii_digit());
-    let b_trimmed = b.trim_start_matches(|c: char| !c.is_ascii_digit());
-    let a_parts: Vec<u64> = a_trimmed.split('.').map(parse_segment).collect();
-    let b_parts: Vec<u64> = b_trimmed.split('.').map(parse_segment).collect();
+    let (a_core, a_suffix) = split_composer_core_and_suffix(a);
+    let (b_core, b_suffix) = split_composer_core_and_suffix(b);
+
+    let a_parts: Vec<u64> = a_core.split('.').map(|s| s.parse().unwrap_or(0)).collect();
+    let b_parts: Vec<u64> = b_core.split('.').map(|s| s.parse().unwrap_or(0)).collect();
 
     let len = a_parts.len().max(b_parts.len());
     for i in 0..len {
@@ -362,6 +434,28 @@ fn compare_versions(a: &str, b: &str) -> i32 {
         if av > bv {
             return 1;
         }
+    }
+
+    let a_q = a_suffix.map_or(
+        ComposerQualifier {
+            rank: COMPOSER_STABLE_RANK,
+            numeric: Vec::new(),
+        },
+        parse_composer_qualifier,
+    );
+    let b_q = b_suffix.map_or(
+        ComposerQualifier {
+            rank: COMPOSER_STABLE_RANK,
+            numeric: Vec::new(),
+        },
+        parse_composer_qualifier,
+    );
+
+    if a_q.rank != b_q.rank {
+        return if a_q.rank < b_q.rank { -1 } else { 1 };
+    }
+    if a_q.numeric != b_q.numeric {
+        return if a_q.numeric < b_q.numeric { -1 } else { 1 };
     }
     0
 }
@@ -467,6 +561,99 @@ mod tests {
         assert!(!f.version_satisfies_requirement("0.0.0", "v"));
     }
 
+    /// Regression test for #418: a stability qualifier suffix must not be silently
+    /// truncated and tie with its stable counterpart.
+    #[test]
+    fn test_compare_versions_prerelease_vs_stable() {
+        assert_eq!(compare_versions("2.0.0", "2.0.0-beta1"), 1);
+        assert_eq!(compare_versions("2.0.0-beta1", "2.0.0"), -1);
+        assert_ne!(compare_versions("2.0.0", "2.0.0-beta1"), 0);
+    }
+
+    #[test]
+    fn test_compare_versions_qualifier_ordering() {
+        // dev < alpha < beta < RC < stable.
+        assert_eq!(compare_versions("1.0.0-dev", "1.0.0-alpha1"), -1);
+        assert_eq!(compare_versions("1.0.0-alpha1", "1.0.0-beta1"), -1);
+        assert_eq!(compare_versions("1.0.0-beta1", "1.0.0-RC1"), -1);
+        assert_eq!(compare_versions("1.0.0-RC1", "1.0.0"), -1);
+        // Keyword aliases (a/b) and case-insensitivity.
+        assert_eq!(compare_versions("1.0.0-a1", "1.0.0-alpha1"), 0);
+        assert_eq!(compare_versions("1.0.0-b1", "1.0.0-beta1"), 0);
+        assert_eq!(compare_versions("1.0.0-rc1", "1.0.0-RC1"), 0);
+    }
+
+    #[test]
+    fn test_compare_versions_qualifier_numeric_suffix() {
+        assert_eq!(compare_versions("1.0.0-beta2", "1.0.0-beta10"), -1);
+        assert_eq!(compare_versions("1.0.0-beta10", "1.0.0-beta2"), 1);
+        assert_eq!(compare_versions("1.0.0-beta.1", "1.0.0-beta.2"), -1);
+    }
+
+    /// Regression test for impl-critic M2: Composer's modifier regex allows any number of
+    /// numeric groups after the stability keyword (`(?:[.-]?\d+)*`), so every group must be
+    /// compared, not just the first — otherwise "alpha1.5" and "alpha1.2" silently tie.
+    #[test]
+    fn test_compare_versions_qualifier_multiple_numeric_groups() {
+        assert_eq!(compare_versions("1.0.0-alpha1.5", "1.0.0-alpha1.2"), 1);
+        assert_eq!(compare_versions("1.0.0-alpha1.2", "1.0.0-alpha1.5"), -1);
+        assert_ne!(compare_versions("1.0.0-alpha1.5", "1.0.0-alpha1.2"), 0);
+    }
+
+    #[test]
+    fn test_compare_versions_numeric_segments_still_correct() {
+        assert_eq!(compare_versions("1.0.0", "1.0.0"), 0);
+        assert_eq!(compare_versions("1.0.1", "1.0.0"), 1);
+        assert_eq!(compare_versions("1.0.0", "1.0.1"), -1);
+        assert_eq!(compare_versions("2.0.0", "1.9.9"), 1);
+        assert_eq!(compare_versions("10.0.0", "9.0.0"), 1);
+    }
+
+    /// A qualified alpha/beta/RC version must not tie with its stable release under this
+    /// comparator. Note this only fixes `version_satisfies_requirement`'s own ordering — it
+    /// does not, by itself, fix "latest version" selection: `registry.rs`'s
+    /// `select_latest_matching` returns the first Packagist entry satisfying a requirement
+    /// with no minimum-stability filter of its own, so a real alpha/beta/RC release (only
+    /// `dev-*`/`*-dev` branches are filtered) can still be reported as "latest" for a
+    /// concrete requirement like `>=1.0` (tracked separately).
+    #[test]
+    fn test_compare_versions_sorts_prerelease_below_stable() {
+        let mut versions = vec!["2.0.0-beta1", "2.0.0", "2.0.0-alpha1", "2.0.0-RC1"];
+        versions.sort_by(|a, b| compare_versions(a, b).cmp(&0));
+        assert_eq!(
+            versions,
+            vec!["2.0.0-alpha1", "2.0.0-beta1", "2.0.0-RC1", "2.0.0"]
+        );
+    }
+
+    #[test]
+    fn test_compare_versions_build_metadata_ignored() {
+        assert_eq!(compare_versions("1.0.0+build1", "1.0.0+build2"), 0);
+    }
+
+    /// Build metadata must be stripped before the qualifier is parsed, not after — otherwise
+    /// a qualifier suffix could be dragged into the discarded build segment or vice versa.
+    #[test]
+    fn test_compare_versions_qualifier_with_build_metadata() {
+        assert_eq!(
+            compare_versions("2.0.0-beta1+build1", "2.0.0-beta1+build2"),
+            0
+        );
+        assert_eq!(compare_versions("2.0.0-beta1+build1", "2.0.0+build2"), -1);
+        assert_eq!(compare_versions("2.0.0+build1", "2.0.0-beta1+build2"), 1);
+    }
+
+    /// Regression guard for a core with fewer dot segments than its counterpart (e.g. a
+    /// Composer partial version): the missing trailing segment must be treated as `0`, not
+    /// cause a spurious mismatch.
+    #[test]
+    fn test_compare_versions_partial_core_length_mismatch() {
+        assert_eq!(compare_versions("1.0", "1.0.0"), 0);
+        assert_eq!(compare_versions("1.0.0", "1.0"), 0);
+        assert_eq!(compare_versions("1.1", "1.0.5"), 1);
+        assert_eq!(compare_versions("1", "1.0.0-beta1"), 1);
+    }
+
     #[test]
     fn test_comparison_operators() {
         let f = ComposerFormatter;
@@ -549,6 +736,23 @@ mod tests {
         assert!(!f.version_satisfies_requirement("2.0.0", "^v1.2.0"));
         // Wildcard with a `v`-prefixed requirement.
         assert!(f.version_satisfies_requirement("1.0.5", "v1.0.*"));
+    }
+
+    /// Regression test for impl-critic S1: a `v`-prefixed literal on the plain
+    /// comparison-operator branches (`>=`, `<=`, `>`, `<`, `=`, `!=`) must be stripped the
+    /// same way the caret/tilde branches already do, not fall into
+    /// `split_composer_core_and_suffix`'s qualifier-suffix branch and compare as core `0`.
+    #[test]
+    fn test_v_prefix_on_comparison_operators() {
+        let f = ComposerFormatter;
+        assert!(f.version_satisfies_requirement("1.5.0", ">=v1.0.0"));
+        assert!(!f.version_satisfies_requirement("0.9.0", ">=v1.0.0"));
+        assert!(f.version_satisfies_requirement("1.5.0", "<=v2.0.0"));
+        assert!(!f.version_satisfies_requirement("2.5.0", "<v2.0.0"));
+        assert!(f.version_satisfies_requirement("2.0.1", ">v2.0.0"));
+        assert!(f.version_satisfies_requirement("2.0.0", "=v2.0.0"));
+        assert!(!f.version_satisfies_requirement("2.0.0", "!=v2.0.0"));
+        assert!(f.version_satisfies_requirement("1.5.0", ">=v1.0.0 <v2.0.0"));
     }
 
     #[test]

--- a/crates/deps-dart/src/version.rs
+++ b/crates/deps-dart/src/version.rs
@@ -3,28 +3,104 @@
 use deps_core::normalize_operator_spacing;
 use std::cmp::Ordering;
 
-pub fn compare_versions(a: &str, b: &str) -> Ordering {
-    let a_parts: Vec<u64> = a
-        .split('.')
-        .filter_map(|p| p.split(|c: char| !c.is_ascii_digit()).next())
-        .filter_map(|p| p.parse().ok())
-        .collect();
-    let b_parts: Vec<u64> = b
-        .split('.')
-        .filter_map(|p| p.split(|c: char| !c.is_ascii_digit()).next())
-        .filter_map(|p| p.parse().ok())
-        .collect();
+/// A single dot-separated SemVer 2.0.0 prerelease identifier (semver spec §11).
+///
+/// A purely numeric identifier compares numerically and always sorts below an
+/// alphanumeric one; alphanumeric identifiers compare lexically by ASCII byte value
+/// (case-sensitive — unlike NuGet's case-folded prerelease scheme, plain SemVer 2.0.0
+/// does not fold case). Declaring `Numeric` before `AlphaNumeric` makes the derived
+/// `Ord` rank every numeric identifier below every alphanumeric one, matching the spec.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum PrereleaseIdentifier {
+    Numeric(u64),
+    AlphaNumeric(String),
+}
 
-    let max_len = a_parts.len().max(b_parts.len());
+impl PrereleaseIdentifier {
+    fn parse(s: &str) -> Self {
+        if !s.is_empty()
+            && s.bytes().all(|b| b.is_ascii_digit())
+            && let Ok(n) = s.parse::<u64>()
+        {
+            return Self::Numeric(n);
+        }
+        Self::AlphaNumeric(s.to_string())
+    }
+}
+
+/// Splits `version` into its bare numeric-dot core and, if present, its raw prerelease
+/// suffix. Build metadata (after `+`) is discarded first; the prerelease suffix is
+/// everything after the first `-` that follows.
+fn split_core_and_prerelease(version: &str) -> (&str, Option<&str>) {
+    let without_build = version.split('+').next().unwrap_or(version);
+    match without_build.split_once('-') {
+        Some((core, pre)) => (core, Some(pre)),
+        None => (without_build, None),
+    }
+}
+
+/// Parses a bare numeric-dot core string into its components, leniently taking each
+/// dot-separated segment's leading digit run (defaulting to `0` for a non-numeric segment).
+fn parse_core_parts(core: &str) -> Vec<u64> {
+    core.split('.')
+        .map(|s| {
+            s.chars()
+                .take_while(char::is_ascii_digit)
+                .collect::<String>()
+                .parse()
+                .unwrap_or(0)
+        })
+        .collect()
+}
+
+/// Compares two Dart version strings.
+///
+/// Numeric core components are compared first (a missing trailing component is treated as
+/// `0`, so `"1.0"` and `"1.0.0"` compare equal), then SemVer 2.0.0 prerelease precedence
+/// (spec §11) applies: a version with no prerelease outranks one with a prerelease of the
+/// same core, and two prereleases are compared identifier-by-identifier, with a longer
+/// identifier list outranking a shared-prefix shorter one. Build metadata (`+...`) is
+/// ignored.
+///
+/// # Examples
+///
+/// ```
+/// use deps_dart::version::compare_versions;
+/// use std::cmp::Ordering;
+///
+/// assert_eq!(compare_versions("2.0.0", "2.0.0-beta1"), Ordering::Greater);
+/// assert_eq!(compare_versions("2.0.0-alpha", "2.0.0-beta"), Ordering::Less);
+/// assert_eq!(compare_versions("1.0.0-alpha", "1.0.0-alpha.1"), Ordering::Less);
+/// ```
+pub fn compare_versions(a: &str, b: &str) -> Ordering {
+    let (a_core, a_pre) = split_core_and_prerelease(a);
+    let (b_core, b_pre) = split_core_and_prerelease(b);
+
+    let a_core_parts = parse_core_parts(a_core);
+    let b_core_parts = parse_core_parts(b_core);
+
+    let max_len = a_core_parts.len().max(b_core_parts.len());
     for i in 0..max_len {
-        let ap = a_parts.get(i).copied().unwrap_or(0);
-        let bp = b_parts.get(i).copied().unwrap_or(0);
+        let ap = a_core_parts.get(i).copied().unwrap_or(0);
+        let bp = b_core_parts.get(i).copied().unwrap_or(0);
         match ap.cmp(&bp) {
             Ordering::Equal => {}
             other => return other,
         }
     }
-    Ordering::Equal
+
+    match (a_pre, b_pre) {
+        (None, None) => Ordering::Equal,
+        (None, Some(_)) => Ordering::Greater,
+        (Some(_), None) => Ordering::Less,
+        (Some(a_pre), Some(b_pre)) => {
+            let a_ids: Vec<PrereleaseIdentifier> =
+                a_pre.split('.').map(PrereleaseIdentifier::parse).collect();
+            let b_ids: Vec<PrereleaseIdentifier> =
+                b_pre.split('.').map(PrereleaseIdentifier::parse).collect();
+            a_ids.cmp(&b_ids)
+        }
+    }
 }
 
 /// Checks if a version satisfies a Dart version constraint.
@@ -88,8 +164,12 @@ fn match_single_constraint(version: &str, constraint: &str) -> bool {
 }
 
 fn matches_caret(version: &str, requirement: &str) -> bool {
+    // Same leading-digit-run extraction as `ver_parts` below, so a requirement segment with
+    // a stray suffix (e.g. `"0-beta"`) zeroes to `0` instead of being dropped and shifting
+    // every later segment's index.
     let req_parts: Vec<u64> = requirement
         .split('.')
+        .filter_map(|p| p.split(|c: char| !c.is_ascii_digit()).next())
         .filter_map(|p| p.parse().ok())
         .collect();
     let ver_parts: Vec<u64> = version
@@ -144,6 +224,61 @@ mod tests {
         assert_eq!(compare_versions("1.0.0", "1.0"), Ordering::Equal);
     }
 
+    /// Regression test for #418: a prerelease/qualifier suffix must not be silently
+    /// truncated and tie with its stable counterpart.
+    #[test]
+    fn test_compare_versions_prerelease_vs_stable() {
+        assert_eq!(compare_versions("2.0.0", "2.0.0-beta1"), Ordering::Greater);
+        assert_eq!(compare_versions("2.0.0-beta1", "2.0.0"), Ordering::Less);
+        assert_ne!(compare_versions("2.0.0", "2.0.0-beta1"), Ordering::Equal);
+        assert_ne!(
+            compare_versions("2.10.0-nullsafety.1", "2.10.0"),
+            Ordering::Equal
+        );
+    }
+
+    #[test]
+    fn test_compare_versions_prerelease_identifier_ordering() {
+        // Numeric identifiers always outrank below alphanumeric ones.
+        assert_eq!(compare_versions("1.0.0-1", "1.0.0-alpha"), Ordering::Less);
+        // Alphanumeric identifiers compare lexically, case-sensitively.
+        assert_eq!(
+            compare_versions("1.0.0-alpha", "1.0.0-beta"),
+            Ordering::Less
+        );
+        // A numeric identifier compares numerically, not lexically.
+        assert_eq!(
+            compare_versions("1.0.0-alpha.2", "1.0.0-alpha.10"),
+            Ordering::Less
+        );
+        // More prerelease fields outrank fewer when the shared prefix is equal.
+        assert_eq!(
+            compare_versions("1.0.0-alpha.1", "1.0.0-alpha"),
+            Ordering::Greater
+        );
+    }
+
+    #[test]
+    fn test_compare_versions_build_metadata_ignored() {
+        assert_eq!(
+            compare_versions("1.0.0+build1", "1.0.0+build2"),
+            Ordering::Equal
+        );
+        assert_eq!(
+            compare_versions("1.0.0-beta+build1", "1.0.0-beta+build2"),
+            Ordering::Equal
+        );
+    }
+
+    /// Regression test for #418: sorting a version list must move every prerelease
+    /// below its own base release, not tie with it.
+    #[test]
+    fn test_compare_versions_sorts_prerelease_below_stable() {
+        let mut versions = vec!["2.0.0-beta1", "2.0.0", "2.0.0-alpha"];
+        versions.sort_by(|a, b| compare_versions(a, b));
+        assert_eq!(versions, vec!["2.0.0-alpha", "2.0.0-beta1", "2.0.0"]);
+    }
+
     #[test]
     fn test_is_prerelease() {
         assert!(!is_prerelease("1.0.0"));
@@ -162,6 +297,15 @@ mod tests {
         assert!(version_matches_constraint("1.99.99", "^1.0.0"));
         assert!(!version_matches_constraint("2.0.0", "^1.0.0"));
         assert!(!version_matches_constraint("0.9.0", "^1.0.0"));
+    }
+
+    /// Regression test for impl-critic M4/#418: a prerelease of the caret floor must not
+    /// satisfy the constraint — pub_semver agrees `^1.0.0` excludes `1.0.0-beta`. Before the
+    /// #418 fix, `compare_versions("1.0.0-beta", "1.0.0")` wrongly returned `Equal`, so the
+    /// `Less`-rejection in `matches_caret` never triggered for this case.
+    #[test]
+    fn test_caret_constraint_excludes_own_floor_prerelease() {
+        assert!(!version_matches_constraint("1.0.0-beta", "^1.0.0"));
     }
 
     #[test]

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -13,10 +13,10 @@ deps-lsp provides comprehensive LSP support for 12 package ecosystems:
 | **PyPI** | Python | `pyproject.toml`, `requirements.txt`, `constraints.txt` | `poetry.lock`, `uv.lock` | Hover with PEP 508 environment marker display ("Active when: `<marker>`"), inlay hints, completion, code actions, diagnostics, code lens |
 | **Go** | Go | `go.mod` | `go.sum` | Hover, inlay hints, completion, code actions, diagnostics, code lens, pseudo-version support |
 | **Bundler** | Ruby | `Gemfile` | `Gemfile.lock` | Hover, inlay hints, completion, code actions, diagnostics, code lens |
-| **Dart** | Dart | `pubspec.yaml` | `pubspec.lock` | Hover, inlay hints, completion, code actions, diagnostics, code lens |
+| **Dart** | Dart | `pubspec.yaml` | `pubspec.lock` | Hover with corrected version ordering (prereleases sort below base release — see below), inlay hints, completion, code actions, diagnostics, code lens |
 | **Maven** | Java | `pom.xml` | `maven-metadata.xml` (CDN) | Hover with corrected version ordering (numeric segments outrank qualifiers, prereleases sort below base release), inlay hints, completion, code actions, diagnostics, code lens (property-versioned dependencies not covered — see below) |
 | **Gradle** | Kotlin/Groovy | `build.gradle`, `build.gradle.kts`, `gradle/libs.versions.toml` | — | Hover with corrected version ordering (same as Maven), inlay hints, completion, code actions, diagnostics, code lens (variable/catalog-versioned dependencies not covered — see below), variable resolution (`gradle.properties`) |
-| **Composer** | PHP | `composer.json` | `composer.lock` | Hover, inlay hints, completion, code actions, diagnostics, code lens |
+| **Composer** | PHP | `composer.json` | `composer.lock` | Hover, inlay hints, completion, code actions, diagnostics, code lens (requirement matching uses corrected stability-qualifier ordering; "latest version" selection does not yet filter unstable releases — see below) |
 | **Swift** | Swift | `Package.swift` | `Package.resolved` | Hover, inlay hints, completion, code actions, diagnostics, code lens (range-form dependencies not covered — see below), GitHub API support |
 | **NuGet** | .NET | `.csproj`, `.fsproj`, `.vbproj`, `Directory.Packages.props`, `packages.config` | `packages.lock.json` | Hover, inlay hints, completion, code actions, diagnostics, code lens, central package management support, SemVer2 prerelease handling |
 | **Deno** | JavaScript/TypeScript (Deno runtime) | `deno.json`, `deno.jsonc` | — (no `deno.lock` support yet) | Hover, inlay hints, completion, code actions, diagnostics, code lens — `jsr:` specifiers via the keyless JSR API, `npm:` specifiers delegate to the same registry client `npm` uses; `imports` map only, `scopes`/`importMap` not covered — see below |
@@ -73,6 +73,25 @@ Versions are now ranked with correct Maven semantics:
 - **Numeric suffixes within qualifiers are compared numerically**: `M10` > `M2` (previously `M2` > `M10`)
 
 These fixes ensure hover's "Recent versions" list and completion sort order match Maven's actual version ordering.
+
+### Dart/Composer Version Comparison
+
+`compare_versions` previously discarded everything after the first non-digit character in a
+dot-separated segment, so a prerelease/qualifier version compared as *equal* to its stable
+counterpart (`2.0.0-beta1` tied with `2.0.0`). Both comparators now apply proper
+prerelease-aware ordering:
+
+- **Dart** (`pubspec.yaml`): SemVer 2.0.0 §11 precedence — numeric identifiers compare
+  numerically, alphanumeric identifiers compare lexically (ASCII), and a version with a
+  prerelease sorts below its base release. Applied both to "latest version" selection
+  (pub.dev's response order) and to constraint matching, so hover/completion sort order and
+  outdated diagnostics are both corrected.
+- **Composer** (`composer.json`): stability precedence `dev` < `alpha` < `beta` < `RC` <
+  `stable`, applied to requirement-satisfaction comparison only. This does **not** extend to
+  "latest version" selection — Packagist's response order is used as-is and
+  `select_latest_matching` has no minimum-stability filter, so an `alpha`/`beta`/`RC` release
+  can still surface as "latest" for a loose requirement. Tracked as a follow-up (see the
+  `registry.rs`-level stability-filtering gap noted in the crate's known issues).
 
 ### Maven/Gradle Version Range Matching
 


### PR DESCRIPTION
## Summary

- `deps-dart` and `deps-composer` each hand-rolled their own `compare_versions`, discarding everything after the first non-digit character in a dot-separated segment. A prerelease/qualifier version therefore compared equal to its stable counterpart (`2.0.0-beta1` == `2.0.0`), producing incorrect "latest version" selection and outdated diagnostics.
- Dart's comparator now applies SemVer 2.0.0 section 11 precedence and is used for both latest-version selection (`registry.rs` sort) and constraint matching — both are corrected.
- Composer's comparator now applies its `dev < alpha < beta < RC < stable` stability precedence for requirement-satisfaction matching. This does **not** extend to latest-version selection: Packagist's response order is used as-is with no minimum-stability filter (`registry.rs:229`/`:341`), so an alpha/beta/RC release can still surface as "latest" for a loose requirement — tracked as a follow-up.
- Went with dedicated per-crate comparators rather than a shared `deps-core` helper, matching the existing pattern in `deps-nuget`/`deps-bundler`/`deps-maven` (each ecosystem's qualifier semantics are structurally different: Dart's dot-identifier SemVer2 scheme vs. Composer's fixed 5-level stability enum).

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` — 2884 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New regression tests cover: prerelease vs stable tie (the core bug), Composer stability ordering, `v`-prefixed requirement literals across all comparison operators, multi-group qualifier numeric suffixes, and Dart's `matches_caret` prerelease exclusion

Closes #418