### PR TITLE
fix(deps-composer): thread minimum-stability, @stability flags, and fix separator-less prerelease classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-composer**: "latest version" selection now excludes alpha/beta/RC releases by default, matching Composer's `minimum-stability: stable` semantics, unless the requirement itself names an unstable version; a wildcard requirement still resolves a prerelease-only package instead of reporting no version found (resolves #421) (#422)
 - **deps-swift**: a package whose only tags so far are prerelease now resolves under a wildcard requirement instead of `select_latest_matching` returning `None` (found via #421's cross-ecosystem conformance test) (#422)
 - **deps-nuget**: a package whose only versions are prerelease now resolves under an existence-check wildcard requirement (`*`/empty) instead of `pick_latest_matching`/`select_latest_matching` returning `None` (resolves #423) (#425)
+- **deps-composer, deps-core, deps-lsp**: "latest version" selection now honors `composer.json`'s `minimum-stability` field and per-dependency `@stability` flags (e.g. `^1.0@beta`), and consistently classifies separator-less/dot-separated prerelease suffixes (`1.0.0RC1`, `2.6.3.alpha`) regardless of `v`-prefix (resolves #424)
 
 ### Changed
 - **deps-bundler, deps-go**: removed private duplicate `LineOffsetTable` structs, both now use the shared `deps_core::lsp_helpers::LineOffsetTable` (resolves #389) (#395)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-composer**: "latest version" selection now excludes alpha/beta/RC releases by default, matching Composer's `minimum-stability: stable` semantics, unless the requirement itself names an unstable version; a wildcard requirement still resolves a prerelease-only package instead of reporting no version found (resolves #421) (#422)
 - **deps-swift**: a package whose only tags so far are prerelease now resolves under a wildcard requirement instead of `select_latest_matching` returning `None` (found via #421's cross-ecosystem conformance test) (#422)
 - **deps-nuget**: a package whose only versions are prerelease now resolves under an existence-check wildcard requirement (`*`/empty) instead of `pick_latest_matching`/`select_latest_matching` returning `None` (resolves #423) (#425)
-- **deps-composer, deps-core, deps-lsp**: "latest version" selection now honors `composer.json`'s `minimum-stability` field and per-dependency `@stability` flags (e.g. `^1.0@beta`), and consistently classifies separator-less/dot-separated prerelease suffixes (`1.0.0RC1`, `2.6.3.alpha`) regardless of `v`-prefix (resolves #424)
+- **deps-composer, deps-core, deps-lsp**: "latest version" selection now honors `composer.json`'s `minimum-stability` field and per-dependency `@stability` flags (e.g. `^1.0@beta`), and consistently classifies separator-less/dot-separated prerelease suffixes (`1.0.0RC1`, `2.6.3.alpha`) regardless of `v`-prefix (resolves #424) (#428)
 
 ### Changed
 - **deps-bundler, deps-go**: removed private duplicate `LineOffsetTable` structs, both now use the shared `deps_core::lsp_helpers::LineOffsetTable` (resolves #389) (#395)

--- a/crates/deps-composer/src/formatter.rs
+++ b/crates/deps-composer/src/formatter.rs
@@ -116,6 +116,12 @@ impl EcosystemFormatter for ComposerFormatter {
             Some(rest) if !rest.is_empty() => rest,
             _ => requirement,
         };
+        // A per-dependency `@stability` flag (`@stable`, `@RC`, `@beta`, `@alpha`, `@dev`) is
+        // a constraint-grammar element, not part of the version-range text — see
+        // `strip_stability_flag`. Must run before the range operators below see the
+        // requirement, or the flag text is parsed as part of the numeric core (#424).
+        let (requirement, _stability_flag) = strip_stability_flag(requirement);
+        let requirement = requirement.trim();
 
         if requirement.is_empty() || requirement == "*" {
             return true;
@@ -356,15 +362,79 @@ fn satisfies_caret(version: &str, req: &str) -> bool {
 /// its own `stable`/`patch`/`pl`/`p` aliases (all release-equivalent), but is not a general
 /// unknown-qualifier rule: a truly unrecognized word is not otherwise a valid Composer
 /// stability suffix.
-const COMPOSER_STABLE_RANK: u8 = 4;
+///
+/// `pub(crate)`: shared with `registry.rs`, which ranks a `composer.json` `minimum-stability`
+/// value and a per-dependency `@stability` flag word on this exact same scale (#424) — one
+/// ranking function for "what does this stability word mean" everywhere in the crate.
+pub(crate) const COMPOSER_STABLE_RANK: u8 = 4;
 
-fn composer_stability_rank(word: &str) -> u8 {
+pub(crate) fn composer_stability_rank(word: &str) -> u8 {
     match word.to_ascii_lowercase().as_str() {
         "dev" => 0,
         "alpha" | "a" => 1,
         "beta" | "b" => 2,
         "rc" => 3,
         _ => COMPOSER_STABLE_RANK,
+    }
+}
+
+/// A version string's own Composer stability rank (`dev < alpha < beta < RC < stable`),
+/// reusing [`split_composer_core_and_suffix`]/[`parse_composer_qualifier`] — the same
+/// separator-optional qualifier parser `compare_versions` already relies on, so a
+/// separator-less suffix (`1.0.0RC1`) ranks identically to its hyphenated form
+/// (`1.0.0-RC1`) with no separate classification path to drift out of sync (#424 S3).
+///
+/// `registry.rs` uses this instead of [`deps_core::Version::is_prerelease`] when filtering
+/// "latest version" candidates against an [`effective_minimum_stability_rank`]-computed
+/// floor: a boolean prerelease flag cannot express "beta or newer, but not alpha" the way a
+/// `minimum-stability: beta` manifest setting requires.
+///
+/// Strips a leading `v`/`V` before splitting — without this, `split_composer_core_and_suffix`
+/// finds its split point at that very first non-digit character, so a real candidate version
+/// like `v2.3.0-alpha.1` (Packagist tags are routinely `v`-prefixed, e.g. every `symfony/*`
+/// release) yields core `""` and qualifier word `"v"`, which `composer_stability_rank` cannot
+/// recognize and ranks as fully stable — silently reopening #422 for every `v`-prefixed
+/// prerelease (#424 critique C1). `version_satisfies_requirement`'s own operator branches
+/// already strip `v` before reaching `compare_versions`/`satisfies_caret`, so this is the only
+/// caller of `split_composer_core_and_suffix` that needed the same guard added directly.
+///
+/// [`effective_minimum_stability_rank`]: crate::registry::effective_minimum_stability_rank
+pub(crate) fn composer_version_stability_rank(version: &str) -> u8 {
+    let version = version.strip_prefix(['v', 'V']).unwrap_or(version);
+    let (_, suffix) = split_composer_core_and_suffix(version);
+    suffix.map_or(COMPOSER_STABLE_RANK, |s| parse_composer_qualifier(s).rank)
+}
+
+/// Splits a trailing Composer per-dependency stability flag (`@stable`, `@RC`, `@beta`,
+/// `@alpha`, `@dev`, matched case-insensitively) off `requirement`, returning the requirement
+/// text with the flag removed and the flag's own word when one was recognized.
+///
+/// The flag is a syntax element of the *constraint* grammar
+/// (`composer/semver`'s `VersionParser::parseStabilityFlag`), not part of the version-range
+/// text itself, so it must be stripped before `satisfies_caret`/`satisfies_tilde_composer`/
+/// `compare_versions` ever see the constraint. Left in place, it is parsed as part of the
+/// numeric core instead (e.g. `^1.0@beta`'s minor segment becomes `"0@beta"`), which only
+/// happens to still match today because `satisfies_caret`'s nonzero-major fast path returns
+/// before it would ever look at that garbled segment — every other operator (tilde,
+/// `>=`/`<=`, exact/partial) has no such fast path and silently never matches (#424).
+///
+/// `pub(crate)`: also used by `registry.rs`'s [`effective_minimum_stability_rank`] to read
+/// the flag as a per-dependency stability opt-in, overriding both the concrete-requirement
+/// default and any manifest-level `minimum-stability`.
+///
+/// [`effective_minimum_stability_rank`]: crate::registry::effective_minimum_stability_rank
+pub(crate) fn strip_stability_flag(requirement: &str) -> (&str, Option<&str>) {
+    let Some(at_idx) = requirement.rfind('@') else {
+        return (requirement, None);
+    };
+    let flag = &requirement[at_idx + 1..];
+    if matches!(
+        flag.to_ascii_lowercase().as_str(),
+        "stable" | "rc" | "beta" | "alpha" | "dev"
+    ) {
+        (&requirement[..at_idx], Some(flag))
+    } else {
+        (requirement, None)
     }
 }
 
@@ -736,6 +806,105 @@ mod tests {
         assert!(!f.version_satisfies_requirement("2.0.0", "^v1.2.0"));
         // Wildcard with a `v`-prefixed requirement.
         assert!(f.version_satisfies_requirement("1.0.5", "v1.0.*"));
+    }
+
+    /// #424 S2: `strip_stability_flag` recognizes every Composer stability flag word
+    /// case-insensitively and leaves an unrecognized trailing `@word` alone.
+    #[test]
+    fn test_strip_stability_flag_recognizes_known_words() {
+        assert_eq!(strip_stability_flag("^1.0@beta"), ("^1.0", Some("beta")));
+        assert_eq!(strip_stability_flag("^1.0@BETA"), ("^1.0", Some("BETA")));
+        assert_eq!(strip_stability_flag("1.0.*@dev"), ("1.0.*", Some("dev")));
+        assert_eq!(strip_stability_flag("2.0@RC"), ("2.0", Some("RC")));
+        assert_eq!(strip_stability_flag("2.0@alpha"), ("2.0", Some("alpha")));
+        assert_eq!(strip_stability_flag("2.0@stable"), ("2.0", Some("stable")));
+    }
+
+    #[test]
+    fn test_strip_stability_flag_no_flag_present() {
+        assert_eq!(strip_stability_flag("^1.0"), ("^1.0", None));
+        assert_eq!(strip_stability_flag("*"), ("*", None));
+    }
+
+    /// An unrecognized trailing `@word` (not one of Composer's five stability flags) must be
+    /// left untouched rather than silently swallowed.
+    #[test]
+    fn test_strip_stability_flag_unrecognized_word_left_alone() {
+        assert_eq!(
+            strip_stability_flag("^1.0@notaflag"),
+            ("^1.0@notaflag", None)
+        );
+    }
+
+    /// #424 S2 correctness prerequisite: with the flag stripped, a tilde requirement whose
+    /// upper bound has no nonzero-major fast path to paper over a leftover flag must still
+    /// compute the correct range.
+    #[test]
+    fn test_version_satisfies_requirement_at_flag_tilde_range() {
+        let f = ComposerFormatter;
+        assert!(f.version_satisfies_requirement("1.2.5", "~1.2.3@beta"));
+        assert!(!f.version_satisfies_requirement("1.3.0", "~1.2.3@beta"));
+        assert!(!f.version_satisfies_requirement("1.2.2", "~1.2.3@beta"));
+    }
+
+    /// #424: `composer_version_stability_rank` ranks a version's own qualifier on the same
+    /// `dev < alpha < beta < RC < stable` scale as `composer_stability_rank`, agreeing with
+    /// `compare_versions`'s qualifier ordering (`test_compare_versions_qualifier_ordering`).
+    #[test]
+    fn test_composer_version_stability_rank_orders_qualifiers() {
+        assert_eq!(composer_version_stability_rank("1.0.0-dev"), 0);
+        assert_eq!(composer_version_stability_rank("1.0.0-alpha1"), 1);
+        assert_eq!(composer_version_stability_rank("1.0.0-beta1"), 2);
+        assert_eq!(composer_version_stability_rank("1.0.0-RC1"), 3);
+        assert_eq!(
+            composer_version_stability_rank("1.0.0"),
+            COMPOSER_STABLE_RANK
+        );
+    }
+
+    /// #424 S3: a separator-less suffix ranks identically to its hyphenated form — the same
+    /// qualifier parser (`split_composer_core_and_suffix`) backs both.
+    #[test]
+    fn test_composer_version_stability_rank_separatorless_suffix() {
+        assert_eq!(
+            composer_version_stability_rank("2.0.0RC1"),
+            composer_version_stability_rank("2.0.0-RC1"),
+        );
+    }
+
+    /// #424 critique C1 (CRITICAL regression): a `v`-prefixed prerelease (e.g. every
+    /// `symfony/*`/`sylius/sylius` release) must still rank below `COMPOSER_STABLE_RANK` —
+    /// before the fix, the leading `v`/`V` was consumed as the qualifier "word" itself,
+    /// which `composer_stability_rank` cannot recognize and silently ranks as stable,
+    /// reopening #422 for any package whose newest release is `v`-prefixed.
+    #[test]
+    fn test_composer_version_stability_rank_strips_v_prefix() {
+        for prerelease in [
+            "v2.3.0-alpha.1",
+            "v6.0.0-BETA1",
+            "v2.0.0-alpha1",
+            "V3.0.0-RC1",
+        ] {
+            assert!(
+                composer_version_stability_rank(prerelease) < COMPOSER_STABLE_RANK,
+                "{prerelease:?} must rank below stable, not be swallowed as an unrecognized qualifier word"
+            );
+        }
+    }
+
+    /// #424 critique C1: a `v`-prefixed prerelease must rank strictly below a `v`-prefixed
+    /// (or plain) stable release of the same series, matching the real Packagist ordering
+    /// `sylius/sylius`'s `v2.3.0-alpha.1` vs. `v2.2.8` regressed on.
+    #[test]
+    fn test_composer_version_stability_rank_v_prefixed_prerelease_below_stable() {
+        assert!(
+            composer_version_stability_rank("v2.3.0-alpha.1")
+                < composer_version_stability_rank("v2.2.8")
+        );
+        assert!(
+            composer_version_stability_rank("v2.3.0-alpha.1")
+                < composer_version_stability_rank("2.3.0")
+        );
     }
 
     /// Regression test for impl-critic S1: a `v`-prefixed literal on the plain

--- a/crates/deps-composer/src/parser.rs
+++ b/crates/deps-composer/src/parser.rs
@@ -48,6 +48,16 @@ impl LineOffsetTable {
 pub struct ComposerParseResult {
     pub dependencies: Vec<ComposerDependency>,
     pub uri: Uri,
+    /// Raw value of the manifest's own top-level `minimum-stability` field (e.g. `"beta"`),
+    /// if present — Composer's project-wide default stability floor, one of `dev`, `alpha`,
+    /// `beta`, `RC`, `stable` (case-insensitive). `None` when the field is absent, which
+    /// Composer itself treats as `stable` (#424).
+    ///
+    /// Consumers rank this word (`registry.rs`'s crate-private stability ranking) rather than
+    /// comparing it as a string — stored raw here rather than pre-ranked so a caller with no
+    /// interest in stability filtering (e.g. a future manifest-summary feature) is not forced
+    /// to depend on that ranking.
+    pub minimum_stability: Option<String>,
 }
 
 impl deps_core::ParseResult for ComposerParseResult {
@@ -159,9 +169,15 @@ pub fn parse_composer_json(content: &str, uri: &Uri) -> Result<ComposerParseResu
         ));
     }
 
+    let minimum_stability = root
+        .get("minimum-stability")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+
     Ok(ComposerParseResult {
         dependencies,
         uri: uri.clone(),
+        minimum_stability,
     })
 }
 
@@ -423,6 +439,28 @@ mod tests {
 
         assert_eq!(require_count, 1);
         assert_eq!(dev_count, 1);
+    }
+
+    /// #424: `minimum-stability` is parsed from the manifest root when present.
+    #[test]
+    fn test_parse_minimum_stability_present() {
+        let json = r#"{
+  "minimum-stability": "beta",
+  "require": {
+    "symfony/console": "^6.0"
+  }
+}"#;
+        let result = parse_composer_json(json, &test_uri()).unwrap();
+        assert_eq!(result.minimum_stability.as_deref(), Some("beta"));
+    }
+
+    /// #424: a manifest with no `minimum-stability` field parses to `None`, not a fabricated
+    /// `"stable"` — the stable default is applied by the registry ranking, not the parser.
+    #[test]
+    fn test_parse_minimum_stability_absent() {
+        let json = r#"{"require": {"symfony/console": "^6.0"}}"#;
+        let result = parse_composer_json(json, &test_uri()).unwrap();
+        assert_eq!(result.minimum_stability, None);
     }
 
     #[test]

--- a/crates/deps-composer/src/registry.rs
+++ b/crates/deps-composer/src/registry.rs
@@ -97,19 +97,27 @@ fn reject_dot_segment(name: &str) -> Result<()> {
 /// Reusing the shared ladder here would silently reintroduce npm's #338 NFR-002
 /// "prefer non-deprecated" preference for Composer, which #347 deliberately opted out of.
 ///
-/// So only rung 1 differs from the shared ladder (prerelease alone, not flagged-or-prerelease);
-/// rungs 2 and 3 are identical in effect since `RemovalStatus::blocks_resolution()` is never
-/// true for Composer's `AdvisoryDeprecated` status (see `reports_yanked` below).
+/// So only rung 1 differs from the shared ladder (a stability-rank floor, `minimum_rank`,
+/// rather than a flagged-or-prerelease boolean); rungs 2 and 3 are identical in effect since
+/// `RemovalStatus::blocks_resolution()` is never true for Composer's `AdvisoryDeprecated`
+/// status (see `reports_yanked` below).
 ///
 /// This divergence is load-bearing, not a style preference, and must not be collapsed back
 /// into a call to the shared ladder: for an abandoned package whose newest version is itself
-/// a prerelease, the shared ladder's rung 1 (flagged-or-prerelease) rejects every entry, and
-/// rung 2 (`blocks_resolution` only) then returns index 0 — the prerelease — since
-/// `AdvisoryDeprecated` never blocks resolution. That silently reopens #421 for exactly the
-/// case this function exists to fix.
+/// below `minimum_rank`, the shared ladder's rung 1 (flagged-or-prerelease) rejects every
+/// entry, and rung 2 (`blocks_resolution` only) then returns index 0 — the too-unstable
+/// version — since `AdvisoryDeprecated` never blocks resolution. That silently reopens #421
+/// for exactly the case this function exists to fix.
+///
+/// `minimum_rank` is the effective stability floor (see
+/// [`effective_minimum_stability_rank`]) — rung 1 keeps only versions ranking at or above it,
+/// rather than the fixed "must be fully stable" rule #421/#422 originally shipped, so a
+/// manifest's `minimum-stability` (#424) can loosen this ladder too, not just the
+/// concrete-requirement branch below.
 fn select_latest_for_existence_composer<T>(
     versions: &[T],
     as_version: impl Fn(&T) -> &dyn deps_core::Version,
+    minimum_rank: u8,
 ) -> Option<usize> {
     if versions.is_empty() {
         return None;
@@ -117,7 +125,10 @@ fn select_latest_for_existence_composer<T>(
     Some(
         versions
             .iter()
-            .position(|v| !as_version(v).is_prerelease())
+            .position(|v| {
+                crate::formatter::composer_version_stability_rank(as_version(v).version_string())
+                    >= minimum_rank
+            })
             .or_else(|| {
                 versions
                     .iter()
@@ -125,6 +136,68 @@ fn select_latest_for_existence_composer<T>(
             })
             .unwrap_or(0),
     )
+}
+
+/// The loosest (lowest-ranked) per-dependency `@stability` flag found anywhere in a compound
+/// `req_str` (#424 critique M1).
+///
+/// [`crate::formatter::strip_stability_flag`] applies `rfind('@')` to the *whole* string,
+/// which only works for a single unadorned constraint like `^1.0@beta`. A compound
+/// requirement splits into multiple constraint tokens — `||` (OR) and, within a
+/// space-separated range, individual tokens like `>=1.0@dev` — and each token may carry its
+/// own flag. `version_satisfies_requirement` already recurses per token to evaluate the
+/// version range correctly; this mirrors that same split (flattened, since only "is there a
+/// flag" is needed here, not per-branch matching) so `^1.0@beta || ^2.0` and
+/// `>=1.0@dev <2.0` are not silently treated as flag-less.
+///
+/// Returns the *loosest* rank among every token's flag (if more than one token carries one):
+/// this never wrongly excludes a version some branch's flag would admit — the final
+/// `version_satisfies_requirement` call still narrows down to which branch, if any, actually
+/// matches.
+fn compound_stability_flag_rank(req_str: &str) -> Option<u8> {
+    req_str
+        .split("||")
+        .flat_map(str::split_whitespace)
+        .filter_map(|token| {
+            let (_, flag) = crate::formatter::strip_stability_flag(token.trim());
+            flag.map(crate::formatter::composer_stability_rank)
+        })
+        .min()
+}
+
+/// The effective Composer stability floor for one dependency's "latest version" selection,
+/// ranked on [`crate::formatter::composer_stability_rank`]'s `dev < alpha < beta < RC <
+/// stable` scale (#424).
+///
+/// Priority, highest first:
+/// 1. An explicit per-dependency `@stability` flag anywhere in `req_str` (`^1.0@beta`, or
+///    within a compound requirement like `>=1.0@dev <2.0`, see
+///    [`compound_stability_flag_rank`]) — Composer lets a single dependency opt into a looser
+///    (or stricter) floor than the project default.
+/// 2. `req_str` itself naming an explicit prerelease version (an exact pin like
+///    `2.0.0-beta1`, or a range whose bound does, see
+///    [`crate::types::is_prerelease_marker`]) — kept from #421: an explicitly named unstable
+///    version must still resolve, so this returns the loosest rank (`0`, dev) rather than
+///    computing the pinned version's own rank, matching the pre-#424 "allow any prerelease"
+///    behavior for this case exactly.
+/// 3. `manifest_minimum` — the manifest's own `minimum-stability` field, when the caller has
+///    one (`select_latest_matching_for_manifest`/`get_latest_matching_for_manifest`).
+/// 4. [`crate::formatter::COMPOSER_STABLE_RANK`] — Composer's `minimum-stability: stable`
+///    default, unchanged from #421/#422 for every caller with no manifest context.
+pub(crate) fn effective_minimum_stability_rank(
+    req_str: &str,
+    manifest_minimum: Option<&str>,
+) -> u8 {
+    let trimmed = req_str.trim();
+    if let Some(rank) = compound_stability_flag_rank(trimmed) {
+        return rank;
+    }
+    if crate::types::is_prerelease_marker(trimmed) {
+        return 0;
+    }
+    manifest_minimum.map_or(crate::formatter::COMPOSER_STABLE_RANK, |s| {
+        crate::formatter::composer_stability_rank(s)
+    })
 }
 
 /// Client for interacting with the Packagist registry.
@@ -175,6 +248,11 @@ impl PackagistRegistry {
     /// matching `deps-cargo`/`deps-pypi`/`deps-dart`/`deps-npm` — rather than returning `None`
     /// for a package whose only releases so far are all prerelease.
     ///
+    /// Equivalent to
+    /// [`get_latest_matching_for_manifest`](Self::get_latest_matching_for_manifest) with no
+    /// manifest `minimum-stability` (`None`) — use that method instead when the caller has a
+    /// parsed `composer.json` available (#424).
+    ///
     /// # Errors
     ///
     /// Returns an error if the HTTP request fails.
@@ -183,24 +261,100 @@ impl PackagistRegistry {
         name: &str,
         req_str: &str,
     ) -> Result<Option<ComposerVersion>> {
+        self.get_latest_matching_impl(name, req_str, None).await
+    }
+
+    /// `composer.json`-aware counterpart of
+    /// [`get_latest_matching`](Self::get_latest_matching): `minimum_stability` is the
+    /// manifest's own top-level `minimum-stability` field
+    /// ([`ComposerParseResult::minimum_stability`](crate::parser::ComposerParseResult::minimum_stability)),
+    /// used as the default stability floor whenever `req_str` carries neither an explicit
+    /// per-dependency `@stability` flag nor a directly pinned prerelease version — both of
+    /// which still take priority over the manifest default, exactly as they do for
+    /// [`get_latest_matching`](Self::get_latest_matching) (#424).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP request fails.
+    pub async fn get_latest_matching_for_manifest(
+        &self,
+        name: &str,
+        req_str: &str,
+        minimum_stability: Option<&str>,
+    ) -> Result<Option<ComposerVersion>> {
+        self.get_latest_matching_impl(name, req_str, minimum_stability)
+            .await
+    }
+
+    async fn get_latest_matching_impl(
+        &self,
+        name: &str,
+        req_str: &str,
+        manifest_minimum: Option<&str>,
+    ) -> Result<Option<ComposerVersion>> {
         let versions = self.get_versions(name).await?;
-        use deps_core::Version;
+
+        let minimum_rank = effective_minimum_stability_rank(req_str, manifest_minimum);
 
         if deps_core::is_existence_wildcard_str(req_str) {
-            let idx =
-                select_latest_for_existence_composer(&versions, |v| v as &dyn deps_core::Version);
+            let idx = select_latest_for_existence_composer(
+                &versions,
+                |v| v as &dyn deps_core::Version,
+                minimum_rank,
+            );
             return Ok(idx.and_then(|idx| versions.into_iter().nth(idx)));
         }
 
         let formatter = crate::formatter::ComposerFormatter;
         use deps_core::lsp_helpers::EcosystemFormatter;
 
-        let req_is_prerelease_bearing = crate::types::is_prerelease_marker(req_str);
-
         Ok(versions.into_iter().find(|v| {
-            (req_is_prerelease_bearing || !v.is_prerelease())
+            crate::formatter::composer_version_stability_rank(&v.version) >= minimum_rank
                 && formatter.version_satisfies_requirement(&v.version, req_str)
         }))
+    }
+
+    /// `composer.json`-aware counterpart of
+    /// [`Registry::select_latest_matching`](deps_core::Registry::select_latest_matching):
+    /// `minimum_stability` is the manifest's own top-level `minimum-stability` field
+    /// ([`ComposerParseResult::minimum_stability`](crate::parser::ComposerParseResult::minimum_stability)),
+    /// used as the default stability floor whenever `req` carries neither an explicit
+    /// per-dependency `@stability` flag nor a directly pinned prerelease version — both of
+    /// which still take priority over the manifest default, exactly as they do for the plain
+    /// trait method (#424).
+    #[must_use]
+    pub fn select_latest_matching_for_manifest(
+        &self,
+        versions: &[Box<dyn deps_core::Version>],
+        req: &deps_core::VersionReq,
+        minimum_stability: Option<&str>,
+    ) -> Option<usize> {
+        self.select_latest_matching_impl(versions, req, minimum_stability)
+    }
+
+    fn select_latest_matching_impl(
+        &self,
+        versions: &[Box<dyn deps_core::Version>],
+        req: &deps_core::VersionReq,
+        manifest_minimum: Option<&str>,
+    ) -> Option<usize> {
+        let minimum_rank = effective_minimum_stability_rank(req.as_str(), manifest_minimum);
+
+        if deps_core::is_existence_wildcard(req) {
+            return select_latest_for_existence_composer(versions, |v| v.as_ref(), minimum_rank);
+        }
+
+        let formatter = crate::formatter::ComposerFormatter;
+        use deps_core::lsp_helpers::EcosystemFormatter;
+
+        versions.iter().position(|v| {
+            // Always true for Composer (`abandoned` maps to `AdvisoryDeprecated`, which
+            // never blocks resolution) — kept to document the contract (#347).
+            !v.removal_status().blocks_resolution()
+                && crate::formatter::composer_version_stability_rank(v.version_string())
+                    >= minimum_rank
+                && formatter.version_satisfies_requirement(v.version_string(), req.as_str())
+        })
     }
 
     /// Searches for packages by name/keywords.
@@ -384,6 +538,24 @@ impl deps_core::Registry for PackagistRegistry {
         })
     }
 
+    /// Routes to [`PackagistRegistry::get_latest_matching_for_manifest`] — see that method
+    /// for the full priority order. This is the trait-level hook a generic LSP fetch loop
+    /// downcasting `Arc<dyn Registry>` cannot bypass by calling
+    /// [`get_latest_matching`](Self::get_latest_matching) instead (#424 S1).
+    fn get_latest_matching_with_context<'a>(
+        &'a self,
+        name: &'a deps_core::PackageName,
+        req: &'a deps_core::VersionReq,
+        minimum_stability: Option<&'a str>,
+    ) -> deps_core::ecosystem::BoxFuture<'a, Result<Option<Box<dyn deps_core::Version>>>> {
+        Box::pin(async move {
+            let version = self
+                .get_latest_matching_for_manifest(name.as_str(), req.as_str(), minimum_stability)
+                .await?;
+            Ok(version.map(|v| Box::new(v) as Box<dyn deps_core::Version>))
+        })
+    }
+
     fn search<'a>(
         &'a self,
         query: &'a str,
@@ -414,31 +586,28 @@ impl deps_core::Registry for PackagistRegistry {
     /// are all prerelease still resolves to its newest one rather than `None`), while keeping
     /// Composer's own #347 ranking rule that `abandoned` never demotes a version.
     ///
-    /// This does not read `composer.json`'s own `minimum-stability` field (unmodeled in this
-    /// crate today) — a manifest that sets a looser project-wide default (e.g.
-    /// `"minimum-stability": "beta"`) still has its unstable releases excluded here for a
-    /// concrete requirement, unless that specific requirement is itself prerelease-bearing.
+    /// Does not read `composer.json`'s own `minimum-stability` field — this trait method has
+    /// no manifest context to read it from. A caller with a parsed manifest available should
+    /// use [`PackagistRegistry::select_latest_matching_for_manifest`] instead, which this
+    /// method is equivalent to with no manifest `minimum-stability` (`None`) (#424).
     fn select_latest_matching(
         &self,
         versions: &[Box<dyn deps_core::Version>],
         req: &deps_core::VersionReq,
     ) -> Option<usize> {
-        if deps_core::is_existence_wildcard(req) {
-            return select_latest_for_existence_composer(versions, |v| v.as_ref());
-        }
+        self.select_latest_matching_impl(versions, req, None)
+    }
 
-        let formatter = crate::formatter::ComposerFormatter;
-        use deps_core::lsp_helpers::EcosystemFormatter;
-
-        let req_is_prerelease_bearing = crate::types::is_prerelease_marker(req.as_str());
-
-        versions.iter().position(|v| {
-            // Always true for Composer (`abandoned` maps to `AdvisoryDeprecated`, which
-            // never blocks resolution) — kept to document the contract (#347).
-            !v.removal_status().blocks_resolution()
-                && (req_is_prerelease_bearing || !v.is_prerelease())
-                && formatter.version_satisfies_requirement(v.version_string(), req.as_str())
-        })
+    /// Routes to [`PackagistRegistry::select_latest_matching_for_manifest`] — the trait-level
+    /// hook a generic LSP fetch loop downcasting `Arc<dyn Registry>` cannot bypass by calling
+    /// the plain `select_latest_matching` instead (#424 S1).
+    fn select_latest_matching_with_context(
+        &self,
+        versions: &[Box<dyn deps_core::Version>],
+        req: &deps_core::VersionReq,
+        minimum_stability: Option<&str>,
+    ) -> Option<usize> {
+        self.select_latest_matching_for_manifest(versions, req, minimum_stability)
     }
 
     // Packagist's `abandoned` is package-level, not per-version: `removal_status`
@@ -1091,6 +1260,622 @@ mod tests {
 
         let version = latest.expect("a prerelease-only package still exists and resolves");
         assert_eq!(version.version, "2.0.0-beta2");
+    }
+
+    // --- #424 S1: manifest-level `minimum-stability` threading ---
+
+    fn stability_fixture() -> Vec<Box<dyn deps_core::Version>> {
+        vec![
+            Box::new(ComposerVersion {
+                version: "2.0.0-alpha1".into(),
+                version_normalized: "2.0.0.0-alpha1".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "2.0.0-beta1".into(),
+                version_normalized: "2.0.0.0-beta1".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "1.5.0".into(),
+                version_normalized: "1.5.0.0".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+        ]
+    }
+
+    /// #424 S1: a manifest with `minimum-stability: beta` must resolve the newest release at
+    /// or above beta (excluding alpha) as "latest", not fall back to the hardcoded
+    /// `minimum-stability: stable` default that would exclude both prereleases.
+    #[test]
+    fn test_select_latest_matching_for_manifest_honors_looser_minimum_stability() {
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions = stability_fixture();
+        let req = deps_core::VersionReq::new("*");
+
+        assert_eq!(
+            registry.select_latest_matching_for_manifest(&versions, &req, Some("beta")),
+            Some(1),
+            "beta release should be latest under minimum-stability: beta"
+        );
+    }
+
+    /// #424 S1: `minimum-stability: alpha` loosens the floor further still, all the way to
+    /// the newest alpha.
+    #[test]
+    fn test_select_latest_matching_for_manifest_honors_alpha_minimum_stability() {
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions = stability_fixture();
+        let req = deps_core::VersionReq::new("*");
+
+        assert_eq!(
+            registry.select_latest_matching_for_manifest(&versions, &req, Some("alpha")),
+            Some(0),
+            "alpha release should be latest under minimum-stability: alpha"
+        );
+    }
+
+    /// #424 S1: with no manifest `minimum-stability` (`None`), behavior must be byte-identical
+    /// to the plain trait method — the hardcoded `stable` default from #421/#422.
+    #[test]
+    fn test_select_latest_matching_for_manifest_none_matches_default() {
+        use deps_core::Registry;
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions = stability_fixture();
+        let req = deps_core::VersionReq::new("*");
+
+        assert_eq!(
+            registry.select_latest_matching_for_manifest(&versions, &req, None),
+            registry.select_latest_matching(&versions, &req),
+        );
+    }
+
+    /// #424 S1: `minimum-stability: stable` (explicit, not just absent) must behave exactly
+    /// like the hardcoded default — Composer's own default value, spelled out.
+    #[test]
+    fn test_select_latest_matching_for_manifest_explicit_stable_excludes_prerelease() {
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions = stability_fixture();
+        let req = deps_core::VersionReq::new("*");
+
+        assert_eq!(
+            registry.select_latest_matching_for_manifest(&versions, &req, Some("stable")),
+            Some(2),
+        );
+    }
+
+    /// #424 S1: the async `get_latest_matching_for_manifest` fetch-loop entry point must
+    /// apply the same manifest stability floor as the pure list-based
+    /// `select_latest_matching_for_manifest`.
+    #[tokio::test]
+    async fn test_get_latest_matching_for_manifest_honors_looser_minimum_stability() {
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let registry = PackagistRegistry::with_registry_base(Arc::new(HttpCache::new()), base);
+
+        server
+            .mock("GET", "/p2/vendor/pkg.json")
+            .with_status(200)
+            .with_body(
+                r#"{"packages": {"vendor/pkg": [
+                    {"version": "2.0.0-beta1", "version_normalized": "2.0.0.0-beta1"},
+                    {"version": "1.5.0", "version_normalized": "1.5.0.0"}
+                ]}}"#,
+            )
+            .create_async()
+            .await;
+
+        let latest = registry
+            .get_latest_matching_for_manifest("vendor/pkg", "*", Some("beta"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            latest.expect("beta release resolves").version,
+            "2.0.0-beta1"
+        );
+    }
+
+    // --- #424 S2: per-dependency `@stability` flags ---
+
+    /// #424 S2: `^1.0@beta` must be recognized as a prerelease-bearing opt-in — a beta
+    /// release satisfying the range must resolve as latest, not be excluded by the default
+    /// stable-only filter.
+    #[test]
+    fn test_select_latest_matching_at_beta_flag_allows_beta() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(ComposerVersion {
+                version: "1.5.0-beta1".into(),
+                version_normalized: "1.5.0.0-beta1".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "1.0.0".into(),
+                version_normalized: "1.0.0.0".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new("^1.0@beta");
+        assert_eq!(
+            registry.select_latest_matching(&versions, &req),
+            Some(0),
+            "beta release matching the range must resolve under an @beta opt-in"
+        );
+    }
+
+    /// #424 S2: an `@beta` opt-in permits beta but not a *looser* alpha release — the flag
+    /// sets a floor, not "allow everything unstable".
+    #[test]
+    fn test_select_latest_matching_at_beta_flag_excludes_alpha() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(ComposerVersion {
+                version: "1.5.0-alpha1".into(),
+                version_normalized: "1.5.0.0-alpha1".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "1.0.0".into(),
+                version_normalized: "1.0.0.0".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new("^1.0@beta");
+        assert_eq!(
+            registry.select_latest_matching(&versions, &req),
+            Some(1),
+            "alpha release must still be excluded under an @beta opt-in"
+        );
+    }
+
+    /// #424 S2: `@stable` is recognized (parses cleanly, does not corrupt range matching) but
+    /// is not itself a prerelease-bearing opt-in — it is Composer's own default spelled out
+    /// explicitly, so an alpha/beta release must still be excluded.
+    #[test]
+    fn test_select_latest_matching_at_stable_flag_still_excludes_prerelease() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(ComposerVersion {
+                version: "1.5.0-beta1".into(),
+                version_normalized: "1.5.0.0-beta1".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "1.0.0".into(),
+                version_normalized: "1.0.0.0".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new("^1.0@stable");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(1));
+    }
+
+    /// #424 tester gap: `@RC` must be exercised end-to-end through `select_latest_matching`,
+    /// not just unit-tested on `strip_stability_flag`/`composer_stability_rank` in isolation.
+    /// An RC release matching the range must resolve, but a looser beta release must not.
+    #[test]
+    fn test_select_latest_matching_at_rc_flag_allows_rc_excludes_beta() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(ComposerVersion {
+                version: "1.5.0-beta1".into(),
+                version_normalized: "1.5.0.0-beta1".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "1.4.0-RC1".into(),
+                version_normalized: "1.4.0.0-RC1".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "1.0.0".into(),
+                version_normalized: "1.0.0.0".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new("^1.0@RC");
+        assert_eq!(
+            registry.select_latest_matching(&versions, &req),
+            Some(1),
+            "RC release must resolve, but a looser beta release must still be excluded"
+        );
+    }
+
+    /// #424 tester gap: `@alpha` end-to-end — the loosest non-dev flag, so it must admit an
+    /// alpha release too (dev-* branches are already filtered out of `get_versions` entirely,
+    /// so `@alpha` and `@dev` are equivalent in practice for real numbered versions).
+    #[test]
+    fn test_select_latest_matching_at_alpha_flag_allows_alpha() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(ComposerVersion {
+                version: "1.5.0-alpha1".into(),
+                version_normalized: "1.5.0.0-alpha1".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "1.0.0".into(),
+                version_normalized: "1.0.0.0".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new("^1.0@alpha");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
+    }
+
+    /// #424 tester gap: `@dev` end-to-end — admits a real numbered alpha/beta release too,
+    /// since `@dev` ranks loosest (rank 0) and `dev-*` branch versions never reach this list.
+    #[test]
+    fn test_select_latest_matching_at_dev_flag_allows_alpha() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(ComposerVersion {
+                version: "1.5.0-alpha1".into(),
+                version_normalized: "1.5.0.0-alpha1".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "1.0.0".into(),
+                version_normalized: "1.0.0.0".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new("^1.0@dev");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
+    }
+
+    // --- #424 critique M1: compound requirements must not drop the `@flag` opt-in ---
+
+    /// #424 critique M1: an `@flag` inside the first OR-branch of a compound requirement
+    /// (`^1.0@beta || ^2.0`) must still be recognized, admitting a beta release matching that
+    /// branch.
+    #[test]
+    fn test_select_latest_matching_at_flag_in_or_branch() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![Box::new(ComposerVersion {
+            version: "1.5.0-beta1".into(),
+            version_normalized: "1.5.0.0-beta1".into(),
+            abandoned: false,
+            published_at: None,
+        })];
+        let req = VersionReq::new("^1.0@beta || ^2.0");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
+    }
+
+    /// #424 critique M1: an `@flag` inside one token of a space-separated AND range
+    /// (`>=1.0@dev <2.0`) must still be recognized.
+    #[test]
+    fn test_select_latest_matching_at_flag_in_and_range() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![Box::new(ComposerVersion {
+            version: "1.5.0-alpha1".into(),
+            version_normalized: "1.5.0.0-alpha1".into(),
+            abandoned: false,
+            published_at: None,
+        })];
+        let req = VersionReq::new(">=1.0@dev <2.0");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
+    }
+
+    /// #424 critique M1: `compound_stability_flag_rank` unit-level — confirms the loosest
+    /// flag among multiple tokens wins, and that a flag-less compound requirement yields
+    /// `None` (falling through to the next priority tier).
+    #[test]
+    fn test_compound_stability_flag_rank() {
+        assert_eq!(
+            compound_stability_flag_rank("^1.0@beta || ^2.0"),
+            Some(crate::formatter::composer_stability_rank("beta"))
+        );
+        assert_eq!(
+            compound_stability_flag_rank(">=1.0@dev <2.0"),
+            Some(crate::formatter::composer_stability_rank("dev"))
+        );
+        assert_eq!(
+            compound_stability_flag_rank("^1.0@alpha || ^2.0@RC"),
+            Some(crate::formatter::composer_stability_rank("alpha")),
+            "the loosest flag among branches must win"
+        );
+        assert_eq!(compound_stability_flag_rank("^1.0 || ^2.0"), None);
+    }
+
+    // --- #424 critique S2: separator-less short-alias (a/b) and dev, end-to-end ---
+
+    /// #424 critique S2 gap: separator-less short alias `a1`/`b1` end-to-end through
+    /// `select_latest_matching`, mirroring the existing separator-less-RC coverage.
+    #[test]
+    fn test_select_latest_matching_excludes_separatorless_short_alias() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(ComposerVersion {
+                version: "2.0.0a1".into(),
+                version_normalized: "2.0.0a1".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "1.5.0".into(),
+                version_normalized: "1.5.0.0".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new(">=1.0");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(1));
+    }
+
+    /// #424 critique S2 gap: an exact separator-less short-alias pin (`2.0.0a1`) must resolve
+    /// to itself — this is the exact case that was broken pre-fix (classifiers disagreed).
+    #[test]
+    fn test_select_latest_matching_allows_separatorless_short_alias_pin_when_requirement_names_it()
+    {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(ComposerVersion {
+                version: "2.0.0a1".into(),
+                version_normalized: "2.0.0a1".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "1.5.0".into(),
+                version_normalized: "1.5.0.0".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new("2.0.0a1");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
+    }
+
+    /// #424 critique S2 gap: separator-less `dev` suffix end-to-end.
+    #[test]
+    fn test_select_latest_matching_excludes_separatorless_dev_suffix() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(ComposerVersion {
+                version: "2.0.0dev".into(),
+                version_normalized: "2.0.0dev".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "1.5.0".into(),
+                version_normalized: "1.5.0.0".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new(">=1.0");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(1));
+    }
+
+    // --- #424 critique C1: v-prefixed prereleases, end-to-end (CRITICAL regression) ---
+
+    /// #424 critique C1: reproduces the live `sylius/sylius` regression — a `v`-prefixed
+    /// alpha release must not be reported as "latest" ahead of an older `v`-prefixed stable
+    /// release. Before the fix, `composer_version_stability_rank` swallowed the leading `v`
+    /// as the qualifier word itself and ranked the alpha release as stable.
+    #[test]
+    fn test_select_latest_matching_v_prefixed_alpha_excluded_by_default() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(ComposerVersion {
+                version: "v2.3.0-alpha.1".into(),
+                version_normalized: "2.3.0.0-alpha1".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "v2.2.8".into(),
+                version_normalized: "2.2.8.0".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new("*");
+        assert_eq!(
+            registry.select_latest_matching(&versions, &req),
+            Some(1),
+            "v2.2.8 (stable) must resolve as latest, not the v-prefixed alpha ahead of it"
+        );
+    }
+
+    /// #424 critique C1: `symfony/*`-style data — a `v`-prefixed RC release ordered ahead of
+    /// a `v`-prefixed stable release in the version list must still be excluded by the
+    /// default stable-only filter for a concrete requirement.
+    #[test]
+    fn test_select_latest_matching_v_prefixed_rc_excluded_for_concrete_requirement() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(ComposerVersion {
+                version: "V3.0.0-RC1".into(),
+                version_normalized: "3.0.0.0-RC1".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "v2.9.0".into(),
+                version_normalized: "2.9.0.0".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new(">=2.0");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(1));
+    }
+
+    // --- #424 S3: separator-less prerelease suffix consistency ---
+
+    /// #424 S3: `1.0.0RC1` (no separator before `RC`) must be excluded from "latest" by the
+    /// default stable-only filter exactly like its hyphenated form `1.0.0-RC1` — classified
+    /// via the primary `is_prerelease_marker` path, independent of `version_normalized`.
+    #[test]
+    fn test_select_latest_matching_excludes_separatorless_rc_suffix() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(ComposerVersion {
+                version: "2.0.0RC1".into(),
+                // `version_normalized` deliberately left un-hyphenated (mirrors a Packagist
+                // response that never expanded it) so the primary path must catch this alone.
+                version_normalized: "2.0.0RC1".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "1.5.0".into(),
+                version_normalized: "1.5.0.0".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new(">=1.0");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(1));
+    }
+
+    /// #424 S3: an exact separator-less pin (`2.0.0RC1`) must still be recognized as a
+    /// prerelease-bearing requirement and resolve to itself — mirroring the hyphenated-pin
+    /// case `test_select_latest_matching_allows_prerelease_when_requirement_names_it`.
+    #[test]
+    fn test_select_latest_matching_allows_separatorless_rc_pin_when_requirement_names_it() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(ComposerVersion {
+                version: "2.0.0RC1".into(),
+                version_normalized: "2.0.0RC1".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "1.5.0".into(),
+                version_normalized: "1.5.0.0".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new("2.0.0RC1");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
+    }
+
+    /// #424 critique N3: a dot-separated qualifier (`2.6.3.alpha`, a live `api-platform/core`
+    /// tag) must be excluded from "latest" by the default stable-only filter, exactly like the
+    /// hyphenated/separator-less forms above.
+    #[test]
+    fn test_select_latest_matching_excludes_dot_separated_alpha_suffix() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(ComposerVersion {
+                version: "2.6.3.alpha".into(),
+                version_normalized: "2.6.3.0-alpha".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "2.6.2".into(),
+                version_normalized: "2.6.2.0".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new(">=2.0");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(1));
+    }
+
+    /// #424 critique N3: an exact pin naming the dot-separated prerelease form directly
+    /// (`2.6.3.alpha`) must still resolve to itself — before the fix, `is_prerelease_marker`
+    /// disagreed with `composer_version_stability_rank` on this exact shape, which is the
+    /// #421 S1 failure mode (a pin that can never match its own version).
+    #[test]
+    fn test_select_latest_matching_allows_dot_separated_alpha_pin_when_requirement_names_it() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![
+            Box::new(ComposerVersion {
+                version: "2.6.3.alpha".into(),
+                version_normalized: "2.6.3.0-alpha".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+            Box::new(ComposerVersion {
+                version: "2.6.2".into(),
+                version_normalized: "2.6.2.0".into(),
+                abandoned: false,
+                published_at: None,
+            }),
+        ];
+        let req = VersionReq::new("2.6.3.alpha");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
     }
 
     #[tokio::test]

--- a/crates/deps-composer/src/types.rs
+++ b/crates/deps-composer/src/types.rs
@@ -117,9 +117,69 @@ fn has_short_stability_alias(s: &str) -> bool {
     false
 }
 
+/// Whether `s` contains a Composer stability keyword (`alpha`/`a`, `beta`/`b`, `RC`, `dev`)
+/// directly adjacent to a numeric run with no separator (e.g. `1.0.0RC1`, `1.0.0a1`,
+/// `1.0.0dev`) — `composer/semver`'s modifier grammar makes the `[._-]?` separator before the
+/// keyword optional for every recognized word (matching
+/// [`crate::formatter::composer_stability_rank`]'s full word list), not just `alpha`/`beta`/
+/// `rc`. The hyphenated forms are already caught by
+/// [`deps_core::has_default_prerelease_marker`]'s `-rc`/`-alpha`/`-beta`/`-dev` substring
+/// checks and [`has_short_stability_alias`]'s hyphenated `-a`/`-b`.
+///
+/// Covering only three of the six recognized words here left this classifier disagreeing with
+/// [`crate::formatter::composer_version_stability_rank`] on bare separator-less short-alias/
+/// `dev` forms (`1.0.0a1`, `1.0.0dev`): the rank function ranks them as prerelease (via the
+/// same word list `composer_stability_rank` uses), but this function said "not prerelease" —
+/// and since `registry.rs`'s `effective_minimum_stability_rank` uses this function for "does
+/// the requirement itself pin a prerelease" while the version-side filter uses the rank
+/// function, disagreement meant a pin like `1.0.0a1` could never match its own version — the
+/// exact #421 S1 failure mode, reintroduced by the original #424 S3 fix instead of being
+/// closed by it (critique S2).
+///
+/// Checked directly on the raw string rather than relying on a hyphen-inserting
+/// `version_normalized` to have expanded it: a requirement string has no `version_normalized`
+/// at all, and even for a real [`ComposerVersion`], Packagist supplying `version_normalized`
+/// is not guaranteed, so classification must not depend on which of the two happens to run
+/// first or be present (#424 S3).
+///
+/// The keyword may also sit directly after a `.`/`_` separator that is itself digit-adjacent
+/// (e.g. `2.6.3.alpha`, a live `api-platform/core` tag) — not just directly after a digit —
+/// since `composer_stability_rank`'s companion parser (`split_composer_core_and_suffix`)
+/// already strips a leading `.`/`_`/`-` separator before reading the qualifier word, so the
+/// rank function sees `2.6.3.alpha` as prerelease while this substring scan previously did
+/// not, the same #421 S1 failure mode S2 fixed for the hyphen-less case (#424 critique N3).
+/// Deliberately excludes `-`: a hyphen-separated qualifier is already covered by
+/// [`deps_core::has_default_prerelease_marker`]/[`has_short_stability_alias`] via a different
+/// algorithm, so including it here would only duplicate, not extend, coverage.
+fn has_separatorless_stability_keyword(s: &str) -> bool {
+    let lower = s.to_lowercase();
+    let bytes = lower.as_bytes();
+    for keyword in ["alpha", "beta", "rc", "dev", "a", "b"] {
+        let mut start = 0;
+        while let Some(rel) = lower[start..].find(keyword) {
+            let idx = start + rel;
+            let preceded_ok = idx > 0
+                && (bytes[idx - 1].is_ascii_digit()
+                    || (matches!(bytes[idx - 1], b'.' | b'_')
+                        && idx > 1
+                        && bytes[idx - 2].is_ascii_digit()));
+            let after = idx + keyword.len();
+            let followed_by_digit_or_end = bytes.get(after).is_none_or(u8::is_ascii_digit);
+            let followed_by_dot_digit = bytes.get(after) == Some(&b'.')
+                && bytes.get(after + 1).is_some_and(u8::is_ascii_digit);
+            if preceded_ok && (followed_by_digit_or_end || followed_by_dot_digit) {
+                return true;
+            }
+            start = idx + 1;
+        }
+    }
+    false
+}
+
 /// Whether `s` carries any Composer stability marker: `deps-core`'s default hyphen-substring
-/// heuristic (`-alpha`, `-beta`, `-rc`, ...) or Composer's short `-a`/`-b` alias (see
-/// [`has_short_stability_alias`]).
+/// heuristic (`-alpha`, `-beta`, `-rc`, ...), Composer's short `-a`/`-b` alias (see
+/// [`has_short_stability_alias`]), or a separator-less keyword suffix (see
+/// [`has_separatorless_stability_keyword`]).
 ///
 /// Shared by [`ComposerVersion`]'s `is_prerelease()` (via `impl_version!` below, applied to a
 /// concrete version string) and `registry.rs`'s "is this requirement itself prerelease-bearing"
@@ -128,7 +188,9 @@ fn has_short_stability_alias(s: &str) -> bool {
 /// as stable while the version it pins is correctly classified as unstable, making it
 /// impossible to ever satisfy (#421 S1).
 pub(crate) fn is_prerelease_marker(s: &str) -> bool {
-    deps_core::has_default_prerelease_marker(s) || has_short_stability_alias(s)
+    deps_core::has_default_prerelease_marker(s)
+        || has_short_stability_alias(s)
+        || has_separatorless_stability_keyword(s)
 }
 
 // Packagist versions aren't strict semver, so this layers a Composer-specific
@@ -283,6 +345,125 @@ mod tests {
                 "{name} prerelease mismatch"
             );
         }
+    }
+
+    /// #424 S3: a separator-less stability keyword suffix (`1.0.0RC1`, no hyphen before
+    /// `RC`) must be classified as prerelease by the primary `is_prerelease_marker` path
+    /// alone — without relying on `version_normalized` to have expanded it.
+    #[test]
+    fn test_is_prerelease_marker_separatorless_suffix() {
+        for (s, expected) in [
+            ("1.0.0RC1", true),
+            ("2.0.0beta3", true),
+            ("2.0.0alpha1", true),
+            ("1.0.0-RC1", true), // hyphenated form still caught (existing heuristic)
+            ("1.0.0", false),
+            ("1.0.0-abandoned", false),
+        ] {
+            assert_eq!(
+                is_prerelease_marker(s),
+                expected,
+                "{s} prerelease-marker mismatch"
+            );
+        }
+    }
+
+    /// #424 critique S2: the short-alias (`a`/`b`) and `dev` separator-less forms must also
+    /// be recognized — not just `alpha`/`beta`/`rc` — or this classifier disagrees with
+    /// `composer_version_stability_rank` on exactly these forms (see that function's rank
+    /// test `test_is_prerelease_marker_separatorless_suffix_agrees_with_rank` below).
+    #[test]
+    fn test_is_prerelease_marker_separatorless_short_alias_and_dev() {
+        for (s, expected) in [
+            ("1.0.0a1", true),
+            ("1.0.0b1", true),
+            ("1.0.0dev", true),
+            ("2.0.0A1", true),
+            ("2.0.0B2", true),
+        ] {
+            assert_eq!(
+                is_prerelease_marker(s),
+                expected,
+                "{s} prerelease-marker mismatch"
+            );
+        }
+    }
+
+    /// #424 critique N3: a dot/underscore-separated qualifier (`2.6.3.alpha`, a live
+    /// `api-platform/core` tag; `version_normalized: "2.6.3.0-alpha"`) must also be recognized
+    /// — the separator before the keyword need not be a bare digit, since
+    /// `split_composer_core_and_suffix` (the rank function's own parser) already strips a
+    /// leading `.`/`_`/`-` before reading the qualifier word.
+    #[test]
+    fn test_is_prerelease_marker_dot_underscore_separated_suffix() {
+        for (s, expected) in [
+            ("2.6.3.alpha", true),
+            ("2.6.3_alpha", true),
+            ("2.6.3.beta1", true),
+            ("2.6.3_dev", true),
+            ("2.6.3.a1", true),
+            ("2.6.3_b2", true),
+            ("2.6.3.rc1", true),
+        ] {
+            assert_eq!(
+                is_prerelease_marker(s),
+                expected,
+                "{s} prerelease-marker mismatch"
+            );
+        }
+    }
+
+    /// #424 critique S2/N3: `is_prerelease_marker` (substring-scan classifier, used for
+    /// requirement strings) and `composer_version_stability_rank` (anchored-parse classifier,
+    /// used for candidate versions) must agree on every grammar-valid bare version-shaped
+    /// string — a real generated cross-product, not a hand-picked table, so a future addition
+    /// to either classifier's word/separator list that misses the other is actually caught,
+    /// not just the handful of shapes someone thought to write down.
+    ///
+    /// Cross product: word (Composer's full recognized set) × separator (the `[._-]?`
+    /// grammar's optional-separator axis, including no separator at all) × `v`/`V` prefix ×
+    /// numeric suffix shape = 216 grammar-valid forms. Critique N3's first pass covered only
+    /// the `-` and `""` separators (the two that already agreed); this covers all four,
+    /// closing the gap on the entire `.`/`_` axis (e.g. the live `api-platform/core` tag
+    /// `v2.6.3.alpha`) that the narrower table never exercised.
+    #[test]
+    fn test_is_prerelease_marker_agrees_with_rank_cross_product() {
+        let mut mismatches = Vec::new();
+        for word in ["alpha", "beta", "rc", "dev", "a", "b"] {
+            for sep in ["-", ".", "_", ""] {
+                for prefix in ["", "v", "V"] {
+                    for suffix in ["", "1", ".1"] {
+                        let s = format!("{prefix}2.6.3{sep}{word}{suffix}");
+                        let is_prerelease = is_prerelease_marker(&s);
+                        let is_stable_rank = crate::formatter::composer_version_stability_rank(&s)
+                            == crate::formatter::COMPOSER_STABLE_RANK;
+                        if is_prerelease == is_stable_rank {
+                            mismatches.push(s);
+                        }
+                    }
+                }
+            }
+        }
+        assert!(
+            mismatches.is_empty(),
+            "{} / 216 grammar-valid forms disagree between is_prerelease_marker and \
+             composer_version_stability_rank: {mismatches:?}",
+            mismatches.len()
+        );
+    }
+
+    /// #424 S3: a `ComposerVersion` whose `version_normalized` was never hyphen-expanded
+    /// (mirrors a Packagist response that returns the separator-less form verbatim in both
+    /// fields) must still classify as prerelease via the raw `version` alone.
+    #[test]
+    fn test_composer_version_separatorless_rc_is_prerelease_without_normalized_expansion() {
+        let version = ComposerVersion {
+            version: "2.0.0RC1".into(),
+            version_normalized: "2.0.0RC1".into(),
+            abandoned: false,
+            published_at: None,
+        };
+        assert!(version.is_prerelease());
     }
 
     #[test]

--- a/crates/deps-core/src/registry.rs
+++ b/crates/deps-core/src/registry.rs
@@ -144,6 +144,31 @@ pub trait Registry: Send + Sync {
         req: &'a VersionReq,
     ) -> BoxFuture<'a, Result<Option<Box<dyn Version>>>>;
 
+    /// Like [`get_latest_matching`](Self::get_latest_matching), but lets a registry whose
+    /// "latest matching" selection can be refined by ecosystem-specific manifest state (e.g.
+    /// Composer's `minimum-stability` field, #424) read it, alongside `req`.
+    ///
+    /// `minimum_stability` is an opaque, ecosystem-defined string (Composer's own stability
+    /// keyword: `"dev"`, `"alpha"`, `"beta"`, `"RC"`, or `"stable"`) rather than a shared type,
+    /// mirroring [`get_versions_with`](Self::get_versions_with)'s
+    /// [`FreshnessSettings`](crate::freshness::FreshnessSettings) precedent for "an optional
+    /// extra parameter most registries ignore" — except here even the *shape* of the extra
+    /// context is ecosystem-specific, so no shared DTO is introduced for it; only the one
+    /// registry that understands the string overrides this method.
+    ///
+    /// Default: forwards to [`get_latest_matching`](Self::get_latest_matching), ignoring
+    /// `minimum_stability`. This keeps every registry with no manifest-level stability
+    /// concept unchanged.
+    fn get_latest_matching_with_context<'a>(
+        &'a self,
+        name: &'a PackageName,
+        req: &'a VersionReq,
+        minimum_stability: Option<&'a str>,
+    ) -> BoxFuture<'a, Result<Option<Box<dyn Version>>>> {
+        let _ = minimum_stability;
+        self.get_latest_matching(name, req)
+    }
+
     /// Searches for packages by name or keywords.
     ///
     /// Returns up to `limit` results sorted by relevance/popularity.
@@ -184,6 +209,25 @@ pub trait Registry: Send + Sync {
         _req: &VersionReq,
     ) -> Option<usize> {
         None
+    }
+
+    /// Like [`select_latest_matching`](Self::select_latest_matching), but lets a registry
+    /// whose selection can be refined by ecosystem-specific manifest state (e.g. Composer's
+    /// `minimum-stability` field, #424) read it, alongside `versions` and `req`. See
+    /// [`get_latest_matching_with_context`](Self::get_latest_matching_with_context) for why
+    /// `minimum_stability` is an opaque per-ecosystem string rather than a shared type.
+    ///
+    /// Default: forwards to [`select_latest_matching`](Self::select_latest_matching), ignoring
+    /// `minimum_stability`. This keeps every registry with no manifest-level stability concept
+    /// unchanged.
+    fn select_latest_matching_with_context(
+        &self,
+        versions: &[Box<dyn Version>],
+        req: &VersionReq,
+        minimum_stability: Option<&str>,
+    ) -> Option<usize> {
+        let _ = minimum_stability;
+        self.select_latest_matching(versions, req)
     }
 
     /// Whether [`get_versions`](Self::get_versions) results carry meaningful

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -36,6 +36,29 @@ fn resolve_ecosystem_id(ecosystem: &dyn Ecosystem) -> EcosystemId {
         .expect("ecosystem.id() must be a registered EcosystemId")
 }
 
+/// Composer's own `minimum-stability` manifest setting, when `parse_result` is a parsed
+/// `composer.json` (#424 S1).
+///
+/// Downcasts via [`deps_core::ParseResult::as_any`] rather than widening the generic
+/// `ParseResult`/`Registry` traits with an ecosystem-specific field: every other ecosystem has
+/// no equivalent manifest-level stability floor, so this stays local to the one call site
+/// (`fetch_latest_versions_parallel`'s caller) that needs to bridge a Composer-specific
+/// manifest value into the generic `Registry::*_with_context` trait hook.
+#[cfg(feature = "composer")]
+fn composer_minimum_stability(parse_result: &dyn deps_core::ParseResult) -> Option<String> {
+    parse_result
+        .as_any()
+        .downcast_ref::<crate::ComposerParseResult>()
+        .and_then(|r| r.minimum_stability.clone())
+}
+
+/// No-op when the `composer` feature is disabled — `crate::ComposerParseResult` does not
+/// exist in that build, so `parse_result` can never downcast to it.
+#[cfg(not(feature = "composer"))]
+fn composer_minimum_stability(_parse_result: &dyn deps_core::ParseResult) -> Option<String> {
+    None
+}
+
 /// Rejects document content larger than [`MAX_FILE_SIZE`].
 ///
 /// Content from `textDocument/didOpen`/`didChange` reaches this crate directly
@@ -633,6 +656,12 @@ struct FetchResult {
 /// - Sequential: 50 × 100ms = 5000ms
 /// - Parallel (no timeout): max(100ms) ≈ 150ms
 /// - Parallel (10s timeout, 1 slow package at 30s): max(10s) ≈ 10s
+#[allow(
+    clippy::too_many_arguments,
+    reason = "internal (non-pub) call-site-controlled fetch tuning + ecosystem-context \
+              parameters; grouping into a config struct would only move, not reduce, the \
+              per-call-site churn across this module's ~15 production and test call sites"
+)]
 async fn fetch_latest_versions_parallel(
     registry: Arc<dyn Registry>,
     package_names: Vec<PackageName>,
@@ -641,6 +670,7 @@ async fn fetch_latest_versions_parallel(
     freshness: deps_core::freshness::FreshnessSettings,
     timeout_secs: u64,
     max_concurrent: usize,
+    minimum_stability: Option<&str>,
 ) -> FetchResult {
     use futures::stream::{self, StreamExt};
     use std::time::Duration;
@@ -698,8 +728,16 @@ async fn fetch_latest_versions_parallel(
                         // `.get(idx)` rather than `versions[idx]`: `select_latest_matching`
                         // is a public `Registry` trait method, so an out-of-tree
                         // implementation returning a stale index must not panic this task.
+                        // `_with_context` (not the plain method) so a registry with
+                        // manifest-level stability state (Composer's `minimum-stability`,
+                        // #424 S1) can apply it — every other registry's default
+                        // implementation just forwards to the plain method unchanged.
                         let resolved = if let Some(v) = registry
-                            .select_latest_matching(&versions, wildcard_req)
+                            .select_latest_matching_with_context(
+                                &versions,
+                                wildcard_req,
+                                minimum_stability,
+                            )
                             .and_then(|idx| versions.get(idx))
                         {
                             let latest = v.version_string().to_string();
@@ -719,7 +757,11 @@ async fn fetch_latest_versions_parallel(
                             // "list-based pick failed" case, not the common path.
                             let fallback = tokio::time::timeout(
                                 timeout,
-                                registry.get_latest_matching(&name, wildcard_req),
+                                registry.get_latest_matching_with_context(
+                                    &name,
+                                    wildcard_req,
+                                    minimum_stability,
+                                ),
                             )
                             .await;
                             match fallback {
@@ -1010,7 +1052,11 @@ pub async fn handle_document_open(
 
         // Collect dependency names and the in-use-version map (§4.6) in one
         // pass while holding the reference (can't hold across await).
-        let (dep_names, in_use): (Vec<PackageName>, HashMap<PackageName, Vec<String>>) = {
+        let (dep_names, in_use, minimum_stability): (
+            Vec<PackageName>,
+            HashMap<PackageName, Vec<String>>,
+            Option<String>,
+        ) = {
             let doc = match state_clone.get_document(&uri_clone) {
                 Some(d) => d,
                 None => {
@@ -1043,7 +1089,8 @@ pub async fn handle_document_open(
                 ecosystem_clone.formatter(),
                 resolve_ecosystem_id(ecosystem_clone.as_ref()),
             );
-            (dep_names, in_use)
+            let minimum_stability = composer_minimum_stability(parse_result);
+            (dep_names, in_use, minimum_stability)
         };
 
         tracing::debug!(count = dep_names.len(), "starting registry fetch");
@@ -1079,6 +1126,7 @@ pub async fn handle_document_open(
             freshness_settings,
             cache_config.fetch_timeout_secs,
             cache_config.max_concurrent_fetches,
+            minimum_stability.as_deref(),
         )
         .await;
 
@@ -1345,6 +1393,14 @@ pub async fn handle_document_change(
 
         // Skip registry fetch if nothing new was added and no existing
         // dependency's version changed.
+        //
+        // Known limitation (#424 N2): editing composer.json's `minimum-stability` field alone
+        // adds no dependency and changes no requirement string, so `deps_to_fetch` stays empty
+        // and this early-return skips the fetch — existing dependencies keep their
+        // `cached_versions` computed under the *previous* stability floor until the document
+        // is closed and reopened. Not fixed here: doing so would mean treating a
+        // `minimum_stability` change as its own full-refetch trigger in the diff above, a
+        // separate concern from #424's parse+thread scope.
         if deps_to_fetch.is_empty() {
             tracing::debug!("no added or version-changed dependencies, skipping registry fetch");
 
@@ -1421,18 +1477,22 @@ pub async fn handle_document_change(
 
         // Build the in-use-version map (§4.6) from the freshly-committed parse
         // result and the resolved versions just loaded above.
-        let in_use: HashMap<PackageName, Vec<String>> = match state_clone.get_document(&uri_clone) {
-            Some(doc) => match doc.parse_result() {
-                Some(pr) => collect_in_use_versions(
-                    pr,
-                    &resolved_versions,
-                    ecosystem_clone.formatter(),
-                    resolve_ecosystem_id(ecosystem_clone.as_ref()),
-                ),
-                None => HashMap::new(),
-            },
-            None => HashMap::new(),
-        };
+        let (in_use, minimum_stability): (HashMap<PackageName, Vec<String>>, Option<String>) =
+            match state_clone.get_document(&uri_clone) {
+                Some(doc) => match doc.parse_result() {
+                    Some(pr) => (
+                        collect_in_use_versions(
+                            pr,
+                            &resolved_versions,
+                            ecosystem_clone.formatter(),
+                            resolve_ecosystem_id(ecosystem_clone.as_ref()),
+                        ),
+                        composer_minimum_stability(pr),
+                    ),
+                    None => (HashMap::new(), None),
+                },
+                None => (HashMap::new(), None),
+            };
 
         // Fetch latest versions only for NEW dependencies
         let registry = ecosystem_clone.registry();
@@ -1444,6 +1504,7 @@ pub async fn handle_document_change(
             freshness_settings,
             cache_config.fetch_timeout_secs,
             cache_config.max_concurrent_fetches,
+            minimum_stability.as_deref(),
         )
         .await;
 
@@ -1884,6 +1945,7 @@ mod tests {
             deps_core::freshness::FreshnessSettings::default(),
             1,
             10,
+            None,
         )
         .await;
 
@@ -1969,6 +2031,7 @@ mod tests {
             deps_core::freshness::FreshnessSettings::default(),
             1,
             10,
+            None,
         )
         .await;
         let elapsed = start.elapsed();
@@ -2085,6 +2148,7 @@ mod tests {
             deps_core::freshness::FreshnessSettings::default(),
             5,
             20,
+            None,
         )
         .await;
 
@@ -2224,6 +2288,7 @@ mod tests {
             deps_core::freshness::FreshnessSettings::default(),
             1,
             10,
+            None,
         )
         .await;
 
@@ -2344,6 +2409,7 @@ mod tests {
             deps_core::freshness::FreshnessSettings::default(),
             10,
             10,
+            None,
         )
         .await;
 
@@ -2468,6 +2534,7 @@ mod tests {
             deps_core::freshness::FreshnessSettings::default(),
             10,
             10,
+            None,
         )
         .await;
 
@@ -2588,6 +2655,7 @@ mod tests {
             FreshnessSettings::default(),
             10,
             10,
+            None,
         )
         .await;
 
@@ -2601,6 +2669,236 @@ mod tests {
             "published_at must come from get_versions_with, not the freshness-blind \
              get_versions (#339)"
         );
+    }
+
+    /// #424 S1: `fetch_latest_versions_parallel` must call `select_latest_matching_with_context`
+    /// with the `minimum_stability` value it was given, not the plain `select_latest_matching`
+    /// — otherwise a registry with manifest-level stability state (e.g. Composer's
+    /// `minimum-stability`) never actually sees it, and #424's S1 fix stays unreachable dead
+    /// code from the live LSP fetch path's perspective (critic S3/tester's reachability gap).
+    #[tokio::test]
+    async fn test_fetch_latest_versions_parallel_threads_minimum_stability_into_select_latest_matching_with_context()
+     {
+        use deps_core::{Metadata, Registry, Version};
+        use std::any::Any;
+        use std::sync::Mutex;
+
+        #[derive(Debug)]
+        struct MockVersion {
+            version: String,
+        }
+
+        impl Version for MockVersion {
+            fn version_string(&self) -> &str {
+                &self.version
+            }
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        struct ContextAwareRegistry {
+            // Records every `minimum_stability` value observed, in call order — an empty
+            // `Vec` after the fetch means the `_with_context` method was never invoked.
+            seen_minimum_stability: Mutex<Vec<Option<String>>>,
+        }
+
+        impl Registry for ContextAwareRegistry {
+            fn get_versions<'a>(
+                &'a self,
+                _name: &'a deps_core::PackageName,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Version>>>>
+            {
+                Box::pin(async move {
+                    Ok(vec![Box::new(MockVersion {
+                        version: "1.0.0".to_string(),
+                    }) as Box<dyn Version>])
+                })
+            }
+
+            fn get_latest_matching<'a>(
+                &'a self,
+                _name: &'a deps_core::PackageName,
+                _req: &'a deps_core::VersionReq,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Option<Box<dyn Version>>>>
+            {
+                Box::pin(async move { Ok(None) })
+            }
+
+            fn search<'a>(
+                &'a self,
+                _query: &'a str,
+                _limit: usize,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Metadata>>>>
+            {
+                Box::pin(async move { Ok(vec![]) })
+            }
+
+            // Deliberately NOT overridden: if the fetch loop ever calls the plain
+            // `select_latest_matching` instead of the `_with_context` variant, this default
+            // (`None`) makes the pick fail, which the fallback below records as "not found" —
+            // distinguishable from the success path this test asserts on.
+            fn select_latest_matching_with_context(
+                &self,
+                versions: &[Box<dyn Version>],
+                _req: &deps_core::VersionReq,
+                minimum_stability: Option<&str>,
+            ) -> Option<usize> {
+                self.seen_minimum_stability
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .push(minimum_stability.map(str::to_string));
+                if versions.is_empty() { None } else { Some(0) }
+            }
+
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        let registry = Arc::new(ContextAwareRegistry {
+            seen_minimum_stability: Mutex::new(Vec::new()),
+        });
+        let packages = vec![PackageName::new("vendor/pkg")];
+
+        let result = fetch_latest_versions_parallel(
+            Arc::clone(&registry) as Arc<dyn Registry>,
+            packages,
+            &HashMap::new(),
+            None,
+            deps_core::freshness::FreshnessSettings::default(),
+            10,
+            10,
+            Some("beta"),
+        )
+        .await;
+
+        assert_eq!(
+            *registry
+                .seen_minimum_stability
+                .lock()
+                .unwrap_or_else(|p| p.into_inner()),
+            vec![Some("beta".to_string())],
+            "select_latest_matching_with_context must receive the caller's minimum_stability"
+        );
+        assert!(
+            result.versions.contains_key("vendor/pkg"),
+            "the pick must still succeed via the _with_context path"
+        );
+    }
+
+    /// #424 S1: the `get_latest_matching` fallback path (used when the pure list-based pick
+    /// finds nothing) must also thread `minimum_stability` through its own `_with_context`
+    /// variant.
+    #[tokio::test]
+    async fn test_fetch_latest_versions_parallel_threads_minimum_stability_into_get_latest_matching_with_context()
+     {
+        use deps_core::{Metadata, Registry, Version};
+        use std::any::Any;
+        use std::sync::Mutex;
+
+        #[derive(Debug)]
+        struct MockVersion {
+            version: String,
+        }
+
+        impl Version for MockVersion {
+            fn version_string(&self) -> &str {
+                &self.version
+            }
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        struct FallbackContextAwareRegistry {
+            // Records every `minimum_stability` value observed, in call order — an empty
+            // `Vec` after the fetch means the `_with_context` method was never invoked.
+            seen_minimum_stability: Mutex<Vec<Option<String>>>,
+        }
+
+        impl Registry for FallbackContextAwareRegistry {
+            fn get_versions<'a>(
+                &'a self,
+                _name: &'a deps_core::PackageName,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Version>>>>
+            {
+                // Empty list forces the fetch loop's `get_latest_matching_with_context`
+                // fallback (the pure list-based pick over an empty list finds nothing).
+                Box::pin(async move { Ok(vec![]) })
+            }
+
+            fn get_latest_matching<'a>(
+                &'a self,
+                _name: &'a deps_core::PackageName,
+                _req: &'a deps_core::VersionReq,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Option<Box<dyn Version>>>>
+            {
+                Box::pin(async move { Ok(None) })
+            }
+
+            fn get_latest_matching_with_context<'a>(
+                &'a self,
+                _name: &'a deps_core::PackageName,
+                _req: &'a deps_core::VersionReq,
+                minimum_stability: Option<&'a str>,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Option<Box<dyn Version>>>>
+            {
+                self.seen_minimum_stability
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .push(minimum_stability.map(str::to_string));
+                Box::pin(async move {
+                    Ok(Some(Box::new(MockVersion {
+                        version: "2.0.0-beta1".to_string(),
+                    }) as Box<dyn Version>))
+                })
+            }
+
+            fn search<'a>(
+                &'a self,
+                _query: &'a str,
+                _limit: usize,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Metadata>>>>
+            {
+                Box::pin(async move { Ok(vec![]) })
+            }
+
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        let registry = Arc::new(FallbackContextAwareRegistry {
+            seen_minimum_stability: Mutex::new(Vec::new()),
+        });
+        let packages = vec![PackageName::new("vendor/pkg")];
+
+        let result = fetch_latest_versions_parallel(
+            Arc::clone(&registry) as Arc<dyn Registry>,
+            packages,
+            &HashMap::new(),
+            None,
+            deps_core::freshness::FreshnessSettings::default(),
+            10,
+            10,
+            Some("beta"),
+        )
+        .await;
+
+        assert_eq!(
+            *registry
+                .seen_minimum_stability
+                .lock()
+                .unwrap_or_else(|p| p.into_inner()),
+            vec![Some("beta".to_string())],
+            "get_latest_matching_with_context must receive the caller's minimum_stability"
+        );
+        let widget = result
+            .versions
+            .get("vendor/pkg")
+            .expect("fallback pick should succeed");
+        assert_eq!(widget.latest, "2.0.0-beta1");
     }
 
     /// S3 regression: a registry whose `get_versions` list is incomplete (e.g. Go's
@@ -2681,6 +2979,7 @@ mod tests {
             deps_core::freshness::FreshnessSettings::default(),
             5,
             10,
+            None,
         )
         .await;
 
@@ -2760,6 +3059,7 @@ mod tests {
             deps_core::freshness::FreshnessSettings::default(),
             5,
             10,
+            None,
         )
         .await;
 
@@ -2853,6 +3153,7 @@ mod tests {
             deps_core::freshness::FreshnessSettings::default(),
             5,
             10,
+            None,
         )
         .await;
 
@@ -2929,6 +3230,7 @@ mod tests {
             deps_core::freshness::FreshnessSettings::default(),
             5,
             10,
+            None,
         )
         .await;
 
@@ -3007,6 +3309,7 @@ mod tests {
             deps_core::freshness::FreshnessSettings::default(),
             5,
             10,
+            None,
         )
         .await;
 
@@ -3081,6 +3384,7 @@ mod tests {
             deps_core::freshness::FreshnessSettings::default(),
             1,
             10,
+            None,
         )
         .await;
 
@@ -3090,6 +3394,74 @@ mod tests {
             HashSet::from([PackageName::new("slow-fallback")])
         );
         assert_eq!(result.failed_count, 1);
+    }
+
+    // Composer-specific tests
+    #[cfg(feature = "composer")]
+    mod composer_tests {
+        use super::*;
+
+        /// #424 S1: `composer_minimum_stability` must extract the manifest's
+        /// `minimum-stability` field via the real `deps_composer::parser::parse_composer_json`
+        /// → `ComposerParseResult` → `deps_core::ParseResult` downcast path, not just a
+        /// hand-built fixture — this is the actual production call path from the fetch task.
+        #[tokio::test]
+        async fn test_composer_minimum_stability_extracts_from_real_parse_result() {
+            let json = r#"{
+  "minimum-stability": "beta",
+  "require": {
+    "symfony/console": "^6.0"
+  }
+}"#;
+            let uri = deps_core::test_util::test_uri("/test/composer.json");
+            let parse_result = crate::parse_composer_json(json, &uri).unwrap();
+
+            assert_eq!(
+                composer_minimum_stability(&parse_result as &dyn deps_core::ParseResult),
+                Some("beta".to_string())
+            );
+        }
+
+        /// #424 S1: a `composer.json` with no `minimum-stability` field extracts to `None`,
+        /// not a fabricated `"stable"`.
+        #[tokio::test]
+        async fn test_composer_minimum_stability_none_when_absent() {
+            let json = r#"{"require": {"symfony/console": "^6.0"}}"#;
+            let uri = deps_core::test_util::test_uri("/test/composer.json");
+            let parse_result = crate::parse_composer_json(json, &uri).unwrap();
+
+            assert_eq!(
+                composer_minimum_stability(&parse_result as &dyn deps_core::ParseResult),
+                None
+            );
+        }
+
+        /// #424 S1: a non-Composer `ParseResult` (the downcast target type mismatches) must
+        /// extract to `None` rather than panicking — this is what every other ecosystem's
+        /// document hits on every fetch cycle.
+        #[test]
+        fn test_composer_minimum_stability_none_for_non_composer_parse_result() {
+            struct OtherParseResult;
+            impl deps_core::ParseResult for OtherParseResult {
+                fn dependencies(&self) -> Vec<&dyn deps_core::Dependency> {
+                    vec![]
+                }
+                fn workspace_root(&self) -> Option<&std::path::Path> {
+                    None
+                }
+                fn uri(&self) -> &Uri {
+                    unimplemented!("not exercised by this test")
+                }
+                fn as_any(&self) -> &dyn std::any::Any {
+                    self
+                }
+            }
+
+            assert_eq!(
+                composer_minimum_stability(&OtherParseResult as &dyn deps_core::ParseResult),
+                None
+            );
+        }
     }
 
     // Cargo-specific tests
@@ -3676,6 +4048,7 @@ dependencies = ["requests>=2.0.0"]
                 deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
+                None,
             )
             .await;
 
@@ -5589,6 +5962,7 @@ tokio = "1.0"
                 deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
+                None,
             )
             .await;
 
@@ -5616,6 +5990,7 @@ tokio = "1.0"
                 deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
+                None,
             )
             .await;
 
@@ -5641,6 +6016,7 @@ tokio = "1.0"
                 deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
+                None,
             )
             .await;
 
@@ -5674,6 +6050,7 @@ tokio = "1.0"
                 deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
+                None,
             )
             .await;
 
@@ -5707,6 +6084,7 @@ tokio = "1.0"
                 deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
+                None,
             )
             .await;
 
@@ -5740,6 +6118,7 @@ tokio = "1.0"
                 deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
+                None,
             )
             .await;
 
@@ -5775,6 +6154,7 @@ tokio = "1.0"
                 deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
+                None,
             )
             .await;
 
@@ -5826,6 +6206,7 @@ tokio = "1.0"
                 deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
+                None,
             )
             .await;
 
@@ -5859,6 +6240,7 @@ tokio = "1.0"
                 deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
+                None,
             )
             .await;
 
@@ -5892,6 +6274,7 @@ tokio = "1.0"
                 deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
+                None,
             )
             .await;
 
@@ -5936,6 +6319,7 @@ tokio = "1.0"
                 deps_core::freshness::FreshnessSettings::default(),
                 5,
                 10,
+                None,
             )
             .await;
 
@@ -5965,6 +6349,7 @@ tokio = "1.0"
                 deps_core::freshness::FreshnessSettings::default(),
                 1,
                 10,
+                None,
             )
             .await;
 

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -108,12 +108,18 @@ prerelease-aware ordering:
   outdated diagnostics are both corrected.
 - **Composer** (`composer.json`): stability precedence `dev` < `alpha` < `beta` < `RC` <
   `stable`, applied both to requirement-satisfaction comparison and to "latest version"
-  selection. `select_latest_matching`/`get_latest_matching` now exclude alpha/beta/RC
-  releases by default (mirroring Composer's `minimum-stability: stable` default) unless the
-  requirement itself names an unstable version; a wildcard/existence-check requirement still
-  resolves a prerelease-only package instead of reporting no version found. Manifest-driven
-  `minimum-stability` overrides from `composer.json` are not yet threaded through — that
-  remains a follow-up.
+  selection. `select_latest_matching`/`get_latest_matching` exclude alpha/beta/RC releases by
+  default (mirroring Composer's `minimum-stability: stable` default) unless overridden; a
+  wildcard/existence-check requirement still resolves a prerelease-only package instead of
+  reporting no version found. The effective stability floor is now manifest- and
+  dependency-aware: a per-dependency `@stability` flag (`^1.0@beta`) or a directly-pinned
+  prerelease version overrides the manifest's own `composer.json` `minimum-stability` field,
+  which in turn overrides the `stable` default — reflected in the live "outdated" diagnostic,
+  not just available as a library-level API. Separator-less and dot/underscore-separated
+  prerelease suffixes (`1.0.0RC1`, `2.6.3.alpha`) classify consistently regardless of
+  `v`/`V` prefix. Known limitation: editing `minimum-stability` alone in an already-open
+  document does not refresh already-fetched dependencies' cached "latest" version until the
+  document is closed and reopened.
 
 ### Maven/Gradle Version Range Matching
 


### PR DESCRIPTION
## Summary

Follow-up from #421/#422 (which excluded alpha/beta/RC releases from "latest version" selection by default). Closes the three gaps that #421/#422 explicitly scoped out:

- `composer.json`'s `minimum-stability` field is now parsed and threaded through to the registry's latest-version selection, overriding the stable-only default when set looser.
- Per-dependency `@stability` flags (`@stable`, `@RC`, `@beta`, `@alpha`, `@dev`) are now recognized as prerelease-bearing opt-ins, consistent with a directly-pinned prerelease version.
- Separator-less and dot/underscore-separated prerelease suffix forms (`1.0.0RC1`, `2.6.3.alpha`) now classify consistently regardless of `v`/`V` prefix, closing a class of inconsistency between the requirement-side and version-side classifiers.

## Design

- A shared Composer stability-rank system (`dev < alpha < beta < RC < stable`) replaces the old boolean prerelease gate in `PackagistRegistry`'s selection paths. Priority for the effective floor: per-dependency `@flag` > explicit prerelease pin > manifest `minimum-stability` > stable default.
- `Registry::select_latest_matching_with_context`/`get_latest_matching_with_context` are new default-provided `deps-core` trait methods (mirroring the existing `get_versions_with`/`FreshnessSettings` pattern) so every other ecosystem crate is unaffected; only `PackagistRegistry` overrides them.
- `deps-lsp`'s `fetch_latest_versions_parallel` threads the manifest's `minimum-stability` through via `ParseResult::as_any()` downcasting, so the fix is reachable from the live "outdated" diagnostic path, not just available as an unused library API.

## Known limitation

Editing `minimum-stability` alone in an already-open `composer.json` does not trigger a refetch of existing dependencies' cached "latest" version — that edit adds no dependency and changes no requirement string, so it doesn't enter the change-diff's fetch set. Diagnostics reflect the new floor after the document is closed and reopened. Documented in-code at the relevant early-return in `lifecycle.rs`. A follow-up issue will track making this edit trigger a refetch.

Also out of scope: `deps-core`'s completion/stable-candidate paths still call `is_prerelease()` directly, so completions don't yet honor `minimum-stability` — tracked as a separate cross-ecosystem-consistency follow-up.

## Test plan

- [x] `cargo nextest run --workspace --all-features --lib --bins` (2935 passed)
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Verified a `v`-prefix stability-ranking regression against live Packagist data (`sylius/sylius`, `symfony/*`) before merge
- [x] Generated 216-form cross-product test confirms the two prerelease classifiers agree on every grammar-valid Composer stability-suffix shape

Closes #424
