### PR TITLE
fix(deps-core): close DNS-rebinding bypass of PublicOnly SSRF guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **deps-core, deps-lsp**: the "requirement satisfiable only by a yanked version" diagnostic no longer lets a co-occurring package-level deprecation finding hide a genuine hard yank (resolves #437) (#438)
 - **deps-deno, deps-npm**: an exact-pin `npm:` dependency in `deno.json` no longer surfaces the yanked-worded diagnostic, matching the equivalent `package.json` dependency's post-#436 behavior; `jsr:` specifiers are unaffected (resolves #448)
+- **deps-core**: block DNS-rebinding to loopback/link-local/cloud-metadata/unspecified addresses at connect time, shared by every ecosystem crate (resolves #449; RFC1918/CGNAT residual tracked in #455) (PR link pending)
 
 ## [0.11.1] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **deps-core, deps-lsp**: the "requirement satisfiable only by a yanked version" diagnostic no longer lets a co-occurring package-level deprecation finding hide a genuine hard yank (resolves #437) (#438)
 - **deps-deno, deps-npm**: an exact-pin `npm:` dependency in `deno.json` no longer surfaces the yanked-worded diagnostic, matching the equivalent `package.json` dependency's post-#436 behavior; `jsr:` specifiers are unaffected (resolves #448)
-- **deps-core**: block DNS-rebinding to loopback/link-local/cloud-metadata/unspecified addresses at connect time, shared by every ecosystem crate (resolves #449; RFC1918/CGNAT residual tracked in #455) (PR link pending)
+- **deps-core**: block DNS-rebinding to loopback/link-local/cloud-metadata/unspecified addresses at connect time, shared by every ecosystem crate (resolves #449; RFC1918/CGNAT residual tracked in #455) (#457)
 
 ## [0.11.1] - 2026-09-01
 

--- a/crates/deps-core/Cargo.toml
+++ b/crates/deps-core/Cargo.toml
@@ -35,7 +35,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true, features = ["std", "parsing"] }
-tokio = { workspace = true, features = ["sync", "time", "fs"] }
+tokio = { workspace = true, features = ["sync", "time", "fs", "net"] }
 tower-lsp-server = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, optional = true }

--- a/crates/deps-core/src/cache.rs
+++ b/crates/deps-core/src/cache.rs
@@ -196,9 +196,10 @@ fn hop_targets_blocked_host(url: &Url) -> bool {
 /// registry redirect target for *any* ecosystem, benefiting every one of the eleven crates
 /// sharing this client, not only Cargo's workspace-declared indexes.
 ///
-/// TODO(#443 follow-up): this only classifies the redirect target's URL, not its
-/// DNS-resolved address — a hop to an attacker-controlled name that merely *resolves* into a
-/// blocked range is not caught here (see plan-1b §5's residual-risk statement, D1).
+/// This only classifies the redirect target's URL string, not its DNS-resolved address — that
+/// residual gap (issue #449, "D1" in PR #447's plan) is now closed by [`BlockedAddrResolver`],
+/// which [`build_client`] wires into every client this module builds: a redirect hop reuses the
+/// same `Client`, so its target's resolved address is validated too, for free (FR-007).
 ///
 /// Every other redirect — including cross-host ones, which are out of scope for this
 /// policy — falls through to reqwest's default (`Policy::limited(10)`), preserving the
@@ -237,15 +238,128 @@ fn trusted_origin_redirect_policy(trusted_origin: String) -> reqwest::redirect::
     })
 }
 
-/// Builds a client with `HttpCache`'s shared configuration (user agent, timeout), varying
-/// only the redirect policy — kept in one place so a future client-wide setting (proxy,
+/// Error returned by [`BlockedAddrResolver`] when a DNS resolution cannot be trusted for
+/// connection use — either it produced no address, or at least one resolved address falls into
+/// a blocked [`crate::net_policy::HostClass`].
+///
+/// Kept distinct from [`DepsError`] since this crosses into `reqwest::dns::Resolve`'s own
+/// `BoxError` (`Box<dyn std::error::Error + Send + Sync>`) return type, not this crate's own
+/// error type.
+#[derive(Debug, thiserror::Error)]
+enum ResolveGuardError {
+    /// The resolver returned zero addresses for `host` — fail-closed (NFR-004) rather than
+    /// silently treating "nothing resolved" as "nothing to block".
+    #[error("DNS resolution for {host} returned no addresses")]
+    NoAddresses { host: String },
+    /// `addr`, resolved for `host`, falls into `class`, one of the
+    /// [`crate::net_policy::HostClass::never_a_registry`] classes no legitimate registry index
+    /// (or a redirect from one) could ever target.
+    #[error("resolved address {addr} for host {host} is {class}, blocked by net_policy")]
+    Blocked {
+        host: String,
+        addr: std::net::IpAddr,
+        class: crate::net_policy::HostClass,
+    },
+}
+
+/// Validates every address `tokio::net::lookup_host` returned for `host`, rejecting the whole
+/// resolution if any is blocked — an attacker's public A record alongside a blocked one must not
+/// keep the probe alive (FR-003).
+fn validate_resolved_addrs(
+    host: &str,
+    addrs: Vec<std::net::SocketAddr>,
+) -> std::result::Result<Vec<std::net::SocketAddr>, ResolveGuardError> {
+    if addrs.is_empty() {
+        tracing::warn!(host, "DNS resolution returned no addresses");
+        return Err(ResolveGuardError::NoAddresses {
+            host: host.to_string(),
+        });
+    }
+    for addr in &addrs {
+        let class = crate::net_policy::classify_addr(addr.ip());
+        if class.never_a_registry() {
+            tracing::warn!(host, addr = %addr.ip(), %class, "blocking DNS-resolved address");
+            return Err(ResolveGuardError::Blocked {
+                host: host.to_string(),
+                addr: addr.ip(),
+                class,
+            });
+        }
+    }
+    Ok(addrs)
+}
+
+/// Connect-time DNS resolver that closes the rebinding TOCTOU gap left by [`ensure_https`]/
+/// [`hop_targets_blocked_host`]'s URL-string-only classification (issue #449): those check the
+/// declared hostname, but `reqwest`'s connector resolves DNS independently, later, and an
+/// attacker who controls the hostname's DNS can rebind it to a blocked address in between.
+///
+/// Wired into every client [`build_client`] returns, so all 11 ecosystem crates sharing this
+/// client pool inherit it with zero per-crate plumbing (FR-006/NFR-002).
+///
+/// # Scope
+///
+/// A resolver only ever sees a hostname, never which [`crate::net_policy::WorkspaceRegistryAccess`]
+/// policy applies to the request that triggered it — so this enforces only the
+/// policy-independent [`crate::net_policy::HostClass::never_a_registry`] tier (loopback,
+/// link-local, cloud-metadata, unspecified), the same tier [`hop_targets_blocked_host`] already
+/// applies. It closes issue #449's filed exploit (cloud-metadata rebinding) but does **not**
+/// enforce full `PublicOnly` semantics: a hostname that legitimately resolves to
+/// `HostClass::Global` at classification time and is rebound to an RFC1918/CGNAT address at
+/// connect time is not caught here — closing that residual needs policy provenance at the
+/// connector, tracked as issue #455.
+///
+/// # Fail-closed (NFR-004)
+///
+/// Returns `Err` — never `Ok`, never a fallback resolver — on a `lookup_host` error, zero
+/// addresses, or any resolved address [`crate::net_policy::HostClass::never_a_registry`] blocks.
+///
+/// # Known limitations
+///
+/// - [`ClientBuilder::resolve`](reqwest::ClientBuilder::resolve)/
+///   [`resolve_to_addrs`](reqwest::ClientBuilder::resolve_to_addrs) overrides wrap *outside* the
+///   configured resolver (`reqwest`'s `DnsResolverWithOverrides`) and would bypass this guard
+///   entirely if ever called — this workspace does not call them today.
+/// - A configured system proxy (`HTTPS_PROXY`) resolves the target hostname itself; this
+///   resolver then only ever sees the proxy's own address. Operator configuration, not
+///   attacker-controlled, so NOT claimed as a defended case.
+/// - Never applies to an IP-literal host (`https://169.254.169.254/`): `hyper-util`'s connector
+///   parses those directly and never calls the configured resolver, so
+///   [`classify_host`](crate::net_policy::classify_host) (via [`ensure_https`]/
+///   [`hop_targets_blocked_host`]) remains the sole guard for literals — a disjoint domain from
+///   this resolver's name-based one, not a gap.
+/// - Unlike [`ensure_https`]/[`hop_targets_blocked_host`], this resolver has **no** `test-util`
+///   carve-out for `Loopback`: it blocks a `localhost`/`127.0.0.1` *name* unconditionally, in
+///   every build. A downstream `test-util` consumer that mocks by binding an IP literal (as
+///   this workspace's own `mockito` usage does) is unaffected — literals never reach this
+///   resolver at all — but one that mocks via a `localhost` *name* would be newly blocked.
+#[derive(Debug, Clone, Copy)]
+struct BlockedAddrResolver;
+
+impl reqwest::dns::Resolve for BlockedAddrResolver {
+    fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
+        let host = name.as_str().to_string();
+        Box::pin(async move {
+            let addrs: Vec<std::net::SocketAddr> =
+                tokio::net::lookup_host((host.as_str(), 0)).await?.collect();
+            let addrs = validate_resolved_addrs(&host, addrs)?;
+            Ok(Box::new(addrs.into_iter()) as reqwest::dns::Addrs)
+        })
+    }
+}
+
+/// Builds a client with `HttpCache`'s shared configuration (user agent, timeout, resolver),
+/// varying only the redirect policy — kept in one place so a future client-wide setting (proxy,
 /// connection pool sizing, etc.) added to [`HttpCache::new`] can't silently miss the pooled
-/// clients [`HttpCache::client_for_origin`] builds.
+/// clients [`HttpCache::client_for_origin`] builds. This is also the workspace's only
+/// `Client::builder()` call site, so [`BlockedAddrResolver`] applies everywhere without
+/// per-crate plumbing.
 fn build_client(redirect: reqwest::redirect::Policy) -> Client {
     Client::builder()
         .user_agent(format!("deps-lsp/{}", env!("CARGO_PKG_VERSION")))
         .timeout(std::time::Duration::from_secs(HTTP_TIMEOUT_SECS))
         .redirect(redirect)
+        .dns_resolver(BlockedAddrResolver)
         .build()
         .expect("failed to create HTTP client")
 }
@@ -1092,6 +1206,115 @@ mod tests {
     fn test_hop_targets_blocked_host_exempts_loopback_under_test_cfg() {
         let url = Url::parse("http://127.0.0.1:1234/api/target").unwrap();
         assert!(!hop_targets_blocked_host(&url));
+    }
+
+    // Issue #449: the connect-time resolver guard's pure classification core, unit-tested
+    // directly rather than through `tokio::net::lookup_host` — no live DNS/network needed.
+    #[test]
+    fn test_validate_resolved_addrs_blocks_cloud_metadata() {
+        let addrs = vec!["169.254.169.254:0".parse().unwrap()];
+        assert!(matches!(
+            validate_resolved_addrs("evil.example", addrs),
+            Err(ResolveGuardError::Blocked { .. })
+        ));
+    }
+
+    // FR-003: an attacker's public A record alongside a blocked one must not keep the probe
+    // alive — the whole resolution is rejected, not filtered down to the public address.
+    #[test]
+    fn test_validate_resolved_addrs_blocks_when_any_address_is_blocked() {
+        let addrs = vec![
+            "1.1.1.1:0".parse().unwrap(),
+            "169.254.169.254:0".parse().unwrap(),
+        ];
+        assert!(matches!(
+            validate_resolved_addrs("evil.example", addrs),
+            Err(ResolveGuardError::Blocked { .. })
+        ));
+    }
+
+    #[test]
+    fn test_validate_resolved_addrs_allows_global() {
+        let addrs = vec!["1.1.1.1:0".parse().unwrap()];
+        assert_eq!(
+            validate_resolved_addrs("index.crates.io", addrs.clone()).unwrap(),
+            addrs
+        );
+    }
+
+    // NFR-004: fail-closed on an empty resolution rather than silently treating "nothing
+    // resolved" as "nothing to block".
+    #[test]
+    fn test_validate_resolved_addrs_fails_closed_on_empty() {
+        assert!(matches!(
+            validate_resolved_addrs("evil.example", vec![]),
+            Err(ResolveGuardError::NoAddresses { .. })
+        ));
+    }
+
+    #[test]
+    fn test_validate_resolved_addrs_unwraps_mapped_v4() {
+        let addrs = vec!["[::ffff:169.254.169.254]:0".parse().unwrap()];
+        assert!(matches!(
+            validate_resolved_addrs("evil.example", addrs),
+            Err(ResolveGuardError::Blocked { .. })
+        ));
+    }
+
+    // Direct unit coverage of `BlockedAddrResolver::resolve` on a *name* (not an IP literal —
+    // that path never reaches any resolver in production, see the struct's `# Known
+    // limitations` doc). `localhost` resolves via the OS's own hosts file, no network needed.
+    // This alone does not prove the resolver is wired into `build_client` — see the sibling
+    // test below (critic S1) for that.
+    #[tokio::test]
+    async fn test_blocked_addr_resolver_rejects_loopback_name_directly() {
+        use reqwest::dns::Resolve;
+
+        let addrs = BlockedAddrResolver
+            .resolve("localhost".parse().unwrap())
+            .await;
+        assert!(addrs.is_err());
+    }
+
+    // Issue #449 critic S1: the previous version of this test called
+    // `BlockedAddrResolver::resolve` directly and never went through `build_client` at all —
+    // deleting `.dns_resolver(BlockedAddrResolver)` from `build_client` left it green. This
+    // version proves actual wiring behaviorally: a real mockito listener answers on
+    // `server.socket_address()`'s port, reached here through the `localhost` *name* (so the
+    // request actually reaches the configured resolver, unlike an IP literal, which
+    // hyper-util's connector parses directly and never consults the resolver — see
+    // `BlockedAddrResolver`'s `# Known limitations` doc). Without the guard wired in, this
+    // request would succeed against the real listener; with it wired in, it must fail before
+    // ever reaching the listener.
+    #[tokio::test]
+    async fn test_build_client_wires_in_blocked_addr_resolver() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/")
+            .with_status(200)
+            .create_async()
+            .await;
+        let port = server.socket_address().port();
+
+        let client = build_client(redirect_policy());
+        let result = client.get(format!("http://localhost:{port}/")).send().await;
+
+        let err = result.expect_err(
+            "expected the wired-in resolver guard to reject a loopback-resolving name even \
+             though a real listener answers at this port",
+        );
+        // Not just any failure: the `Debug` impl (unlike `Display`) surfaces the boxed
+        // `source` chain, so this confirms `ResolveGuardError::Blocked` itself produced the
+        // error rather than an unrelated failure (timeout, TLS, connection refused)
+        // coincidentally also erroring. `derive(Debug)` on an enum prints only the variant
+        // name, not `ResolveGuardError::`, hence checking for `Blocked`/`Loopback` together
+        // rather than the enum's own name.
+        let debug = format!("{err:?}");
+        assert!(
+            debug.contains("Blocked") && debug.contains("Loopback"),
+            "expected the failure to originate from ResolveGuardError::Blocked with class \
+             Loopback, got: {debug}"
+        );
     }
 
     // S5 (plan-1b §1.1/§4): a 302 to the cloud-metadata IP must be stopped by the

--- a/crates/deps-core/src/net_policy.rs
+++ b/crates/deps-core/src/net_policy.rs
@@ -14,7 +14,7 @@
 //! the same class of validation (DRY). [`crate::cache`]'s redirect-hop hardening also needs
 //! this exact classifier — see [`HostClass::never_a_registry`].
 
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::atomic::{AtomicU8, Ordering};
 
 /// Classification of a URL's host, for [`RegistryAccessPolicy`] to evaluate against
@@ -88,22 +88,46 @@ impl std::fmt::Display for HostClass {
     }
 }
 
-/// Unwraps an IPv4-mapped IPv6 address (`::ffff:a.b.c.d`) to its embedded IPv4 form, so
-/// classification cannot be bypassed by writing the same address in its mapped form (e.g.
-/// `::ffff:169.254.169.254`).
+/// Unwraps an IPv4-mapped (`::ffff:a.b.c.d`) or NAT64-embedded (`64:ff9b::a.b.c.d`, RFC 6052
+/// well-known prefix) IPv6 address to its embedded IPv4 form, so classification cannot be
+/// bypassed by writing the same address in either v4-in-v6 form (e.g. `::ffff:169.254.169.254`
+/// or `64:ff9b::a9fe:a9fe`). The NAT64 case matters here specifically because an attacker's DNS
+/// answer can return any AAAA record it likes, and a client behind a NAT64/DNS64 gateway (or a
+/// local 464XLAT/CLAT translator) treats `64:ff9b::/96` as routable to the embedded IPv4 address
+/// (impl-critic finding, verified empirically: `64:ff9b::a9fe:a9fe` classified `Global` before
+/// this fix).
 ///
-/// Deliberately does **not** additionally unwrap the deprecated IPv4-*compatible* form
-/// (`::a.b.c.d`, RFC 4291 §2.5.5.1, no `ffff` prefix): `Ipv6Addr::to_ipv4()` treats *any*
-/// address with its first 96 bits zero as embedding an IPv4 address, which would
-/// misclassify `::1` (loopback) as `0.0.0.1` and `::` (unspecified) as `0.0.0.0` — a
-/// narrower, *new* bypass in exchange for closing a narrower, legacy one. Modern network
-/// stacks generally do not route this deprecated form at all, so it is accepted as
-/// low-real-world-risk (impl-critic finding, unwrap-mapped-v6 is the actively-exploitable
-/// form and is handled above).
+/// Deliberately does **not** additionally unwrap:
+/// - The deprecated IPv4-*compatible* form (`::a.b.c.d`, RFC 4291 §2.5.5.1, no `ffff` prefix):
+///   `Ipv6Addr::to_ipv4()` treats *any* address with its first 96 bits zero as embedding an
+///   IPv4 address, which would misclassify `::1` (loopback) as `0.0.0.1` and `::` (unspecified)
+///   as `0.0.0.0` — a narrower, *new* bypass in exchange for closing a narrower, legacy one.
+///   Modern network stacks generally do not route this deprecated form at all, so it is
+///   accepted as low-real-world-risk (impl-critic finding, unwrap-mapped-v6/NAT64 are the
+///   actively-exploitable forms and are handled above).
+/// - 6to4 (`2002::/16`, RFC 3056), which also embeds an IPv4 address in its prefix: a narrower,
+///   largely-deprecated IPv6-transition mechanism — NAT64/DNS64 remains commonly deployed
+///   today, 6to4 does not — documented as a residual, not fixed by this pass.
 fn unwrap_mapped_v4(addr: IpAddr) -> IpAddr {
     match addr {
-        IpAddr::V6(v6) => v6.to_ipv4_mapped().map_or(addr, IpAddr::V4),
+        IpAddr::V6(v6) => v6
+            .to_ipv4_mapped()
+            .or_else(|| nat64_embedded_v4(v6))
+            .map_or(addr, IpAddr::V4),
         IpAddr::V4(_) => addr,
+    }
+}
+
+/// Extracts the IPv4 address embedded in a NAT64 well-known-prefix (RFC 6052 `64:ff9b::/96`)
+/// IPv6 address, e.g. `64:ff9b::a9fe:a9fe` -> `169.254.169.254`.
+fn nat64_embedded_v4(v6: Ipv6Addr) -> Option<Ipv4Addr> {
+    let segments = v6.segments();
+    if segments[0] == 0x0064 && segments[1] == 0xff9b && segments[2..6] == [0, 0, 0, 0] {
+        let [a, b] = segments[6].to_be_bytes();
+        let [c, d] = segments[7].to_be_bytes();
+        Some(Ipv4Addr::new(a, b, c, d))
+    } else {
+        None
     }
 }
 
@@ -113,7 +137,7 @@ fn classify_ip(addr: IpAddr) -> HostClass {
         IpAddr::V4(v4) => {
             if v4.is_loopback() {
                 HostClass::Loopback
-            } else if v4 == std::net::Ipv4Addr::new(169, 254, 169, 254) {
+            } else if v4 == Ipv4Addr::new(169, 254, 169, 254) {
                 HostClass::CloudMetadata
             } else if v4.is_link_local() {
                 HostClass::LinkLocal
@@ -174,6 +198,27 @@ fn classify_name(host: &str) -> HostClass {
         return HostClass::InternalName;
     }
     HostClass::Global
+}
+
+/// Classifies a DNS-resolved socket address into a [`HostClass`].
+///
+/// The counterpart to [`classify_host`] used by [`crate::cache`]'s connect-time resolver guard
+/// (issue #449) to close the DNS-rebinding TOCTOU gap the module docs describe: a hostname's
+/// *resolved* address, not just its string form, needs the same classification. Reuses this
+/// module's own private IP-classification and mapped-address-unwrapping helpers rather than
+/// duplicating their match arms (DRY).
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::net_policy::{HostClass, classify_addr};
+///
+/// let addr = "169.254.169.254".parse().unwrap();
+/// assert_eq!(classify_addr(addr), HostClass::CloudMetadata);
+/// ```
+#[must_use]
+pub fn classify_addr(addr: IpAddr) -> HostClass {
+    classify_ip(unwrap_mapped_v4(addr))
 }
 
 /// Classifies `url`'s host into a [`HostClass`], from the URL alone — **no DNS resolution**
@@ -329,6 +374,17 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_cloud_metadata_nat64_bypass() {
+        // The NAT64 well-known-prefix bypass (impl-critic finding, verified empirically):
+        // `64:ff9b::/96` embeds an IPv4 address and must classify identically to the bare
+        // IPv4 form, not fall through to `Global`.
+        assert_eq!(
+            host_class("https://[64:ff9b::a9fe:a9fe]/"),
+            HostClass::CloudMetadata
+        );
+    }
+
+    #[test]
     fn test_classify_cloud_metadata_ec2_ipv6() {
         assert_eq!(
             host_class("https://[fd00:ec2::254]/"),
@@ -432,6 +488,44 @@ mod tests {
     #[test]
     fn test_classify_global_public_name() {
         assert_eq!(host_class("https://index.crates.io/"), HostClass::Global);
+    }
+
+    #[test]
+    fn test_classify_addr_cloud_metadata() {
+        let addr: IpAddr = "169.254.169.254".parse().unwrap();
+        assert_eq!(classify_addr(addr), HostClass::CloudMetadata);
+    }
+
+    #[test]
+    fn test_classify_addr_private_v4() {
+        let addr: IpAddr = "10.0.0.1".parse().unwrap();
+        assert_eq!(classify_addr(addr), HostClass::PrivateV4);
+    }
+
+    #[test]
+    fn test_classify_addr_unwraps_mapped_v4() {
+        let addr: IpAddr = "::ffff:169.254.169.254".parse().unwrap();
+        assert_eq!(classify_addr(addr), HostClass::CloudMetadata);
+    }
+
+    #[test]
+    fn test_classify_addr_unwraps_nat64_cloud_metadata() {
+        // impl-critic S2: verified empirically that this classified `Global` before the fix.
+        let addr: IpAddr = "64:ff9b::a9fe:a9fe".parse().unwrap();
+        assert_eq!(classify_addr(addr), HostClass::CloudMetadata);
+    }
+
+    #[test]
+    fn test_classify_addr_unwraps_nat64_loopback() {
+        // impl-critic S2's second verified example: `64:ff9b::7f00:1` embeds `127.0.0.1`.
+        let addr: IpAddr = "64:ff9b::7f00:1".parse().unwrap();
+        assert_eq!(classify_addr(addr), HostClass::Loopback);
+    }
+
+    #[test]
+    fn test_classify_addr_global() {
+        let addr: IpAddr = "1.1.1.1".parse().unwrap();
+        assert_eq!(classify_addr(addr), HostClass::Global);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`classify_host` in `deps-core::net_policy` classifies a workspace-declared registry URL's host from the URL string alone, never from DNS resolution. `WorkspaceRegistryAccess::PublicOnly` (the default policy shipped in #447) allows any host that classifies `HostClass::Global`. A DNS-rebinding hostname minted via a public wildcard-DNS service (e.g. `169.254.169.254.nip.io`) looks public at classification time but resolves, at connect time, straight to a blocked address such as cloud-metadata — bypassing the guard entirely with zero attacker infrastructure.

This PR adds a connect-time `reqwest::dns::Resolve` guard (`BlockedAddrResolver`) wired into `deps-core`'s shared `build_client`, the workspace's sole `Client::builder` call site, so all 11 ecosystem crates inherit the protection with no per-crate plumbing. The guard classifies every resolved address via the existing `HostClass` machinery and fails closed — rejecting the whole resolution — on any address in `HostClass::never_a_registry()` (cloud-metadata, loopback, link-local, unspecified), on resolver error, or on an empty resolution.

It also unwraps NAT64-embedded (RFC 6052) IPv4-in-IPv6 addresses before classification, closing a related bypass found during review where a resolved AAAA record encoding a blocked IPv4 address previously classified as `Global`.

## Scope

The guard enforces the policy-independent `never_a_registry()` tier only, since a `build_client`-level resolver sees just a hostname, not which `WorkspaceRegistryAccess` policy governs the request that triggered it. This fully closes the exploit as filed (cloud-metadata via wildcard-DNS rebinding). DNS-rebinding to RFC1918/CGNAT addresses under `PublicOnly` remains open and is tracked separately in #455, since closing it needs policy provenance at the connector rather than the shared client — a larger architectural change deliberately kept out of this fix.

## Review notes

This went through a full security-chain review (security audit, implementation, adversarial critique, code review, two rounds of fixes). Findings caught along the way:
- A wiring test that constructed the resolver directly instead of exercising it through `build_client` — rewritten to prove the guard is actually load-bearing.
- The NAT64 bypass mentioned above.
- A CHANGELOG entry that initially overclaimed the fix's scope, narrowed to match what actually shipped.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (3282 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --all-features`
- [x] `cargo test --doc -p deps-core --all-features`
- [x] New unit tests cover: all-public addresses (allowed), all-blocked (rejected), mixed public+blocked (rejected, no partial-pass), zero addresses (rejected), IPv4-mapped and NAT64-embedded blocked addresses (rejected), and wiring through `build_client` against a live listener

Closes #449