### PR TITLE
fix(deps-composer): exclude alpha/beta/RC releases from latest-version selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-pypi, deps-lsp**: package-name completion now works for PEP 621 `dependencies`/`optional-dependencies` arrays in `pyproject.toml`, which previously always returned zero results (resolves #390) (#397)
 - **workspace**: bumped the transitively-pinned `chacha20` from the yanked `0.10.1` to `0.10.2` in `Cargo.lock`, reachable via `reqwest`'s optional HTTP/3 stack (resolves #407) (#414)
 - **deps-dart, deps-composer**: `compare_versions` no longer truncates prerelease/qualifier suffixes, so a prerelease no longer compares equal to its stable counterpart (resolves #418) (#420)
-- **deps-composer**: "latest version" selection now excludes alpha/beta/RC releases by default, matching Composer's `minimum-stability: stable` semantics, unless the requirement itself names an unstable version; a wildcard requirement still resolves a prerelease-only package instead of reporting no version found (resolves #421)
-- **deps-swift**: a package whose only tags so far are prerelease now resolves under a wildcard requirement instead of `select_latest_matching` returning `None` (found via #421's cross-ecosystem conformance test)
+- **deps-composer**: "latest version" selection now excludes alpha/beta/RC releases by default, matching Composer's `minimum-stability: stable` semantics, unless the requirement itself names an unstable version; a wildcard requirement still resolves a prerelease-only package instead of reporting no version found (resolves #421) (#422)
+- **deps-swift**: a package whose only tags so far are prerelease now resolves under a wildcard requirement instead of `select_latest_matching` returning `None` (found via #421's cross-ecosystem conformance test) (#422)
 
 ### Changed
 - **deps-bundler, deps-go**: removed private duplicate `LineOffsetTable` structs, both now use the shared `deps_core::lsp_helpers::LineOffsetTable` (resolves #389) (#395)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-pypi, deps-lsp**: package-name completion now works for PEP 621 `dependencies`/`optional-dependencies` arrays in `pyproject.toml`, which previously always returned zero results (resolves #390) (#397)
 - **workspace**: bumped the transitively-pinned `chacha20` from the yanked `0.10.1` to `0.10.2` in `Cargo.lock`, reachable via `reqwest`'s optional HTTP/3 stack (resolves #407) (#414)
 - **deps-dart, deps-composer**: `compare_versions` no longer truncates prerelease/qualifier suffixes, so a prerelease no longer compares equal to its stable counterpart (resolves #418) (#420)
+- **deps-composer**: "latest version" selection now excludes alpha/beta/RC releases by default, matching Composer's `minimum-stability: stable` semantics, unless the requirement itself names an unstable version; a wildcard requirement still resolves a prerelease-only package instead of reporting no version found (resolves #421)
+- **deps-swift**: a package whose only tags so far are prerelease now resolves under a wildcard requirement instead of `select_latest_matching` returning `None` (found via #421's cross-ecosystem conformance test)
 
 ### Changed
 - **deps-bundler, deps-go**: removed private duplicate `LineOffsetTable` structs, both now use the shared `deps_core::lsp_helpers::LineOffsetTable` (resolves #389) (#395)

--- a/crates/deps-composer/src/registry.rs
+++ b/crates/deps-composer/src/registry.rs
@@ -87,6 +87,46 @@ fn reject_dot_segment(name: &str) -> Result<()> {
     Ok(())
 }
 
+/// Composer's own wildcard-requirement existence-check ladder (#421 S2).
+///
+/// Deliberately does not reuse [`deps_core::select_latest_for_existence`]: that shared
+/// ladder's rung 1 excludes both a prerelease *and* a flagged (`is_flagged()`) version, but
+/// Composer's `abandoned` flag is package-level advisory data, not a per-version ranking
+/// signal — `select_latest_matching`'s concrete-requirement branch already documents (#347)
+/// that the newest version must resolve as latest regardless of its `abandoned` flag.
+/// Reusing the shared ladder here would silently reintroduce npm's #338 NFR-002
+/// "prefer non-deprecated" preference for Composer, which #347 deliberately opted out of.
+///
+/// So only rung 1 differs from the shared ladder (prerelease alone, not flagged-or-prerelease);
+/// rungs 2 and 3 are identical in effect since `RemovalStatus::blocks_resolution()` is never
+/// true for Composer's `AdvisoryDeprecated` status (see `reports_yanked` below).
+///
+/// This divergence is load-bearing, not a style preference, and must not be collapsed back
+/// into a call to the shared ladder: for an abandoned package whose newest version is itself
+/// a prerelease, the shared ladder's rung 1 (flagged-or-prerelease) rejects every entry, and
+/// rung 2 (`blocks_resolution` only) then returns index 0 — the prerelease — since
+/// `AdvisoryDeprecated` never blocks resolution. That silently reopens #421 for exactly the
+/// case this function exists to fix.
+fn select_latest_for_existence_composer<T>(
+    versions: &[T],
+    as_version: impl Fn(&T) -> &dyn deps_core::Version,
+) -> Option<usize> {
+    if versions.is_empty() {
+        return None;
+    }
+    Some(
+        versions
+            .iter()
+            .position(|v| !as_version(v).is_prerelease())
+            .or_else(|| {
+                versions
+                    .iter()
+                    .position(|v| !as_version(v).removal_status().blocks_resolution())
+            })
+            .unwrap_or(0),
+    )
+}
+
 /// Client for interacting with the Packagist registry.
 ///
 /// Uses the Packagist v2 API for package metadata and search.
@@ -126,6 +166,15 @@ impl PackagistRegistry {
 
     /// Finds the latest non-abandoned version satisfying the given requirement.
     ///
+    /// Applies the same `minimum-stability: stable` default as
+    /// [`Registry::select_latest_matching`](deps_core::Registry::select_latest_matching)
+    /// (#421): an alpha/beta/RC release is excluded unless `req_str` itself is
+    /// prerelease-bearing. Under a wildcard/empty `req_str` (see
+    /// [`deps_core::is_existence_wildcard_str`]) this is an existence check, not an upgrade
+    /// recommendation, so it falls back to [`deps_core::select_latest_for_existence`] —
+    /// matching `deps-cargo`/`deps-pypi`/`deps-dart`/`deps-npm` — rather than returning `None`
+    /// for a package whose only releases so far are all prerelease.
+    ///
     /// # Errors
     ///
     /// Returns an error if the HTTP request fails.
@@ -135,12 +184,23 @@ impl PackagistRegistry {
         req_str: &str,
     ) -> Result<Option<ComposerVersion>> {
         let versions = self.get_versions(name).await?;
+        use deps_core::Version;
+
+        if deps_core::is_existence_wildcard_str(req_str) {
+            let idx =
+                select_latest_for_existence_composer(&versions, |v| v as &dyn deps_core::Version);
+            return Ok(idx.and_then(|idx| versions.into_iter().nth(idx)));
+        }
+
         let formatter = crate::formatter::ComposerFormatter;
         use deps_core::lsp_helpers::EcosystemFormatter;
 
-        Ok(versions
-            .into_iter()
-            .find(|v| formatter.version_satisfies_requirement(&v.version, req_str)))
+        let req_is_prerelease_bearing = crate::types::is_prerelease_marker(req_str);
+
+        Ok(versions.into_iter().find(|v| {
+            (req_is_prerelease_bearing || !v.is_prerelease())
+                && formatter.version_satisfies_requirement(&v.version, req_str)
+        }))
     }
 
     /// Searches for packages by name/keywords.
@@ -338,18 +398,45 @@ impl deps_core::Registry for PackagistRegistry {
         })
     }
 
+    /// Picks the latest version satisfying `req`, applying Composer's default
+    /// `minimum-stability: stable` semantics (#421): an alpha/beta/RC release is
+    /// excluded from "latest" unless `req` itself names an unstable version (e.g. an
+    /// exact `2.0.0-beta1` pin or a lower bound like `>=2.0.0-beta1`) — mirroring
+    /// `deps-nuget`'s prerelease-bearing-requirement exception (`registry.rs`'s
+    /// `pick_latest_matching`). `dev-*`/`*-dev` branches never reach here at all:
+    /// `expand_minified_versions` already filters them out of every `Registry::get_versions`
+    /// result.
+    ///
+    /// Under a wildcard/empty `req` (see [`deps_core::is_existence_wildcard`]) this is an
+    /// existence check, not an upgrade recommendation, so it defers to
+    /// `select_latest_for_existence_composer` instead — matching the *shape* of
+    /// `deps-cargo`/`deps-pypi`/`deps-dart`/`deps-npm` (a package whose only releases so far
+    /// are all prerelease still resolves to its newest one rather than `None`), while keeping
+    /// Composer's own #347 ranking rule that `abandoned` never demotes a version.
+    ///
+    /// This does not read `composer.json`'s own `minimum-stability` field (unmodeled in this
+    /// crate today) — a manifest that sets a looser project-wide default (e.g.
+    /// `"minimum-stability": "beta"`) still has its unstable releases excluded here for a
+    /// concrete requirement, unless that specific requirement is itself prerelease-bearing.
     fn select_latest_matching(
         &self,
         versions: &[Box<dyn deps_core::Version>],
         req: &deps_core::VersionReq,
     ) -> Option<usize> {
+        if deps_core::is_existence_wildcard(req) {
+            return select_latest_for_existence_composer(versions, |v| v.as_ref());
+        }
+
         let formatter = crate::formatter::ComposerFormatter;
         use deps_core::lsp_helpers::EcosystemFormatter;
+
+        let req_is_prerelease_bearing = crate::types::is_prerelease_marker(req.as_str());
 
         versions.iter().position(|v| {
             // Always true for Composer (`abandoned` maps to `AdvisoryDeprecated`, which
             // never blocks resolution) — kept to document the contract (#347).
             !v.removal_status().blocks_resolution()
+                && (req_is_prerelease_bearing || !v.is_prerelease())
                 && formatter.version_satisfies_requirement(v.version_string(), req.as_str())
         })
     }
@@ -784,6 +871,226 @@ mod tests {
 
         let version = latest.expect("an all-abandoned package still exists and resolves");
         assert_eq!(version.version, "2.0.0");
+    }
+
+    /// Regression for #421: `select_latest_matching` must not surface a real
+    /// alpha/beta/RC release as "latest" for a loose requirement — Composer's default
+    /// `minimum-stability: stable` excludes it even though it satisfies `>=1.0`.
+    #[test]
+    fn test_select_latest_matching_excludes_prerelease_for_loose_requirement() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(ComposerVersion {
+                version: "2.0.0-beta1".into(),
+                version_normalized: "2.0.0.0-beta1".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "1.5.0".into(),
+                version_normalized: "1.5.0.0".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new(">=1.0");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(1));
+    }
+
+    /// Regression for #421: an explicit prerelease-bearing requirement (e.g. an exact
+    /// `2.0.0-beta1` pin) must still resolve to that prerelease — the default stability
+    /// filter only applies when the requirement itself does not name an unstable version.
+    #[test]
+    fn test_select_latest_matching_allows_prerelease_when_requirement_names_it() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(ComposerVersion {
+                version: "2.0.0-beta1".into(),
+                version_normalized: "2.0.0.0-beta1".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "1.5.0".into(),
+                version_normalized: "1.5.0.0".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new("2.0.0-beta1");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
+    }
+
+    /// Regression for #421 (S2): the inherent `get_latest_matching` fetch-loop fallback
+    /// must apply the same default stability filter as `select_latest_matching`.
+    #[tokio::test]
+    async fn test_get_latest_matching_wildcard_excludes_prerelease() {
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let registry = PackagistRegistry::with_registry_base(Arc::new(HttpCache::new()), base);
+
+        server
+            .mock("GET", "/p2/vendor/pkg.json")
+            .with_status(200)
+            .with_body(
+                r#"{"packages": {"vendor/pkg": [
+                    {"version": "2.0.0-beta1", "version_normalized": "2.0.0.0-beta1"},
+                    {"version": "1.5.0", "version_normalized": "1.5.0.0"}
+                ]}}"#,
+            )
+            .create_async()
+            .await;
+
+        let latest = registry
+            .get_latest_matching("vendor/pkg", "*")
+            .await
+            .unwrap();
+
+        let version = latest.expect("a package with a stable release still resolves");
+        assert_eq!(version.version, "1.5.0");
+    }
+
+    /// Regression for #421 S1: the "is this requirement prerelease-bearing" check must use
+    /// the same predicate as `Version::is_prerelease()`, including Composer's short `-a`/`-b`
+    /// stability alias — not just `deps-core`'s default `-alpha`/`-beta`/`-rc` substrings.
+    /// Before the fix, an exact `2.0.0-a1` pin was not recognized as prerelease-bearing even
+    /// though the version it names (`2.0.0-a1`) is itself classified as a prerelease, making
+    /// it impossible to ever satisfy.
+    #[test]
+    fn test_select_latest_matching_allows_short_alias_prerelease_when_requirement_names_it() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(ComposerVersion {
+                version: "2.0.0-a1".into(),
+                version_normalized: "2.0.0.0-alpha1".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "1.5.0".into(),
+                version_normalized: "1.5.0.0".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new("2.0.0-a1");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
+    }
+
+    /// Regression for #421 S1's exact measured case: a caret requirement whose lower bound
+    /// is a short-alias prerelease (`^1.0.0-a1`) must also be recognized as
+    /// prerelease-bearing, not just an exact pin.
+    #[test]
+    fn test_select_latest_matching_allows_short_alias_prerelease_with_caret_requirement() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![Box::new(ComposerVersion {
+            version: "1.0.0-a1".into(),
+            version_normalized: "1.0.0.0-alpha1".into(),
+            abandoned: false,
+            published_at: None,
+        })];
+        let req = VersionReq::new("^1.0.0-a1");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
+    }
+
+    /// Regression for #421 (M2): the async `get_latest_matching` fetch-loop fallback must
+    /// also honor an explicit prerelease-bearing requirement, mirroring
+    /// `test_select_latest_matching_allows_prerelease_when_requirement_names_it`.
+    #[tokio::test]
+    async fn test_get_latest_matching_allows_prerelease_when_requirement_names_it() {
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let registry = PackagistRegistry::with_registry_base(Arc::new(HttpCache::new()), base);
+
+        server
+            .mock("GET", "/p2/vendor/pkg.json")
+            .with_status(200)
+            .with_body(
+                r#"{"packages": {"vendor/pkg": [
+                    {"version": "2.0.0-beta1", "version_normalized": "2.0.0.0-beta1"},
+                    {"version": "1.5.0", "version_normalized": "1.5.0.0"}
+                ]}}"#,
+            )
+            .create_async()
+            .await;
+
+        let latest = registry
+            .get_latest_matching("vendor/pkg", "2.0.0-beta1")
+            .await
+            .unwrap();
+
+        let version = latest.expect("an explicit prerelease pin resolves to that prerelease");
+        assert_eq!(version.version, "2.0.0-beta1");
+    }
+
+    /// Regression for #421 (S2): a package whose only releases so far are all prerelease
+    /// must still resolve under a wildcard requirement — matching
+    /// `deps-cargo`/`deps-pypi`/`deps-dart`/`deps-npm`'s existence-check behavior — instead
+    /// of `select_latest_matching` returning `None` and the package appearing unresolvable.
+    #[test]
+    fn test_select_latest_matching_wildcard_prerelease_only_still_resolves() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(ComposerVersion {
+                version: "2.0.0-beta2".into(),
+                version_normalized: "2.0.0.0-beta2".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "2.0.0-beta1".into(),
+                version_normalized: "2.0.0.0-beta1".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new("*");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
+    }
+
+    /// Regression for #421 (S2): the async `get_latest_matching` fetch-loop fallback must
+    /// resolve a prerelease-only package under a wildcard requirement too, mirroring
+    /// `test_select_latest_matching_wildcard_prerelease_only_still_resolves`.
+    #[tokio::test]
+    async fn test_get_latest_matching_wildcard_prerelease_only_still_resolves() {
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let registry = PackagistRegistry::with_registry_base(Arc::new(HttpCache::new()), base);
+
+        server
+            .mock("GET", "/p2/vendor/prerelease-only.json")
+            .with_status(200)
+            .with_body(
+                r#"{"packages": {"vendor/prerelease-only": [
+                    {"version": "2.0.0-beta2", "version_normalized": "2.0.0.0-beta2"},
+                    {"version": "2.0.0-beta1", "version_normalized": "2.0.0.0-beta1"}
+                ]}}"#,
+            )
+            .create_async()
+            .await;
+
+        let latest = registry
+            .get_latest_matching("vendor/prerelease-only", "*")
+            .await
+            .unwrap();
+
+        let version = latest.expect("a prerelease-only package still exists and resolves");
+        assert_eq!(version.version, "2.0.0-beta2");
     }
 
     #[tokio::test]

--- a/crates/deps-composer/src/types.rs
+++ b/crates/deps-composer/src/types.rs
@@ -117,6 +117,20 @@ fn has_short_stability_alias(s: &str) -> bool {
     false
 }
 
+/// Whether `s` carries any Composer stability marker: `deps-core`'s default hyphen-substring
+/// heuristic (`-alpha`, `-beta`, `-rc`, ...) or Composer's short `-a`/`-b` alias (see
+/// [`has_short_stability_alias`]).
+///
+/// Shared by [`ComposerVersion`]'s `is_prerelease()` (via `impl_version!` below, applied to a
+/// concrete version string) and `registry.rs`'s "is this requirement itself prerelease-bearing"
+/// check (applied to a requirement string, e.g. an exact `2.0.0-a1` pin) — both sides must use
+/// the same predicate, or a requirement naming a short-alias prerelease would be misclassified
+/// as stable while the version it pins is correctly classified as unstable, making it
+/// impossible to ever satisfy (#421 S1).
+pub(crate) fn is_prerelease_marker(s: &str) -> bool {
+    deps_core::has_default_prerelease_marker(s) || has_short_stability_alias(s)
+}
+
 // Packagist versions aren't strict semver, so this layers a Composer-specific
 // short-stability-alias check on the raw `version` on top of `deps-core`'s
 // default hyphen-substring heuristic instead of relying on it alone, which
@@ -131,9 +145,8 @@ deps_core::impl_version!(ComposerVersion {
     status: |v: &ComposerVersion| deps_core::RemovalStatus::from_advisory(v.abandoned),
     published_at: published_at,
     prerelease: |v: &ComposerVersion| {
-        deps_core::has_default_prerelease_marker(&v.version)
+        is_prerelease_marker(&v.version)
             || deps_core::has_default_prerelease_marker(&v.version_normalized)
-            || has_short_stability_alias(&v.version)
     },
 });
 

--- a/crates/deps-lsp/src/lib.rs
+++ b/crates/deps-lsp/src/lib.rs
@@ -397,6 +397,42 @@ mod tests {
             ]
         }
 
+        // #421 S2: a package whose only releases so far are all prerelease must still
+        // resolve under a wildcard requirement, same as an all-`AdvisoryDeprecated` one
+        // above — a prerelease-only flag is a ranking preference for "latest", not a hard
+        // removal from existence. `is_prerelease()` is overridden directly rather than
+        // relying on a hyphenated version string, so this fixture is unambiguous regardless
+        // of which ecosystem-specific parser (if any) `select_latest_matching` re-parses
+        // `version_string()` with.
+        struct PrereleaseOnlyVersion {
+            version: &'static str,
+        }
+
+        impl Version for PrereleaseOnlyVersion {
+            fn version_string(&self) -> &str {
+                self.version
+            }
+
+            fn is_prerelease(&self) -> bool {
+                true
+            }
+
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        fn prerelease_only_fixture() -> Vec<Box<dyn Version>> {
+            vec![
+                Box::new(PrereleaseOnlyVersion {
+                    version: "2.0.0-beta2",
+                }),
+                Box::new(PrereleaseOnlyVersion {
+                    version: "2.0.0-beta1",
+                }),
+            ]
+        }
+
         let registry = Arc::new(EcosystemRegistry::new());
         let cache = Arc::new(HttpCache::new());
         register_ecosystems(&registry, Arc::clone(&cache));
@@ -421,6 +457,33 @@ mod tests {
                 subject.is_some(),
                 "{id}: an advisory-only flag must not hide an existing package under a \
                  wildcard requirement (#347)"
+            );
+
+            // Go and NuGet are deliberate exceptions to this invariant, not #421-class bugs:
+            //
+            // - Go (`deps-go/src/registry.rs`, documented at #364): `select_latest_matching`
+            //   intentionally excludes prerelease pseudo-versions unconditionally, with no
+            //   wildcard fallback, so the `/@v/list`-based pick never shadows the `/@latest`
+            //   fallback the fetch loop needs for a module whose only tags are prerelease.
+            // - NuGet (`deps-nuget/src/registry.rs`, `pick_latest_matching`/`resolve_float`):
+            //   `req = "*"` is NuGet's own floating-version syntax for "latest stable",
+            //   distinct from this ladder's "existence check" wildcard — NuGet's own spec
+            //   requires the separate `*-*` floating pattern to opt into prerelease, so a
+            //   bare `"*"` correctly returning nothing for an all-prerelease package is
+            //   NuGet-specific intended behavior, not a gap to close here.
+            //
+            // Asserting this invariant for either would mean "fixing" behavior that was
+            // already deliberately chosen.
+            if matches!(id, "go" | "nuget") {
+                continue;
+            }
+
+            let prerelease_subject =
+                ecosystem_registry.select_latest_matching(&prerelease_only_fixture(), &req);
+            assert!(
+                prerelease_subject.is_some(),
+                "{id}: a package whose only releases so far are prerelease must still \
+                 resolve under a wildcard requirement (#421)"
             );
         }
     }

--- a/crates/deps-swift/src/registry.rs
+++ b/crates/deps-swift/src/registry.rs
@@ -641,11 +641,22 @@ impl deps_core::Registry for SwiftRegistry {
         })
     }
 
+    /// Under a wildcard/empty `req` (see [`deps_core::is_existence_wildcard`]) this is an
+    /// existence check, not an upgrade recommendation — deferred to
+    /// [`deps_core::select_latest_for_existence`], matching
+    /// `deps-cargo`/`deps-pypi`/`deps-dart`/`deps-npm`. Without this gate, a package whose
+    /// only tags so far are prerelease could never resolve under `*`: the `semver` crate's
+    /// `VersionReq::parse("*")` does not match a prerelease `Version` unless the requirement
+    /// itself carries a prerelease component (found via #421's cross-ecosystem conformance
+    /// test in `deps-lsp`).
     fn select_latest_matching(
         &self,
         versions: &[Box<dyn deps_core::Version>],
         req: &deps_core::VersionReq,
     ) -> Option<usize> {
+        if deps_core::is_existence_wildcard(req) {
+            return deps_core::select_latest_for_existence(versions, |v| v.as_ref());
+        }
         let parsed_req = semver::VersionReq::parse(req.as_str()).ok()?;
         versions.iter().position(|v| {
             semver::Version::parse(v.version_string()).is_ok_and(|ver| parsed_req.matches(&ver))

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -16,7 +16,7 @@ deps-lsp provides comprehensive LSP support for 12 package ecosystems:
 | **Dart** | Dart | `pubspec.yaml` | `pubspec.lock` | Hover with corrected version ordering (prereleases sort below base release — see below), inlay hints, completion, code actions, diagnostics, code lens |
 | **Maven** | Java | `pom.xml` | `maven-metadata.xml` (CDN) | Hover with corrected version ordering (numeric segments outrank qualifiers, prereleases sort below base release), inlay hints, completion, code actions, diagnostics, code lens (property-versioned dependencies not covered — see below) |
 | **Gradle** | Kotlin/Groovy | `build.gradle`, `build.gradle.kts`, `gradle/libs.versions.toml` | — | Hover with corrected version ordering (same as Maven), inlay hints, completion, code actions, diagnostics, code lens (variable/catalog-versioned dependencies not covered — see below), variable resolution (`gradle.properties`) |
-| **Composer** | PHP | `composer.json` | `composer.lock` | Hover, inlay hints, completion, code actions, diagnostics, code lens (requirement matching uses corrected stability-qualifier ordering; "latest version" selection does not yet filter unstable releases — see below) |
+| **Composer** | PHP | `composer.json` | `composer.lock` | Hover, inlay hints, completion, code actions, diagnostics, code lens (requirement matching and "latest version" selection both use corrected stability-qualifier ordering — see below) |
 | **Swift** | Swift | `Package.swift` | `Package.resolved` | Hover, inlay hints, completion, code actions, diagnostics, code lens (range-form dependencies not covered — see below), GitHub API support |
 | **NuGet** | .NET | `.csproj`, `.fsproj`, `.vbproj`, `Directory.Packages.props`, `packages.config` | `packages.lock.json` | Hover, inlay hints, completion, code actions, diagnostics, code lens, central package management support, SemVer2 prerelease handling |
 | **Deno** | JavaScript/TypeScript (Deno runtime) | `deno.json`, `deno.jsonc` | — (no `deno.lock` support yet) | Hover, inlay hints, completion, code actions, diagnostics, code lens — `jsr:` specifiers via the keyless JSR API, `npm:` specifiers delegate to the same registry client `npm` uses; `imports` map only, `scopes`/`importMap` not covered — see below |
@@ -87,11 +87,13 @@ prerelease-aware ordering:
   (pub.dev's response order) and to constraint matching, so hover/completion sort order and
   outdated diagnostics are both corrected.
 - **Composer** (`composer.json`): stability precedence `dev` < `alpha` < `beta` < `RC` <
-  `stable`, applied to requirement-satisfaction comparison only. This does **not** extend to
-  "latest version" selection — Packagist's response order is used as-is and
-  `select_latest_matching` has no minimum-stability filter, so an `alpha`/`beta`/`RC` release
-  can still surface as "latest" for a loose requirement. Tracked as a follow-up (see the
-  `registry.rs`-level stability-filtering gap noted in the crate's known issues).
+  `stable`, applied both to requirement-satisfaction comparison and to "latest version"
+  selection. `select_latest_matching`/`get_latest_matching` now exclude alpha/beta/RC
+  releases by default (mirroring Composer's `minimum-stability: stable` default) unless the
+  requirement itself names an unstable version; a wildcard/existence-check requirement still
+  resolves a prerelease-only package instead of reporting no version found. Manifest-driven
+  `minimum-stability` overrides from `composer.json` are not yet threaded through — that
+  remains a follow-up.
 
 ### Maven/Gradle Version Range Matching
 


### PR DESCRIPTION
## Summary
- `select_latest_matching`/`get_latest_matching` in `deps-composer` now exclude prerelease (alpha/beta/RC) versions by default, mirroring Composer's `minimum-stability: stable` default, unless the requirement itself names an unstable version.
- A wildcard/existence-check requirement (`*`, `""`) still resolves a prerelease-only package via a Composer-specific existence ladder, preserving the abandoned-flag ranking invariant from #347, instead of reporting no version found.
- Incidental fix: `deps-swift` had the same bug class (no existence-wildcard gate at all) — surfaced by a new prerelease-only arm added to the shared cross-ecosystem conformance test in `deps-lsp/src/lib.rs`. `deps-go` and `deps-nuget` are intentionally excluded from that new assertion (documented inline) — Go has its own pseudo-version rescue path (#364), NuGet's exclusion is only partially justified and is tracked as a follow-up.
- `docs/ECOSYSTEM_GUIDE.md` updated to remove the now-fixed "does not yet filter unstable releases" known-issue note for Composer.

Manifest-driven `minimum-stability` overrides from `composer.json` are not threaded through in this change — that plumbing is unmodeled in the crate today and is out of scope for this bug-fix-sized PR; tracked as a follow-up issue.

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (2964 passed, 49 pre-existing skipped)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings --deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --all-features`
- [x] New regression tests for: loose-requirement prerelease exclusion, prerelease-bearing-requirement inclusion (sync + async), short-alias prerelease pins (`1.0.0-a1`, `^1.0.0-a1`), all-prerelease-only wildcard resolution, abandoned-flag ranking preserved

Closes #421