### PR TITLE
fix(deps-deno,deps-npm): align deno npm: yanked diagnostic with npm's suppressed behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **deps-core, deps-lsp**: the "requirement satisfiable only by a yanked version" diagnostic no longer lets a co-occurring package-level deprecation finding hide a genuine hard yank (resolves #437) (#438)
+- **deps-deno, deps-npm**: an exact-pin `npm:` dependency in `deno.json` no longer surfaces the yanked-worded diagnostic, matching the equivalent `package.json` dependency's post-#436 behavior; `jsr:` specifiers are unaffected (resolves #448)
 
 ## [0.11.1] - 2026-09-01
 

--- a/crates/deps-core/src/lsp_helpers/diagnostics.rs
+++ b/crates/deps-core/src/lsp_helpers/diagnostics.rs
@@ -739,7 +739,7 @@ pub fn generate_diagnostics_from_cache(
             && formatter.can_resolve_source(&dep.source()))
         .then(|| dep.version_requirement())
         .flatten()
-        .filter(|version_req| formatter.yanked_diagnostic_applies_to(version_req))
+        .filter(|version_req| formatter.yanked_diagnostic_applies_to(dep, version_req))
         .and_then(|version_req| {
             requirement_matches_only_yanked(
                 formatter,

--- a/crates/deps-core/src/lsp_helpers/mod.rs
+++ b/crates/deps-core/src/lsp_helpers/mod.rs
@@ -1031,14 +1031,27 @@ pub trait EcosystemFormatter: Send + Sync {
     /// `removal_status()` data is trusted at all (and thus whether the separate #263
     /// in-use-version yanked check runs), while this hook only narrows *this* diagnostic.
     ///
-    /// `DenoFormatter` restricts this to exact-pin requirements — its `jsr:`/`npm:`
-    /// specifiers share npm's package-wide deprecation semantics — see that formatter's docs.
-    /// `NpmFormatter` returns `false` unconditionally (#436): npm's `AdvisoryDeprecated` is
-    /// genuinely per-version but commonly applied package-wide, so even an exact pin would
-    /// often just duplicate the dedicated package-level deprecation diagnostic
-    /// ([`Self::deprecated_message`], issue #205); npm keeps `reports_yanked() == true`; so the
-    /// #263 in-use-version check stays live. `ComposerFormatter` does not override this hook
-    /// at all — it opts out at the registry level instead
+    /// `dep` is passed alongside `requirement` (rather than `requirement` alone) so an
+    /// implementor can key its decision off the dependency's package name — needed by
+    /// `DenoFormatter` (#448) to tell its `jsr:`- and `npm:`-scheme specifiers apart, since
+    /// the scheme lives in the name, not in the requirement text. At the sole call site
+    /// (`crate::lsp_helpers::diagnostics::generate_diagnostics_from_cache`), `requirement`
+    /// is always `dep.version_requirement().unwrap()` for the same `dep` — the two are
+    /// never independent, though an implementor is free to key off either or both.
+    ///
+    /// `DenoFormatter` returns `false` unconditionally for `npm:` specifiers, mirroring
+    /// `NpmFormatter` (#448), and restricts `jsr:` specifiers to exact-pin requirements — a
+    /// scope decision carried over from before this hook could tell the two schemes apart,
+    /// not a technical constraint: JSR's `yanked` flag is a genuine per-version signal with
+    /// no package-level deprecation diagnostic to conflate with (unlike npm's), so relaxing
+    /// it is a real option, just one left to a tracked follow-up (#454) rather than done
+    /// here — see that formatter's docs. `NpmFormatter` returns `false`
+    /// unconditionally (#436): npm's `AdvisoryDeprecated` is genuinely per-version but
+    /// commonly applied package-wide, so even an exact pin would often just duplicate the
+    /// dedicated package-level deprecation diagnostic ([`Self::deprecated_message`], issue
+    /// #205); npm keeps `reports_yanked() == true`; so the #263 in-use-version check stays
+    /// live. `ComposerFormatter` does not override this hook at all — it opts out at the
+    /// registry level instead
     /// ([`Registry::reports_yanked`](crate::Registry::reports_yanked) `== false`, pre-dating
     /// #436, independently justified by #233 R2): Packagist's `abandoned` is package-level via
     /// p2 minified inheritance, so its yanked map is never populated and this hook has nothing
@@ -1048,7 +1061,7 @@ pub trait EcosystemFormatter: Send + Sync {
     ///
     /// ```
     /// use deps_core::lsp_helpers::EcosystemFormatter;
-    /// use deps_core::{ConcreteVersion, PackageName, VersionReq};
+    /// use deps_core::{ConcreteVersion, Dependency, PackageName, VersionReq};
     ///
     /// struct DefaultFormatter;
     /// impl EcosystemFormatter for DefaultFormatter {
@@ -1060,9 +1073,36 @@ pub trait EcosystemFormatter: Send + Sync {
     ///     }
     /// }
     ///
-    /// assert!(DefaultFormatter.yanked_diagnostic_applies_to(&VersionReq::new("^1.2")));
+    /// # struct FakeDep(PackageName);
+    /// # impl Dependency for FakeDep {
+    /// #     fn name(&self) -> &PackageName {
+    /// #         &self.0
+    /// #     }
+    /// #     fn name_range(&self) -> tower_lsp_server::ls_types::Range {
+    /// #         tower_lsp_server::ls_types::Range::default()
+    /// #     }
+    /// #     fn version_requirement(&self) -> Option<&VersionReq> {
+    /// #         None
+    /// #     }
+    /// #     fn version_range(&self) -> Option<tower_lsp_server::ls_types::Range> {
+    /// #         None
+    /// #     }
+    /// #     fn source(&self) -> deps_core::parser::DependencySource {
+    /// #         deps_core::parser::DependencySource::Registry
+    /// #     }
+    /// #     fn as_any(&self) -> &dyn std::any::Any {
+    /// #         self
+    /// #     }
+    /// # }
+    /// #
+    /// let dep = FakeDep(PackageName::new("example"));
+    /// assert!(DefaultFormatter.yanked_diagnostic_applies_to(&dep, &VersionReq::new("^1.2")));
     /// ```
-    fn yanked_diagnostic_applies_to(&self, _requirement: &VersionReq) -> bool {
+    fn yanked_diagnostic_applies_to(
+        &self,
+        _dep: &dyn Dependency,
+        _requirement: &VersionReq,
+    ) -> bool {
         true
     }
 

--- a/crates/deps-deno/src/formatter.rs
+++ b/crates/deps-deno/src/formatter.rs
@@ -132,24 +132,31 @@ impl EcosystemFormatter for DenoFormatter {
             .map(|req| Box::new(NodeSemverMatcher(req)) as Box<dyn RequirementMatcher>)
     }
 
-    /// Restricts the yanked-only-match diagnostic to an exact-pin requirement: evaluating
-    /// a range requirement against a package-wide deprecation signal would flag every
-    /// dependency on such a package, conflating this diagnostic with package-level
-    /// deprecation (issue #205). Applies uniformly to `jsr:` and `npm:` since this hook
-    /// takes only a `&VersionReq`, with no way to tell which scheme it came from (accepted
-    /// limitation L1 — JSR's genuinely better per-version signal is under-used for range
-    /// requirements, in exchange for not reintroducing npm's package-wide-`deprecated`
-    /// false-positive storm).
+    /// Scheme-aware (#448, fixing the #436 M1 divergence): for `npm:` specifiers, returns
+    /// `false` unconditionally, mirroring `NpmFormatter::yanked_diagnostic_applies_to`'s
+    /// post-#436 behavior — an exact-pin `npm:` dependency in `deno.json` (e.g.
+    /// `npm:lodash@4.17.20`) no longer surfaces this diagnostic, consistent with the
+    /// equivalent exact-pin `package.json` dependency.
     ///
-    /// Known cross-ecosystem divergence (#436 M1, not fixed here — out of scope for that
-    /// issue's npm/Composer-only formatter changes): `NpmFormatter::yanked_diagnostic_applies_to`
-    /// now returns `false` unconditionally, so an exact-pin `npm:` dependency in `deno.json`
-    /// (e.g. `npm:lodash@4.17.20`) can still surface this diagnostic while the equivalent
-    /// exact-pin `package.json` dependency (`"lodash": "4.17.20"`) no longer does, since this
-    /// method doesn't delegate to `NpmFormatter`'s. Candidate for a follow-up issue rather than
-    /// silently matched or left unremarked.
-    fn yanked_diagnostic_applies_to(&self, requirement: &VersionReq) -> bool {
-        node_semver::Version::parse(requirement.as_str().trim()).is_ok()
+    /// For `jsr:` specifiers, keeps the pre-existing exact-pin restriction. Historically
+    /// this was the only option: the hook took just a `&VersionReq`, with no way to tell
+    /// `jsr:` from `npm:` apart, so both had to share one answer. That blindness is now
+    /// fixed, and it does not actually justify restricting `jsr:` on its own terms — unlike
+    /// npm's `deprecated`, JSR's `yanked` flag is a genuine per-version signal with no
+    /// package-level deprecation diagnostic (#205) for a range-requirement check to
+    /// conflate with. Keeping the restriction here is a deliberate scope decision, not a
+    /// technical constraint: relaxing it is out of scope for #448, which targets only the
+    /// `npm:` cross-ecosystem divergence. Tracked as a follow-up: #454.
+    fn yanked_diagnostic_applies_to(&self, dep: &dyn Dependency, requirement: &VersionReq) -> bool {
+        match split_scheme(dep.name().as_str()) {
+            Some((Scheme::Npm, _)) => false,
+            // `None` is unreachable in practice — every parser-produced `DenoDependency` name
+            // is scheme-qualified (see `package_url`'s `warn_rejected_value` handling of the
+            // same case above) — folded into the `jsr:` exact-pin path as a harmless default.
+            Some((Scheme::Jsr, _)) | None => {
+                node_semver::Version::parse(requirement.as_str().trim()).is_ok()
+            }
+        }
     }
 
     /// `npm:` dependencies map to OSV's `npm` ecosystem via their bare name (D5);
@@ -343,12 +350,49 @@ mod tests {
         );
     }
 
+    // Mirrors the sole call site (`crate::lsp_helpers::diagnostics::generate_diagnostics_from_cache`),
+    // where `requirement` is always `dep.version_requirement().unwrap()` — never an
+    // unrelated pair, even though `DenoFormatter` itself only consults `dep.name()`.
+    fn test_dep(name: &str, requirement: &str) -> crate::types::DenoDependency {
+        crate::types::DenoDependency {
+            name: PackageName::new(name),
+            name_range: tower_lsp_server::ls_types::Range::default(),
+            version_req: Some(VersionReq::new(requirement)),
+            version_range: None,
+            section: crate::types::DenoDependencySection::Imports,
+        }
+    }
+
     #[test]
-    fn test_yanked_diagnostic_applies_to_exact_pin_only() {
+    fn test_yanked_diagnostic_applies_to_jsr_exact_pin_only() {
         let formatter = DenoFormatter;
-        assert!(formatter.yanked_diagnostic_applies_to(&VersionReq::new("1.2.3")));
-        assert!(!formatter.yanked_diagnostic_applies_to(&VersionReq::new("^1.2.3")));
-        assert!(!formatter.yanked_diagnostic_applies_to(&VersionReq::new("*")));
+        assert!(formatter.yanked_diagnostic_applies_to(
+            &test_dep("jsr:@std/fs", "1.2.3"),
+            &VersionReq::new("1.2.3")
+        ));
+        assert!(!formatter.yanked_diagnostic_applies_to(
+            &test_dep("jsr:@std/fs", "^1.2.3"),
+            &VersionReq::new("^1.2.3")
+        ));
+        assert!(
+            !formatter
+                .yanked_diagnostic_applies_to(&test_dep("jsr:@std/fs", "*"), &VersionReq::new("*"))
+        );
+    }
+
+    /// #448: fixes the #436 M1 cross-ecosystem divergence — an `npm:` specifier in
+    /// `deno.json` no longer surfaces this diagnostic, for any requirement shape,
+    /// consistent with `NpmFormatter`'s post-#436 behavior for `package.json`.
+    #[test]
+    fn test_yanked_diagnostic_applies_to_npm_scheme_always_false() {
+        let formatter = DenoFormatter;
+        for requirement in ["1.2.3", "^1.2.3", "~1.2.3", "*"] {
+            let dep = test_dep("npm:lodash", requirement);
+            assert!(
+                !formatter.yanked_diagnostic_applies_to(&dep, &VersionReq::new(requirement)),
+                "expected {requirement:?} to be rejected for npm: scheme"
+            );
+        }
     }
 
     #[test]

--- a/crates/deps-lsp/src/handlers/diagnostics.rs
+++ b/crates/deps-lsp/src/handlers/diagnostics.rs
@@ -804,6 +804,121 @@ serde = "1.0.0"
         }
     }
 
+    // Deno-specific tests
+    #[cfg(feature = "deno")]
+    mod deno_tests {
+        use super::*;
+        use crate::document::DocumentState;
+        use deps_core::EcosystemFormatter;
+
+        /// #448 regression: mirrors npm_tests'
+        /// `test_handle_diagnostics_manifest_requirement_yanked_stays_suppressed_for_exact_pin`
+        /// through the real `DocumentState` -> `Ecosystem::generate_diagnostics` ->
+        /// `generate_diagnostics_from_cache` -> `DenoFormatter::yanked_diagnostic_applies_to`
+        /// path — an exact-pin `npm:` specifier in `deno.json` satisfiable only by a flagged
+        /// version must NOT surface the #247 manifest-requirement yanked diagnostic, exactly
+        /// like the equivalent `package.json` dependency (fixes the #436 M1 divergence).
+        #[tokio::test]
+        async fn test_handle_diagnostics_npm_scheme_exact_pin_yanked_stays_suppressed() {
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/deno.json");
+            let config = DiagnosticsConfig::default();
+
+            let ecosystem = state.ecosystem_registry.get("deno").unwrap();
+            let content = r#"{"imports": {"lodash": "npm:lodash@4.17.20"}}"#.to_string();
+            let parse_result = ecosystem
+                .parse_manifest(&content, &uri)
+                .await
+                .expect("Failed to parse manifest");
+
+            let mut doc_state =
+                DocumentState::new_from_parse_result(EcosystemId::Deno, content, parse_result);
+
+            let mut cached = std::collections::HashMap::new();
+            cached.insert(
+                "npm:lodash".into(),
+                deps_core::PackageVersions {
+                    // The pin is satisfiable only by a flagged version — for `package.json`
+                    // this exact shape used to fire the #247 "yanked" diagnostic pre-#436.
+                    latest: "4.17.20".into(),
+                    available: std::sync::Arc::from(vec!["4.17.20".into()]),
+                    yanked: std::sync::Arc::from(vec![(
+                        "4.17.20".into(),
+                        deps_core::RemovalStatus::AdvisoryDeprecated,
+                    )]),
+                    published_at: None,
+                },
+            );
+            doc_state.update_cached_versions(cached);
+            // No `resolved_versions`/`yanked_versions` — isolates this assertion to the #247
+            // manifest-requirement path, same as the npm companion test.
+            state.update_document(uri.clone(), doc_state);
+
+            let (client, full_config) = create_test_client_and_config();
+            let result = handle_diagnostics(state, &uri, &config, client, full_config).await;
+
+            assert!(
+                result.is_empty(),
+                "expected no diagnostics for an exact-pin npm: specifier satisfiable only by a \
+                 flagged version — the #247 manifest-requirement diagnostic must stay \
+                 suppressed for deno's npm: scheme (#448), got {result:?}"
+            );
+        }
+
+        /// #448 companion: `jsr:` specifiers keep the pre-existing exact-pin-only behavior
+        /// (L1) — proves the scheme split actually discriminates end-to-end, not just in the
+        /// isolated `yanked_diagnostic_applies_to` unit tests.
+        #[tokio::test]
+        async fn test_handle_diagnostics_jsr_scheme_exact_pin_yanked_still_fires() {
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/deno.json");
+            let config = DiagnosticsConfig::default();
+
+            let ecosystem = state.ecosystem_registry.get("deno").unwrap();
+            let content = r#"{"imports": {"@std/fs": "jsr:@std/fs@1.0.0"}}"#.to_string();
+            let parse_result = ecosystem
+                .parse_manifest(&content, &uri)
+                .await
+                .expect("Failed to parse manifest");
+
+            let mut doc_state =
+                DocumentState::new_from_parse_result(EcosystemId::Deno, content, parse_result);
+
+            let mut cached = std::collections::HashMap::new();
+            cached.insert(
+                "jsr:@std/fs".into(),
+                deps_core::PackageVersions {
+                    latest: "1.0.1".into(),
+                    available: std::sync::Arc::from(vec!["1.0.1".into(), "1.0.0".into()]),
+                    yanked: std::sync::Arc::from(vec![(
+                        "1.0.0".into(),
+                        deps_core::RemovalStatus::Yanked,
+                    )]),
+                    published_at: None,
+                },
+            );
+            doc_state.update_cached_versions(cached);
+            state.update_document(uri.clone(), doc_state);
+
+            let (client, full_config) = create_test_client_and_config();
+            let result = handle_diagnostics(state, &uri, &config, client, full_config).await;
+
+            assert_eq!(
+                result.len(),
+                1,
+                "expected the #247 diagnostic to still fire for an exact-pin jsr: specifier, \
+                 got {result:?}"
+            );
+            assert_eq!(
+                result[0].message,
+                format!(
+                    "{}; latest is 1.0.1",
+                    deps_deno::DenoFormatter.yanked_message()
+                )
+            );
+        }
+    }
+
     // PyPI-specific tests
     #[cfg(feature = "pypi")]
     mod pypi_tests {

--- a/crates/deps-npm/src/formatter.rs
+++ b/crates/deps-npm/src/formatter.rs
@@ -1,5 +1,5 @@
 use deps_core::lsp_helpers::{EcosystemFormatter, RequirementMatcher};
-use deps_core::{ConcreteVersion, InvalidPackageName, PackageName, VersionReq};
+use deps_core::{ConcreteVersion, Dependency, InvalidPackageName, PackageName, VersionReq};
 
 /// Precise npm semver range matcher, compiled once per dependency by
 /// [`NpmFormatter::compile_requirement`].
@@ -169,7 +169,11 @@ impl EcosystemFormatter for NpmFormatter {
     /// `crates/deps-core/src/lsp_helpers/diagnostics.rs`) reads real per-version data and
     /// stays live — e.g. a lockfile-pinned old version flagged by `npm deprecate pkg@"<1.2.3"`
     /// while `latest` is clean still surfaces its own "yanked" diagnostic.
-    fn yanked_diagnostic_applies_to(&self, _requirement: &VersionReq) -> bool {
+    fn yanked_diagnostic_applies_to(
+        &self,
+        _dep: &dyn Dependency,
+        _requirement: &VersionReq,
+    ) -> bool {
         false
     }
 }
@@ -421,10 +425,21 @@ mod tests {
     /// restriction used to still allow through.
     #[test]
     fn test_yanked_diagnostic_applies_to_always_false() {
+        use crate::types::{NpmDependency, NpmDependencySection};
+
         let formatter = NpmFormatter;
         for requirement in ["1.2.3", "^1.2.3", "~1.2.3", ">=1.0.0 <2.0.0", "*", "1.x"] {
+            // Mirrors the sole call site (`crate::lsp_helpers::diagnostics::generate_diagnostics_from_cache`),
+            // where `requirement` is always `dep.version_requirement().unwrap()`.
+            let dep = NpmDependency {
+                name: PackageName::new("lodash"),
+                name_range: tower_lsp_server::ls_types::Range::default(),
+                version_req: Some(VersionReq::new(requirement)),
+                version_range: None,
+                section: NpmDependencySection::Dependencies,
+            };
             assert!(
-                !formatter.yanked_diagnostic_applies_to(&VersionReq::new(requirement)),
+                !formatter.yanked_diagnostic_applies_to(&dep, &VersionReq::new(requirement)),
                 "expected {requirement:?} to be rejected"
             );
         }

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -485,21 +485,25 @@ would independently find a yanked verdict, but `generate_diagnostics_from_cache`
 check once the in-use-version check has already emitted a diagnostic for the same
 dependency, so only one yanked diagnostic is ever shown per dependency.
 
-- **npm and Composer are restricted to exact-pin requirements.** Both source their yanked
-  flag from a package-wide signal — npm's from `deprecated` (live-verified: the `request`
-  package has 126/126 versions marked deprecated), Composer's from `abandoned` — not a true
-  per-version yank. Evaluating a range requirement against either would flag every dependency
-  on a deprecated/abandoned package under this diagnostic's wording, which is a distinct
-  diagnostic — see [Package Deprecation Diagnostics](#package-deprecation-diagnostics-issue-205)
-  below. A bare exact pin (`"1.2.3"`, not `"^1.2.3"`) is unaffected by that ambiguity, so the
-  check still applies there.
+- **npm is disabled entirely; Composer is restricted to exact-pin requirements.** Both source
+  their yanked flag from a package-wide signal — npm's from `deprecated` (live-verified: the
+  `request` package has 126/126 versions marked deprecated), Composer's from `abandoned` — not
+  a true per-version yank, which is why this is a distinct diagnostic from [Package
+  Deprecation Diagnostics](#package-deprecation-diagnostics-issue-205) below rather than the
+  same one. For npm, evaluating *any* requirement shape against that package-wide signal —
+  including a bare exact pin — would too often just duplicate the package-level deprecation
+  diagnostic, so this check is unconditionally off for npm (resolves #436); this also covers
+  Deno's `npm:` specifiers, which delegate to npm's own registry data (resolves #448). For
+  Composer, evaluating a range requirement against it would flag every dependency on an
+  abandoned package, so a bare exact pin (`"1.2.3"`, not `"^1.2.3"`) is unaffected by that
+  ambiguity and the check still applies there.
 
 **Ecosystem coverage, live-verified per registry rather than assumed from code:**
 
 | Ecosystem | Works today? | Source |
 | --------- | ------------- | ------ |
 | Cargo | Yes | sparse index `yanked` field |
-| npm | Yes, exact pins only | `deprecated` (see restriction above) |
+| npm | No | `deprecated` exists but the check is unconditionally off (see restriction above) |
 | PyPI | Yes | PEP 592 `yanked` |
 | Composer | Yes, exact pins only | `abandoned` (see restriction above) |
 | Dart | Yes | pub.dev `retracted` |
@@ -509,11 +513,12 @@ dependency, so only one yanked diagnostic is ever shown per dependency.
 | Gradle | No | reuses Maven Central's registry client, same hardcoded `false` |
 | NuGet | No | `NuGetVersion::is_yanked` is a hardcoded `false` constant |
 | Swift | No | `SwiftVersion.yanked` is a field that is always `false` for GitHub tags (no such concept in the source) |
-| Deno | Yes, exact pins only | JSR `meta.json` per-version `yanked` for `jsr:` specifiers; npm `deprecated` (see restriction above) for `npm:` specifiers |
+| Deno | `jsr:` yes, exact pins only; `npm:` no | JSR `meta.json` per-version `yanked` for `jsr:` specifiers; npm `deprecated` (unconditionally off, see restriction above) for `npm:` specifiers |
 
-6 of 12 ecosystems can produce this diagnostic today; the other 6 have no real yanked signal
-to source it from (three are architecturally impossible — no such registry concept exists —
-and Go's is a fixable but separate gap).
+5 of 12 ecosystems can produce this diagnostic today; npm is disabled by design rather than
+lacking a real signal (see restriction above), and that also covers Deno's `npm:` specifiers;
+the remaining 6 have no real yanked signal to source it from (three are architecturally
+impossible — no such registry concept exists — and Go's is a fixable but separate gap).
 
 ### Package Deprecation Diagnostics (issue #205)
 


### PR DESCRIPTION
## Summary

- `DenoFormatter::yanked_diagnostic_applies_to` could not distinguish `npm:` from `jsr:` specifiers, since the scheme lives in the package name, not the version requirement — this kept an exact-pin `npm:` dependency in `deno.json` surfacing the yanked-worded diagnostic after #436/#439 suppressed the equivalent `package.json` case.
- `EcosystemFormatter::yanked_diagnostic_applies_to` now takes `&dyn Dependency` in addition to the requirement, letting `DenoFormatter` branch on scheme: `npm:` now matches `NpmFormatter`'s unconditional `false`, while `jsr:` keeps its existing exact-pin-only restriction unchanged (that restriction's rationale is now documented honestly rather than the no-longer-applicable one; a separate scope decision on relaxing it is tracked in #454).
- Updated `docs/ECOSYSTEM_GUIDE.md`'s yanked-diagnostic table/tally and `CHANGELOG.md`.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (3271 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New end-to-end diagnostics tests: exact-pin `npm:lodash@4.17.20` in `deno.json` no longer produces the yanked diagnostic; exact-pin `jsr:@std/fs@1.0.0` still does
- [x] Unit tests updated in `deps-npm`/`deps-deno` formatters for the new trait signature

Closes #448