### PR TITLE
release: v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-09-01
+
 ### Fixed
 - **deps-pypi, deps-core, deps-lsp**: PyPI package-name completion, previously a permanent zero-results stub, now serves matches from a live PyPI package-name index (resolves #419) (#426)
 - **docs**: `ECOSYSTEM_GUIDE.md`'s Deno row now lists code lens support, matching the shared `deps-core` default it already receives (resolves #410) (#416)
@@ -644,7 +646,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TLS enforced via rustls
 - cargo-deny configured for vulnerability scanning
 
-[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/bug-ops/deps-lsp/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/bug-ops/deps-lsp/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/bug-ops/deps-lsp/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/bug-ops/deps-lsp/compare/v0.9.5...v0.10.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "deps-bundler"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "criterion",
  "deps-core",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "deps-cargo"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "criterion",
  "deps-core",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "deps-composer"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "deps-core",
  "mockito",
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "deps-core"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bytes",
  "criterion",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "deps-dart"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "criterion",
  "deps-core",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "deps-deno"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "deps-core",
  "deps-npm",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "deps-go"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "criterion",
  "deps-core",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "deps-gradle"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "deps-core",
  "deps-maven",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "deps-lsp"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "criterion",
  "dashmap",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "deps-maven"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bytes",
  "dashmap",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "deps-npm"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "criterion",
  "dashmap",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "deps-nuget"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "criterion",
  "deps-core",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "deps-pypi"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "criterion",
  "deps-core",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "deps-swift"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bytes",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/deps-zed"]
 resolver = "3"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 rust-version = "1.91"
 authors = ["Andrei G"]
@@ -14,20 +14,20 @@ repository = "https://github.com/bug-ops/deps-lsp"
 [workspace.dependencies]
 criterion = "0.8"
 dashmap = "6.2"
-deps-core = { version = "0.11.0", path ="crates/deps-core" }
-deps-cargo = { version = "0.11.0", path ="crates/deps-cargo" }
-deps-deno = { version = "0.11.0", path ="crates/deps-deno" }
-deps-npm = { version = "0.11.0", path ="crates/deps-npm" }
-deps-pypi = { version = "0.11.0", path ="crates/deps-pypi" }
-deps-go = { version = "0.11.0", path ="crates/deps-go" }
-deps-bundler = { version = "0.11.0", path ="crates/deps-bundler" }
-deps-dart = { version = "0.11.0", path ="crates/deps-dart" }
-deps-maven = { version = "0.11.0", path ="crates/deps-maven" }
-deps-nuget = { version = "0.11.0", path ="crates/deps-nuget" }
-deps-composer = { version = "0.11.0", path ="crates/deps-composer" }
-deps-gradle = { version = "0.11.0", path ="crates/deps-gradle" }
-deps-swift = { version = "0.11.0", path ="crates/deps-swift" }
-deps-lsp = { version = "0.11.0", path ="crates/deps-lsp" }
+deps-core = { version = "0.11.1", path ="crates/deps-core" }
+deps-cargo = { version = "0.11.1", path ="crates/deps-cargo" }
+deps-deno = { version = "0.11.1", path ="crates/deps-deno" }
+deps-npm = { version = "0.11.1", path ="crates/deps-npm" }
+deps-pypi = { version = "0.11.1", path ="crates/deps-pypi" }
+deps-go = { version = "0.11.1", path ="crates/deps-go" }
+deps-bundler = { version = "0.11.1", path ="crates/deps-bundler" }
+deps-dart = { version = "0.11.1", path ="crates/deps-dart" }
+deps-maven = { version = "0.11.1", path ="crates/deps-maven" }
+deps-nuget = { version = "0.11.1", path ="crates/deps-nuget" }
+deps-composer = { version = "0.11.1", path ="crates/deps-composer" }
+deps-gradle = { version = "0.11.1", path ="crates/deps-gradle" }
+deps-swift = { version = "0.11.1", path ="crates/deps-swift" }
+deps-lsp = { version = "0.11.1", path ="crates/deps-lsp" }
 futures = "0.3"
 insta = "1.48"
 jsonc-parser = "0.33"

--- a/crates/deps-cargo/README.md
+++ b/crates/deps-cargo/README.md
@@ -17,6 +17,8 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 - **crates.io registry** — Sparse index client for version lookups and package metadata
 - **Semver resolution** — Resolve `^`, `~`, `*`, and range specifiers against available versions
 - **Workspace support** — Handle `workspace.dependencies` inheritance and `version.workspace = true`
+- **Target-specific dependencies** — Parse `[target.<cfg-expr-or-triple>.dependencies]`/`.dev-dependencies`/`.build-dependencies` tables, same as top-level ones
+- **Git dependency refs** — `tag`/`branch`/`rev` keys on a git dependency populate `DependencySource::Git.rev`
 
 ## Installation
 

--- a/crates/deps-composer/README.md
+++ b/crates/deps-composer/README.md
@@ -18,6 +18,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 - **Version resolution** — Composer-specific version matching (`^`, `~`, `*`, `||`, ranges)
 - **Platform filtering** — Excludes `php`, `ext-*`, and `lib-*` pseudo-packages from registry lookups
 - **Case-insensitive names** — Package names normalized to lowercase (`vendor/package`)
+- **Stability-aware version selection** — "Latest version" excludes alpha/beta/RC releases by default (matching Composer's `minimum-stability: stable`), unless overridden by `composer.json`'s `minimum-stability` field or a per-dependency `@stability` flag (`^1.0@beta`); a wildcard requirement still resolves a prerelease-only package
 
 > [!NOTE]
 > Composer's tilde operator has different semantics from npm: `~1.2` means `>=1.2.0 <2.0.0` (not `>=1.2.0 <1.3.0`).


### PR DESCRIPTION
## Summary

- Bump version from 0.11.0 to 0.11.1
- Move [Unreleased] into a dated CHANGELOG.md section covering 22 commits (#395-#432)

## Checklist

- [x] Version updated in all manifests (workspace.package and workspace.dependencies)
- [x] CHANGELOG.md has release section with date
- [x] README reflects new version (no changes needed - dependency snippets pin major.minor only)
- [x] All CI checks pass locally (fmt, clippy, nextest, doc-tests, rustdoc gate)
- [ ] Ready for tagging after merge