### PR TITLE
feat(deps-core,deps-npm,deps-composer,deps-lsp): package-level deprecation diagnostics with suggested replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **deps-core, deps-npm, deps-composer, deps-lsp**: package-level deprecation/abandoned diagnostic and hover section (npm `deprecated`, Composer `abandoned`), plus a Composer-only "Replace with X" code action when a successor package is named (resolves #205)
+
 ## [0.11.1] - 2026-09-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **deps-core, deps-npm, deps-composer, deps-lsp**: package-level deprecation/abandoned diagnostic and hover section (npm `deprecated`, Composer `abandoned`), plus a Composer-only "Replace with X" code action when a successor package is named (resolves #205)
+- **deps-core, deps-npm, deps-composer, deps-lsp**: package-level deprecation/abandoned diagnostic and hover section (npm `deprecated`, Composer `abandoned`), plus a Composer-only "Replace with X" code action when a successor package is named (resolves #205) (#435)
 
 ## [0.11.1] - 2026-09-01
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A universal Language Server Protocol (LSP) server for dependency management acro
 - **Version hints** — Inlay hints showing latest available versions
 - **Loading indicators** — Visual feedback during registry fetches with LSP progress support
 - **Lock file support** — Reads resolved versions from Cargo.lock, package-lock.json, poetry.lock, uv.lock, go.sum, Gemfile.lock, pubspec.lock, Package.resolved, composer.lock
-- **Diagnostics** — Warnings for outdated, unknown, yanked, or unsatisfiable-requirement dependencies
+- **Diagnostics** — Warnings for outdated, unknown, yanked, unsatisfiable-requirement, or deprecated/abandoned dependencies
 - **Vulnerability scanning** — OSV.dev-backed advisories in diagnostics and hover, across all supported ecosystems
 - **Release-freshness signal** — Flags a "latest" version still within a cooldown window in hover and completion, mirroring GitHub Dependabot's default 3-day package cooldown
 - **Hover information** — Package descriptions with resolved version from lock file
@@ -248,6 +248,7 @@ Configure via LSP initialization options:
     "unknown_severity": "warning",
     "yanked_severity": "warning",
     "unsatisfiable_severity": "warning",
+    "deprecated_severity": "warning",
     "vulnerabilities_enabled": true
   },
   "freshness": {
@@ -277,6 +278,9 @@ Configure via LSP initialization options:
 
 > [!NOTE]
 > `diagnostics.outdated_severity`, `diagnostics.unknown_severity`, `diagnostics.unsatisfiable_severity`, and `diagnostics.yanked_severity` are all honored end-to-end. The yanked diagnostic fires in two independent cases (never both at once for the same dependency): (1) the dependency's in-use version — lock-file-resolved, or an exact pin such as `requirements.txt`'s `==1.2.3` — is itself reported as yanked/deprecated/retracted, supported for **Cargo, npm, PyPI, Bundler, and Dart**; or (2) the dependency's declared version *requirement* (a range) is currently satisfiable only by yanked versions, even with no lock file at all. See [Yanked Version Diagnostic](docs/ECOSYSTEM_GUIDE.md#yanked-version-diagnostic) for exact semantics and per-ecosystem coverage of each case (RubyGems cannot be detected by either mechanism, since its registry omits yanked versions from the list entirely rather than flagging them).
+
+> [!NOTE]
+> `diagnostics.deprecated_severity` flags a dependency whose *package* — not a specific version — is reported as deprecated/abandoned (`This package is deprecated: <reason>`), with a matching hover section and, for Composer packages naming a successor, a "Replace with X" quick fix. Currently sourced from **npm**'s `deprecated` field and **Composer**'s `abandoned` field only. See [Package Deprecation Diagnostics](docs/ECOSYSTEM_GUIDE.md#package-deprecation-diagnostics-issue-205) for the full ecosystem coverage table and how this differs from the yanked diagnostic above.
 
 ### Configuration reference
 

--- a/crates/deps-composer/src/formatter.rs
+++ b/crates/deps-composer/src/formatter.rs
@@ -4,6 +4,7 @@ use deps_core::PackageName;
 use deps_core::VersionReq;
 use deps_core::lsp_helpers::{EcosystemFormatter, RequirementMatcher, compile_requirement_unless};
 use deps_core::normalize_operator_spacing;
+use tower_lsp_server::ls_types::Position;
 
 /// Whether `segment` matches Packagist's vendor/package name-segment charset: starts and ends
 /// with an ASCII alphanumeric character, with only `.`, `_`, `-` allowed in between (Composer's
@@ -90,6 +91,58 @@ impl EcosystemFormatter for ComposerFormatter {
 
     fn yanked_label(&self) -> &'static str {
         "*(abandoned)*"
+    }
+
+    /// Reuses Packagist's own "abandoned" wording for #205's package-level diagnostic,
+    /// mirroring the yanked pair above rather than the trait default's generic
+    /// "deprecated" — pattern reuse, not a new ecosystem-specific branch.
+    fn deprecated_message(&self) -> &'static str {
+        "This package is abandoned"
+    }
+
+    fn deprecated_label(&self) -> &'static str {
+        "*(abandoned)*"
+    }
+
+    /// Packagist's `abandoned` replacement name is a structured, registry-validated
+    /// field (see `deprecation_from_abandoned` in `registry.rs`), unlike npm's free-text
+    /// `deprecated` message — safe to offer as a rename target.
+    fn supports_package_rename(&self) -> bool {
+        true
+    }
+
+    /// Widens the rename quickfix's discoverability: without this, only a cursor on
+    /// `version_range` (the default) reaches `generate_code_actions`, so a user reading
+    /// "this package is abandoned" and clicking the package *name* — the very token the
+    /// rename rewrites — would find no action offered.
+    ///
+    /// Rejects a degenerate (zero-width) `name_range` rather than reusing the default's
+    /// `version_range`-only check plus this: `find_positions` (`parser.rs`) falls back to
+    /// `Range::default()` — `(0,0)-(0,0)` — when its name-literal search misses (e.g. a
+    /// legal escaped-solidus `"vendor\/package"` key), and `position_in_range` is
+    /// inclusive on both ends, so an unguarded widen would make that sentinel
+    /// *selectable* by a cursor resting on the file's opening `{` — reopening the exact
+    /// `Range::default()` hazard `build_replacement_action`'s literal-span guard exists
+    /// to prevent, just through the position check instead of the edit itself.
+    ///
+    /// This is the shared entry point [`generate_code_actions`](deps_core::lsp_helpers::generate_code_actions)
+    /// uses to find "the dependency at this position" for *every* action kind, not only
+    /// the rename — a cursor on the package name in `composer.json` now also surfaces
+    /// the version-bump/vulnerability-fix actions it previously didn't (their edits still
+    /// target `version_range` regardless of where the cursor landed, so this only widens
+    /// where the actions are *offered from*, never what they write). Accepted, not scoped
+    /// narrower to the rename alone: a single shared boolean gate has no per-action-kind
+    /// dial, and a cursor on the name is exactly where a user reading "this package is
+    /// abandoned" is likely to click for *any* fix, not just the rename.
+    fn is_position_on_dependency(&self, dep: &dyn Dependency, position: Position) -> bool {
+        let name_range = dep.name_range();
+        if name_range.start != name_range.end
+            && deps_core::lsp_helpers::position_in_range(position, name_range)
+        {
+            return true;
+        }
+        dep.version_range()
+            .is_some_and(|r| deps_core::lsp_helpers::position_in_range(position, r))
     }
 
     /// Checks if a version satisfies a Composer version requirement.
@@ -261,8 +314,8 @@ impl EcosystemFormatter for ComposerFormatter {
     /// onto every version entry of an abandoned package — not a true per-version yank.
     /// Evaluating a range requirement (`^1.0`, `~2.3`) against it would flag every dependency
     /// on such a package with this diagnostic's "yanked" wording, conflating it with
-    /// package-level abandonment, which is a distinct, separately-planned diagnostic
-    /// (issue #205).
+    /// package-level abandonment, which is a distinct diagnostic
+    /// ([`EcosystemFormatter::deprecated_message`], issue #205).
     fn yanked_diagnostic_applies_to(&self, requirement: &VersionReq) -> bool {
         is_exact_pin(requirement.as_str())
     }
@@ -533,6 +586,9 @@ fn compare_versions(a: &str, b: &str) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::{ComposerDependency, ComposerSection};
+    use std::collections::HashMap;
+    use tower_lsp_server::ls_types::Range;
 
     #[test]
     fn test_normalize_package_name() {
@@ -1054,6 +1110,241 @@ mod tests {
                 f.validate_package_name(name).is_err(),
                 "expected {name:?} to be rejected"
             );
+        }
+    }
+
+    // --- #205 package-level deprecation ---
+
+    #[test]
+    fn test_deprecated_message_and_label_reuse_abandoned_wording() {
+        let f = ComposerFormatter;
+        assert_eq!(f.deprecated_message(), "This package is abandoned");
+        assert_eq!(f.deprecated_label(), "*(abandoned)*");
+    }
+
+    #[test]
+    fn test_supports_package_rename_true() {
+        assert!(ComposerFormatter.supports_package_rename());
+    }
+
+    /// W1: the discoverability override must reject a degenerate (zero-width) name
+    /// range — `find_positions` (`parser.rs`) falls back to `Range::default()`
+    /// (`(0,0)-(0,0)`) on a name-locator miss, and `position_in_range` is inclusive on
+    /// both ends, so an unguarded widen would make that sentinel selectable by a cursor
+    /// resting on the file's opening `{`, reopening the C2 `Range::default()` hazard.
+    #[test]
+    fn test_is_position_on_dependency_rejects_zero_width_name_range() {
+        use tower_lsp_server::ls_types::Position;
+
+        let dep = ComposerDependency {
+            name: "vendor/package".into(),
+            name_range: Range::default(),
+            version_req: Some("^1.0".into()),
+            version_range: Some(Range::new(Position::new(1, 20), Position::new(1, 25))),
+            section: ComposerSection::Require,
+        };
+
+        let f = ComposerFormatter;
+        assert!(
+            !f.is_position_on_dependency(&dep, Position::new(0, 0)),
+            "a degenerate name_range must never be selectable, even at its own (0,0) span"
+        );
+        // The version range still works normally.
+        assert!(f.is_position_on_dependency(&dep, Position::new(1, 22)));
+    }
+
+    /// The override still widens discoverability for a real (non-degenerate) name
+    /// range — the whole point of overriding the shared default.
+    #[test]
+    fn test_is_position_on_dependency_accepts_real_name_range() {
+        use tower_lsp_server::ls_types::Position;
+
+        let dep = ComposerDependency {
+            name: "vendor/package".into(),
+            name_range: Range::new(Position::new(1, 4), Position::new(1, 20)),
+            version_req: Some("^1.0".into()),
+            version_range: Some(Range::new(Position::new(1, 23), Position::new(1, 28))),
+            section: ComposerSection::Require,
+        };
+
+        let f = ComposerFormatter;
+        assert!(f.is_position_on_dependency(&dep, Position::new(1, 10)));
+    }
+
+    /// T1 (D7(a)/C2): a Composer manifest whose name locator misses — a legal
+    /// escaped-solidus `"vendor\/package"` key, which `find_positions`'s literal search
+    /// for the serde-unescaped `"vendor/package"` never matches — must never offer a
+    /// "Replace with X" rename action, rather than emitting a corrupting edit at
+    /// `(0,0)`.
+    ///
+    /// Exercised two ways: end to end through the real parser (today's actual
+    /// behavior — safe only because `version_range` also stays `None`, an incidental
+    /// coupling, not a guarantee), and directly against `name_literal_guard`-shaped
+    /// input (`version_range: Some(..)`, `name_range: Range::default()`) so the test
+    /// still catches a regression if that coupling is ever broken by a parser change.
+    #[tokio::test]
+    async fn test_generate_code_actions_escaped_solidus_name_offers_no_rename_action() {
+        let json = r#"{"require": {"vendor\/package": "^1.0"}}"#;
+        let uri = deps_core::test_util::test_uri("/test/composer.json");
+        let parse_result = crate::parser::parse_composer_json(json, &uri).unwrap();
+        assert_eq!(parse_result.dependencies.len(), 1);
+        let dep = &parse_result.dependencies[0];
+        assert_eq!(
+            dep.name_range,
+            Range::default(),
+            "escaped-solidus key must miss the literal-text search"
+        );
+        assert!(
+            dep.version_range.is_none(),
+            "today's incidental coupling: the version search never runs either"
+        );
+
+        let mut deprecations = HashMap::new();
+        deprecations.insert(
+            "vendor/package".to_string(),
+            deps_core::Deprecation {
+                reason: None,
+                replacement: Some("other/package".to_string()),
+            },
+        );
+        let cached = HashMap::new();
+        let resolved = HashMap::new();
+        let versions =
+            deps_core::VersionData::new(&cached, &resolved).with_deprecations(&deprecations);
+
+        let actions = deps_core::lsp_helpers::generate_code_actions(
+            &parse_result,
+            Position::new(0, 0),
+            &uri,
+            versions,
+            json,
+            &NoNetworkRegistry,
+            &ComposerFormatter,
+        )
+        .await;
+        assert!(
+            actions.iter().all(|a| !a.title.starts_with("Replace with")),
+            "no rename action may be offered when the name locator missed: {actions:?}"
+        );
+
+        // Direct regression guard for the guard mechanism itself (not just today's
+        // incidental version_range coupling): a hand-built dependency with a valid
+        // version_range but a degenerate name_range must still be rejected.
+        let corrupted_dep = ComposerDependency {
+            name: "vendor/package".into(),
+            name_range: Range::default(),
+            version_req: Some("^1.0".into()),
+            version_range: Some(Range::new(Position::new(0, 33), Position::new(0, 37))),
+            section: ComposerSection::Require,
+        };
+        let corrupted_result = crate::parser::ComposerParseResult {
+            dependencies: vec![corrupted_dep],
+            uri: uri.clone(),
+            minimum_stability: None,
+        };
+        let actions = deps_core::lsp_helpers::generate_code_actions(
+            &corrupted_result,
+            Position::new(0, 34),
+            &uri,
+            versions,
+            json,
+            &NoNetworkRegistry,
+            &ComposerFormatter,
+        )
+        .await;
+        assert!(
+            actions.iter().all(|a| !a.title.starts_with("Replace with")),
+            "the name-literal guard must reject a degenerate name_range independent of \
+             version_range: {actions:?}"
+        );
+    }
+
+    /// Positive path (D7): a well-formed manifest with a real replacement name offers
+    /// the "Replace with X" rename quickfix, targeting `name_range` with `replacement`.
+    #[tokio::test]
+    async fn test_generate_code_actions_offers_rename_action_for_well_formed_manifest() {
+        let json = r#"{"require": {"vendor/package": "^1.0"}}"#;
+        let uri = deps_core::test_util::test_uri("/test/composer.json");
+        let parse_result = crate::parser::parse_composer_json(json, &uri).unwrap();
+        let dep = &parse_result.dependencies[0];
+        assert_ne!(dep.name_range, Range::default());
+        let version_range = dep.version_range.expect("version_range must be present");
+
+        let mut deprecations = HashMap::new();
+        deprecations.insert(
+            "vendor/package".to_string(),
+            deps_core::Deprecation {
+                reason: None,
+                replacement: Some("other/package".to_string()),
+            },
+        );
+        let cached = HashMap::new();
+        let resolved = HashMap::new();
+        let versions =
+            deps_core::VersionData::new(&cached, &resolved).with_deprecations(&deprecations);
+
+        let actions = deps_core::lsp_helpers::generate_code_actions(
+            &parse_result,
+            version_range.start,
+            &uri,
+            versions,
+            json,
+            &NoNetworkRegistry,
+            &ComposerFormatter,
+        )
+        .await;
+
+        let rename = actions
+            .iter()
+            .find(|a| a.title == "Replace with other/package")
+            .unwrap_or_else(|| panic!("expected a rename action, got: {actions:?}"));
+        let edits = rename
+            .edit
+            .as_ref()
+            .and_then(|e| e.changes.as_ref())
+            .and_then(|c| c.get(&uri))
+            .expect("rename action must carry a WorkspaceEdit for this URI");
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].range, dep.name_range);
+        assert_eq!(edits[0].new_text, "other/package");
+    }
+
+    /// No-op [`deps_core::Registry`] so #205 code-action tests never hit the network —
+    /// `generate_code_actions` calls `registry.get_versions` unconditionally after the
+    /// registry-independent fix/rename actions are built.
+    struct NoNetworkRegistry;
+
+    impl deps_core::Registry for NoNetworkRegistry {
+        fn get_versions<'a>(
+            &'a self,
+            _name: &'a PackageName,
+        ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn deps_core::Version>>>>
+        {
+            Box::pin(async move { Ok(vec![]) })
+        }
+
+        fn get_latest_matching<'a>(
+            &'a self,
+            _name: &'a PackageName,
+            _req: &'a VersionReq,
+        ) -> deps_core::ecosystem::BoxFuture<
+            'a,
+            deps_core::Result<Option<Box<dyn deps_core::Version>>>,
+        > {
+            Box::pin(async move { Ok(None) })
+        }
+
+        fn search<'a>(
+            &'a self,
+            _query: &'a str,
+            _limit: usize,
+        ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn deps_core::Metadata>>>>
+        {
+            Box::pin(async move { Ok(vec![]) })
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
         }
     }
 }

--- a/crates/deps-composer/src/registry.rs
+++ b/crates/deps-composer/src/registry.rs
@@ -9,7 +9,9 @@
 //! by inheriting from the previous complete entry.
 
 use crate::types::{ComposerPackage, ComposerVersion};
-use deps_core::{DepsError, HttpCache, Result, is_dot_segment, lsp_helpers::warn_rejected_value};
+use deps_core::{
+    Deprecation, DepsError, HttpCache, Result, is_dot_segment, lsp_helpers::warn_rejected_value,
+};
 use serde::Deserialize;
 use std::any::Any;
 use std::sync::Arc;
@@ -448,6 +450,7 @@ fn expand_minified_versions(entries: Vec<MinifiedVersion>) -> Vec<ComposerVersio
             .abandoned
             .as_ref()
             .is_some_and(|v| v.as_bool() == Some(true) || v.is_string());
+        let deprecation = deprecation_from_abandoned(current.abandoned.as_ref());
 
         result.push(ComposerVersion {
             version: version.clone(),
@@ -456,11 +459,41 @@ fn expand_minified_versions(entries: Vec<MinifiedVersion>) -> Vec<ComposerVersio
                 .clone()
                 .unwrap_or_else(|| version.clone()),
             abandoned,
+            deprecation,
             published_at,
         });
     }
 
     result
+}
+
+/// Derives a #205 [`Deprecation`](deps_core::Deprecation) payload from Packagist's
+/// `abandoned` field.
+///
+/// Packagist's `abandoned` is either absent/`false`/`null` (not abandoned), bare `true`
+/// (abandoned, no known successor), or a string naming a replacement package — a
+/// structured, registry-validated field, unlike npm's free-text `deprecated` message,
+/// which is what makes Composer (and only Composer) safe to offer a rename quickfix for
+/// (see `ComposerFormatter::supports_package_rename`).
+///
+/// M2: an all-whitespace replacement string produces a bare `Deprecation` (both fields
+/// `None`) rather than one with an empty `replacement`, mirroring
+/// `deps_npm::deprecation_from_message`'s empty-payload guard — though for Composer this
+/// is defense-in-depth rather than an observed real-world case, since a real
+/// `abandoned: true` already takes the same path.
+fn deprecation_from_abandoned(abandoned: Option<&serde_json::Value>) -> Option<Deprecation> {
+    let value = abandoned?;
+    if value.as_bool() == Some(true) {
+        return Some(Deprecation {
+            reason: None,
+            replacement: None,
+        });
+    }
+    let replacement = value.as_str()?;
+    Some(Deprecation {
+        reason: None,
+        replacement: (!replacement.trim().is_empty()).then(|| replacement.trim().to_string()),
+    })
 }
 
 /// Parses Packagist v2 API response JSON.
@@ -828,6 +861,69 @@ mod tests {
         let versions = expand_minified_versions(entries);
         assert_eq!(versions.len(), 1);
         assert!(versions[0].abandoned);
+        assert_eq!(
+            versions[0].deprecation,
+            Some(Deprecation {
+                reason: None,
+                replacement: Some("Use other/package".to_string()),
+            })
+        );
+    }
+
+    /// #205: a bare `"abandoned": true` still fires — both `Deprecation` fields `None`
+    /// (no known successor) — distinct from `Some` with an empty payload.
+    #[test]
+    fn test_expand_minified_versions_abandoned_true_has_no_replacement() {
+        let entries = vec![MinifiedVersion {
+            version: Some("3.0.0".into()),
+            version_normalized: Some("3.0.0.0".into()),
+            abandoned: Some(serde_json::Value::Bool(true)),
+            time: None,
+        }];
+
+        let versions = expand_minified_versions(entries);
+        assert_eq!(
+            versions[0].deprecation,
+            Some(Deprecation {
+                reason: None,
+                replacement: None,
+            })
+        );
+    }
+
+    /// #205 M2: an all-whitespace replacement string must not leak through as an empty,
+    /// dangling `replacement` — the package is still abandoned (mirrors bare `true`).
+    #[test]
+    fn test_expand_minified_versions_abandoned_whitespace_replacement_is_none() {
+        let entries = vec![MinifiedVersion {
+            version: Some("3.0.0".into()),
+            version_normalized: Some("3.0.0.0".into()),
+            abandoned: Some(serde_json::Value::String("   ".into())),
+            time: None,
+        }];
+
+        let versions = expand_minified_versions(entries);
+        assert_eq!(
+            versions[0].deprecation,
+            Some(Deprecation {
+                reason: None,
+                replacement: None,
+            })
+        );
+    }
+
+    /// Not abandoned at all: no `Deprecation` payload.
+    #[test]
+    fn test_expand_minified_versions_not_abandoned_has_no_deprecation() {
+        let entries = vec![MinifiedVersion {
+            version: Some("3.0.0".into()),
+            version_normalized: Some("3.0.0.0".into()),
+            abandoned: None,
+            time: None,
+        }];
+
+        let versions = expand_minified_versions(entries);
+        assert_eq!(versions[0].deprecation, None);
     }
 
     #[test]
@@ -1005,12 +1101,14 @@ mod tests {
                 version: "2.0.0".into(),
                 version_normalized: "2.0.0.0".into(),
                 abandoned: true,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "1.0.0".into(),
                 version_normalized: "1.0.0.0".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1032,12 +1130,14 @@ mod tests {
                 version: "2.0.0".into(),
                 version_normalized: "2.0.0.0".into(),
                 abandoned: true,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "1.0.0".into(),
                 version_normalized: "1.0.0.0".into(),
                 abandoned: true,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1092,12 +1192,14 @@ mod tests {
                 version: "2.0.0-beta1".into(),
                 version_normalized: "2.0.0.0-beta1".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "1.5.0".into(),
                 version_normalized: "1.5.0.0".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1119,12 +1221,14 @@ mod tests {
                 version: "2.0.0-beta1".into(),
                 version_normalized: "2.0.0.0-beta1".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "1.5.0".into(),
                 version_normalized: "1.5.0.0".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1178,12 +1282,14 @@ mod tests {
                 version: "2.0.0-a1".into(),
                 version_normalized: "2.0.0.0-alpha1".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "1.5.0".into(),
                 version_normalized: "1.5.0.0".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1204,6 +1310,7 @@ mod tests {
             version: "1.0.0-a1".into(),
             version_normalized: "1.0.0.0-alpha1".into(),
             abandoned: false,
+            deprecation: None,
             published_at: None,
         })];
         let req = VersionReq::new("^1.0.0-a1");
@@ -1255,12 +1362,14 @@ mod tests {
                 version: "2.0.0-beta2".into(),
                 version_normalized: "2.0.0.0-beta2".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "2.0.0-beta1".into(),
                 version_normalized: "2.0.0.0-beta1".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1306,18 +1415,21 @@ mod tests {
                 version: "2.0.0-alpha1".into(),
                 version_normalized: "2.0.0.0-alpha1".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "2.0.0-beta1".into(),
                 version_normalized: "2.0.0.0-beta1".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "1.5.0".into(),
                 version_normalized: "1.5.0.0".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ]
@@ -1436,12 +1548,14 @@ mod tests {
                 version: "1.5.0-beta1".into(),
                 version_normalized: "1.5.0.0-beta1".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "1.0.0".into(),
                 version_normalized: "1.0.0.0".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1466,12 +1580,14 @@ mod tests {
                 version: "1.5.0-alpha1".into(),
                 version_normalized: "1.5.0.0-alpha1".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "1.0.0".into(),
                 version_normalized: "1.0.0.0".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1497,12 +1613,14 @@ mod tests {
                 version: "1.5.0-beta1".into(),
                 version_normalized: "1.5.0.0-beta1".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "1.0.0".into(),
                 version_normalized: "1.0.0.0".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1524,18 +1642,21 @@ mod tests {
                 version: "1.5.0-beta1".into(),
                 version_normalized: "1.5.0.0-beta1".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "1.4.0-RC1".into(),
                 version_normalized: "1.4.0.0-RC1".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "1.0.0".into(),
                 version_normalized: "1.0.0.0".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1561,12 +1682,14 @@ mod tests {
                 version: "1.5.0-alpha1".into(),
                 version_normalized: "1.5.0.0-alpha1".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "1.0.0".into(),
                 version_normalized: "1.0.0.0".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1587,12 +1710,14 @@ mod tests {
                 version: "1.5.0-alpha1".into(),
                 version_normalized: "1.5.0.0-alpha1".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "1.0.0".into(),
                 version_normalized: "1.0.0.0".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1615,6 +1740,7 @@ mod tests {
             version: "1.5.0-beta1".into(),
             version_normalized: "1.5.0.0-beta1".into(),
             abandoned: false,
+            deprecation: None,
             published_at: None,
         })];
         let req = VersionReq::new("^1.0@beta || ^2.0");
@@ -1633,6 +1759,7 @@ mod tests {
             version: "1.5.0-alpha1".into(),
             version_normalized: "1.5.0.0-alpha1".into(),
             abandoned: false,
+            deprecation: None,
             published_at: None,
         })];
         let req = VersionReq::new(">=1.0@dev <2.0");
@@ -1675,12 +1802,14 @@ mod tests {
                 version: "2.0.0a1".into(),
                 version_normalized: "2.0.0a1".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "1.5.0".into(),
                 version_normalized: "1.5.0.0".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1702,12 +1831,14 @@ mod tests {
                 version: "2.0.0a1".into(),
                 version_normalized: "2.0.0a1".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "1.5.0".into(),
                 version_normalized: "1.5.0.0".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1727,12 +1858,14 @@ mod tests {
                 version: "2.0.0dev".into(),
                 version_normalized: "2.0.0dev".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "1.5.0".into(),
                 version_normalized: "1.5.0.0".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1757,12 +1890,14 @@ mod tests {
                 version: "v2.3.0-alpha.1".into(),
                 version_normalized: "2.3.0.0-alpha1".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "v2.2.8".into(),
                 version_normalized: "2.2.8.0".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1788,12 +1923,14 @@ mod tests {
                 version: "V3.0.0-RC1".into(),
                 version_normalized: "3.0.0.0-RC1".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "v2.9.0".into(),
                 version_normalized: "2.9.0.0".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1819,12 +1956,14 @@ mod tests {
                 // response that never expanded it) so the primary path must catch this alone.
                 version_normalized: "2.0.0RC1".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "1.5.0".into(),
                 version_normalized: "1.5.0.0".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1846,12 +1985,14 @@ mod tests {
                 version: "2.0.0RC1".into(),
                 version_normalized: "2.0.0RC1".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "1.5.0".into(),
                 version_normalized: "1.5.0.0".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1873,12 +2014,14 @@ mod tests {
                 version: "2.6.3.alpha".into(),
                 version_normalized: "2.6.3.0-alpha".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "2.6.2".into(),
                 version_normalized: "2.6.2.0".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1901,12 +2044,14 @@ mod tests {
                 version: "2.6.3.alpha".into(),
                 version_normalized: "2.6.3.0-alpha".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(ComposerVersion {
                 version: "2.6.2".into(),
                 version_normalized: "2.6.2.0".into(),
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];

--- a/crates/deps-composer/src/types.rs
+++ b/crates/deps-composer/src/types.rs
@@ -70,6 +70,7 @@ pub enum ComposerSection {
 ///     version: "6.0.0".into(),
 ///     version_normalized: "6.0.0.0".into(),
 ///     abandoned: false,
+///     deprecation: None,
 ///     published_at: None,
 /// };
 ///
@@ -80,6 +81,11 @@ pub struct ComposerVersion {
     pub version: String,
     pub version_normalized: String,
     pub abandoned: bool,
+    /// Package-level deprecation payload (issue #205), derived from Packagist's
+    /// `abandoned` field. `Some(Deprecation { reason: None, replacement: None })` for a
+    /// bare `"abandoned": true`; `replacement` populated when `abandoned` names a
+    /// successor package. `None` only when `abandoned` is absent/`false`/`null`.
+    pub deprecation: Option<deps_core::Deprecation>,
     /// Publish timestamp, parsed from the p2 entry's own `time` field.
     ///
     /// Taken only from the entry itself, never inherited from a previous
@@ -210,6 +216,7 @@ deps_core::impl_version!(ComposerVersion {
         is_prerelease_marker(&v.version)
             || deps_core::has_default_prerelease_marker(&v.version_normalized)
     },
+    deprecation: |v: &ComposerVersion| v.deprecation.as_ref(),
 });
 
 /// Package metadata from Packagist search.
@@ -285,6 +292,7 @@ mod tests {
             version: "2.0.0".into(),
             version_normalized: "2.0.0.0".into(),
             abandoned: true,
+            deprecation: None,
             published_at: None,
         };
 
@@ -296,6 +304,37 @@ mod tests {
         assert!(!version.removal_status().blocks_resolution());
     }
 
+    /// #205: `Version::deprecation()` reads the dedicated field, independent of the
+    /// `removal_status`-driving `abandoned` bool.
+    #[test]
+    fn test_composer_version_deprecation_accessor() {
+        let with_payload = ComposerVersion {
+            version: "2.0.0".into(),
+            version_normalized: "2.0.0.0".into(),
+            abandoned: true,
+            deprecation: Some(deps_core::Deprecation {
+                reason: None,
+                replacement: Some("other/package".to_string()),
+            }),
+            published_at: None,
+        };
+        assert_eq!(
+            with_payload
+                .deprecation()
+                .and_then(|d| d.replacement.as_deref()),
+            Some("other/package")
+        );
+
+        let without_payload = ComposerVersion {
+            version: "1.0.0".into(),
+            version_normalized: "1.0.0.0".into(),
+            abandoned: false,
+            deprecation: None,
+            published_at: None,
+        };
+        assert!(without_payload.deprecation().is_none());
+    }
+
     #[test]
     fn test_composer_version_short_stability_alias_is_prerelease() {
         // Regression test for #327 M2: Composer's short "-a"/"-b" stability
@@ -305,12 +344,14 @@ mod tests {
             version: "1.0.0-a1".into(),
             version_normalized: "1.0.0.0-alpha1".into(),
             abandoned: false,
+            deprecation: None,
             published_at: None,
         };
         let beta = ComposerVersion {
             version: "1.0.0-b1".into(),
             version_normalized: "1.0.0.0-beta1".into(),
             abandoned: false,
+            deprecation: None,
             published_at: None,
         };
         assert!(alpha.is_prerelease());
@@ -337,6 +378,7 @@ mod tests {
                 version: name.into(),
                 version_normalized: name.into(), // no expansion happened
                 abandoned: false,
+                deprecation: None,
                 published_at: None,
             };
             assert_eq!(
@@ -461,6 +503,7 @@ mod tests {
             version: "2.0.0RC1".into(),
             version_normalized: "2.0.0RC1".into(),
             abandoned: false,
+            deprecation: None,
             published_at: None,
         };
         assert!(version.is_prerelease());
@@ -472,6 +515,7 @@ mod tests {
             version: "6.0.0".into(),
             version_normalized: "6.0.0.0".into(),
             abandoned: false,
+            deprecation: None,
             published_at: None,
         };
         assert!(!version.is_prerelease());

--- a/crates/deps-core/src/lib.rs
+++ b/crates/deps-core/src/lib.rs
@@ -56,8 +56,9 @@ pub use parser::{
     check_toml_nesting_depth, check_yaml_expansion, check_yaml_nesting_depth, parse_json_checked,
 };
 pub use registry::{
-    Metadata, Registry, RemovalStatus, Version, find_latest_stable, has_default_prerelease_marker,
-    is_existence_wildcard, is_existence_wildcard_str, select_latest_for_existence,
+    Deprecation, Metadata, Registry, RemovalStatus, Version, find_latest_stable,
+    has_default_prerelease_marker, is_existence_wildcard, is_existence_wildcard_str,
+    select_latest_for_existence,
 };
 pub use version_matcher::{
     Pep440Matcher, SemverMatcher, VersionRequirementMatcher, extract_pypi_min_version,

--- a/crates/deps-core/src/lsp_helpers/code_actions.rs
+++ b/crates/deps-core/src/lsp_helpers/code_actions.rs
@@ -5,9 +5,9 @@ use crate::osv::ScanOutcome;
 use crate::{Dependency, ParseResult, Registry, VersionReq};
 
 use super::{
-    EcosystemFormatter, LineOffsetTable, UNSATISFIABLE_DIAGNOSTIC_CODE, VersionData,
-    is_safe_version_string, literal_span_matches, requirement_is_unsatisfiable, single_file_edit,
-    slice_for_range, strip_whitespace, warn_rejected_value,
+    DEPRECATED_DIAGNOSTIC_CODE, EcosystemFormatter, LineOffsetTable, UNSATISFIABLE_DIAGNOSTIC_CODE,
+    VersionData, is_safe_version_string, literal_span_matches, requirement_is_unsatisfiable,
+    single_file_edit, slice_for_range, strip_whitespace, warn_rejected_value,
 };
 
 /// The vulnerability-fix quickfix built by [`build_vulnerability_fix_action`],
@@ -262,6 +262,78 @@ fn build_unsatisfiable_fix_action(
     })
 }
 
+/// Builds the "Replace with X" package-rename quickfix for `dep` (issue #205), if this
+/// ecosystem opts in via [`EcosystemFormatter::supports_package_rename`] and a
+/// registry-supplied replacement name is on record.
+///
+/// **Composer-only in Phase 1** — see `EcosystemFormatter::supports_package_rename`'s
+/// docs for why this must not be enabled for an ecosystem whose replacement name is
+/// regex-extracted free text (a typosquatting vector).
+///
+/// D7(a): guarded by the same literal-span discipline `generate_code_actions` applies to
+/// `version_range` — several parsers (Composer's `find_positions` included, when a
+/// legal escaped-solidus key like `"vendor\/package"` never matches the raw-text search)
+/// fall back to `Range::default()` for `name_range` on a lookup miss. Comparing the
+/// slice at `name_range` against `dep.name()` rejects that sentinel automatically: an
+/// empty (or wrong) slice never equals the declared name, so no edit is ever written at
+/// `(0,0)`.
+fn build_replacement_action(
+    dep: &dyn Dependency,
+    uri: &Uri,
+    version_range: Range,
+    versions: VersionData<'_>,
+    content: &str,
+    line_offsets: &LineOffsetTable,
+    formatter: &dyn EcosystemFormatter,
+) -> Option<CodeAction> {
+    if !formatter.supports_package_rename() {
+        return None;
+    }
+
+    let normalized_name = formatter.normalize_package_name(dep.name());
+    let replacement = versions
+        .deprecations
+        .and_then(|d| d.get(&normalized_name))
+        .and_then(|dep_info| dep_info.replacement.as_deref())
+        .filter(|r| !r.is_empty())?;
+
+    if formatter.validate_package_name(replacement).is_err() {
+        return None;
+    }
+
+    let name_range = dep.name_range();
+    let name_slice = slice_for_range(content, line_offsets, name_range);
+    // I7: reuses `literal_span_matches` rather than a name-specific equality check purely
+    // for the sentinel-rejecting behavior its whitespace-insensitive comparison already
+    // gives (see D7(a)'s doc above). Its `[{slice}] == requirement` NuGet-bracket branch
+    // is inert here — a package name never contains `[`/`]` (rejected by every
+    // ecosystem's `validate_package_name`) — so it never changes this call's outcome.
+    if !literal_span_matches(name_slice, dep.name().as_str()) {
+        return None;
+    }
+
+    let edits = single_file_edit(uri, name_range, replacement.to_string());
+
+    Some(CodeAction {
+        title: format!("Replace with {replacement}"),
+        kind: Some(CodeActionKind::QUICKFIX),
+        edit: Some(WorkspaceEdit {
+            changes: Some(edits),
+            ..Default::default()
+        }),
+        is_preferred: None,
+        // Same binding mechanism `build_vulnerability_fix_action`/`build_unsatisfiable_fix_action`
+        // use: `diagnostic_range` names D4's deprecation-diagnostic range (`version_range`,
+        // not `name_range`) so `bind_diagnostics` attaches this action to the diagnostic the
+        // client's lightbulb gesture actually surfaces.
+        data: Some(serde_json::json!({
+            "diagnostic_codes": [DEPRECATED_DIAGNOSTIC_CODE],
+            "diagnostic_range": version_range,
+        })),
+        ..Default::default()
+    })
+}
+
 /// Generates the code actions offered for the dependency at `position`.
 ///
 /// Finds the dependency whose declared version `position` falls on
@@ -410,6 +482,17 @@ pub async fn generate_code_actions<R: Registry + ?Sized>(
     );
     let unsat_fix =
         build_unsatisfiable_fix_action(dep, uri, version_range, versions, version_req, formatter);
+    // Registry-independent for the same FR-007 reason as the two fix actions above —
+    // `versions.deprecations` is cache-derived, not a fresh registry call.
+    let replacement_action = build_replacement_action(
+        dep,
+        uri,
+        version_range,
+        versions,
+        content,
+        &line_offsets,
+        formatter,
+    );
 
     let registry_versions = registry.get_versions(dep.name()).await.ok();
 
@@ -455,6 +538,9 @@ pub async fn generate_code_actions<R: Registry + ?Sized>(
     if let Some(unsat_fix) = unsat_fix {
         unsat_idx = Some(actions.len());
         actions.push(unsat_fix.action);
+    }
+    if let Some(replacement_action) = replacement_action {
+        actions.push(replacement_action);
     }
 
     // De-duplicates every REFACTOR action's formatted edit text against the declared

--- a/crates/deps-core/src/lsp_helpers/diagnostics.rs
+++ b/crates/deps-core/src/lsp_helpers/diagnostics.rs
@@ -4,8 +4,8 @@ use tower_lsp_server::ls_types::{
 
 use crate::osv::{ADVISORY_DISPLAY_CAP, ScanOutcome, diagnostic_severity_for};
 use crate::{
-    Dependency, ParseResult, PublishTime, Registry, VersionReq, format_relative_age,
-    is_within_cooldown,
+    Dependency, Deprecation, ParseResult, PublishTime, Registry, RemovalStatus, VersionReq,
+    format_relative_age, is_within_cooldown,
 };
 
 use super::{EcosystemFormatter, RequirementMatcher, RequirementStatus, VersionData};
@@ -18,6 +18,13 @@ use super::{EcosystemFormatter, RequirementMatcher, RequirementStatus, VersionDa
 /// advisory id, generalized to a constant since this diagnostic has no per-instance
 /// identifier.
 pub const UNSATISFIABLE_DIAGNOSTIC_CODE: &str = "unsatisfiable-requirement";
+
+/// Stable [`Diagnostic::code`] set on the package-level deprecation diagnostic (issue #205).
+///
+/// Mirrors [`UNSATISFIABLE_DIAGNOSTIC_CODE`] — lets `build_replacement_action`'s stashed
+/// `CodeAction::data` name it so the `deps-lsp` handler's diagnostic-binding step can
+/// attach the "Replace with X" quickfix to the diagnostic it resolves.
+pub const DEPRECATED_DIAGNOSTIC_CODE: &str = "deprecated-package";
 
 /// Diagnostic severity levels for the four per-dependency issue categories.
 ///
@@ -36,6 +43,7 @@ pub const UNSATISFIABLE_DIAGNOSTIC_CODE: &str = "unsatisfiable-requirement";
 /// assert_eq!(severities.unknown, DiagnosticSeverity::WARNING);
 /// assert_eq!(severities.yanked, DiagnosticSeverity::WARNING);
 /// assert_eq!(severities.unsatisfiable, DiagnosticSeverity::WARNING);
+/// assert_eq!(severities.deprecated, DiagnosticSeverity::WARNING);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DiagnosticSeverities {
@@ -47,6 +55,9 @@ pub struct DiagnosticSeverities {
     pub yanked: DiagnosticSeverity,
     /// Severity for a dependency whose requirement matches zero published versions.
     pub unsatisfiable: DiagnosticSeverity,
+    /// Severity for a dependency on a package the registry reports as
+    /// deprecated/abandoned (issue #205).
+    pub deprecated: DiagnosticSeverity,
 }
 
 impl Default for DiagnosticSeverities {
@@ -56,6 +67,7 @@ impl Default for DiagnosticSeverities {
             unknown: DiagnosticSeverity::WARNING,
             yanked: DiagnosticSeverity::WARNING,
             unsatisfiable: DiagnosticSeverity::WARNING,
+            deprecated: DiagnosticSeverity::WARNING,
         }
     }
 }
@@ -449,7 +461,52 @@ pub fn generate_diagnostics_from_cache(
         // `versions.ecosystem` being set (production always sets it; the
         // check is skipped, matching pre-#394 behavior, for the test
         // fixtures that do not).
-        let yanked_diagnostic_pushed = if let Some(yanked_version) =
+        // #205: a package-level deprecation finding is derived and pushed independently
+        // of the yanked check below, for the same FR-007-style reason as the
+        // vulnerability push above — a registry-reported deprecation must never be
+        // suppressed by an unrelated "latest" lookup failure.
+        //
+        // I4: gated on `is_version_resolvable()`, same guard `unsatisfiable`/`yanked_only`
+        // apply further down — `versions.deprecations` is name-keyed, so a git/path/SDK
+        // occurrence sharing a name with an unrelated registry-resolved package (the same
+        // #248 coincidental-namesake hazard) must not surface a diagnostic for a package
+        // it doesn't actually resolve against. Folded into `deprecation` itself (rather
+        // than only guarding the `push` call) so the D5 suppression gate below — which
+        // reads `deprecation.is_some()` — sees the same answer.
+        let deprecation = dep
+            .source()
+            .is_version_resolvable()
+            .then(|| versions.deprecations.and_then(|d| d.get(&normalized_name)))
+            .flatten();
+        if let Some(dep_info) = deprecation {
+            push_deprecation_diagnostic(&mut diagnostics, dep, formatter, dep_info, severities);
+        }
+
+        // D5: a package-level deprecation finding suppresses the in-use-version yanked
+        // check (#263) below and, transitively via `yanked_diagnostic_pushed`, the
+        // yanked-only-match check (#247) further down — but only when the underlying
+        // yanked finding's status is `AdvisoryDeprecated`, never when it is `Yanked`. A
+        // genuine hard yank ("the exact version you pinned was withdrawn") is strictly
+        // more actionable than a package-level deprecation notice ("the project is
+        // archived"), so it must never be hidden behind one.
+        //
+        // Requires an *actual* `versions.yanked` (#263) entry with that status — a
+        // vacuous `None` (`is_none_or` would default to "suppress") must NOT suppress.
+        // #247 reads a different data source (`package_versions.yanked`, a bare
+        // `Arc<[String]>` with no `RemovalStatus` attached, built independently of the
+        // #263 map — see lifecycle.rs), so "no #263 finding for this name" is not
+        // evidence that #247's finding (if any) is safe to hide: #247 can fire for a
+        // range requirement satisfiable only by a yanked version even when no specific
+        // in-use/latest version was itself flagged (impl-critic I1).
+        let deprecation_suppresses_yanked = deprecation.is_some()
+            && versions
+                .yanked
+                .and_then(|y| y.get(&normalized_name))
+                .is_some_and(|(_, status)| *status != RemovalStatus::Yanked);
+
+        let yanked_diagnostic_pushed = if deprecation_suppresses_yanked {
+            true
+        } else if let Some((yanked_version, _status)) =
             versions.yanked.and_then(|y| y.get(&normalized_name))
             && versions.ecosystem.is_none_or(|ecosystem| {
                 super::in_use_version(
@@ -461,7 +518,8 @@ pub fn generate_diagnostics_from_cache(
                 )
                 .as_deref()
                     == Some(yanked_version.as_str())
-            }) {
+            })
+        {
             diagnostics.push(Diagnostic {
                 range: dep.version_range().unwrap_or_else(|| dep.name_range()),
                 severity: Some(severities.yanked),
@@ -648,6 +706,41 @@ pub fn generate_diagnostics_from_cache(
     }
 
     diagnostics
+}
+
+/// Pushes the package-level deprecation [`Diagnostic`] for `dep` (issue #205).
+///
+/// Modeled on `push_vulnerability_diagnostics`: anchored on `dep.version_range()`,
+/// falling back to `dep.name_range()` — the same range D4 requires so the client's
+/// lightbulb gesture lands where `generate_code_actions`' quickfixes already work (see
+/// `EcosystemFormatter::is_position_on_dependency`'s default).
+fn push_deprecation_diagnostic(
+    diagnostics: &mut Vec<Diagnostic>,
+    dep: &dyn Dependency,
+    formatter: &dyn EcosystemFormatter,
+    deprecation: &Deprecation,
+    severities: DiagnosticSeverities,
+) {
+    use std::fmt::Write as _;
+
+    let range = dep.version_range().unwrap_or_else(|| dep.name_range());
+
+    let mut message = formatter.deprecated_message().to_string();
+    if let Some(reason) = deprecation.reason.as_deref().filter(|r| !r.is_empty()) {
+        let _ = write!(message, ": {reason}");
+    }
+    if let Some(replacement) = deprecation.replacement.as_deref().filter(|r| !r.is_empty()) {
+        let _ = write!(message, " (replacement: {replacement})");
+    }
+
+    diagnostics.push(Diagnostic {
+        range,
+        severity: Some(severities.deprecated),
+        message,
+        source: Some("deps-lsp".into()),
+        code: Some(NumberOrString::String(DEPRECATED_DIAGNOSTIC_CODE.into())),
+        ..Default::default()
+    });
 }
 
 /// Pushes one [`Diagnostic`] per advisory (each with its own severity, code,
@@ -1545,7 +1638,10 @@ mod tests {
         let cached_versions = HashMap::new();
         let resolved_versions = HashMap::new();
         let mut yanked = HashMap::new();
-        yanked.insert("serde".to_string(), "1.0.5".to_string());
+        yanked.insert(
+            "serde".to_string(),
+            ("1.0.5".to_string(), RemovalStatus::Yanked),
+        );
 
         let severities = DiagnosticSeverities {
             yanked: DiagnosticSeverity::ERROR,
@@ -1589,7 +1685,10 @@ mod tests {
         let cached_versions = HashMap::new();
         let resolved_versions = HashMap::new();
         let mut yanked = HashMap::new();
-        yanked.insert("serde".to_string(), "1.0.5".to_string());
+        yanked.insert(
+            "serde".to_string(),
+            ("1.0.5".to_string(), RemovalStatus::Yanked),
+        );
 
         let diagnostics = generate_diagnostics_from_cache(
             &parse_result,
@@ -1672,7 +1771,10 @@ mod tests {
         cached_versions.insert("serde".into(), PackageVersions::latest_only("2.0.0"));
         let resolved_versions = HashMap::new();
         let mut yanked = HashMap::new();
-        yanked.insert("serde".to_string(), "1.0.5".to_string());
+        yanked.insert(
+            "serde".to_string(),
+            ("1.0.5".to_string(), RemovalStatus::Yanked),
+        );
 
         let diagnostics = generate_diagnostics_from_cache(
             &parse_result,
@@ -1700,6 +1802,283 @@ mod tests {
         );
     }
 
+    /// T2 (D5 collision): an exact-pin dependency whose package is both package-level
+    /// deprecated and whose in-use-version yanked finding carries `AdvisoryDeprecated`
+    /// (npm's real shape — its yanked map is always sourced from `from_advisory`, never
+    /// `from_yanked`) must produce **exactly one** diagnostic: the deprecation
+    /// diagnostic suppresses the yanked one, since the two are one signal.
+    #[test]
+    fn test_generate_diagnostics_from_cache_deprecation_suppresses_advisory_deprecated_yanked_finding()
+     {
+        use std::collections::HashMap;
+        use tower_lsp_server::ls_types::{Position, Range};
+
+        let formatter = MockFormatter;
+        let parse_result = MockParseResult {
+            deps: vec![MockDep {
+                name: "left-pad".into(),
+                version_req: "1.3.0".into(),
+                version_range: Range::new(Position::new(0, 10), Position::new(0, 20)),
+                name_range: Range::new(Position::new(0, 0), Position::new(0, 5)),
+            }],
+            uri: crate::test_util::test_uri("/test/package.json"),
+        };
+
+        let mut cached_versions = HashMap::new();
+        cached_versions.insert("left-pad".into(), PackageVersions::latest_only("1.3.0"));
+        let resolved_versions = HashMap::new();
+        let mut yanked = HashMap::new();
+        yanked.insert(
+            "left-pad".to_string(),
+            ("1.3.0".to_string(), RemovalStatus::AdvisoryDeprecated),
+        );
+        let mut deprecations = HashMap::new();
+        deprecations.insert(
+            "left-pad".to_string(),
+            Deprecation {
+                reason: Some("use String.prototype.padStart()".to_string()),
+                replacement: None,
+            },
+        );
+
+        let diagnostics = generate_diagnostics_from_cache(
+            &parse_result,
+            VersionData::new(&cached_versions, &resolved_versions)
+                .with_yanked(&yanked)
+                .with_deprecations(&deprecations),
+            &formatter,
+            crate::freshness::FreshnessSettings::default(),
+            DiagnosticSeverities::default(),
+            PublishTime::now(),
+        );
+
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "the deprecation diagnostic must suppress the AdvisoryDeprecated yanked \
+             finding, not double-report: {diagnostics:?}"
+        );
+        assert!(
+            diagnostics[0]
+                .message
+                .starts_with(formatter.deprecated_message())
+        );
+    }
+
+    /// T6 (D5 gate): a synthetic `Yanked` finding — unreachable for any Phase-1
+    /// ecosystem, but the guard for the PyPI fast-follow, the first ecosystem with both
+    /// real yanks and package deprecation — must **never** be suppressed by a
+    /// package-level deprecation finding on the same dependency. Both diagnostics fire.
+    #[test]
+    fn test_generate_diagnostics_from_cache_deprecation_never_suppresses_real_yanked_finding() {
+        use std::collections::HashMap;
+        use tower_lsp_server::ls_types::{Position, Range};
+
+        let formatter = MockFormatter;
+        let parse_result = MockParseResult {
+            deps: vec![MockDep {
+                name: "pkg".into(),
+                version_req: "1.0.0".into(),
+                version_range: Range::new(Position::new(0, 10), Position::new(0, 20)),
+                name_range: Range::new(Position::new(0, 0), Position::new(0, 5)),
+            }],
+            uri: crate::test_util::test_uri("/test/pyproject.toml"),
+        };
+
+        let mut cached_versions = HashMap::new();
+        cached_versions.insert("pkg".into(), PackageVersions::latest_only("1.0.0"));
+        let resolved_versions = HashMap::new();
+        let mut yanked = HashMap::new();
+        yanked.insert(
+            "pkg".to_string(),
+            ("1.0.0".to_string(), RemovalStatus::Yanked),
+        );
+        let mut deprecations = HashMap::new();
+        deprecations.insert(
+            "pkg".to_string(),
+            Deprecation {
+                reason: Some("project archived".to_string()),
+                replacement: None,
+            },
+        );
+
+        let diagnostics = generate_diagnostics_from_cache(
+            &parse_result,
+            VersionData::new(&cached_versions, &resolved_versions)
+                .with_yanked(&yanked)
+                .with_deprecations(&deprecations),
+            &formatter,
+            crate::freshness::FreshnessSettings::default(),
+            DiagnosticSeverities::default(),
+            PublishTime::now(),
+        );
+
+        assert_eq!(
+            diagnostics.len(),
+            2,
+            "a genuine Yanked finding must never be hidden behind a package-level \
+             deprecation notice: {diagnostics:?}"
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message.starts_with(formatter.yanked_message()))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message.starts_with(formatter.deprecated_message()))
+        );
+    }
+
+    /// T6b (D5 gate, severity independence): on an npm-shaped fixture where the two
+    /// signals genuinely are one (`AdvisoryDeprecated`), suppression must be identical
+    /// regardless of the configured severities — a user setting `deprecated_severity:
+    /// hint` cannot thereby silence a `yanked_severity: error` finding, because severity
+    /// is not an input to the suppression decision at all.
+    #[test]
+    fn test_generate_diagnostics_from_cache_deprecation_suppression_is_severity_independent() {
+        use std::collections::HashMap;
+        use tower_lsp_server::ls_types::{Position, Range};
+
+        let formatter = MockFormatter;
+        let parse_result = MockParseResult {
+            deps: vec![MockDep {
+                name: "left-pad".into(),
+                version_req: "1.3.0".into(),
+                version_range: Range::new(Position::new(0, 10), Position::new(0, 20)),
+                name_range: Range::new(Position::new(0, 0), Position::new(0, 5)),
+            }],
+            uri: crate::test_util::test_uri("/test/package.json"),
+        };
+
+        let mut cached_versions = HashMap::new();
+        cached_versions.insert("left-pad".into(), PackageVersions::latest_only("1.3.0"));
+        let resolved_versions = HashMap::new();
+        let mut yanked = HashMap::new();
+        yanked.insert(
+            "left-pad".to_string(),
+            ("1.3.0".to_string(), RemovalStatus::AdvisoryDeprecated),
+        );
+        let mut deprecations = HashMap::new();
+        deprecations.insert(
+            "left-pad".to_string(),
+            Deprecation {
+                reason: Some("use String.prototype.padStart()".to_string()),
+                replacement: None,
+            },
+        );
+        let versions = VersionData::new(&cached_versions, &resolved_versions)
+            .with_yanked(&yanked)
+            .with_deprecations(&deprecations);
+
+        let default_severities = DiagnosticSeverities::default();
+        let inverted_severities = DiagnosticSeverities {
+            deprecated: DiagnosticSeverity::HINT,
+            yanked: DiagnosticSeverity::ERROR,
+            ..DiagnosticSeverities::default()
+        };
+
+        for severities in [default_severities, inverted_severities] {
+            let diagnostics = generate_diagnostics_from_cache(
+                &parse_result,
+                versions,
+                &formatter,
+                crate::freshness::FreshnessSettings::default(),
+                severities,
+                PublishTime::now(),
+            );
+            assert_eq!(
+                diagnostics.len(),
+                1,
+                "suppression must not depend on severity configuration: {diagnostics:?}"
+            );
+            assert!(
+                diagnostics[0]
+                    .message
+                    .starts_with(formatter.deprecated_message())
+            );
+        }
+    }
+
+    /// I4: `versions.deprecations` is name-keyed, so a git/path/SDK/workspace dependency
+    /// whose name coincidentally matches an unrelated registry-resolved package's
+    /// deprecation finding must not surface that diagnostic — the same #248 hazard
+    /// `unsatisfiable`/`unknown`/`yanked_only` already guard against.
+    #[test]
+    fn test_generate_diagnostics_from_cache_deprecation_skipped_for_non_registry_sources() {
+        use crate::parser::DependencySource;
+
+        let mut cached_versions = HashMap::new();
+        cached_versions.insert("dep".into(), PackageVersions::latest_only("1.0.0"));
+        let resolved_versions = HashMap::new();
+        let mut deprecations = HashMap::new();
+        deprecations.insert(
+            "dep".to_string(),
+            Deprecation {
+                reason: Some("archived".to_string()),
+                replacement: None,
+            },
+        );
+        let uri = crate::test_util::test_uri("/test/Cargo.toml");
+
+        for source in [
+            DependencySource::Path {
+                path: "../local".into(),
+            },
+            DependencySource::Git {
+                url: "https://example.com/repo.git".into(),
+                rev: None,
+            },
+            DependencySource::Sdk {
+                sdk: "flutter".into(),
+            },
+            DependencySource::Workspace,
+        ] {
+            let parse_result = SingleDepParseResult {
+                dep: NonRegistryDep(dep_at("dep"), source.clone()),
+                uri: uri.clone(),
+            };
+            let diagnostics = generate_diagnostics_from_cache(
+                &parse_result,
+                VersionData::new(&cached_versions, &resolved_versions)
+                    .with_deprecations(&deprecations),
+                &MockFormatter,
+                crate::freshness::FreshnessSettings::default(),
+                DiagnosticSeverities::default(),
+                PublishTime::now(),
+            );
+            assert!(
+                diagnostics
+                    .iter()
+                    .all(|d| !d.message.starts_with(MockFormatter.deprecated_message())),
+                "source {source:?} must never surface the deprecation diagnostic for a \
+                 coincidentally-named registry package: {diagnostics:?}"
+            );
+        }
+
+        // Control: the same fixture on a Registry-source dependency DOES produce the
+        // diagnostic, proving the loop above isn't vacuously passing.
+        let registry_parse_result = SingleDepParseResult {
+            dep: dep_at("dep"),
+            uri,
+        };
+        let diagnostics = generate_diagnostics_from_cache(
+            &registry_parse_result,
+            VersionData::new(&cached_versions, &resolved_versions).with_deprecations(&deprecations),
+            &MockFormatter,
+            crate::freshness::FreshnessSettings::default(),
+            DiagnosticSeverities::default(),
+            PublishTime::now(),
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message.starts_with(MockFormatter.deprecated_message())),
+            "control case: a Registry-source dependency must still produce the diagnostic"
+        );
+    }
+
     #[test]
     fn test_generate_diagnostics_from_cache_yanked_no_version_range_uses_name_range() {
         use std::collections::HashMap;
@@ -1720,7 +2099,10 @@ mod tests {
         let cached_versions = HashMap::new();
         let resolved_versions = HashMap::new();
         let mut yanked = HashMap::new();
-        yanked.insert("serde".to_string(), "1.0.5".to_string());
+        yanked.insert(
+            "serde".to_string(),
+            ("1.0.5".to_string(), RemovalStatus::Yanked),
+        );
 
         let diagnostics = generate_diagnostics_from_cache(
             &parse_result,
@@ -1774,7 +2156,10 @@ mod tests {
         let resolved_versions = HashMap::new();
         let mut yanked = HashMap::new();
         // Keyed by the *normalized* (lowercase) name, not the raw manifest name.
-        yanked.insert("newtonsoft.json".to_string(), "13.0.1".to_string());
+        yanked.insert(
+            "newtonsoft.json".to_string(),
+            ("13.0.1".to_string(), RemovalStatus::Yanked),
+        );
 
         let diagnostics = generate_diagnostics_from_cache(
             &parse_result,
@@ -1827,7 +2212,10 @@ mod tests {
         let cached_versions = HashMap::new();
         let resolved_versions = HashMap::new();
         let mut yanked = HashMap::new();
-        yanked.insert("time".to_string(), "0.1.43".to_string());
+        yanked.insert(
+            "time".to_string(),
+            ("0.1.43".to_string(), RemovalStatus::Yanked),
+        );
 
         let diagnostics = generate_diagnostics_from_cache(
             &parse_result,
@@ -1889,7 +2277,10 @@ mod tests {
         let cached_versions = HashMap::new();
         let resolved_versions = HashMap::new();
         let mut yanked = HashMap::new();
-        yanked.insert("time".to_string(), "0.1.43".to_string());
+        yanked.insert(
+            "time".to_string(),
+            ("0.1.43".to_string(), RemovalStatus::Yanked),
+        );
 
         let diagnostics = generate_diagnostics_from_cache(
             &parse_result,
@@ -3073,6 +3464,76 @@ mod tests {
             );
         }
 
+        /// I1 (D5 gate regression): a package-level deprecation finding must NOT suppress
+        /// the #247 `requirement_matches_only_yanked` check when there is no corresponding
+        /// #263 (`versions.yanked`) entry to justify it. #247 reads a different data source
+        /// (`package_versions.yanked`, no `RemovalStatus` attached) than #263 does, so "no
+        /// #263 finding for this name" is not evidence the #247 finding (if any) is safe to
+        /// hide — an earlier version of the gate suppressed #247 unconditionally in exactly
+        /// this case (vacuous `is_none_or` on a missing #263 entry).
+        #[test]
+        fn test_generate_diagnostics_from_cache_deprecation_does_not_suppress_yanked_only_match_without_263_entry()
+         {
+            let formatter = TableFormatter::new(|v| Some(v == "1.2.1"));
+
+            let parse_result = MockParseResult {
+                deps: vec![MockDep {
+                    name: "serde".into(),
+                    version_req: "modelled".into(),
+                    version_range: Range::new(Position::new(0, 10), Position::new(0, 20)),
+                    name_range: Range::new(Position::new(0, 0), Position::new(0, 5)),
+                }],
+                uri: crate::test_util::test_uri("/test/Cargo.toml"),
+            };
+
+            let mut cached_versions = HashMap::new();
+            cached_versions.insert(
+                "serde".into(),
+                PackageVersions {
+                    latest: "2.0.0".to_string(),
+                    available: Arc::from(vec!["2.0.0".to_string(), "1.2.1".to_string()]),
+                    yanked: Arc::from(vec!["1.2.1".to_string()]),
+                    published_at: None,
+                },
+            );
+            let resolved_versions = HashMap::new();
+            // Deliberately empty: no #263 (in-use-version) finding for "serde" — the bug
+            // this test guards against is suppression that vacuously fires on this case.
+            let yanked: HashMap<String, (String, RemovalStatus)> = HashMap::new();
+            let mut deprecations = HashMap::new();
+            deprecations.insert(
+                "serde".to_string(),
+                Deprecation {
+                    reason: Some("archived".to_string()),
+                    replacement: None,
+                },
+            );
+
+            let diagnostics = generate_diagnostics_from_cache(
+                &parse_result,
+                VersionData::new(&cached_versions, &resolved_versions)
+                    .with_yanked(&yanked)
+                    .with_deprecations(&deprecations),
+                &formatter,
+                crate::freshness::FreshnessSettings::default(),
+                DiagnosticSeverities::default(),
+                PublishTime::now(),
+            );
+
+            assert!(
+                diagnostics
+                    .iter()
+                    .any(|d| d.message.starts_with(formatter.yanked_message())),
+                "the #247 yanked-only-match finding must still fire: {diagnostics:?}"
+            );
+            assert!(
+                diagnostics
+                    .iter()
+                    .any(|d| d.message.starts_with(formatter.deprecated_message())),
+                "the deprecation finding must also still fire: {diagnostics:?}"
+            );
+        }
+
         /// #247 vs. #263 dedup: a dependency whose in-use version (lock-file-resolved, or an
         /// exact pin) is yanked *and* is the only version satisfying its own requirement
         /// triggers both the in-use-version check (`versions.yanked`, #263) and the
@@ -3104,7 +3565,10 @@ mod tests {
             );
             let resolved_versions = HashMap::new();
             let mut in_use_yanked = HashMap::new();
-            in_use_yanked.insert("serde".to_string(), "1.2.1".to_string());
+            in_use_yanked.insert(
+                "serde".to_string(),
+                ("1.2.1".to_string(), RemovalStatus::Yanked),
+            );
 
             let diagnostics = generate_diagnostics_from_cache(
                 &parse_result,

--- a/crates/deps-core/src/lsp_helpers/hover.rs
+++ b/crates/deps-core/src/lsp_helpers/hover.rs
@@ -2,7 +2,7 @@ use tower_lsp_server::ls_types::{Hover, HoverContents, MarkupContent, MarkupKind
 
 use crate::osv::{ADVISORY_DISPLAY_CAP, ScanOutcome};
 use crate::{
-    ParseResult, PublishTime, Registry, Version, VersionReq, format_relative_age,
+    Deprecation, ParseResult, PublishTime, Registry, Version, VersionReq, format_relative_age,
     is_within_cooldown,
 };
 
@@ -276,6 +276,13 @@ pub async fn generate_hover<R: Registry + ?Sized>(
             .or_else(|| m.get(&normalized_name))
             .or_else(|| m.get(dep.name().as_str()))
     });
+    // Package-level context (#205) renders before per-version security advisories:
+    // deprecation is a property of the package, advisories of the version.
+    push_deprecation_hover_section(
+        &mut markdown,
+        formatter,
+        versions.deprecations.and_then(|m| m.get(&normalized_name)),
+    );
     push_vulnerability_hover_section(&mut markdown, vuln_outcome);
 
     if let Some(available_versions) = &available_versions {
@@ -346,6 +353,43 @@ const fn severity_label(severity: crate::osv::VulnSeverity) -> &'static str {
         crate::osv::VulnSeverity::Medium => "medium",
         crate::osv::VulnSeverity::Low => "low",
         crate::osv::VulnSeverity::Unknown => "unknown severity",
+    }
+}
+
+/// Appends the hover "Deprecated" section (issue #205), gated strictly on `deprecation`
+/// being present — never rendered as "not deprecated" for a clean package, the same
+/// discipline [`push_vulnerability_hover_section`] applies to `Skipped`/`None`.
+///
+/// Deliberately not deduped against npm's per-row `*(deprecated)*` "Recent versions"
+/// labels (S4, plan.md D6): suppressing those would require threading this finding into
+/// the version-list renderer, which takes no such parameter today.
+fn push_deprecation_hover_section(
+    markdown: &mut String,
+    formatter: &dyn EcosystemFormatter,
+    deprecation: Option<&Deprecation>,
+) {
+    use std::fmt::Write as _;
+
+    let Some(deprecation) = deprecation else {
+        return;
+    };
+
+    // I3: each part gets its own blank-line-separated paragraph, mirroring
+    // `push_vulnerability_hover_section`'s discipline — three bare consecutive
+    // `writeln!` lines with no blank line between them collapse into one CommonMark
+    // paragraph, rendering the message/reason/replacement joined instead of as the
+    // visually distinct lines the section is meant to show.
+    markdown.push_str("### Deprecated\n\n");
+    let _ = writeln!(markdown, "{}\n", formatter.deprecated_message());
+    if let Some(reason) = deprecation.reason.as_deref().filter(|r| !r.is_empty()) {
+        let _ = writeln!(markdown, "{}\n", escape_markdown(reason));
+    }
+    if let Some(replacement) = deprecation.replacement.as_deref().filter(|r| !r.is_empty()) {
+        let _ = writeln!(
+            markdown,
+            "Suggested replacement: {}\n",
+            markdown_code_span(replacement)
+        );
     }
 }
 
@@ -1521,6 +1565,97 @@ mod tests {
         assert!(
             content.value.contains("- `2.0.0` *(latest)* *(yanked)*"),
             "the resolved latest must keep its yanked label, got: {}",
+            content.value
+        );
+    }
+
+    /// npm-shaped formatter stub for T7: overrides `yanked_label` to npm's actual
+    /// `"*(deprecated)*"` wording (`deps-npm/src/formatter.rs`), everything else default.
+    struct NpmLikeFormatter;
+
+    impl EcosystemFormatter for NpmLikeFormatter {
+        fn format_version_for_text_edit(&self, version: &str) -> String {
+            version.to_string()
+        }
+
+        fn package_url(&self, name: &crate::PackageName) -> String {
+            format!("https://example.com/{name}")
+        }
+
+        fn yanked_label(&self) -> &'static str {
+            "*(deprecated)*"
+        }
+    }
+
+    /// T7 (S4, accepted redundancy): hover for a deprecated npm-shaped package renders
+    /// **both** the new `### Deprecated` section (D6) and the pre-existing per-row
+    /// `*(deprecated)*` "Recent versions" labels — pinning the deliberate decision not to
+    /// dedupe them (plan.md D6), so a later dedupe reads as an intentional change rather
+    /// than a silent regression.
+    #[tokio::test]
+    async fn test_generate_hover_deprecated_section_and_per_row_labels_both_render() {
+        use std::collections::HashMap;
+
+        let now = PublishTime::now();
+        let registry = MockRegistryPreferringUnflagged {
+            versions: vec![MockVersionWithStatus {
+                version: "1.0.0".to_string(),
+                status: RemovalStatus::AdvisoryDeprecated,
+            }],
+        };
+
+        let parse_result = freshness_test_parse_result("pkg");
+        let cached_versions = HashMap::new();
+        let resolved_versions = HashMap::new();
+        let mut deprecations = HashMap::new();
+        deprecations.insert(
+            "pkg".to_string(),
+            crate::Deprecation {
+                reason: Some("no longer maintained".to_string()),
+                replacement: None,
+            },
+        );
+
+        let hover = generate_hover(
+            &parse_result,
+            Position::new(0, 2),
+            VersionData::new(&cached_versions, &resolved_versions).with_deprecations(&deprecations),
+            &registry,
+            &NpmLikeFormatter,
+            crate::freshness::FreshnessSettings::default(),
+            now,
+        )
+        .await
+        .expect("hover should be generated for a dependency at the cursor");
+
+        let HoverContents::Markup(content) = hover.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(
+            content.value.contains("### Deprecated"),
+            "expected the package-level Deprecated section, got: {}",
+            content.value
+        );
+        assert!(
+            content.value.contains("no longer maintained"),
+            "expected the deprecation reason, got: {}",
+            content.value
+        );
+        // I3: the message and the reason must render as separate CommonMark paragraphs
+        // (blank-line separated), not collapse into one joined paragraph.
+        assert!(
+            content
+                .value
+                .contains("This package is deprecated\n\nno longer maintained"),
+            "expected the message and reason on separate paragraphs, got: {}",
+            content.value
+        );
+        assert!(
+            content
+                .value
+                .contains("- `1.0.0` *(latest)* *(deprecated)*"),
+            "expected the pre-existing per-row label to still render alongside the new \
+             section (deliberately not deduped, S4), got: {}",
             content.value
         );
     }

--- a/crates/deps-core/src/lsp_helpers/mod.rs
+++ b/crates/deps-core/src/lsp_helpers/mod.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 use tower_lsp_server::ls_types::{Position, Range, TextEdit, Uri};
 
 use crate::osv::VulnerabilityMap;
-use crate::{Dependency, EcosystemId, InvalidPackageName, PackageName, VersionReq};
+use crate::{
+    Dependency, Deprecation, EcosystemId, InvalidPackageName, PackageName, RemovalStatus,
+    VersionReq,
+};
 
 mod code_actions;
 mod code_lenses;
@@ -19,8 +22,9 @@ mod test_support;
 pub use code_actions::generate_code_actions;
 pub use code_lenses::{collect_update_all_edits, generate_code_lenses};
 pub use diagnostics::{
-    DiagnosticSeverities, UNSATISFIABLE_DIAGNOSTIC_CODE, compile_requirement_unless,
-    generate_diagnostics, generate_diagnostics_from_cache, requirement_is_unsatisfiable,
+    DEPRECATED_DIAGNOSTIC_CODE, DiagnosticSeverities, UNSATISFIABLE_DIAGNOSTIC_CODE,
+    compile_requirement_unless, generate_diagnostics, generate_diagnostics_from_cache,
+    requirement_is_unsatisfiable,
 };
 pub use hover::generate_hover;
 pub use in_use_version::{concrete_pin_version, in_use_version};
@@ -168,12 +172,20 @@ pub struct VersionData<'a> {
     /// scan has run yet (e.g. the feature is disabled) — distinct from an
     /// empty map, which would mean "scanned, nothing found".
     pub vulnerabilities: Option<&'a VulnerabilityMap>,
-    /// Yanked-version findings, keyed by normalized package name -> the
+    /// Yanked-version findings, keyed by normalized package name -> (the
     /// version string found yanked (the in-use version, or `latest` when
-    /// only `latest` itself is yanked — see `deps-lsp`'s lifecycle probe).
-    /// `None` when no yanked check has run yet — distinct from an empty map,
-    /// which would mean "checked, nothing yanked".
-    pub yanked: Option<&'a HashMap<String, String>>,
+    /// only `latest` itself is yanked — see `deps-lsp`'s lifecycle probe),
+    /// its [`RemovalStatus`]). The status rides alongside the version string
+    /// so [`generate_diagnostics_from_cache`] can gate #205's package-level
+    /// deprecation suppression on `AdvisoryDeprecated` specifically, never on
+    /// a genuine `Yanked` finding (see that function's D5 handling). `None`
+    /// when no yanked check has run yet — distinct from an empty map, which
+    /// would mean "checked, nothing yanked".
+    pub yanked: Option<&'a HashMap<String, (String, RemovalStatus)>>,
+    /// Package-level deprecation findings, keyed by normalized package name.
+    /// `None` when no fetch has run yet — distinct from an empty map, which
+    /// would mean "checked, nothing deprecated". See [`crate::Deprecation`].
+    pub deprecations: Option<&'a HashMap<String, Deprecation>>,
     /// Packages whose registry fetch errored or timed out during the most
     /// recent lifecycle fetch, keyed by normalized package name. Lets
     /// [`generate_diagnostics_from_cache`] distinguish "the registry was
@@ -226,6 +238,7 @@ impl<'a> VersionData<'a> {
             resolved,
             vulnerabilities: None,
             yanked: None,
+            deprecations: None,
             fetch_failed: None,
             ecosystem: None,
         }
@@ -257,18 +270,38 @@ impl<'a> VersionData<'a> {
     /// # Examples
     ///
     /// ```
-    /// use deps_core::VersionData;
+    /// use deps_core::{RemovalStatus, VersionData};
     /// use std::collections::HashMap;
     ///
     /// let cached = HashMap::new();
     /// let resolved = HashMap::new();
-    /// let yanked = HashMap::new();
+    /// let yanked: HashMap<String, (String, RemovalStatus)> = HashMap::new();
     /// let versions = VersionData::new(&cached, &resolved).with_yanked(&yanked);
     /// assert!(versions.yanked.is_some());
     /// ```
     #[must_use]
-    pub fn with_yanked(mut self, yanked: &'a HashMap<String, String>) -> Self {
+    pub fn with_yanked(mut self, yanked: &'a HashMap<String, (String, RemovalStatus)>) -> Self {
         self.yanked = Some(yanked);
+        self
+    }
+
+    /// Attaches package-level deprecation findings to this `VersionData`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use deps_core::{Deprecation, VersionData};
+    /// use std::collections::HashMap;
+    ///
+    /// let cached = HashMap::new();
+    /// let resolved = HashMap::new();
+    /// let deprecations: HashMap<String, Deprecation> = HashMap::new();
+    /// let versions = VersionData::new(&cached, &resolved).with_deprecations(&deprecations);
+    /// assert!(versions.deprecations.is_some());
+    /// ```
+    #[must_use]
+    pub fn with_deprecations(mut self, deprecations: &'a HashMap<String, Deprecation>) -> Self {
+        self.deprecations = Some(deprecations);
         self
     }
 
@@ -936,6 +969,35 @@ pub trait EcosystemFormatter: Send + Sync {
         "*(yanked)*"
     }
 
+    /// Message for a package-level deprecation/abandonment diagnostic (issue #205).
+    ///
+    /// Distinct from [`Self::yanked_message`]: that one describes a single flagged
+    /// *version*, this one describes the *package* being deprecated/abandoned/archived.
+    /// Default wording is generic; `ComposerFormatter` overrides both this and
+    /// [`Self::deprecated_label`] to "abandoned", matching Packagist's own vocabulary —
+    /// the same pattern it already applies to the yanked pair.
+    fn deprecated_message(&self) -> &'static str {
+        "This package is deprecated"
+    }
+
+    /// Label for a deprecated package in hover.
+    fn deprecated_label(&self) -> &'static str {
+        "*(deprecated)*"
+    }
+
+    /// Whether this ecosystem's deprecation payload ([`crate::Deprecation::replacement`])
+    /// is safe to offer as a "Replace with X" rename quickfix.
+    ///
+    /// Default `false`. Only an ecosystem whose replacement name comes from a
+    /// **structured, registry-validated** field may override this to `true` — never one
+    /// synthesized by parsing free text, which is a typosquatting vector (npm's
+    /// `deprecated` message names a successor only in prose). `ComposerFormatter`
+    /// overrides this to `true`: Packagist's `abandoned` replacement is a real package
+    /// name field, not extracted text.
+    fn supports_package_rename(&self) -> bool {
+        false
+    }
+
     /// Whether the "requirement satisfiable only by a yanked version" diagnostic
     /// (`crate::lsp_helpers::requirement_matches_only_yanked`) should evaluate `requirement`
     /// at all for this ecosystem.
@@ -949,9 +1011,9 @@ pub trait EcosystemFormatter: Send + Sync {
     /// npm package had 126/126 versions marked deprecated), so evaluating a range
     /// requirement against them would flag every dependency on a deprecated/abandoned
     /// package under this diagnostic's wording, conflating it with package-level
-    /// deprecation — a distinct, separately-planned diagnostic (issue #205). Restricting to
-    /// an exact pin keeps this diagnostic scoped to #247's actual scenario: "you are pinned
-    /// to this one specific version, and it has been yanked."
+    /// deprecation — a distinct diagnostic ([`Self::deprecated_message`], issue #205).
+    /// Restricting to an exact pin keeps this diagnostic scoped to #247's actual scenario:
+    /// "you are pinned to this one specific version, and it has been yanked."
     ///
     /// # Examples
     ///

--- a/crates/deps-core/src/macros.rs
+++ b/crates/deps-core/src/macros.rs
@@ -105,6 +105,10 @@ macro_rules! impl_dependency {
 ///   it when the default is provably correct for the registry's version
 ///   format (as of #322, `deps-composer` is the sole deliberate holdout,
 ///   since Packagist versions aren't strict semver).
+/// * `deprecation` - Optional, requires both `published_at` and `prerelease` to also be
+///   given: expression evaluating to a closure `Fn(&$type) -> Option<&Deprecation>`,
+///   for an ecosystem whose registry exposes a package-level deprecation payload
+///   (issue #205). Omitting this arm installs the trait default (`None`).
 ///
 /// # Examples
 ///
@@ -243,6 +247,45 @@ macro_rules! impl_version {
 
             fn is_prerelease(&self) -> bool {
                 ($prerelease)(self)
+            }
+
+            fn as_any(&self) -> &dyn ::std::any::Any {
+                self
+            }
+        }
+    };
+    ($type:ty {
+        version: $version:ident,
+        status: $status:expr,
+        published_at: $published_at:ident,
+        prerelease: $prerelease:expr,
+        deprecation: $deprecation:expr $(,)?
+    }) => {
+        impl $crate::registry::Version for $type {
+            fn version_string(&self) -> &str {
+                &self.$version
+            }
+
+            fn removal_status(&self) -> $crate::registry::RemovalStatus {
+                ($status)(self)
+            }
+
+            fn published_at(&self) -> Option<$crate::freshness::PublishTime> {
+                self.$published_at
+            }
+
+            fn is_prerelease(&self) -> bool {
+                ($prerelease)(self)
+            }
+
+            fn deprecation(&self) -> Option<&$crate::registry::Deprecation> {
+                // Coerced through a plain `fn` pointer (rather than calling the closure
+                // expression directly) so it is forced to be `for<'a> Fn(&'a Self) ->
+                // Option<&'a Deprecation>` — a bare closure literal here infers a single
+                // concrete lifetime from its first call site instead of generalizing,
+                // which fails to typecheck against `self`'s elided lifetime.
+                let f: fn(&$type) -> Option<&$crate::registry::Deprecation> = $deprecation;
+                f(self)
             }
 
             fn as_any(&self) -> &dyn ::std::any::Any {

--- a/crates/deps-core/src/registry.rs
+++ b/crates/deps-core/src/registry.rs
@@ -403,6 +403,42 @@ impl RemovalStatus {
     }
 }
 
+/// Package-level deprecation/abandonment payload: why a package is deprecated, and what
+/// to use instead.
+///
+/// Distinct from [`RemovalStatus`], which answers *"may resolution select this
+/// version"*. `Deprecation` answers *"what should the user be told"* — the reason text
+/// and/or a registry-supplied replacement package name. Kept as a separate type rather
+/// than a payload-carrying `RemovalStatus` variant: `RemovalStatus` is `Copy`, returned
+/// from `const fn`s, and matched in every ecosystem crate, so widening it would ripple
+/// everywhere for a concept that only a couple of registries expose.
+///
+/// Both fields are `None` when the registry has nothing to say beyond "deprecated" —
+/// e.g. Packagist's bare `"abandoned": true`, with no replacement named.
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::Deprecation;
+///
+/// let deprecation = Deprecation {
+///     reason: Some("no longer maintained".into()),
+///     replacement: Some("some-other/package".into()),
+/// };
+///
+/// assert_eq!(deprecation.reason.as_deref(), Some("no longer maintained"));
+/// assert_eq!(deprecation.replacement.as_deref(), Some("some-other/package"));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Deprecation {
+    /// Free-text reason the registry gives for the deprecation, if any.
+    pub reason: Option<String>,
+    /// Registry-supplied replacement package name, if any. Only ever populated from a
+    /// structured registry field (never regex-extracted from free text — see #205's
+    /// typosquatting rationale), so it is safe to offer as a rename target.
+    pub replacement: Option<String>,
+}
+
 /// Version information trait.
 ///
 /// All version types must implement this to work with generic handlers.
@@ -416,6 +452,15 @@ pub trait Version: Send + Sync {
     /// yank/deprecation signal need no override.
     fn removal_status(&self) -> RemovalStatus {
         RemovalStatus::Available
+    }
+
+    /// Package-level deprecation payload, when this version's registry data carries one.
+    ///
+    /// Default `None` — the `Option` is the capability gate: an ecosystem that never
+    /// overrides this produces no deprecation diagnostic/hover/quickfix at all, rather
+    /// than depending on a separate "does this ecosystem report deprecation" predicate.
+    fn deprecation(&self) -> Option<&Deprecation> {
+        None
     }
 
     /// Whether this version is a pre-release (alpha, beta, rc, etc.).

--- a/crates/deps-lsp/src/config.rs
+++ b/crates/deps-lsp/src/config.rs
@@ -104,6 +104,7 @@ impl Default for InlayHintsConfig {
 /// - `unknown_severity`: `WARNING` - Dependencies not found in registry
 /// - `yanked_severity`: `WARNING` - Dependencies using yanked versions
 /// - `unsatisfiable_severity`: `WARNING` - Dependencies whose requirement matches zero published versions
+/// - `deprecated_severity`: `WARNING` - Dependencies on a package the registry reports as deprecated/abandoned
 ///
 /// # Examples
 ///
@@ -116,6 +117,7 @@ impl Default for InlayHintsConfig {
 ///     unknown_severity: DiagnosticSeverity::ERROR,
 ///     yanked_severity: DiagnosticSeverity::ERROR,
 ///     unsatisfiable_severity: DiagnosticSeverity::ERROR,
+///     deprecated_severity: DiagnosticSeverity::ERROR,
 ///     vulnerabilities_enabled: true,
 /// };
 ///
@@ -131,6 +133,14 @@ pub struct DiagnosticsConfig {
     pub yanked_severity: DiagnosticSeverity,
     #[serde(default = "default_unsatisfiable_severity")]
     pub unsatisfiable_severity: DiagnosticSeverity,
+    /// Severity for a dependency on a package the registry reports as
+    /// deprecated/abandoned (issue #205). No corresponding `deprecated_enabled`
+    /// toggle: unlike `vulnerabilities_enabled`, this signal is derived from
+    /// already-fetched data (zero new registry requests — see #205's plan §1
+    /// D2), so a boolean would gate only string formatting, not a network
+    /// call. Matches the severity-only precedent set by the four fields above.
+    #[serde(default = "default_deprecated_severity")]
+    pub deprecated_severity: DiagnosticSeverity,
     /// Whether to run the OSV.dev vulnerability scan and render its
     /// diagnostics/hover content. Default `true` (opt-out): `cargo audit`/
     /// `npm audit` run by default, and an opt-in gate would undercut the
@@ -146,6 +156,7 @@ impl Default for DiagnosticsConfig {
             unknown_severity: default_unknown_severity(),
             yanked_severity: default_yanked_severity(),
             unsatisfiable_severity: default_unsatisfiable_severity(),
+            deprecated_severity: default_deprecated_severity(),
             vulnerabilities_enabled: true,
         }
     }
@@ -166,6 +177,7 @@ impl DiagnosticsConfig {
     /// assert_eq!(severities.unknown, config.unknown_severity);
     /// assert_eq!(severities.yanked, config.yanked_severity);
     /// assert_eq!(severities.unsatisfiable, config.unsatisfiable_severity);
+    /// assert_eq!(severities.deprecated, config.deprecated_severity);
     /// ```
     #[must_use]
     pub const fn to_severities(&self) -> deps_core::DiagnosticSeverities {
@@ -174,6 +186,7 @@ impl DiagnosticsConfig {
             unknown: self.unknown_severity,
             yanked: self.yanked_severity,
             unsatisfiable: self.unsatisfiable_severity,
+            deprecated: self.deprecated_severity,
         }
     }
 }
@@ -330,6 +343,10 @@ const fn default_yanked_severity() -> DiagnosticSeverity {
 }
 
 const fn default_unsatisfiable_severity() -> DiagnosticSeverity {
+    DiagnosticSeverity::WARNING
+}
+
+const fn default_deprecated_severity() -> DiagnosticSeverity {
     DiagnosticSeverity::WARNING
 }
 
@@ -598,7 +615,8 @@ mod tests {
             "outdated_severity": 1,
             "unknown_severity": 2,
             "yanked_severity": 2,
-            "unsatisfiable_severity": 1
+            "unsatisfiable_severity": 1,
+            "deprecated_severity": 1
         }"#;
 
         let config: DiagnosticsConfig = serde_json::from_str(json).unwrap();
@@ -606,6 +624,7 @@ mod tests {
         assert_eq!(config.unknown_severity, DiagnosticSeverity::WARNING);
         assert_eq!(config.yanked_severity, DiagnosticSeverity::WARNING);
         assert_eq!(config.unsatisfiable_severity, DiagnosticSeverity::ERROR);
+        assert_eq!(config.deprecated_severity, DiagnosticSeverity::ERROR);
     }
 
     #[test]
@@ -616,6 +635,18 @@ mod tests {
         let json = r"{}";
         let config: DiagnosticsConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.unsatisfiable_severity, DiagnosticSeverity::WARNING);
+    }
+
+    /// D8/O3: no `deprecated_enabled` toggle exists — severity is the only knob, matching
+    /// the other four fields' precedent (deprecation adds no network call).
+    #[test]
+    fn test_diagnostics_config_deprecated_severity_defaults_warning() {
+        let config = DiagnosticsConfig::default();
+        assert_eq!(config.deprecated_severity, DiagnosticSeverity::WARNING);
+
+        let json = r"{}";
+        let config: DiagnosticsConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.deprecated_severity, DiagnosticSeverity::WARNING);
     }
 
     #[test]

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -8,11 +8,13 @@ use super::state::{DocumentState, ServerState};
 use crate::config::DepsConfig;
 use crate::handlers::diagnostics;
 use crate::progress::{ProgressSender, RegistryProgress};
+use deps_core::Deprecation;
 use deps_core::Ecosystem;
 use deps_core::EcosystemId;
 use deps_core::PackageName;
 use deps_core::PackageVersions;
 use deps_core::Registry;
+use deps_core::RemovalStatus;
 use deps_core::Result;
 use deps_core::VersionReq;
 use deps_core::lsp_helpers::in_use_version;
@@ -114,10 +116,62 @@ fn preserve_cache(new_state: &mut DocumentState, old_state: &DocumentState) {
     new_state
         .yanked_versions
         .clone_from(&old_state.yanked_versions);
+    // Same rationale — without this the #205 deprecation diagnostic/hover/quickfix
+    // would flicker off on every keystroke until the next fetch.
+    new_state.deprecations.clone_from(&old_state.deprecations);
     // Same rationale — without this a registry-outage package would flip
     // back to a misleading "Unknown package" diagnostic on every keystroke
     // until the next fetch cycle re-populates it (#267).
     new_state.fetch_failed.clone_from(&old_state.fetch_failed);
+}
+
+/// Merges a partial fetch's #205 deprecation findings into `doc.deprecations`
+/// (incremental didChange path — S1).
+///
+/// Without the clearing half of this (S1), a package that stops being deprecated
+/// (`npm deprecate pkg ""`) would keep a stale finding for the document's lifetime —
+/// nothing else ever removes one (a package-level finding does not become stale on a
+/// version-only edit — see the comment above `diff.version_changed`'s pruning loop in
+/// `handle_document_change`).
+///
+/// `fetched_names` — every raw package name successfully fetched this round (i.e. the
+/// keys of `fetch_result.versions`, captured before it is consumed) — must clear any
+/// previously-recorded finding when `fetched_deprecations` has no entry for it ("fetched
+/// and clean"); a name *not* fetched this round (untouched by `deps_to_fetch`) must not
+/// be touched at all, which is why this takes the explicit fetched-name list rather than
+/// iterating `doc.deprecations` itself.
+fn merge_deprecations_after_fetch(
+    doc: &mut DocumentState,
+    fetched_names: &[PackageName],
+    mut fetched_deprecations: HashMap<PackageName, Deprecation>,
+    formatter: &dyn deps_core::lsp_helpers::EcosystemFormatter,
+) {
+    // I2: decided per *normalized* name in one pass, not applied incrementally per raw
+    // name — `fetched_names` iterates a `HashMap`'s keys, so its order is unspecified,
+    // and two raw names that normalize to the same key (e.g. Composer's case-insensitive
+    // `require` keys) would otherwise let "insert B's finding, then clear it because A
+    // (processed after) had none" flip on iteration order alone. Collecting first means
+    // "any fetched raw name under this key reported a finding" wins deterministically,
+    // regardless of which one is visited first.
+    let mut per_normalized: HashMap<String, Option<Deprecation>> = HashMap::new();
+    for name in fetched_names {
+        let normalized = formatter.normalize_package_name(name);
+        let found = fetched_deprecations.remove(name);
+        let entry = per_normalized.entry(normalized).or_insert(None);
+        if entry.is_none() {
+            *entry = found;
+        }
+    }
+    for (normalized, deprecation) in per_normalized {
+        match deprecation {
+            Some(deprecation) => {
+                doc.deprecations.insert(normalized, deprecation);
+            }
+            None => {
+                doc.deprecations.remove(&normalized);
+            }
+        }
+    }
 }
 
 /// Ceiling on the OSV scan timeout, independent of the configured
@@ -598,10 +652,18 @@ struct FetchResult {
     versions: HashMap<PackageName, PackageVersions>,
     /// Yanked-version findings, keyed by **raw** package name (unlike
     /// `DocumentState::yanked_versions`, which is normalized-keyed — see
-    /// §3.1 of the design). Callers must re-key through
-    /// `EcosystemFormatter::normalize_package_name` before merging into
-    /// document state.
-    yanked_versions: HashMap<PackageName, String>,
+    /// §3.1 of the design), to (the version string found yanked, its
+    /// `RemovalStatus`). The status rides alongside so #205's package-level
+    /// deprecation diagnostic can gate its yanked-check suppression on
+    /// `AdvisoryDeprecated` specifically, never a genuine `Yanked` finding.
+    /// Callers must re-key through `EcosystemFormatter::normalize_package_name`
+    /// before merging into document state.
+    yanked_versions: HashMap<PackageName, (String, RemovalStatus)>,
+    /// Package-level deprecation findings (issue #205), keyed by **raw** package name
+    /// (same raw/normalized split as `yanked_versions` above). Derived from the
+    /// `resolved`/"latest" pick in the fetch loop below, not by scanning the full
+    /// `versions` list — see that loop's comments for why.
+    deprecations: HashMap<PackageName, Deprecation>,
     /// Packages whose registry fetch errored or timed out, keyed by **raw**
     /// package name (same raw/normalized split as `yanked_versions` above).
     /// Lets diagnostic generation (#267) distinguish "the registry said this
@@ -703,8 +765,9 @@ async fn fetch_latest_versions_parallel(
                     tokio::time::timeout(timeout, registry.get_versions_with(&name, freshness))
                         .await;
 
-                let mut yanked: Option<(PackageName, String)> = None;
+                let mut yanked: Option<(PackageName, String, RemovalStatus)> = None;
                 let mut failed_name: Option<PackageName> = None;
+                let mut deprecation: Option<(PackageName, Deprecation)> = None;
                 let version = match result {
                     Ok(Ok(versions)) => {
                         let available: Arc<[String]> = versions
@@ -742,7 +805,12 @@ async fn fetch_latest_versions_parallel(
                         {
                             let latest = v.version_string().to_string();
                             tracing::debug!(package = %name, version = %latest, "fetched");
-                            Some((latest, v.removal_status().is_flagged(), v.published_at()))
+                            Some((
+                                latest,
+                                v.removal_status(),
+                                v.published_at(),
+                                v.deprecation().cloned(),
+                            ))
                         } else {
                             // The pure list-based pick found nothing — for most
                             // ecosystems this genuinely means "no version found", but
@@ -774,8 +842,9 @@ async fn fetch_latest_versions_parallel(
                                     );
                                     Some((
                                         latest,
-                                        v.removal_status().is_flagged(),
+                                        v.removal_status(),
                                         v.published_at(),
+                                        v.deprecation().cloned(),
                                     ))
                                 }
                                 Ok(Ok(None)) => {
@@ -824,8 +893,10 @@ async fn fetch_latest_versions_parallel(
                             // registry under today's hardcoded wildcard (one
                             // never returns a yanked version for `*`), but
                             // stays correct as a defense-in-depth check.
-                            if let Some((latest, true, _)) = &resolved {
-                                yanked = Some((name.clone(), latest.clone()));
+                            if let Some((latest, status, _, _)) = &resolved
+                                && status.is_flagged()
+                            {
+                                yanked = Some((name.clone(), latest.clone(), *status));
                             }
 
                             // Row 2/3 (§4.7, revised under #206): `versions`
@@ -847,17 +918,38 @@ async fn fetch_latest_versions_parallel(
                             // yanked pin on any occurrence is never missed
                             // just because another occurrence happens to
                             // share the registry lookup.
-                            if let Some(iv) = in_use_versions.iter().find(|iv| {
-                                versions.iter().any(|v| {
-                                    v.version_string() == iv.as_str()
-                                        && v.removal_status().is_flagged()
-                                })
+                            // Filters on `is_flagged()` inside the `find` predicate itself
+                            // (not via a separate `.filter()` on the first version-string
+                            // match) so a registry response with more than one entry sharing
+                            // `iv`'s version string still finds a flagged one if any exists —
+                            // mirroring the pre-#205 `.any(matches && flagged)` scan rather
+                            // than narrowing to "is the *first* same-string entry flagged".
+                            if let Some((iv, status)) = in_use_versions.iter().find_map(|iv| {
+                                versions
+                                    .iter()
+                                    .find(|v| {
+                                        v.version_string() == iv.as_str()
+                                            && v.removal_status().is_flagged()
+                                    })
+                                    .map(|v| (iv, v.removal_status()))
                             }) {
-                                yanked = Some((name.clone(), iv.clone()));
+                                yanked = Some((name.clone(), iv.clone(), status));
                             }
                         }
 
-                        resolved.map(|(latest, _, published_at)| {
+                        // #205: the package-level deprecation finding is derived from the
+                        // same `Version` `resolved` already picked as "latest" — covering
+                        // the `get_latest_matching_with_context` fallback branch above too,
+                        // whose returned `Version` is not a member of `versions` at all. See
+                        // `FetchResult::deprecations`'s docs for why this must not instead
+                        // scan `versions`.
+                        if let Some((_, _, _, dep_info)) = &resolved
+                            && let Some(dep_info) = dep_info
+                        {
+                            deprecation = Some((name.clone(), dep_info.clone()));
+                        }
+
+                        resolved.map(|(latest, _, published_at, _)| {
                             (
                                 name.clone(),
                                 PackageVersions {
@@ -903,7 +995,7 @@ async fn fetch_latest_versions_parallel(
                     sender.send(count);
                 }
 
-                (version, yanked, failed_name)
+                (version, yanked, failed_name, deprecation)
             }
         })
         .buffer_unordered(max_concurrent)
@@ -913,15 +1005,19 @@ async fn fetch_latest_versions_parallel(
     let mut versions = HashMap::with_capacity(results.len());
     let mut yanked_versions = HashMap::new();
     let mut fetch_failed = HashSet::new();
-    for (version, yanked, failed_name) in results {
+    let mut deprecations = HashMap::new();
+    for (version, yanked, failed_name, deprecation) in results {
         if let Some((name, v)) = version {
             versions.insert(name, v);
         }
-        if let Some((name, v)) = yanked {
-            yanked_versions.insert(name, v);
+        if let Some((name, v, status)) = yanked {
+            yanked_versions.insert(name, (v, status));
         }
         if let Some(name) = failed_name {
             fetch_failed.insert(name);
+        }
+        if let Some((name, d)) = deprecation {
+            deprecations.insert(name, d);
         }
     }
 
@@ -929,6 +1025,7 @@ async fn fetch_latest_versions_parallel(
         versions,
         yanked_versions,
         fetch_failed,
+        deprecations,
         failed_count: failed.load(std::sync::atomic::Ordering::Relaxed),
         first_error: first_error.lock().unwrap_or_else(|p| p.into_inner()).take(),
     }
@@ -1144,6 +1241,13 @@ pub async fn handle_document_open(
             // Re-key raw -> normalized (§3.1): `FetchResult::yanked_versions`
             // is raw-keyed, `DocumentState::yanked_versions` is normalized.
             let formatter = ecosystem_clone.formatter();
+            doc.update_deprecations(
+                fetch_result
+                    .deprecations
+                    .into_iter()
+                    .map(|(name, d)| (formatter.normalize_package_name(&name), d))
+                    .collect(),
+            );
             doc.update_yanked_versions(
                 fetch_result
                     .yanked_versions
@@ -1316,6 +1420,9 @@ pub async fn handle_document_change(
         doc_state
             .fetch_failed
             .remove(&formatter.normalize_package_name(removed_dep));
+        doc_state
+            .deprecations
+            .remove(&formatter.normalize_package_name(removed_dep));
     }
 
     // A version-only edit (name unchanged, requirement changed) invalidates
@@ -1327,6 +1434,11 @@ pub async fn handle_document_change(
     // the *new* version also turns out to be yanked. Same for `fetch_failed`
     // (#267): a stale fetch-error marker must not survive an edit that gets
     // re-fetched below.
+    //
+    // Deliberately NOT mirrored for `deprecations`: #205's finding is
+    // package-level, derived from `latest`, not the dependency's declared
+    // version — editing which version is pinned does not make the package
+    // any less (or more) deprecated, so there is nothing stale to drop here.
     for changed_dep in &diff.version_changed {
         doc_state
             .yanked_versions
@@ -1512,6 +1624,11 @@ pub async fn handle_document_change(
 
         // Merge new versions into existing cache
         if let Some(mut doc) = state_clone.documents.get_mut(&uri_clone) {
+            // Captured before `fetch_result.versions` is consumed below: every name
+            // successfully fetched this round, used by the S1 deprecation-clearing
+            // loop further down to distinguish "fetched and clean" from "not fetched
+            // this round" — only the former may clear a stale finding.
+            let fetched_names: Vec<PackageName> = fetch_result.versions.keys().cloned().collect();
             for (name, version) in fetch_result.versions {
                 doc.cached_versions.insert(name, version);
             }
@@ -1525,6 +1642,12 @@ pub async fn handle_document_change(
                 doc.fetch_failed
                     .insert(formatter.normalize_package_name(&name));
             }
+            merge_deprecations_after_fetch(
+                &mut doc,
+                &fetched_names,
+                fetch_result.deprecations,
+                formatter,
+            );
             if success {
                 doc.set_loaded();
             } else {
@@ -3990,7 +4113,7 @@ dependencies = ["requests>=2.0.0"]
             pinned_version: &'static str,
         ) -> (
             Vec<tower_lsp_server::ls_types::Diagnostic>,
-            HashMap<String, String>,
+            HashMap<String, (String, RemovalStatus)>,
         ) {
             let state = Arc::new(ServerState::new());
             let uri = deps_core::test_util::test_uri("/test/pyproject.toml");
@@ -4052,7 +4175,7 @@ dependencies = ["requests>=2.0.0"]
             )
             .await;
 
-            let yanked_versions: HashMap<String, String> = fetch_result
+            let yanked_versions: HashMap<String, (String, RemovalStatus)> = fetch_result
                 .yanked_versions
                 .into_iter()
                 .map(|(name, v)| (formatter.normalize_package_name(&name), v))
@@ -4087,7 +4210,7 @@ dependencies = ["requests>=2.0.0"]
 
             assert_eq!(
                 yanked_versions.get("typing-extensions"),
-                Some(&"4.9.0".to_string()),
+                Some(&("4.9.0".to_string(), RemovalStatus::Yanked)),
                 "must be keyed by the normalized (dash) name, not the raw manifest name"
             );
             assert!(
@@ -4102,7 +4225,7 @@ dependencies = ["requests>=2.0.0"]
 
             assert_eq!(
                 yanked_versions.get("zope-interface"),
-                Some(&"5.0.0".to_string()),
+                Some(&("5.0.0".to_string(), RemovalStatus::Yanked)),
                 "must be keyed by the normalized (dotted -> dash) name"
             );
             assert!(
@@ -4405,7 +4528,7 @@ time = "0.1.43"
                 let mut doc = state.documents.get_mut(&uri).unwrap();
                 doc.update_yanked_versions(HashMap::from([(
                     "time".to_string(),
-                    "0.1.43".to_string(),
+                    ("0.1.43".to_string(), RemovalStatus::Yanked),
                 )]));
             }
 
@@ -4429,7 +4552,338 @@ time = "0.1.43"
             state.update_document(uri.clone(), doc_state2);
 
             let doc = state.get_document(&uri).unwrap();
-            assert_eq!(doc.yanked_versions.get("time"), Some(&"0.1.43".to_string()));
+            assert_eq!(
+                doc.yanked_versions.get("time"),
+                Some(&("0.1.43".to_string(), RemovalStatus::Yanked))
+            );
+        }
+
+        #[tokio::test]
+        async fn test_preserve_cache_carries_deprecations_across_edit() {
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+
+            let content1 = r#"[dependencies]
+time = "0.1.43"
+"#;
+            let ecosystem = state.ecosystem_registry.get("cargo").unwrap();
+            let parse_result1 = ecosystem.parse_manifest(content1, &uri).await.unwrap();
+            let doc_state1 = DocumentState::new_from_parse_result(
+                EcosystemId::Cargo,
+                content1.to_string(),
+                parse_result1,
+            );
+            state.update_document(uri.clone(), doc_state1);
+
+            {
+                let mut doc = state.documents.get_mut(&uri).unwrap();
+                doc.update_deprecations(HashMap::from([(
+                    "time".to_string(),
+                    Deprecation {
+                        reason: Some("archived".to_string()),
+                        replacement: None,
+                    },
+                )]));
+            }
+
+            // A whitespace-only edit: DocumentState is rebuilt from scratch, which
+            // would silently flicker the deprecation diagnostic off on every keystroke
+            // without preserve_cache carrying it through.
+            let content2 = r#"[dependencies]
+time = "0.1.43"
+
+"#;
+            let parse_result2 = ecosystem.parse_manifest(content2, &uri).await.unwrap();
+            let mut doc_state2 = DocumentState::new_from_parse_result(
+                EcosystemId::Cargo,
+                content2.to_string(),
+                parse_result2,
+            );
+
+            if let Some(old_doc) = state.get_document(&uri) {
+                preserve_cache(&mut doc_state2, &old_doc);
+            }
+            state.update_document(uri.clone(), doc_state2);
+
+            let doc = state.get_document(&uri).unwrap();
+            assert_eq!(
+                doc.deprecations.get("time"),
+                Some(&Deprecation {
+                    reason: Some("archived".to_string()),
+                    replacement: None,
+                })
+            );
+        }
+
+        #[tokio::test]
+        async fn test_deprecations_pruned_on_dependency_removal_by_normalized_name() {
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+
+            let content1 = r#"[dependencies]
+serde = "1.0"
+time = "0.1.43"
+"#;
+            let ecosystem = state.ecosystem_registry.get("cargo").unwrap();
+            let parse_result1 = ecosystem.parse_manifest(content1, &uri).await.unwrap();
+            let doc_state1 = DocumentState::new_from_parse_result(
+                EcosystemId::Cargo,
+                content1.to_string(),
+                parse_result1,
+            );
+            state.update_document(uri.clone(), doc_state1);
+
+            {
+                let mut doc = state.documents.get_mut(&uri).unwrap();
+                doc.update_deprecations(HashMap::from([(
+                    "time".to_string(),
+                    Deprecation {
+                        reason: Some("archived".to_string()),
+                        replacement: None,
+                    },
+                )]));
+            }
+
+            let content2 = r#"[dependencies]
+serde = "1.0"
+"#;
+            let old_deps: HashMap<PackageName, Vec<Option<VersionReq>>> =
+                [("serde", None), ("time", None)]
+                    .into_iter()
+                    .map(|(n, r)| (PackageName::new(n), vec![r]))
+                    .collect();
+            let new_deps: HashMap<PackageName, Vec<Option<VersionReq>>> =
+                std::iter::once((PackageName::new("serde"), vec![None])).collect();
+            let diff = DependencyDiff::compute(&old_deps, &new_deps);
+            assert_eq!(diff.removed, vec![PackageName::new("time")]);
+
+            let parse_result2 = ecosystem.parse_manifest(content2, &uri).await.unwrap();
+            let mut doc_state2 = DocumentState::new_from_parse_result(
+                EcosystemId::Cargo,
+                content2.to_string(),
+                parse_result2,
+            );
+
+            if let Some(old_doc) = state.get_document(&uri) {
+                preserve_cache(&mut doc_state2, &old_doc);
+            }
+
+            let formatter = ecosystem.formatter();
+            for removed_dep in &diff.removed {
+                doc_state2
+                    .deprecations
+                    .remove(&formatter.normalize_package_name(removed_dep));
+            }
+
+            state.update_document(uri.clone(), doc_state2);
+
+            let doc = state.get_document(&uri).unwrap();
+            assert!(
+                !doc.deprecations.contains_key("time"),
+                "removed dependency's deprecation entry must be pruned"
+            );
+        }
+
+        /// D2 invariant: unlike `yanked_versions`, a #205 finding is package-level, not
+        /// tied to the declared version — editing which version is pinned must NOT
+        /// drop it, mirroring the deliberate absence of a
+        /// `diff.version_changed`-triggered prune in `handle_document_change`.
+        #[tokio::test]
+        async fn test_deprecations_survive_version_change_unlike_yanked_versions() {
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+
+            let content1 = r#"[dependencies]
+time = "0.1.44"
+"#;
+            let ecosystem = state.ecosystem_registry.get("cargo").unwrap();
+            let parse_result1 = ecosystem.parse_manifest(content1, &uri).await.unwrap();
+            let doc_state1 = DocumentState::new_from_parse_result(
+                EcosystemId::Cargo,
+                content1.to_string(),
+                parse_result1,
+            );
+            state.update_document(uri.clone(), doc_state1);
+
+            {
+                let mut doc = state.documents.get_mut(&uri).unwrap();
+                doc.update_yanked_versions(HashMap::from([(
+                    "time".to_string(),
+                    ("0.1.44".to_string(), RemovalStatus::Yanked),
+                )]));
+                doc.update_deprecations(HashMap::from([(
+                    "time".to_string(),
+                    Deprecation {
+                        reason: Some("archived".to_string()),
+                        replacement: None,
+                    },
+                )]));
+            }
+
+            // Edit the pin from a yanked version to a safe one — the *version-level*
+            // yanked finding is stale and must be dropped, but the *package-level*
+            // deprecation finding is not tied to which version is pinned.
+            let content2 = r#"[dependencies]
+time = "0.1.43"
+"#;
+            let parse_result2 = ecosystem.parse_manifest(content2, &uri).await.unwrap();
+            let mut doc_state2 = DocumentState::new_from_parse_result(
+                EcosystemId::Cargo,
+                content2.to_string(),
+                parse_result2,
+            );
+
+            if let Some(old_doc) = state.get_document(&uri) {
+                preserve_cache(&mut doc_state2, &old_doc);
+            }
+            doc_state2.yanked_versions.remove("time");
+
+            state.update_document(uri.clone(), doc_state2);
+
+            let doc = state.get_document(&uri).unwrap();
+            assert!(
+                !doc.yanked_versions.contains_key("time"),
+                "the stale version-level yanked finding must be dropped"
+            );
+            assert_eq!(
+                doc.deprecations.get("time"),
+                Some(&Deprecation {
+                    reason: Some("archived".to_string()),
+                    replacement: None,
+                }),
+                "the package-level deprecation finding must survive a version-only edit"
+            );
+        }
+
+        /// T4 (C3): a deprecation finding recorded on the full-fetch path must survive
+        /// a partial didChange fetch that does not re-fetch that package.
+        #[test]
+        fn test_merge_deprecations_after_fetch_retains_finding_for_name_not_refetched() {
+            let state = ServerState::new();
+            let ecosystem = state.ecosystem_registry.get("cargo").unwrap();
+            let formatter = ecosystem.formatter();
+            let mut doc =
+                DocumentState::new_without_parse_result(EcosystemId::Cargo, String::new());
+            doc.deprecations.insert(
+                "vendor/a".to_string(),
+                Deprecation {
+                    reason: None,
+                    replacement: Some("vendor/a2".to_string()),
+                },
+            );
+
+            // Only "vendor/b" was fetched this round (e.g. a new dependency added by
+            // the edit); "vendor/a" was untouched.
+            let mut fetched = HashMap::new();
+            fetched.insert(
+                PackageName::new("vendor/b"),
+                Deprecation {
+                    reason: Some("abandoned".to_string()),
+                    replacement: None,
+                },
+            );
+            merge_deprecations_after_fetch(
+                &mut doc,
+                &[PackageName::new("vendor/b")],
+                fetched,
+                formatter,
+            );
+
+            assert_eq!(
+                doc.deprecations.get("vendor/a"),
+                Some(&Deprecation {
+                    reason: None,
+                    replacement: Some("vendor/a2".to_string()),
+                }),
+                "a finding for a name not in this round's fetch must survive untouched"
+            );
+            assert_eq!(
+                doc.deprecations.get("vendor/b"),
+                Some(&Deprecation {
+                    reason: Some("abandoned".to_string()),
+                    replacement: None,
+                })
+            );
+        }
+
+        /// T5 (S1): a package that stops being deprecated must have its finding
+        /// cleared once re-fetched clean — distinct from a name simply not fetched
+        /// this round (T4), which must be left untouched.
+        #[test]
+        fn test_merge_deprecations_after_fetch_clears_finding_when_refetched_clean() {
+            let state = ServerState::new();
+            let ecosystem = state.ecosystem_registry.get("cargo").unwrap();
+            let formatter = ecosystem.formatter();
+            let mut doc =
+                DocumentState::new_without_parse_result(EcosystemId::Cargo, String::new());
+            doc.deprecations.insert(
+                "vendor/a".to_string(),
+                Deprecation {
+                    reason: None,
+                    replacement: None,
+                },
+            );
+
+            // "vendor/a" was re-fetched this round and no longer reports a finding.
+            merge_deprecations_after_fetch(
+                &mut doc,
+                &[PackageName::new("vendor/a")],
+                HashMap::new(),
+                formatter,
+            );
+
+            assert!(
+                !doc.deprecations.contains_key("vendor/a"),
+                "a name that was fetched and produced no finding must be cleared"
+            );
+        }
+
+        /// I2: two raw names that normalize to the same key (Composer's `normalize_package_name`
+        /// lowercases, so `"Vendor/Package"` and `"vendor/package"` collide) must merge
+        /// deterministically — a finding under either raw name must survive regardless of
+        /// `fetched_names`' (unspecified `HashMap::keys()`) iteration order.
+        #[test]
+        fn test_merge_deprecations_after_fetch_is_order_independent_across_normalization_collision()
+        {
+            let state = ServerState::new();
+            let ecosystem = state.ecosystem_registry.get("composer").unwrap();
+            let formatter = ecosystem.formatter();
+
+            for names in [
+                [
+                    PackageName::new("vendor/package"),
+                    PackageName::new("Vendor/Package"),
+                ],
+                [
+                    PackageName::new("Vendor/Package"),
+                    PackageName::new("vendor/package"),
+                ],
+            ] {
+                let mut doc =
+                    DocumentState::new_without_parse_result(EcosystemId::Composer, String::new());
+
+                let mut fetched = HashMap::new();
+                fetched.insert(
+                    PackageName::new("Vendor/Package"),
+                    Deprecation {
+                        reason: None,
+                        replacement: Some("vendor/other".to_string()),
+                    },
+                );
+                // "vendor/package" (lowercase) is fetched too and reports no finding.
+
+                merge_deprecations_after_fetch(&mut doc, &names, fetched, formatter);
+
+                assert_eq!(
+                    doc.deprecations.get("vendor/package"),
+                    Some(&Deprecation {
+                        reason: None,
+                        replacement: Some("vendor/other".to_string()),
+                    }),
+                    "a finding under either raw name sharing a normalized key must survive, \
+                     regardless of fetch order: {names:?}"
+                );
+            }
         }
 
         #[tokio::test]
@@ -4454,7 +4908,7 @@ time = "0.1.43"
                 let mut doc = state.documents.get_mut(&uri).unwrap();
                 doc.update_yanked_versions(HashMap::from([(
                     "time".to_string(),
-                    "0.1.43".to_string(),
+                    ("0.1.43".to_string(), RemovalStatus::Yanked),
                 )]));
             }
 
@@ -4527,7 +4981,7 @@ time = "=0.1.43"
                 let mut doc = state.documents.get_mut(&uri).unwrap();
                 doc.update_yanked_versions(HashMap::from([(
                     "time".to_string(),
-                    "0.1.43".to_string(),
+                    ("0.1.43".to_string(), RemovalStatus::Yanked),
                 )]));
             }
 
@@ -4714,7 +5168,7 @@ time = "0.1.43"
                 let mut doc = state.documents.get_mut(&uri).unwrap();
                 doc.update_yanked_versions(HashMap::from([(
                     "time".to_string(),
-                    "0.1.43".to_string(),
+                    ("0.1.43".to_string(), RemovalStatus::Yanked),
                 )]));
             }
 
@@ -4738,7 +5192,10 @@ time = "0.1.43"
             // un-yanked (or a different version newly yanked) in the
             // lockfile in the meantime, nothing here would know.
             let doc = state.get_document(&uri).unwrap();
-            assert_eq!(doc.yanked_versions.get("time"), Some(&"0.1.43".to_string()));
+            assert_eq!(
+                doc.yanked_versions.get("time"),
+                Some(&("0.1.43".to_string(), RemovalStatus::Yanked))
+            );
         }
 
         #[tokio::test]
@@ -6057,7 +6514,7 @@ tokio = "1.0"
             assert_eq!(fetch_calls.load(Ordering::Relaxed), 1);
             assert_eq!(
                 result.yanked_versions.get(&PackageName::new("pkg")),
-                Some(&"1.0.0".to_string())
+                Some(&("1.0.0".to_string(), RemovalStatus::Yanked))
             );
         }
 
@@ -6124,7 +6581,7 @@ tokio = "1.0"
 
             assert_eq!(
                 result.yanked_versions.get(&PackageName::new("pkg")),
-                Some(&"1.0.0".to_string())
+                Some(&("1.0.0".to_string(), RemovalStatus::Yanked))
             );
             assert!(result.versions.is_empty());
         }
@@ -6168,7 +6625,7 @@ tokio = "1.0"
             );
             assert_eq!(
                 result.yanked_versions.get(&PackageName::new("pkg")),
-                Some(&"1.0.0".to_string())
+                Some(&("1.0.0".to_string(), RemovalStatus::Yanked))
             );
         }
 
@@ -6212,7 +6669,7 @@ tokio = "1.0"
 
             assert_eq!(
                 result.yanked_versions.get(&PackageName::new("pkg")),
-                Some(&"2.0.0".to_string()),
+                Some(&("2.0.0".to_string(), RemovalStatus::Yanked)),
                 "the yanked occurrence must be found even though a name-keyed \
                  single-value map could have kept only the non-yanked \"1.0.0\" pin"
             );
@@ -6246,7 +6703,7 @@ tokio = "1.0"
 
             assert_eq!(
                 result.yanked_versions.get(&PackageName::new("pkg")),
-                Some(&"1.0.0".to_string())
+                Some(&("1.0.0".to_string(), RemovalStatus::Yanked))
             );
         }
 
@@ -6356,6 +6813,137 @@ tokio = "1.0"
             assert!(result.yanked_versions.is_empty());
             assert_eq!(result.failed_count, 1);
             assert!(result.versions.is_empty());
+        }
+    }
+
+    /// #205: the `fetch_latest_versions_parallel` wiring that derives `FetchResult::deprecations`
+    /// from the `resolved`/"latest" pick, self-contained rather than extending
+    /// `yanked_check_tests`'s shared `MockYankVersion`/`FetchOutcome` (whose tuple shape has
+    /// no room for a per-version `Deprecation` payload without touching its many existing
+    /// call sites).
+    mod deprecation_derivation_tests {
+        use super::*;
+        use deps_core::{Metadata, Version};
+        use std::any::Any;
+
+        struct MockDeprecatedVersion {
+            version: &'static str,
+            deprecation: Option<Deprecation>,
+        }
+
+        impl Version for MockDeprecatedVersion {
+            fn version_string(&self) -> &str {
+                self.version
+            }
+            fn removal_status(&self) -> RemovalStatus {
+                RemovalStatus::from_advisory(self.deprecation.is_some())
+            }
+            fn deprecation(&self) -> Option<&Deprecation> {
+                self.deprecation.as_ref()
+            }
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        /// Always resolves to its single configured version.
+        struct SingleVersionRegistry {
+            deprecation: Option<Deprecation>,
+        }
+
+        impl Registry for SingleVersionRegistry {
+            fn get_versions<'a>(
+                &'a self,
+                _name: &'a PackageName,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Version>>>>
+            {
+                let deprecation = self.deprecation.clone();
+                Box::pin(async move {
+                    Ok(vec![Box::new(MockDeprecatedVersion {
+                        version: "1.0.0",
+                        deprecation,
+                    }) as Box<dyn Version>])
+                })
+            }
+
+            fn select_latest_matching(
+                &self,
+                versions: &[Box<dyn Version>],
+                _req: &VersionReq,
+            ) -> Option<usize> {
+                (!versions.is_empty()).then_some(0)
+            }
+
+            fn get_latest_matching<'a>(
+                &'a self,
+                _name: &'a PackageName,
+                _req: &'a VersionReq,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Option<Box<dyn Version>>>>
+            {
+                Box::pin(async move { Ok(None) })
+            }
+
+            fn search<'a>(
+                &'a self,
+                _query: &'a str,
+                _limit: usize,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Metadata>>>>
+            {
+                Box::pin(async move { Ok(vec![]) })
+            }
+
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        #[tokio::test]
+        async fn fetch_result_carries_deprecation_from_resolved_pick() {
+            let registry: Arc<dyn Registry> = Arc::new(SingleVersionRegistry {
+                deprecation: Some(Deprecation {
+                    reason: Some("archived".to_string()),
+                    replacement: Some("other/pkg".to_string()),
+                }),
+            });
+
+            let result = fetch_latest_versions_parallel(
+                registry,
+                vec![PackageName::new("pkg")],
+                &HashMap::new(),
+                None,
+                deps_core::freshness::FreshnessSettings::default(),
+                5,
+                10,
+                None,
+            )
+            .await;
+
+            assert_eq!(
+                result.deprecations.get(&PackageName::new("pkg")),
+                Some(&Deprecation {
+                    reason: Some("archived".to_string()),
+                    replacement: Some("other/pkg".to_string()),
+                })
+            );
+        }
+
+        #[tokio::test]
+        async fn fetch_result_has_no_deprecation_when_resolved_pick_is_clean() {
+            let registry: Arc<dyn Registry> = Arc::new(SingleVersionRegistry { deprecation: None });
+
+            let result = fetch_latest_versions_parallel(
+                registry,
+                vec![PackageName::new("pkg")],
+                &HashMap::new(),
+                None,
+                deps_core::freshness::FreshnessSettings::default(),
+                5,
+                10,
+                None,
+            )
+            .await;
+
+            assert!(result.deprecations.is_empty());
         }
     }
 }

--- a/crates/deps-lsp/src/document/state.rs
+++ b/crates/deps-lsp/src/document/state.rs
@@ -2,7 +2,10 @@ use dashmap::DashMap;
 use deps_core::HttpCache;
 use deps_core::lockfile::LockFileCache;
 use deps_core::osv::{OsvClient, VulnerabilityMap};
-use deps_core::{EcosystemId, EcosystemRegistry, PackageName, PackageVersions, ParseResult};
+use deps_core::{
+    Deprecation, EcosystemId, EcosystemRegistry, PackageName, PackageVersions, ParseResult,
+    RemovalStatus,
+};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -61,7 +64,12 @@ pub struct DocumentState {
     /// ecosystems where normalization changes the name (e.g. PyPI). Empty
     /// until the first fetch completes; carried across document edits by
     /// `preserve_cache`.
-    pub yanked_versions: HashMap<String, String>,
+    pub yanked_versions: HashMap<String, (String, RemovalStatus)>,
+    /// Package-level deprecation findings from the lifecycle's registry fetch (issue
+    /// #205), keyed by **normalized** package name — same raw/normalized split
+    /// rationale as [`Self::yanked_versions`]. Empty until the first fetch completes;
+    /// carried across document edits by `preserve_cache`.
+    pub deprecations: HashMap<String, Deprecation>,
     /// Packages whose registry fetch errored or timed out on the most recent
     /// lifecycle fetch, keyed by **normalized** package name (same raw/normalized
     /// split as `yanked_versions` above, for the same reason — see §3.1). Lets
@@ -97,6 +105,7 @@ impl Clone for DocumentState {
             resolved_versions: self.resolved_versions.clone(),
             vulnerabilities: self.vulnerabilities.clone(),
             yanked_versions: self.yanked_versions.clone(),
+            deprecations: self.deprecations.clone(),
             fetch_failed: self.fetch_failed.clone(),
             parsed_at: self.parsed_at,
             loading_state: self.loading_state,
@@ -197,6 +206,7 @@ impl std::fmt::Debug for DocumentState {
             .field("resolved_versions_count", &self.resolved_versions.len())
             .field("vulnerabilities_count", &self.vulnerabilities.len())
             .field("yanked_versions_count", &self.yanked_versions.len())
+            .field("deprecations_count", &self.deprecations.len())
             .field("fetch_failed_count", &self.fetch_failed.len())
             .field("parsed_at", &self.parsed_at)
             .field("loading_state", &self.loading_state)
@@ -223,6 +233,7 @@ impl DocumentState {
             resolved_versions: HashMap::new(),
             vulnerabilities: VulnerabilityMap::new(),
             yanked_versions: HashMap::new(),
+            deprecations: HashMap::new(),
             fetch_failed: HashSet::new(),
             parsed_at: Instant::now(),
             loading_state: LoadingState::Idle,
@@ -244,6 +255,7 @@ impl DocumentState {
             resolved_versions: HashMap::new(),
             vulnerabilities: VulnerabilityMap::new(),
             yanked_versions: HashMap::new(),
+            deprecations: HashMap::new(),
             fetch_failed: HashSet::new(),
             parsed_at: Instant::now(),
             loading_state: LoadingState::Idle,
@@ -290,8 +302,17 @@ impl DocumentState {
     }
 
     /// Updates the yanked-version findings, keyed by normalized package name.
-    pub fn update_yanked_versions(&mut self, yanked_versions: HashMap<String, String>) {
+    pub fn update_yanked_versions(
+        &mut self,
+        yanked_versions: HashMap<String, (String, RemovalStatus)>,
+    ) {
         self.yanked_versions = yanked_versions;
+    }
+
+    /// Updates the package-level deprecation findings (issue #205), keyed by
+    /// normalized package name.
+    pub fn update_deprecations(&mut self, deprecations: HashMap<String, Deprecation>) {
+        self.deprecations = deprecations;
     }
 
     /// Replaces the set of packages whose registry fetch errored or timed out

--- a/crates/deps-lsp/src/handlers/code_actions.rs
+++ b/crates/deps-lsp/src/handlers/code_actions.rs
@@ -39,6 +39,7 @@ pub async fn handle_code_actions(
         cached_versions,
         resolved_versions,
         vulnerabilities,
+        deprecations,
         content,
     )) = state
         .with_document(uri, |doc| {
@@ -51,6 +52,7 @@ pub async fn handle_code_actions(
                 doc.cached_versions.clone(),
                 doc.resolved_versions.clone(),
                 doc.vulnerabilities.clone(),
+                doc.deprecations.clone(),
                 doc.content.clone(),
             ))
         })
@@ -66,6 +68,7 @@ pub async fn handle_code_actions(
             uri,
             VersionData::new(&cached_versions, &resolved_versions)
                 .with_vulnerabilities(&vulnerabilities)
+                .with_deprecations(&deprecations)
                 .with_ecosystem(ecosystem_id),
             &content,
         )

--- a/crates/deps-lsp/src/handlers/diagnostics.rs
+++ b/crates/deps-lsp/src/handlers/diagnostics.rs
@@ -65,6 +65,7 @@ pub(crate) async fn generate_diagnostics_internal(
             doc.resolved_versions.clone(),
             doc.vulnerabilities.clone(),
             doc.yanked_versions.clone(),
+            doc.deprecations.clone(),
             doc.fetch_failed.clone(),
         ))
     }) else {
@@ -80,6 +81,7 @@ pub(crate) async fn generate_diagnostics_internal(
         resolved_versions,
         vulnerabilities,
         yanked_versions,
+        deprecations,
         fetch_failed,
     )) = extracted
     else {
@@ -92,6 +94,7 @@ pub(crate) async fn generate_diagnostics_internal(
             VersionData::new(&cached_versions, &resolved_versions)
                 .with_vulnerabilities(&vulnerabilities)
                 .with_yanked(&yanked_versions)
+                .with_deprecations(&deprecations)
                 .with_fetch_failed(&fetch_failed)
                 .with_ecosystem(ecosystem_id),
             uri,

--- a/crates/deps-lsp/src/handlers/hover.rs
+++ b/crates/deps-lsp/src/handlers/hover.rs
@@ -40,6 +40,7 @@ pub async fn handle_hover(
         cached_versions,
         resolved_versions,
         vulnerabilities,
+        deprecations,
     ) = state
         .with_document(uri, |doc| {
             let ecosystem = state.ecosystem_registry.get(doc.ecosystem_id())?;
@@ -51,6 +52,7 @@ pub async fn handle_hover(
                 doc.cached_versions.clone(),
                 doc.resolved_versions.clone(),
                 doc.vulnerabilities.clone(),
+                doc.deprecations.clone(),
             ))
         })
         .flatten()?;
@@ -61,6 +63,7 @@ pub async fn handle_hover(
             position,
             VersionData::new(&cached_versions, &resolved_versions)
                 .with_vulnerabilities(&vulnerabilities)
+                .with_deprecations(&deprecations)
                 .with_ecosystem(ecosystem_id),
             freshness,
         )

--- a/crates/deps-npm/src/formatter.rs
+++ b/crates/deps-npm/src/formatter.rs
@@ -159,8 +159,9 @@ impl EcosystemFormatter for NpmFormatter {
     /// versions marked deprecated) — a package-level signal, not a true per-version yank.
     /// Evaluating a range requirement (`^1.0`, `~2.3.0`) against it would flag every
     /// dependency on such a package with this diagnostic's "yanked" wording, conflating it
-    /// with package-level deprecation, which is a distinct, separately-planned diagnostic
-    /// (issue #205). `node_semver::Version::parse` succeeds only for a bare version string,
+    /// with package-level deprecation, which is a distinct diagnostic
+    /// ([`EcosystemFormatter::deprecated_message`], issue #205). `node_semver::Version::parse`
+    /// succeeds only for a bare version string,
     /// never a range/caret/tilde/wildcard, so it doubles as the exact-pin test.
     fn yanked_diagnostic_applies_to(&self, requirement: &VersionReq) -> bool {
         node_semver::Version::parse(requirement.as_str().trim()).is_ok()
@@ -170,6 +171,24 @@ impl EcosystemFormatter for NpmFormatter {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// O2: npm never offers the #205 "Replace with X" rename action — its only
+    /// successor signal is free text (`deprecated`'s message), and regex-extracting a
+    /// package name from registry-controlled prose to rewrite a manifest is a
+    /// typosquatting vector. `supports_package_rename` stays the trait default (`false`).
+    #[test]
+    fn test_supports_package_rename_false() {
+        assert!(!NpmFormatter.supports_package_rename());
+    }
+
+    /// npm's deprecation wording reuses the trait default (only Composer overrides it,
+    /// to match Packagist's "abandoned" vocabulary).
+    #[test]
+    fn test_deprecated_message_and_label_use_defaults() {
+        let f = NpmFormatter;
+        assert_eq!(f.deprecated_message(), "This package is deprecated");
+        assert_eq!(f.deprecated_label(), "*(deprecated)*");
+    }
 
     #[test]
     fn test_validate_package_name_accepts_hostile_but_legitimate_names() {

--- a/crates/deps-npm/src/registry.rs
+++ b/crates/deps-npm/src/registry.rs
@@ -491,6 +491,23 @@ struct VersionMetadata {
     deprecated: Option<String>,
 }
 
+/// Derives a #205 [`Deprecation`](deps_core::Deprecation) payload from npm's free-text
+/// `deprecated` field, or `None` if there is nothing worth telling the user.
+///
+/// M2: an all-whitespace `deprecated` string (`"deprecated": ""` is how a package is
+/// *un*-deprecated in practice) must produce `None`, not a `Deprecation` with a
+/// dangling, empty reason — `removal_status()` above is unaffected (it still treats
+/// `Some("")` as flagged, matching pre-#205 behavior; this is only about the payload
+/// shown to the user). Never populates `replacement`: npm has no structured successor
+/// field, only free text (see [`NpmVersion::deprecation`]'s docs).
+fn deprecation_from_message(message: Option<&str>) -> Option<deps_core::Deprecation> {
+    let reason = message.map(str::trim).filter(|s| !s.is_empty())?;
+    Some(deps_core::Deprecation {
+        reason: Some(reason.to_string()),
+        replacement: None,
+    })
+}
+
 /// Parses JSON response from npm package metadata API.
 fn parse_package_metadata(data: &[u8]) -> Result<Vec<NpmVersion>> {
     let metadata: PackageMetadata = deps_core::parse_json_checked(data)?;
@@ -505,6 +522,7 @@ fn parse_package_metadata(data: &[u8]) -> Result<Vec<NpmVersion>> {
                 NpmVersion {
                     version,
                     deprecated: meta.deprecated.is_some(),
+                    deprecation: deprecation_from_message(meta.deprecated.as_deref()),
                     published_at: None,
                 },
                 parsed,
@@ -1066,8 +1084,51 @@ mod tests {
         assert_eq!(versions.len(), 2);
         assert_eq!(versions[0].version, "1.3.0");
         assert!(versions[0].deprecated);
+        assert_eq!(
+            versions[0]
+                .deprecation
+                .as_ref()
+                .and_then(|d| d.reason.as_deref()),
+            Some("use String.prototype.padStart()")
+        );
         assert_eq!(versions[1].version, "1.2.0");
         assert!(!versions[1].deprecated);
+        assert!(versions[1].deprecation.is_none());
+    }
+
+    /// #205 M2: `"deprecated": ""` is npm's own convention for *un*-deprecating a
+    /// package — the `Deprecation` payload must be `None`, not `Some` with a dangling
+    /// empty reason, even though `removal_status()` (unaffected, pre-existing behavior)
+    /// still treats `Some("")` as flagged.
+    #[test]
+    fn test_parse_abbreviated_packument_empty_string_deprecated_has_no_payload() {
+        let json = r#"{
+  "name": "pkg",
+  "versions": {
+    "1.0.0": {"deprecated": ""}
+  }
+}"#;
+        let versions = parse_package_metadata(json.as_bytes()).unwrap();
+        assert_eq!(versions.len(), 1);
+        assert!(
+            versions[0].deprecated,
+            "removal_status derivation is unaffected"
+        );
+        assert!(versions[0].deprecation.is_none());
+    }
+
+    #[test]
+    fn test_deprecation_from_message_trims_and_rejects_empty() {
+        assert_eq!(deprecation_from_message(None), None);
+        assert_eq!(deprecation_from_message(Some("")), None);
+        assert_eq!(deprecation_from_message(Some("   ")), None);
+        assert_eq!(
+            deprecation_from_message(Some("  use foo instead  ")),
+            Some(deps_core::Deprecation {
+                reason: Some("use foo instead".to_string()),
+                replacement: None,
+            })
+        );
     }
 
     #[test]
@@ -1183,11 +1244,13 @@ mod tests {
             Box::new(NpmVersion {
                 version: "2.0.0".into(),
                 deprecated: true,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(NpmVersion {
                 version: "1.0.0".into(),
                 deprecated: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1208,11 +1271,13 @@ mod tests {
             Box::new(NpmVersion {
                 version: "1.3.0".into(),
                 deprecated: true,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(NpmVersion {
                 version: "1.2.0".into(),
                 deprecated: true,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1231,6 +1296,7 @@ mod tests {
         let versions: Vec<Box<dyn deps_core::Version>> = vec![Box::new(NpmVersion {
             version: "1.0.0".into(),
             deprecated: true,
+            deprecation: None,
             published_at: None,
         })];
         let req = VersionReq::new("");
@@ -1253,11 +1319,13 @@ mod tests {
             Box::new(NpmVersion {
                 version: "19.2.0-canary.1".into(),
                 deprecated: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(NpmVersion {
                 version: "19.1.0".into(),
                 deprecated: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1278,11 +1346,13 @@ mod tests {
             Box::new(NpmVersion {
                 version: "2.0.0-alpha".into(),
                 deprecated: false,
+                deprecation: None,
                 published_at: None,
             }),
             Box::new(NpmVersion {
                 version: "1.0.0-beta".into(),
                 deprecated: false,
+                deprecation: None,
                 published_at: None,
             }),
         ];
@@ -1366,6 +1436,7 @@ mod tests {
                 Box::new(NpmVersion {
                     version: (*version).to_string(),
                     deprecated: *deprecated,
+                    deprecation: None,
                     published_at: None,
                 }) as Box<dyn deps_core::Version>
             })
@@ -1481,6 +1552,11 @@ mod tests {
         let version = latest.expect("an all-deprecated package must still resolve a latest");
         assert_eq!(version.version, "1.3.0");
         assert!(version.deprecated);
+        assert!(
+            version.deprecation.is_some(),
+            "T3/C1: when every non-prerelease version is deprecated, rung 1 finds \
+             nothing and rung 2 returns a deprecated pick — the #205 finding must fire"
+        );
     }
 
     /// #338 NFR-002 (regression): a mix of deprecated and non-deprecated versions under a
@@ -1509,12 +1585,20 @@ mod tests {
         let version = latest.expect("widget has a non-deprecated version");
         assert_eq!(version.version, "1.0.0");
         assert!(!version.deprecated);
+        assert!(
+            version.deprecation.is_none(),
+            "T3/C1: a partially-deprecated version list must yield no #205 finding — \
+             rung 1 finds the clean 1.0.0 before rung 2 (the all-deprecated fallback) \
+             ever runs; a developer expecting 'latest is deprecated' semantics here \
+             would wrongly conclude the plumbing is broken"
+        );
     }
 
     fn npm_v(s: &str) -> NpmVersion {
         NpmVersion {
             version: s.to_string(),
             deprecated: false,
+            deprecation: None,
             published_at: None,
         }
     }

--- a/crates/deps-npm/src/types.rs
+++ b/crates/deps-npm/src/types.rs
@@ -81,6 +81,7 @@ pub enum NpmDependencySection {
 /// let version = NpmVersion {
 ///     version: "4.18.2".into(),
 ///     deprecated: false,
+///     deprecation: None,
 ///     published_at: None,
 /// };
 ///
@@ -90,6 +91,15 @@ pub enum NpmDependencySection {
 pub struct NpmVersion {
     pub version: String,
     pub deprecated: bool,
+    /// Package-level deprecation payload (issue #205), derived from the packument's
+    /// `deprecated` free-text field. `None` whenever `deprecated` is absent, `null`, or
+    /// an all-whitespace string — npm's own convention for "un-deprecating" a package is
+    /// republishing with an empty `deprecated` string, so that case must not produce a
+    /// dangling, information-free diagnostic (see `deprecation_from_message`). Carries no
+    /// `replacement`: npm only ever names a successor in free text, and regex-extracting
+    /// a package name from registry-controlled prose to rewrite a manifest is a
+    /// typosquatting vector — see `NpmFormatter::supports_package_rename`.
+    pub deprecation: Option<deps_core::Deprecation>,
     /// Publish timestamp, populated only when `Registry::get_versions_with` is called with
     /// freshness enabled — derived from the full packument's `time` map, never the
     /// abbreviated packument `get_versions` otherwise uses.
@@ -108,6 +118,7 @@ deps_core::impl_version!(NpmVersion {
     prerelease: |v: &NpmVersion| {
         node_semver::Version::parse(&v.version).is_ok_and(|parsed| parsed.is_prerelease())
     },
+    deprecation: |v: &NpmVersion| v.deprecation.as_ref(),
 });
 
 /// Package metadata from npm registry.
@@ -189,6 +200,7 @@ mod tests {
         let version = NpmVersion {
             version: "1.0.0".into(),
             deprecated: false,
+            deprecation: None,
             published_at: None,
         };
 
@@ -201,6 +213,7 @@ mod tests {
         let version = NpmVersion {
             version: "2.0.0".into(),
             deprecated: true,
+            deprecation: None,
             published_at: None,
         };
 
@@ -212,16 +225,45 @@ mod tests {
         assert!(!version.removal_status().blocks_resolution());
     }
 
+    /// #205: `Version::deprecation()` reads the dedicated field, independent of the
+    /// `removal_status`-driving `deprecated` bool.
+    #[test]
+    fn test_npm_version_deprecation_accessor() {
+        let with_payload = NpmVersion {
+            version: "2.0.0".into(),
+            deprecated: true,
+            deprecation: Some(deps_core::Deprecation {
+                reason: Some("use foo".to_string()),
+                replacement: None,
+            }),
+            published_at: None,
+        };
+        assert_eq!(
+            with_payload.deprecation().and_then(|d| d.reason.as_deref()),
+            Some("use foo")
+        );
+
+        let without_payload = NpmVersion {
+            version: "1.0.0".into(),
+            deprecated: false,
+            deprecation: None,
+            published_at: None,
+        };
+        assert!(without_payload.deprecation().is_none());
+    }
+
     #[test]
     fn test_npm_version_is_prerelease() {
         let stable = NpmVersion {
             version: "18.0.0".into(),
             deprecated: false,
+            deprecation: None,
             published_at: None,
         };
         let prerelease = NpmVersion {
             version: "18.0.0-beta.1".into(),
             deprecated: false,
+            deprecation: None,
             published_at: None,
         };
 

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -413,10 +413,10 @@ dependency, so only one yanked diagnostic is ever shown per dependency.
   flag from a package-wide signal — npm's from `deprecated` (live-verified: the `request`
   package has 126/126 versions marked deprecated), Composer's from `abandoned` — not a true
   per-version yank. Evaluating a range requirement against either would flag every dependency
-  on a deprecated/abandoned package under this diagnostic's wording, which is a distinct,
-  separately-planned diagnostic (package-level deprecation, issue #205). A bare exact pin
-  (`"1.2.3"`, not `"^1.2.3"`) is unaffected by that ambiguity, so the check still applies
-  there.
+  on a deprecated/abandoned package under this diagnostic's wording, which is a distinct
+  diagnostic — see [Package Deprecation Diagnostics](#package-deprecation-diagnostics-issue-205)
+  below. A bare exact pin (`"1.2.3"`, not `"^1.2.3"`) is unaffected by that ambiguity, so the
+  check still applies there.
 
 **Ecosystem coverage, live-verified per registry rather than assumed from code:**
 
@@ -438,6 +438,45 @@ dependency, so only one yanked diagnostic is ever shown per dependency.
 6 of 12 ecosystems can produce this diagnostic today; the other 6 have no real yanked signal
 to source it from (three are architecturally impossible — no such registry concept exists —
 and Go's is a fixable but separate gap).
+
+### Package Deprecation Diagnostics (issue #205)
+
+The two yanked diagnostics above answer "is *this version* installable"; this one answers a
+different, package-level question — "is the project itself still maintained" — regardless of
+which version is declared or resolved. When the registry reports the package's latest version
+as deprecated/abandoned, `deps-lsp` shows a diagnostic (configurable via
+`diagnostics.deprecated_severity`, default WARNING):
+
+```
+This package is deprecated: use String.prototype.padStart() instead
+```
+
+The hover popup gets a matching `### Deprecated` section with the same reason text and, when
+the registry names one, a suggested replacement package. Derived entirely from data the
+regular version fetch already retrieves — no extra registry request.
+
+**Suppression against the yanked diagnostics above.** npm's yanked signal is itself sourced
+from the same `deprecated` field this diagnostic reads, so a dependency pinned to an exact,
+deprecated version would otherwise show two near-duplicate diagnostics. When this diagnostic
+fires, it suppresses the in-use-version yanked check for the same dependency — but only when
+the yanked finding's underlying signal is an advisory (`AdvisoryDeprecated`), never a genuine
+hard yank/retraction. A package that is both deprecated *and* has a specific version really
+withdrawn from resolution still shows both diagnostics; "the exact version you have was
+pulled" is strictly more actionable than "the project is archived," and one must never hide
+the other.
+
+**Composer-only "Replace with X" code action.** When Packagist's `abandoned` field names a
+successor package, a `QUICKFIX` titled `Replace with <package>` rewrites the dependency's name
+in place. Not offered for npm: its only successor signal is free-text prose inside the
+`deprecated` message, and regex-extracting a package name from registry-controlled text to
+rewrite a manifest is a typosquatting vector — npm still gets the diagnostic and hover (the
+message is shown verbatim, which is the useful part), just not an automated rename.
+
+| Ecosystem | Works today? | Source |
+| --------- | ------------- | ------ |
+| npm | Yes | `deprecated` free-text message (no structured replacement — see above) |
+| Composer | Yes, with replace action | `abandoned` (bare `true`, or a string naming a successor package) |
+| Cargo, Go, PyPI, Bundler, Dart, Maven, Gradle, Swift, NuGet, Deno | Not yet | No registry-native package-level deprecation signal wired up yet (tracked as fast-follows; Dart's `isDiscontinued`/`replacedBy` and PyPI's PEP 792 `project-status` already exist on the wire and are the best next targets) |
 
 ### npm Package Name Validation
 


### PR DESCRIPTION
## Summary

- Adds a WARNING diagnostic and hover section for packages the registry reports as deprecated/abandoned (distinct from the existing per-version yanked diagnostic), plus a Composer-only "Replace with X" quick fix when a successor package is named.
- Phase 1 scope: `deps-core` plumbing + npm (`deprecated`) and Composer (`abandoned`) data extraction. The other 9 ecosystem crates compile unchanged via defaulted trait methods. NuGet, pub.dev, deps.dev, and PyPI are sized as fast-follows.
- Zero new HTTP requests: the finding is derived from data already fetched during the normal version lookup.
- The suppression gate against the existing yanked diagnostics is keyed on the underlying `RemovalStatus` (`AdvisoryDeprecated` vs `Yanked`), not on configured severity, so a genuine hard yank is never hidden behind a deprecation notice.
- The rename action is intentionally Composer-only: npm's successor name lives only in free text, and regex-extracting a package name from registry-controlled prose to rewrite a manifest would be a typosquatting vector.

## Process

This went through the full `team-develop` pipeline: architect → critic (3 adversarial review rounds, catching real bugs each round — npm's `latest`-selector semantics, a `Range::default()` hazard in Composer's parser, missing lifecycle writeback sites, a severity/suppression interaction, and a zero-width-range guard bug introduced by the critic's own earlier recommendation) → developer → parallel validation (tester, perf, security, implementation critic — the impl-critic pass caught one more real defect, a suppression gate that didn't cover an independent code path) → code review (one gap: missing CHANGELOG entry, plus a self-identified follow-up: root README/ECOSYSTEM_GUIDE.md needed updates too).

Design doc: `.local/specs/011-deprecation-replacement-diagnostics/plan.md` (not committed — local planning artifact).

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (3125 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Live-verified against real registries: npm `left-pad` (all versions deprecated) and Packagist `swiftmailer/swiftmailer` (`abandoned: "symfony/mailer"`)

Closes #205