### PR TITLE
chore: alphabetize per-crate [dependencies]/[dev-dependencies] tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **repo**: root `Cargo.toml` `[workspace.dependencies]` is now fully, case-insensitively sorted alphabetically (resolves #442) (#444)
-- **repo**: per-crate `[dependencies]`/`[dev-dependencies]` tables in 8 member crates are now sorted alphabetically (resolves #445) (#NNN)
+- **repo**: per-crate `[dependencies]`/`[dev-dependencies]` tables in 8 member crates are now sorted alphabetically (resolves #445) (#446)
 - **Breaking (pre-1.0, public API)**: `PackageVersions::yanked` field type changed from `Arc<[ConcreteVersion]>` to `Arc<[(ConcreteVersion, RemovalStatus)]>`, carrying each yanked/deprecated version's `RemovalStatus` (resolves #437) (#438)
 - **deps-npm, deps-composer**: `AdvisoryDeprecated` no longer feeds the manifest-requirement yanked diagnostic; the #205 package-level deprecation diagnostic is now its sole signal (resolves #436) (#439)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **repo**: root `Cargo.toml` `[workspace.dependencies]` is now fully, case-insensitively sorted alphabetically (resolves #442) (#444)
+- **repo**: per-crate `[dependencies]`/`[dev-dependencies]` tables in 8 member crates are now sorted alphabetically (resolves #445) (#NNN)
 - **Breaking (pre-1.0, public API)**: `PackageVersions::yanked` field type changed from `Arc<[ConcreteVersion]>` to `Arc<[(ConcreteVersion, RemovalStatus)]>`, carrying each yanked/deprecated version's `RemovalStatus` (resolves #437) (#438)
 - **deps-npm, deps-composer**: `AdvisoryDeprecated` no longer feeds the manifest-requirement yanked diagnostic; the #205 package-level deprecation diagnostic is now its sole signal (resolves #436) (#439)
 

--- a/crates/deps-bundler/Cargo.toml
+++ b/crates/deps-bundler/Cargo.toml
@@ -24,8 +24,8 @@ tracing = { workspace = true }
 urlencoding = { workspace = true }
 
 [dev-dependencies]
-deps-core = { workspace = true, features = ["test-util"] }
 criterion = { workspace = true, features = ["html_reports"] }
+deps-core = { workspace = true, features = ["test-util"] }
 insta = { workspace = true, features = ["json"] }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/deps-cargo/Cargo.toml
+++ b/crates/deps-cargo/Cargo.toml
@@ -36,9 +36,9 @@ url = { workspace = true }
 urlencoding = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true, features = ["html_reports"] }
 deps-cargo = { path = ".", features = ["test-util"] }
 deps-core = { workspace = true, features = ["test-util"] }
-criterion = { workspace = true, features = ["html_reports"] }
 insta = { workspace = true, features = ["json"] }
 mockito = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/deps-dart/Cargo.toml
+++ b/crates/deps-dart/Cargo.toml
@@ -24,8 +24,8 @@ urlencoding = { workspace = true }
 yaml-rust2 = { workspace = true }
 
 [dev-dependencies]
-deps-core = { workspace = true, features = ["test-util"] }
 criterion = { workspace = true, features = ["html_reports"] }
+deps-core = { workspace = true, features = ["test-util"] }
 insta = { workspace = true, features = ["json"] }
 mockito = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/deps-go/Cargo.toml
+++ b/crates/deps-go/Cargo.toml
@@ -13,22 +13,22 @@ workspace = true
 
 [dependencies]
 deps-core = { workspace = true }
+regex.workspace = true
+semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tower-lsp-server.workspace = true
 tracing.workspace = true
-regex.workspace = true
-semver.workspace = true
 urlencoding.workspace = true
 
 [dev-dependencies]
+criterion.workspace = true
 deps-core = { workspace = true, features = ["test-util"] }
+tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 tokio-test.workspace = true
-tempfile.workspace = true
-criterion.workspace = true
 url.workspace = true
 
 [[bench]]

--- a/crates/deps-lsp/Cargo.toml
+++ b/crates/deps-lsp/Cargo.toml
@@ -39,19 +39,19 @@ deno = ["dep:deps-deno"]
 
 [dependencies]
 # Internal crates
-deps-core = { workspace = true }
+deps-bundler = { workspace = true, optional = true }
 deps-cargo = { workspace = true, optional = true }
 deps-composer = { workspace = true, optional = true }
-deps-deno = { workspace = true, optional = true }
-deps-npm = { workspace = true, optional = true }
-deps-pypi = { workspace = true, optional = true }
-deps-go = { workspace = true, optional = true }
-deps-bundler = { workspace = true, optional = true }
+deps-core = { workspace = true }
 deps-dart = { workspace = true, optional = true }
-deps-maven = { workspace = true, optional = true }
+deps-deno = { workspace = true, optional = true }
+deps-go = { workspace = true, optional = true }
 deps-gradle = { workspace = true, optional = true }
-deps-swift = { workspace = true, optional = true }
+deps-maven = { workspace = true, optional = true }
+deps-npm = { workspace = true, optional = true }
 deps-nuget = { workspace = true, optional = true }
+deps-pypi = { workspace = true, optional = true }
+deps-swift = { workspace = true, optional = true }
 
 # External dependencies
 dashmap = { workspace = true }
@@ -65,8 +65,8 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [dev-dependencies]
-deps-core = { workspace = true, features = ["test-util"] }
 criterion = { workspace = true }
+deps-core = { workspace = true, features = ["test-util"] }
 insta = { workspace = true, features = ["json"] }
 mockito = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/deps-npm/Cargo.toml
+++ b/crates/deps-npm/Cargo.toml
@@ -34,8 +34,8 @@ tracing = { workspace = true }
 urlencoding = { workspace = true }
 
 [dev-dependencies]
-deps-core = { workspace = true, features = ["test-util"] }
 criterion = { workspace = true, features = ["html_reports"] }
+deps-core = { workspace = true, features = ["test-util"] }
 insta = { workspace = true, features = ["json"] }
 mockito = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/deps-pypi/Cargo.toml
+++ b/crates/deps-pypi/Cargo.toml
@@ -21,14 +21,14 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-tower-lsp-server = { workspace = true }
 toml-span = { workspace = true }
+tower-lsp-server = { workspace = true }
 tracing = { workspace = true }
 urlencoding = { workspace = true }
 
 [dev-dependencies]
-deps-core = { workspace = true, features = ["test-util"] }
 criterion = { workspace = true, features = ["html_reports"] }
+deps-core = { workspace = true, features = ["test-util"] }
 insta = { workspace = true, features = ["json"] }
 mockito = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/deps-swift/Cargo.toml
+++ b/crates/deps-swift/Cargo.toml
@@ -15,15 +15,15 @@ workspace = true
 bytes = { workspace = true }
 dashmap = { workspace = true }
 deps-core = { workspace = true }
-reqwest = { workspace = true }
 regex = { workspace = true }
+reqwest = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread"] }
 tower-lsp-server = { workspace = true }
 tracing = { workspace = true }
-thiserror = { workspace = true }
 urlencoding = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

- Follow-up from #442, which alphabetized only the root `[workspace.dependencies]` table. Extends the same sort to per-crate `[dependencies]`/`[dev-dependencies]` tables.
- Sorts 11 tables across 8 member crates alphabetically by key: `deps-bundler`, `deps-cargo`, `deps-dart`, `deps-go`, `deps-lsp`, `deps-npm`, `deps-pypi`, `deps-swift`. All other member crates were already sorted.
- Pure reorder — no version, feature, or dependency-value changes. Verified as an exact line-multiset permutation against `main` for each file.
- `deps-lsp`'s pre-existing `# Internal crates` / `# External dependencies` section-header comments were kept (sorted within each group) rather than flattened, since the internal-crate group maps 1:1 onto the `[features]` table directly above it, and flattening would delete content beyond this issue's stated "pure reorder" scope.

## Test plan

- [x] `cargo check --workspace --all-features` — clean
- [x] `cargo nextest run --workspace --all-features --lib --bins` — 3100 passed, 48 skipped, 0 failed
- [x] `cargo +nightly fmt --all -- --check` — clean (no `.rs` files touched)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo metadata --no-deps` — parses cleanly for all crates

Closes #445

https://claude.ai/code/session_01N3GfHZRjr7jQoXaZoJqqtJ