### PR TITLE
fix(deps-nuget): rescue latest-version selection for prerelease-only packages under existence-check wildcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-dart, deps-composer**: `compare_versions` no longer truncates prerelease/qualifier suffixes, so a prerelease no longer compares equal to its stable counterpart (resolves #418) (#420)
 - **deps-composer**: "latest version" selection now excludes alpha/beta/RC releases by default, matching Composer's `minimum-stability: stable` semantics, unless the requirement itself names an unstable version; a wildcard requirement still resolves a prerelease-only package instead of reporting no version found (resolves #421) (#422)
 - **deps-swift**: a package whose only tags so far are prerelease now resolves under a wildcard requirement instead of `select_latest_matching` returning `None` (found via #421's cross-ecosystem conformance test) (#422)
-- **deps-nuget**: a package whose only versions are prerelease now resolves under an existence-check wildcard requirement (`*`/empty) instead of `pick_latest_matching`/`select_latest_matching` returning `None` (resolves #423)
+- **deps-nuget**: a package whose only versions are prerelease now resolves under an existence-check wildcard requirement (`*`/empty) instead of `pick_latest_matching`/`select_latest_matching` returning `None` (resolves #423) (#425)
 
 ### Changed
 - **deps-bundler, deps-go**: removed private duplicate `LineOffsetTable` structs, both now use the shared `deps_core::lsp_helpers::LineOffsetTable` (resolves #389) (#395)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-dart, deps-composer**: `compare_versions` no longer truncates prerelease/qualifier suffixes, so a prerelease no longer compares equal to its stable counterpart (resolves #418) (#420)
 - **deps-composer**: "latest version" selection now excludes alpha/beta/RC releases by default, matching Composer's `minimum-stability: stable` semantics, unless the requirement itself names an unstable version; a wildcard requirement still resolves a prerelease-only package instead of reporting no version found (resolves #421) (#422)
 - **deps-swift**: a package whose only tags so far are prerelease now resolves under a wildcard requirement instead of `select_latest_matching` returning `None` (found via #421's cross-ecosystem conformance test) (#422)
+- **deps-nuget**: a package whose only versions are prerelease now resolves under an existence-check wildcard requirement (`*`/empty) instead of `pick_latest_matching`/`select_latest_matching` returning `None` (resolves #423)
 
 ### Changed
 - **deps-bundler, deps-go**: removed private duplicate `LineOffsetTable` structs, both now use the shared `deps_core::lsp_helpers::LineOffsetTable` (resolves #389) (#395)

--- a/crates/deps-lsp/src/lib.rs
+++ b/crates/deps-lsp/src/lib.rs
@@ -459,22 +459,20 @@ mod tests {
                  wildcard requirement (#347)"
             );
 
-            // Go and NuGet are deliberate exceptions to this invariant, not #421-class bugs:
+            // Go is a deliberate exception to this invariant, not an #421-class bug
+            // (documented at #364): `select_latest_matching` intentionally excludes
+            // prerelease pseudo-versions unconditionally, with no wildcard fallback, so the
+            // `/@v/list`-based pick never shadows the `/@latest` fallback the fetch loop
+            // needs for a module whose only tags are prerelease. Asserting this invariant
+            // for Go would mean "fixing" behavior that was already deliberately chosen.
             //
-            // - Go (`deps-go/src/registry.rs`, documented at #364): `select_latest_matching`
-            //   intentionally excludes prerelease pseudo-versions unconditionally, with no
-            //   wildcard fallback, so the `/@v/list`-based pick never shadows the `/@latest`
-            //   fallback the fetch loop needs for a module whose only tags are prerelease.
-            // - NuGet (`deps-nuget/src/registry.rs`, `pick_latest_matching`/`resolve_float`):
-            //   `req = "*"` is NuGet's own floating-version syntax for "latest stable",
-            //   distinct from this ladder's "existence check" wildcard — NuGet's own spec
-            //   requires the separate `*-*` floating pattern to opt into prerelease, so a
-            //   bare `"*"` correctly returning nothing for an all-prerelease package is
-            //   NuGet-specific intended behavior, not a gap to close here.
-            //
-            // Asserting this invariant for either would mean "fixing" behavior that was
-            // already deliberately chosen.
-            if matches!(id, "go" | "nuget") {
+            // NuGet used to be excluded here too (`req = "*"` read as NuGet's own
+            // floating-version "latest stable" syntax rather than this ladder's existence
+            // check), but #423 added a fallback rung to `pick_latest_matching`/
+            // `select_latest_matching` (`deps-nuget/src/registry.rs`) so a prerelease-only
+            // package now resolves under a bare wildcard too, matching every other
+            // ecosystem — no exception needed anymore.
+            if matches!(id, "go") {
                 continue;
             }
 

--- a/crates/deps-nuget/src/registry.rs
+++ b/crates/deps-nuget/src/registry.rs
@@ -501,6 +501,12 @@ pub fn parse_flat_container(data: &[u8]) -> Result<Vec<NuGetVersion>> {
 /// version list. `req` is treated as `"*"` when empty. Prerelease versions are excluded
 /// unless `req` itself is prerelease-bearing (contains `-`) or is a floating pattern whose
 /// own prerelease inclusion is handled by `crate::version::resolve_float`.
+///
+/// Under an existence-check wildcard (`req` trimmed is `""` or `"*"`), a normal match that
+/// comes up empty falls back to [`deps_core::select_latest_for_existence`] so a
+/// prerelease-only package still reports its newest version instead of `None` — see that
+/// function's doc comment for the 3-rung contract. Non-wildcard requirements (e.g.
+/// `"*-*"`, `"1.*"`) are unaffected: this fallback never fires for them.
 fn pick_latest_matching(versions: Vec<NuGetVersion>, req: &str) -> Option<NuGetVersion> {
     if versions.is_empty() {
         return None;
@@ -508,18 +514,32 @@ fn pick_latest_matching(versions: Vec<NuGetVersion>, req: &str) -> Option<NuGetV
 
     let req = if req.is_empty() { "*" } else { req };
 
-    if req.contains('*') {
+    let matched = if req.contains('*') {
         let strings: Vec<String> = versions.iter().map(|v| v.version.clone()).collect();
-        return crate::version::resolve_float(&strings, req).map(|v| NuGetVersion {
+        crate::version::resolve_float(&strings, req).map(|v| NuGetVersion {
             version: v.to_string(),
             published_at: None,
-        });
-    }
+        })
+    } else {
+        let req_is_prerelease_bearing = req.contains('-');
+        versions
+            .iter()
+            .find(|v| {
+                crate::version::satisfies(&v.version, req)
+                    && (req_is_prerelease_bearing || !crate::version::is_prerelease(&v.version))
+            })
+            .cloned()
+    };
 
-    let req_is_prerelease_bearing = req.contains('-');
-    versions.into_iter().find(|v| {
-        crate::version::satisfies(&v.version, req)
-            && (req_is_prerelease_bearing || !crate::version::is_prerelease(&v.version))
+    matched.or_else(|| {
+        if deps_core::is_existence_wildcard_str(req) {
+            let idx = deps_core::select_latest_for_existence(&versions, |v| {
+                v as &dyn deps_core::Version
+            })?;
+            Some(versions[idx].clone())
+        } else {
+            None
+        }
     })
 }
 
@@ -613,19 +633,26 @@ impl deps_core::Registry for NuGetRegistry {
         let req_str = req.as_str();
         let req_str = if req_str.is_empty() { "*" } else { req_str };
 
-        if req_str.contains('*') {
+        let matched = if req_str.contains('*') {
             let strings: Vec<String> = versions
                 .iter()
                 .map(|v| v.version_string().to_string())
                 .collect();
-            let matched = crate::version::resolve_float(&strings, req_str)?;
-            return strings.iter().position(|s| s == matched);
-        }
+            crate::version::resolve_float(&strings, req_str)
+                .and_then(|matched| strings.iter().position(|s| s == matched))
+        } else {
+            let req_is_prerelease_bearing = req_str.contains('-');
+            versions.iter().position(|v| {
+                crate::version::satisfies(v.version_string(), req_str)
+                    && (req_is_prerelease_bearing
+                        || !crate::version::is_prerelease(v.version_string()))
+            })
+        };
 
-        let req_is_prerelease_bearing = req_str.contains('-');
-        versions.iter().position(|v| {
-            crate::version::satisfies(v.version_string(), req_str)
-                && (req_is_prerelease_bearing || !crate::version::is_prerelease(v.version_string()))
+        matched.or_else(|| {
+            deps_core::is_existence_wildcard_str(req_str)
+                .then(|| deps_core::select_latest_for_existence(versions, |v| v.as_ref()))
+                .flatten()
         })
     }
 
@@ -952,6 +979,56 @@ mod tests {
         assert!(pick_latest_matching(versions, "[1.0.0]").is_none());
     }
 
+    /// Regression for #423: a package whose only releases so far are all prerelease must
+    /// still resolve under a wildcard requirement — matching `deps-cargo`/`deps-composer`'s
+    /// existence-check behavior — instead of `pick_latest_matching` returning `None`.
+    #[test]
+    fn test_pick_latest_matching_wildcard_prerelease_only_still_resolves() {
+        let versions = vec![v("2.0.0-beta2"), v("2.0.0-beta1")];
+        let matched = pick_latest_matching(versions, "*");
+        assert_eq!(matched.unwrap().version, "2.0.0-beta2");
+    }
+
+    /// Regression for #423: empty `req` is treated as `"*"`, so it must also rescue a
+    /// prerelease-only package instead of returning `None`.
+    #[test]
+    fn test_pick_latest_matching_empty_req_prerelease_only_still_resolves() {
+        let versions = vec![v("2.0.0-beta2"), v("2.0.0-beta1")];
+        let matched = pick_latest_matching(versions, "");
+        assert_eq!(matched.unwrap().version, "2.0.0-beta2");
+    }
+
+    /// Regression guard for #423: `"*-*"` is prerelease-bearing but not an existence-check
+    /// wildcard (`is_existence_wildcard_str` requires trimmed `""`/`"*"`), so it must keep
+    /// resolving via `resolve_float`'s own best-match logic, unaffected by the new fallback.
+    #[test]
+    fn test_pick_latest_matching_prerelease_bearing_wildcard_unaffected_by_rescue() {
+        let versions = vec![v("2.0.0-rc"), v("1.5.0"), v("1.0.0")];
+        let matched = pick_latest_matching(versions, "*-*");
+        assert_eq!(matched.unwrap().version, "2.0.0-rc");
+    }
+
+    /// Regression guard for #423: a concrete non-wildcard requirement must NOT be rescued
+    /// by the existence-check fallback, even over a prerelease-only version list — the gate
+    /// is `is_existence_wildcard_str`, not "contains a `*`". If that gate were ever loosened
+    /// to `req.contains('*')`, a floating pattern like `1.*` would start getting rescued
+    /// too; this pins `None` so such a regression fails loudly instead of silently.
+    #[test]
+    fn test_pick_latest_matching_concrete_floating_requirement_not_rescued() {
+        let versions = vec![v("2.0.0-beta2"), v("2.0.0-beta1")];
+        assert!(pick_latest_matching(versions, "1.*").is_none());
+    }
+
+    /// Regression guard for #423: an exact-pin requirement that matches nothing in a
+    /// prerelease-only list must NOT be rescued either — mirrors
+    /// `test_pick_latest_matching_concrete_floating_requirement_not_rescued` for the
+    /// non-floating (exact-pin) matcher branch.
+    #[test]
+    fn test_pick_latest_matching_exact_pin_not_rescued() {
+        let versions = vec![v("2.0.0-beta2"), v("2.0.0-beta1")];
+        assert!(pick_latest_matching(versions, "[9.9.9]").is_none());
+    }
+
     #[test]
     fn test_registry_creation_and_trait_impls() {
         use deps_core::Registry;
@@ -997,6 +1074,84 @@ mod tests {
             vec![Box::new(v("1.1.0-rc.1")), Box::new(v("1.0.0"))];
         let req = VersionReq::new("*");
         assert_eq!(registry.select_latest_matching(&versions, &req), Some(1));
+    }
+
+    /// Regression for #423: the trait impl's `select_latest_matching` must rescue a
+    /// prerelease-only package under a wildcard requirement too, mirroring
+    /// `test_pick_latest_matching_wildcard_prerelease_only_still_resolves`.
+    #[test]
+    fn test_select_latest_matching_wildcard_prerelease_only_still_resolves() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = NuGetRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> =
+            vec![Box::new(v("2.0.0-beta2")), Box::new(v("2.0.0-beta1"))];
+        let req = VersionReq::new("*");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
+    }
+
+    /// Regression for #423: empty `req` on the trait impl must also rescue a
+    /// prerelease-only package, matching the free-function behavior.
+    #[test]
+    fn test_select_latest_matching_empty_req_prerelease_only_still_resolves() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = NuGetRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> =
+            vec![Box::new(v("2.0.0-beta2")), Box::new(v("2.0.0-beta1"))];
+        let req = VersionReq::new("");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
+    }
+
+    /// Regression guard for #423: `"*-*"` is not an existence-check wildcard, so the trait
+    /// impl must keep resolving via `resolve_float`'s best-match logic, unaffected by the
+    /// new fallback — mirrors
+    /// `test_pick_latest_matching_prerelease_bearing_wildcard_unaffected_by_rescue`.
+    #[test]
+    fn test_select_latest_matching_prerelease_bearing_wildcard_unaffected_by_rescue() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = NuGetRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(v("2.0.0-rc")),
+            Box::new(v("1.5.0")),
+            Box::new(v("1.0.0")),
+        ];
+        let req = VersionReq::new("*-*");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
+    }
+
+    /// Regression guard for #423: a concrete floating requirement must NOT be rescued by
+    /// the trait impl's existence-check fallback, even over a prerelease-only list — mirrors
+    /// `test_pick_latest_matching_concrete_floating_requirement_not_rescued`.
+    #[test]
+    fn test_select_latest_matching_concrete_floating_requirement_not_rescued() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = NuGetRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> =
+            vec![Box::new(v("2.0.0-beta2")), Box::new(v("2.0.0-beta1"))];
+        let req = VersionReq::new("1.*");
+        assert_eq!(registry.select_latest_matching(&versions, &req), None);
+    }
+
+    /// Regression guard for #423: a concrete exact-pin requirement matching nothing in a
+    /// prerelease-only list must NOT be rescued either — mirrors
+    /// `test_pick_latest_matching_exact_pin_not_rescued` for the trait impl.
+    #[test]
+    fn test_select_latest_matching_exact_pin_not_rescued() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = NuGetRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> =
+            vec![Box::new(v("2.0.0-beta2")), Box::new(v("2.0.0-beta1"))];
+        let req = VersionReq::new("[9.9.9]");
+        assert_eq!(registry.select_latest_matching(&versions, &req), None);
     }
 
     // --- ServiceIndex::resolve: registrations_base_url preference (S2/rev2 OQ6) ---


### PR DESCRIPTION
## Summary
- `pick_latest_matching` and the `Registry` trait impl's `select_latest_matching` in `deps-nuget` now fall back to `deps_core::select_latest_for_existence` when a normal match under an existence-check wildcard requirement (`*`/empty) comes up empty, instead of returning `None`.
- Matches the rescue rung already present in cargo/pypi/dart/npm/composer/swift (see #421/#422). Genuine NuGet floating-version semantics (`*-*`, `1.*`, exact pins) are unaffected — the fallback only fires when the trimmed requirement is exactly `""` or `"*"`.
- Re-enabled the deps-nuget assertion in the cross-ecosystem conformance test in `deps-lsp/src/lib.rs` (Go stays excluded per its documented pseudo-version protection, `#364`).
- Added regression tests: positive rescue cases for both entry points under `*`/`""`, a `*-*` non-wildcard guard, and 4 negative-regression tests proving concrete requirements (`1.*`, `[9.9.9]`) on a prerelease-only list stay `None`.

## Test plan
- [x] `cargo nextest run -p deps-nuget` (187 passed)
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (2974 passed)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`

Closes #423