### PR TITLE
refactor(deps-npm,deps-composer): retire AdvisoryDeprecated -> yanked map feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Breaking (pre-1.0, public API)**: `PackageVersions::yanked` field type changed from `Arc<[ConcreteVersion]>` to `Arc<[(ConcreteVersion, RemovalStatus)]>`, carrying each yanked/deprecated version's `RemovalStatus` (resolves #437) (#438)
-- **deps-npm, deps-composer**: `AdvisoryDeprecated` no longer feeds the manifest-requirement yanked diagnostic; the #205 package-level deprecation diagnostic is now its sole signal (resolves #436)
+- **deps-npm, deps-composer**: `AdvisoryDeprecated` no longer feeds the manifest-requirement yanked diagnostic; the #205 package-level deprecation diagnostic is now its sole signal (resolves #436) (#439)
 
 ### Fixed
 - **deps-core, deps-lsp**: the "requirement satisfiable only by a yanked version" diagnostic no longer lets a co-occurring package-level deprecation finding hide a genuine hard yank (resolves #437) (#438)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Breaking (pre-1.0, public API)**: `PackageVersions::yanked` field type changed from `Arc<[ConcreteVersion]>` to `Arc<[(ConcreteVersion, RemovalStatus)]>`, carrying each yanked/deprecated version's `RemovalStatus` (resolves #437) (#438)
+- **deps-npm, deps-composer**: `AdvisoryDeprecated` no longer feeds the manifest-requirement yanked diagnostic; the #205 package-level deprecation diagnostic is now its sole signal (resolves #436)
 
 ### Fixed
 - **deps-core, deps-lsp**: the "requirement satisfiable only by a yanked version" diagnostic no longer lets a co-occurring package-level deprecation finding hide a genuine hard yank (resolves #437) (#438)

--- a/crates/deps-composer/src/formatter.rs
+++ b/crates/deps-composer/src/formatter.rs
@@ -309,46 +309,6 @@ impl EcosystemFormatter for ComposerFormatter {
             ComposerMatcher,
         )
     }
-
-    /// Restricts the yanked-only-match diagnostic to an exact-pin requirement.
-    ///
-    /// Composer's `Version::removal_status()` reports `AdvisoryDeprecated`, sourced from
-    /// `abandoned` (`ComposerVersion::abandoned`), a package-level flag Packagist replicates
-    /// onto every version entry of an abandoned package — not a true per-version yank.
-    /// Evaluating a range requirement (`^1.0`, `~2.3`) against it would flag every dependency
-    /// on such a package with this diagnostic's "yanked" wording, conflating it with
-    /// package-level abandonment, which is a distinct diagnostic
-    /// ([`EcosystemFormatter::deprecated_message`], issue #205).
-    fn yanked_diagnostic_applies_to(&self, requirement: &VersionReq) -> bool {
-        is_exact_pin(requirement.as_str())
-    }
-}
-
-/// Whether `requirement` is a bare exact version pin (e.g. `"1.2.3"`, `"v1.2.3"`,
-/// `"=1.2.3"`), as opposed to a range, wildcard, OR-combinator, or partial version.
-///
-/// Deliberately conservative: a partial version like `"1.2"` is Composer shorthand for
-/// `>=1.2.0 <1.3.0` (see `test_partial_version`), not an exact pin, so this requires at
-/// least three dot-separated, purely numeric segments before any `-`-prefixed suffix
-/// (pre-release/build metadata). Anything ambiguous is treated as *not* exact, which is the
-/// safe direction for [`ComposerFormatter::yanked_diagnostic_applies_to`]'s caller.
-fn is_exact_pin(requirement: &str) -> bool {
-    let r = requirement.trim();
-    if r.is_empty() || r.contains(char::is_whitespace) || r.contains("||") || r.contains('*') {
-        return false;
-    }
-    if matches!(r.chars().next(), Some('^' | '~' | '>' | '<')) || r.starts_with("!=") {
-        return false;
-    }
-    let r = r.strip_prefix('=').unwrap_or(r).trim();
-    let r = r.strip_prefix('v').unwrap_or(r);
-
-    let core = r.split('-').next().unwrap_or(r);
-    let segments: Vec<&str> = core.split('.').collect();
-    segments.len() >= 3
-        && segments
-            .iter()
-            .all(|seg| !seg.is_empty() && seg.bytes().all(|b| b.is_ascii_digit()))
 }
 
 /// Composer tilde semantics.
@@ -1032,56 +992,6 @@ mod tests {
                 .is_none()
         );
         assert!(f.compile_requirement(&VersionReq::new("2.0@dev")).is_none());
-    }
-
-    #[test]
-    fn test_is_exact_pin_accepts_bare_and_prefixed_full_versions() {
-        for requirement in ["1.2.3", "v1.2.3", "=1.2.3", "1.2.3-beta1", "1.2.3.4"] {
-            assert!(
-                is_exact_pin(requirement),
-                "expected {requirement:?} to be recognized as an exact pin"
-            );
-        }
-    }
-
-    /// Composer treats a partial version ("1", "1.2") as shorthand for a range
-    /// (`test_partial_version` above), not an exact pin.
-    #[test]
-    fn test_is_exact_pin_rejects_partial_versions() {
-        for requirement in ["1", "1.2"] {
-            assert!(
-                !is_exact_pin(requirement),
-                "expected {requirement:?} to be rejected"
-            );
-        }
-    }
-
-    #[test]
-    fn test_is_exact_pin_rejects_ranges_and_wildcards() {
-        for requirement in [
-            "^1.2.3",
-            "~1.2.3",
-            ">=1.0.0 <2.0.0",
-            "1.0.*",
-            "1.0 || 2.0",
-            "*",
-        ] {
-            assert!(
-                !is_exact_pin(requirement),
-                "expected {requirement:?} to be rejected"
-            );
-        }
-    }
-
-    /// S1 regression: `yanked_diagnostic_applies_to` must reject a range requirement, since
-    /// Composer's `removal_status()` is sourced from `abandoned`, a package-level flag
-    /// replicated onto every version — a range requirement would flag every dependency on an
-    /// abandoned package, conflating this diagnostic with package-level abandonment (issue #205).
-    #[test]
-    fn test_yanked_diagnostic_applies_to_matches_is_exact_pin() {
-        let f = ComposerFormatter;
-        assert!(f.yanked_diagnostic_applies_to(&VersionReq::new("1.2.3")));
-        assert!(!f.yanked_diagnostic_applies_to(&VersionReq::new("^1.2.3")));
     }
 
     #[test]

--- a/crates/deps-core/src/lsp_helpers/diagnostics.rs
+++ b/crates/deps-core/src/lsp_helpers/diagnostics.rs
@@ -681,9 +681,12 @@ pub fn generate_diagnostics_from_cache(
 
         // Same source-resolvability guard as `unsatisfiable` above — only meaningful once a
         // requirement is known to match *something* in `available` (see `requirement_is_unsatisfiable`).
-        // `yanked_diagnostic_applies_to` additionally opts an ecosystem out for a requirement
-        // shape where `removal_status()` is not a genuine per-version signal (npm/Composer
-        // restrict to exact pins — see that method's docs). Skipped entirely when the in-use-version
+        // `yanked_diagnostic_applies_to` additionally opts an ecosystem out of *this specific*
+        // diagnostic for a requirement shape (or, npm, unconditionally, #436) where it would
+        // duplicate a more specific one or where `removal_status()` isn't a reliable enough
+        // per-version signal — see that method's docs. Independent of the #263 in-use-version
+        // check just above, which reads `versions.yanked` directly and is unaffected by this
+        // hook. Skipped entirely when the in-use-version
         // check above already pushed a yanked diagnostic for this dependency (see
         // `yanked_263_diagnostic_pushed`), so the two checks never double-report — but,
         // critically (#437 S1), NOT skipped merely because the #263 check was D5-suppressed:

--- a/crates/deps-core/src/lsp_helpers/mod.rs
+++ b/crates/deps-core/src/lsp_helpers/mod.rs
@@ -1024,17 +1024,26 @@ pub trait EcosystemFormatter: Send + Sync {
     /// at all for this ecosystem.
     ///
     /// Default `true` — no restriction, every requirement shape is checked. Override to
-    /// `false` for a requirement shape where this ecosystem's `Version::removal_status()` is
-    /// not a genuine per-version signal. `NpmFormatter` and `ComposerFormatter` restrict this to
-    /// exact-pin requirements: npm's yanked flag is sourced from `deprecated`
-    /// (`NpmVersion::deprecated`), and Composer's from `abandoned`
-    /// (`ComposerVersion::abandoned`) — both are commonly package-wide (a live-verified
-    /// npm package had 126/126 versions marked deprecated), so evaluating a range
-    /// requirement against them would flag every dependency on a deprecated/abandoned
-    /// package under this diagnostic's wording, conflating it with package-level
-    /// deprecation — a distinct diagnostic ([`Self::deprecated_message`], issue #205).
-    /// Restricting to an exact pin keeps this diagnostic scoped to #247's actual scenario:
-    /// "you are pinned to this one specific version, and it has been yanked."
+    /// `false` for a requirement shape (or, returning `false` unconditionally, for every
+    /// requirement) where this diagnostic would duplicate a more specific one, or where this
+    /// ecosystem's `Version::removal_status()` is not a reliable enough per-version signal.
+    /// This is independent of
+    /// [`Registry::reports_yanked`](crate::Registry::reports_yanked): that flag gates whether
+    /// `removal_status()` data is trusted at all (and thus whether the separate #263
+    /// in-use-version yanked check runs), while this hook only narrows *this* diagnostic.
+    ///
+    /// `DenoFormatter` restricts this to exact-pin requirements — its `jsr:`/`npm:`
+    /// specifiers share npm's package-wide deprecation semantics — see that formatter's docs.
+    /// `NpmFormatter` returns `false` unconditionally (#436): npm's `AdvisoryDeprecated` is
+    /// genuinely per-version but commonly applied package-wide, so even an exact pin would
+    /// often just duplicate the dedicated package-level deprecation diagnostic
+    /// ([`Self::deprecated_message`], issue #205); npm keeps `reports_yanked() == true`; so the
+    /// #263 in-use-version check stays live. `ComposerFormatter` does not override this hook
+    /// at all — it opts out at the registry level instead
+    /// ([`Registry::reports_yanked`](crate::Registry::reports_yanked) `== false`, pre-dating
+    /// #436, independently justified by #233 R2): Packagist's `abandoned` is package-level via
+    /// p2 minified inheritance, so its yanked map is never populated and this hook has nothing
+    /// to restrict.
     ///
     /// # Examples
     ///

--- a/crates/deps-deno/src/formatter.rs
+++ b/crates/deps-deno/src/formatter.rs
@@ -132,12 +132,22 @@ impl EcosystemFormatter for DenoFormatter {
             .map(|req| Box::new(NodeSemverMatcher(req)) as Box<dyn RequirementMatcher>)
     }
 
-    /// Restricts the yanked-only-match diagnostic to an exact-pin requirement, copying
-    /// npm's rationale (`deps-npm/src/formatter.rs`): applies uniformly to `jsr:` and
-    /// `npm:` since this hook takes only a `&VersionReq`, with no way to tell which
-    /// scheme it came from (accepted limitation L1 — JSR's genuinely better per-version
-    /// signal is under-used for range requirements, in exchange for not reintroducing
-    /// npm's package-wide-`deprecated` false-positive storm).
+    /// Restricts the yanked-only-match diagnostic to an exact-pin requirement: evaluating
+    /// a range requirement against a package-wide deprecation signal would flag every
+    /// dependency on such a package, conflating this diagnostic with package-level
+    /// deprecation (issue #205). Applies uniformly to `jsr:` and `npm:` since this hook
+    /// takes only a `&VersionReq`, with no way to tell which scheme it came from (accepted
+    /// limitation L1 — JSR's genuinely better per-version signal is under-used for range
+    /// requirements, in exchange for not reintroducing npm's package-wide-`deprecated`
+    /// false-positive storm).
+    ///
+    /// Known cross-ecosystem divergence (#436 M1, not fixed here — out of scope for that
+    /// issue's npm/Composer-only formatter changes): `NpmFormatter::yanked_diagnostic_applies_to`
+    /// now returns `false` unconditionally, so an exact-pin `npm:` dependency in `deno.json`
+    /// (e.g. `npm:lodash@4.17.20`) can still surface this diagnostic while the equivalent
+    /// exact-pin `package.json` dependency (`"lodash": "4.17.20"`) no longer does, since this
+    /// method doesn't delegate to `NpmFormatter`'s. Candidate for a follow-up issue rather than
+    /// silently matched or left unremarked.
     fn yanked_diagnostic_applies_to(&self, requirement: &VersionReq) -> bool {
         node_semver::Version::parse(requirement.as_str().trim()).is_ok()
     }

--- a/crates/deps-lsp/src/handlers/diagnostics.rs
+++ b/crates/deps-lsp/src/handlers/diagnostics.rs
@@ -642,6 +642,7 @@ serde = "1.0.0"
     mod npm_tests {
         use super::*;
         use crate::document::DocumentState;
+        use deps_core::EcosystemFormatter;
 
         #[tokio::test]
         async fn test_handle_diagnostics() {
@@ -664,6 +665,142 @@ serde = "1.0.0"
             let (client, full_config) = create_test_client_and_config();
             let _result = handle_diagnostics(state, &uri, &config, client, full_config).await;
             // Test passes if no panic occurs
+        }
+
+        /// #436 S1 regression: after #436 narrowed npm's fix to only suppress the
+        /// manifest-requirement-level yanked diagnostic (`NpmFormatter::yanked_diagnostic_applies_to`
+        /// now unconditionally `false`), the independent #263 in-use-version yanked diagnostic
+        /// must still fire through the real `DocumentState` -> `Ecosystem::generate_diagnostics`
+        /// -> `generate_diagnostics_from_cache` path — the same live path the LSP server
+        /// actually calls, using the real `NpmFormatter`/`NpmRegistry`-backed npm ecosystem
+        /// (not a generic `MockRegistry`).
+        ///
+        /// Mirrors the canonical `npm deprecate left-pad@"<1.0.2" "..."` scenario: the
+        /// manifest declares a range (`^1.0.0`), `latest` (1.0.2) is clean, but the
+        /// lockfile-resolved in-use version (1.0.1) is flagged. This is exactly the coverage
+        /// the critic's S1 finding said `Registry::reports_yanked() == false` would have
+        /// silently killed had npm's first #436 pass gone unrevised.
+        #[tokio::test]
+        async fn test_handle_diagnostics_in_use_version_yanked_still_fires_post_436() {
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/package.json");
+            let config = DiagnosticsConfig::default();
+
+            let ecosystem = state.ecosystem_registry.get("npm").unwrap();
+            let content = r#"{"dependencies": {"left-pad": "^1.0.0"}}"#.to_string();
+            let parse_result = ecosystem
+                .parse_manifest(&content, &uri)
+                .await
+                .expect("Failed to parse manifest");
+
+            let mut doc_state =
+                DocumentState::new_from_parse_result(EcosystemId::Npm, content, parse_result);
+
+            let mut cached = std::collections::HashMap::new();
+            cached.insert(
+                "left-pad".into(),
+                deps_core::PackageVersions {
+                    latest: "1.0.2".into(),
+                    available: std::sync::Arc::from(vec![
+                        "1.0.2".into(),
+                        "1.0.1".into(),
+                        "1.0.0".into(),
+                    ]),
+                    yanked: std::sync::Arc::from(Vec::new()),
+                    published_at: None,
+                },
+            );
+            doc_state.update_cached_versions(cached);
+
+            // Lockfile resolves the "^1.0.0" range to the old, flagged 1.0.1 — `latest`
+            // itself is clean, so this is only reachable via the lockfile-resolved
+            // in-use-version check (#263), not the manifest-requirement check (#247).
+            let mut resolved = std::collections::HashMap::new();
+            resolved.insert("left-pad".into(), "1.0.1".into());
+            doc_state.update_resolved_versions(resolved);
+
+            let mut yanked_versions = std::collections::HashMap::new();
+            yanked_versions.insert(
+                "left-pad".to_string(),
+                ("1.0.1".into(), deps_core::RemovalStatus::AdvisoryDeprecated),
+            );
+            doc_state.update_yanked_versions(yanked_versions);
+
+            state.update_document(uri.clone(), doc_state);
+
+            let (client, full_config) = create_test_client_and_config();
+            let result = handle_diagnostics(state, &uri, &config, client, full_config).await;
+
+            assert_eq!(
+                result.len(),
+                1,
+                "expected exactly one diagnostic, got {result:?}"
+            );
+            assert_eq!(
+                result[0].severity,
+                Some(tower_lsp_server::ls_types::DiagnosticSeverity::WARNING)
+            );
+            assert_eq!(
+                result[0].message,
+                format!("{} (1.0.1)", deps_npm::NpmFormatter.yanked_message())
+            );
+        }
+
+        /// #436 S1 companion: the manifest-requirement-level yanked diagnostic (#247) must
+        /// stay suppressed for npm even for an exact-pin requirement — the one shape the
+        /// pre-#436 restriction still let through. Deliberately isolated from the #263 path
+        /// (no `resolved_versions`/`yanked_versions` set) so this proves
+        /// `NpmFormatter::yanked_diagnostic_applies_to`'s unconditional `false` is doing real
+        /// work here, not merely benefiting from the `yanked_263_diagnostic_pushed` dedup
+        /// guard the sibling test above would also satisfy on its own.
+        #[tokio::test]
+        async fn test_handle_diagnostics_manifest_requirement_yanked_stays_suppressed_for_exact_pin()
+         {
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/package.json");
+            let config = DiagnosticsConfig::default();
+
+            let ecosystem = state.ecosystem_registry.get("npm").unwrap();
+            // Bare exact pin (npm's ordinary package.json style, no `=` marker) — the
+            // shape `yanked_diagnostic_applies_to` still allowed through pre-#436.
+            let content = r#"{"dependencies": {"old-pkg": "1.0.1"}}"#.to_string();
+            let parse_result = ecosystem
+                .parse_manifest(&content, &uri)
+                .await
+                .expect("Failed to parse manifest");
+
+            let mut doc_state =
+                DocumentState::new_from_parse_result(EcosystemId::Npm, content, parse_result);
+
+            let mut cached = std::collections::HashMap::new();
+            cached.insert(
+                "old-pkg".into(),
+                deps_core::PackageVersions {
+                    // The pin is satisfiable only by a flagged version — pre-#436, this
+                    // exact shape fired the #247 "yanked" diagnostic.
+                    latest: "1.0.1".into(),
+                    available: std::sync::Arc::from(vec!["1.0.1".into()]),
+                    yanked: std::sync::Arc::from(vec![(
+                        "1.0.1".into(),
+                        deps_core::RemovalStatus::AdvisoryDeprecated,
+                    )]),
+                    published_at: None,
+                },
+            );
+            doc_state.update_cached_versions(cached);
+            // No `resolved_versions`/`yanked_versions` — the #263 in-use-version path has
+            // nothing to match against, isolating this assertion to the #247 path alone.
+            state.update_document(uri.clone(), doc_state);
+
+            let (client, full_config) = create_test_client_and_config();
+            let result = handle_diagnostics(state, &uri, &config, client, full_config).await;
+
+            assert!(
+                result.is_empty(),
+                "expected no diagnostics for an exact pin satisfiable only by a flagged \
+                 version — the #247 manifest-requirement diagnostic must stay suppressed for \
+                 npm regardless of requirement shape (#436), got {result:?}"
+            );
         }
     }
 

--- a/crates/deps-npm/src/formatter.rs
+++ b/crates/deps-npm/src/formatter.rs
@@ -153,20 +153,24 @@ impl EcosystemFormatter for NpmFormatter {
         true
     }
 
-    /// Restricts the yanked-only-match diagnostic to an exact-pin requirement.
+    /// Disables the manifest-requirement-level "requirement satisfiable only by a yanked
+    /// version" diagnostic entirely (#436, follow-up to #205's plan.md §6): unconditionally
+    /// `false`, for every requirement shape, not only ranges.
     ///
-    /// npm's `Version::removal_status()` is sourced from `deprecated` (`NpmVersion::deprecated`),
-    /// which `npm deprecate` sets per-version but is routinely applied to *every* published
+    /// npm's `Version::removal_status()` is genuinely per-version data (`npm deprecate` can
+    /// target one version), but `npm deprecate` is routinely applied to *every* published
     /// version of a package at once (live-verified: the `request` package has all 126/126
-    /// versions marked deprecated) — a package-level signal, not a true per-version yank.
-    /// Evaluating a range requirement (`^1.0`, `~2.3.0`) against it would flag every
-    /// dependency on such a package with this diagnostic's "yanked" wording, conflating it
-    /// with package-level deprecation, which is a distinct diagnostic
-    /// ([`EcosystemFormatter::deprecated_message`], issue #205). `node_semver::Version::parse`
-    /// succeeds only for a bare version string,
-    /// never a range/caret/tilde/wildcard, so it doubles as the exact-pin test.
-    fn yanked_diagnostic_applies_to(&self, requirement: &VersionReq) -> bool {
-        node_semver::Version::parse(requirement.as_str().trim()).is_ok()
+    /// versions marked deprecated) — common enough that this diagnostic would frequently
+    /// duplicate the dedicated package-level deprecation diagnostic
+    /// ([`EcosystemFormatter::deprecated_message`], issue #205), including for an exact-pin
+    /// requirement (the case this hook used to still allow through). This does not touch
+    /// [`Registry::reports_yanked`](deps_core::Registry::reports_yanked), which npm keeps at
+    /// its default `true`: the independent in-use-version yanked check (#263,
+    /// `crates/deps-core/src/lsp_helpers/diagnostics.rs`) reads real per-version data and
+    /// stays live — e.g. a lockfile-pinned old version flagged by `npm deprecate pkg@"<1.2.3"`
+    /// while `latest` is clean still surfaces its own "yanked" diagnostic.
+    fn yanked_diagnostic_applies_to(&self, _requirement: &VersionReq) -> bool {
+        false
     }
 }
 
@@ -412,24 +416,16 @@ mod tests {
         );
     }
 
+    /// #436: the manifest-requirement-level yanked diagnostic never applies to npm, for
+    /// any requirement shape — including an exact pin, which the pre-#436 exact-pin
+    /// restriction used to still allow through.
     #[test]
-    fn test_yanked_diagnostic_applies_to_exact_pin() {
+    fn test_yanked_diagnostic_applies_to_always_false() {
         let formatter = NpmFormatter;
-        assert!(formatter.yanked_diagnostic_applies_to(&VersionReq::new("1.2.3")));
-    }
-
-    /// S1 regression: a range/caret/tilde requirement must not trigger the yanked-only-match
-    /// diagnostic, since npm's `removal_status()` is sourced from `deprecated`, which is commonly
-    /// applied to every published version of a package at once — a range requirement would
-    /// flag every dependency on such a package, conflating this diagnostic with package-level
-    /// deprecation (issue #205).
-    #[test]
-    fn test_yanked_diagnostic_applies_to_rejects_ranges() {
-        let formatter = NpmFormatter;
-        for requirement in ["^1.2.3", "~1.2.3", ">=1.0.0 <2.0.0", "*", "1.x"] {
+        for requirement in ["1.2.3", "^1.2.3", "~1.2.3", ">=1.0.0 <2.0.0", "*", "1.x"] {
             assert!(
                 !formatter.yanked_diagnostic_applies_to(&VersionReq::new(requirement)),
-                "expected {requirement:?} to be rejected as not an exact pin"
+                "expected {requirement:?} to be rejected"
             );
         }
     }

--- a/crates/deps-npm/src/registry.rs
+++ b/crates/deps-npm/src/registry.rs
@@ -810,6 +810,19 @@ mod tests {
         assert!(url.contains("%25"));
     }
 
+    /// #436: npm keeps `reports_yanked() == true` (the trait default) — the registry's
+    /// `removal_status()` is genuine per-version data, and the #263 in-use-version yanked
+    /// check (`crates/deps-core/src/lsp_helpers/diagnostics.rs`) depends on this staying
+    /// populated. Only the manifest-requirement-level diagnostic is suppressed, via
+    /// `NpmFormatter::yanked_diagnostic_applies_to` — see that method's docs.
+    #[test]
+    fn test_registry_reports_yanked_true() {
+        use deps_core::Registry;
+
+        let registry = NpmRegistry::new(Arc::new(HttpCache::new()));
+        assert!(registry.reports_yanked());
+    }
+
     #[test]
     fn test_package_url_empty_name() {
         assert_eq!(package_url(""), "https://www.npmjs.com/package/");


### PR DESCRIPTION
## Summary

- Suppresses the manifest-requirement yanked diagnostic sourced from npm's `deprecated` / Composer's `abandoned` (`AdvisoryDeprecated`) for any requirement shape (exact pin and range alike). The #205 package-level deprecation diagnostic is now the sole signal for that overlap.
- npm's `Registry::reports_yanked()` stays at its trait default (`true`), so the independent in-use-version yanked check (#263) keeps working for a lockfile-resolved version genuinely flagged yanked/deprecated. Composer's `reports_yanked()` was already `false` before this PR, so its now-dead `yanked_diagnostic_applies_to` override and `is_exact_pin` helper are removed along with their tests.
- Documents (does not fix) a pre-existing Deno `npm:` divergence from native npm manifests in `crates/deps-deno/src/formatter.rs` — out of scope for this issue; a `cross-ecosystem`-labeled follow-up issue is recommended.

## Review history

This PR went through an internal architecture-review cycle before commit: the first implementation attempt (literally following the issue's proposed `reports_yanked() = false`) was caught by adversarial critique for silently also disabling the unrelated #263 in-use-version yanked diagnostic for npm. The fix was narrowed to only suppress the manifest-requirement diagnostic path, preserving #263. A regression test (`test_handle_diagnostics_in_use_version_yanked_still_fires_post_436` in `crates/deps-lsp/src/handlers/diagnostics.rs`) was added and verified to prove #263 still fires through the real npm pipeline, and was independently confirmed by review to come from the genuinely distinct #263 message path (not #205's or #247's).

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (3131 passed, 49 skipped)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] `cargo test --workspace --doc --all-features`
- [x] New npm end-to-end regression test proves #263 in-use-version yanked diagnostic still fires post-change, through the real `NpmFormatter`/`NpmRegistry` pipeline

Closes #436