### PR TITLE
chore: alphabetize [workspace.dependencies] in root Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-npm, deps-composer, deps-lsp**: package-level deprecation/abandoned diagnostic and hover section (npm `deprecated`, Composer `abandoned`), plus a Composer-only "Replace with X" code action when a successor package is named (resolves #205) (#435)
 
 ### Changed
+- **repo**: root `Cargo.toml` `[workspace.dependencies]` is now fully, case-insensitively sorted alphabetically (resolves #442)
 - **Breaking (pre-1.0, public API)**: `PackageVersions::yanked` field type changed from `Arc<[ConcreteVersion]>` to `Arc<[(ConcreteVersion, RemovalStatus)]>`, carrying each yanked/deprecated version's `RemovalStatus` (resolves #437) (#438)
 - **deps-npm, deps-composer**: `AdvisoryDeprecated` no longer feeds the manifest-requirement yanked diagnostic; the #205 package-level deprecation diagnostic is now its sole signal (resolves #436) (#439)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-npm, deps-composer, deps-lsp**: package-level deprecation/abandoned diagnostic and hover section (npm `deprecated`, Composer `abandoned`), plus a Composer-only "Replace with X" code action when a successor package is named (resolves #205) (#435)
 
 ### Changed
-- **repo**: root `Cargo.toml` `[workspace.dependencies]` is now fully, case-insensitively sorted alphabetically (resolves #442)
+- **repo**: root `Cargo.toml` `[workspace.dependencies]` is now fully, case-insensitively sorted alphabetically (resolves #442) (#444)
 - **Breaking (pre-1.0, public API)**: `PackageVersions::yanked` field type changed from `Arc<[ConcreteVersion]>` to `Arc<[(ConcreteVersion, RemovalStatus)]>`, carrying each yanked/deprecated version's `RemovalStatus` (resolves #437) (#438)
 - **deps-npm, deps-composer**: `AdvisoryDeprecated` no longer feeds the manifest-requirement yanked diagnostic; the #205 package-level deprecation diagnostic is now its sole signal (resolves #436) (#439)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,22 +12,23 @@ license = "MIT"
 repository = "https://github.com/bug-ops/deps-lsp"
 
 [workspace.dependencies]
+bytes = "1"
 criterion = "0.8"
 dashmap = "6.2"
-deps-core = { version = "0.11.1", path ="crates/deps-core" }
-deps-cargo = { version = "0.11.1", path ="crates/deps-cargo" }
-deps-deno = { version = "0.11.1", path ="crates/deps-deno" }
-deps-npm = { version = "0.11.1", path ="crates/deps-npm" }
-deps-pypi = { version = "0.11.1", path ="crates/deps-pypi" }
-deps-go = { version = "0.11.1", path ="crates/deps-go" }
 deps-bundler = { version = "0.11.1", path ="crates/deps-bundler" }
-deps-dart = { version = "0.11.1", path ="crates/deps-dart" }
-deps-maven = { version = "0.11.1", path ="crates/deps-maven" }
-deps-nuget = { version = "0.11.1", path ="crates/deps-nuget" }
+deps-cargo = { version = "0.11.1", path ="crates/deps-cargo" }
 deps-composer = { version = "0.11.1", path ="crates/deps-composer" }
+deps-core = { version = "0.11.1", path ="crates/deps-core" }
+deps-dart = { version = "0.11.1", path ="crates/deps-dart" }
+deps-deno = { version = "0.11.1", path ="crates/deps-deno" }
+deps-go = { version = "0.11.1", path ="crates/deps-go" }
 deps-gradle = { version = "0.11.1", path ="crates/deps-gradle" }
-deps-swift = { version = "0.11.1", path ="crates/deps-swift" }
 deps-lsp = { version = "0.11.1", path ="crates/deps-lsp" }
+deps-maven = { version = "0.11.1", path ="crates/deps-maven" }
+deps-npm = { version = "0.11.1", path ="crates/deps-npm" }
+deps-nuget = { version = "0.11.1", path ="crates/deps-nuget" }
+deps-pypi = { version = "0.11.1", path ="crates/deps-pypi" }
+deps-swift = { version = "0.11.1", path ="crates/deps-swift" }
 futures = "0.3"
 insta = "1.48"
 jsonc-parser = "0.33"
@@ -35,7 +36,7 @@ mockito = "1"
 node-semver = "2.2"
 pep440_rs = "0.7"
 pep508_rs = "0.9"
-bytes = "1"
+quick-xml = "0.42"
 regex = "1"
 reqwest = "0.13"
 semver = "1"
@@ -50,9 +51,8 @@ toml-span = "0.7"
 tower-lsp-server = "0.23"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-urlencoding = "2.1"
 url = "2.5"
-quick-xml = "0.42"
+urlencoding = "2.1"
 yaml-rust2 = "0.12"
 zed_extension_api = "0.7"
 


### PR DESCRIPTION
## Summary
- Sorted `[workspace.dependencies]` in root `Cargo.toml` alphabetically (case-insensitive), merging the `deps-*` workspace-member crates into the single ordering rather than a separate subgroup — matches the project's `.claude/rules/dependencies.md` rule ("All dependencies sorted alphabetically") without ambiguity.
- Pure reorder: no versions, features, or paths changed; nothing added, removed, or renamed.
- Added a CHANGELOG `[Unreleased]` entry.

Closes #442

## Test plan
- [x] `cargo metadata --format-version 1` parses cleanly
- [x] `cargo check --workspace --all-features` — no errors/warnings
- [x] `cargo nextest run --workspace --all-features --lib --bins` — 3100 passed, 48 skipped, 0 failed
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] Adversarial critique + code review both passed (verdict: approved)

## Follow-up
A follow-up issue will be filed for unsorted `[dependencies]`/`[dev-dependencies]` tables in individual member-crate `Cargo.toml` files (out of scope for this PR, per `.local/handoff/2026-09-01T21-30-20-critic.md` finding M2).

https://claude.ai/code/session_019fg5i1svS13WAVCNmsFYqU