### PR TITLE
fix(deps-deno): drop jsr exact-pin-only restriction on yanked diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-lsp**: the "requirement satisfiable only by a yanked version" diagnostic no longer lets a co-occurring package-level deprecation finding hide a genuine hard yank (resolves #437) (#438)
 - **deps-deno, deps-npm**: an exact-pin `npm:` dependency in `deno.json` no longer surfaces the yanked-worded diagnostic, matching the equivalent `package.json` dependency's post-#436 behavior; `jsr:` specifiers are unaffected (resolves #448)
 - **deps-core**: block DNS-rebinding to loopback/link-local/cloud-metadata/unspecified addresses at connect time, shared by every ecosystem crate (resolves #449; RFC1918/CGNAT residual tracked in #455) (#457)
+- **deps-deno**: a `jsr:` range requirement satisfiable only by yanked versions now surfaces the yanked diagnostic, matching Cargo/PyPI/Dart's behavior for the equivalent case (resolves #454)
 
 ## [0.11.1] - 2026-09-01
 

--- a/crates/deps-core/src/lsp_helpers/mod.rs
+++ b/crates/deps-core/src/lsp_helpers/mod.rs
@@ -1040,12 +1040,11 @@ pub trait EcosystemFormatter: Send + Sync {
     /// never independent, though an implementor is free to key off either or both.
     ///
     /// `DenoFormatter` returns `false` unconditionally for `npm:` specifiers, mirroring
-    /// `NpmFormatter` (#448), and restricts `jsr:` specifiers to exact-pin requirements — a
-    /// scope decision carried over from before this hook could tell the two schemes apart,
-    /// not a technical constraint: JSR's `yanked` flag is a genuine per-version signal with
-    /// no package-level deprecation diagnostic to conflate with (unlike npm's), so relaxing
-    /// it is a real option, just one left to a tracked follow-up (#454) rather than done
-    /// here — see that formatter's docs. `NpmFormatter` returns `false`
+    /// `NpmFormatter` (#448), and applies unconditionally (`true`, the same as leaving this
+    /// hook at its default) for `jsr:` specifiers, for any requirement shape (#454): unlike
+    /// npm's `deprecated`, JSR's `yanked` flag is a genuine per-version signal with no
+    /// package-level deprecation diagnostic to conflate with, so `jsr:` needs no restriction
+    /// here at all — see that formatter's docs. `NpmFormatter` returns `false`
     /// unconditionally (#436): npm's `AdvisoryDeprecated` is genuinely per-version but
     /// commonly applied package-wide, so even an exact pin would often just duplicate the
     /// dedicated package-level deprecation diagnostic ([`Self::deprecated_message`], issue

--- a/crates/deps-deno/README.md
+++ b/crates/deps-deno/README.md
@@ -51,9 +51,11 @@ render the scheme as part of the package name. See the crate's module docs
 - No `deno.lock` support — hover/completion/diagnostics compare against the manifest
   requirement, not a resolved version (consistent with Gradle's lockfile-free MVP)
 - The `scopes` field and `importMap` file are not parsed — only the `imports` map
-- The yanked-only-match diagnostic is restricted to exact-pin requirements for both `jsr:`
-  and `npm:` specifiers (matches `deps-npm`'s own restriction, for the same reason:
-  avoiding false positives from package-wide deprecation)
+- The yanked-only-match diagnostic is disabled entirely for `npm:` specifiers (matches
+  `deps-npm`'s own restriction: npm's `deprecated` flag is often applied package-wide,
+  which would too often duplicate the package-level deprecation diagnostic instead of
+  signaling a genuine per-version yank); `jsr:` specifiers are unaffected and fire it for
+  any requirement shape, since JSR's `yanked` flag is a true per-version signal
 - Package-name completion works for a bare, still-being-typed `jsr:`/`npm:` specifier
   (`"jsr:"`, `"jsr:@"`, `"jsr:@std"`, `"jsr:@std/"`): `partial_name_range` in
   `specifier.rs` models the in-progress name so completion has a dependency to attach to,

--- a/crates/deps-deno/src/formatter.rs
+++ b/crates/deps-deno/src/formatter.rs
@@ -138,24 +138,29 @@ impl EcosystemFormatter for DenoFormatter {
     /// `npm:lodash@4.17.20`) no longer surfaces this diagnostic, consistent with the
     /// equivalent exact-pin `package.json` dependency.
     ///
-    /// For `jsr:` specifiers, keeps the pre-existing exact-pin restriction. Historically
-    /// this was the only option: the hook took just a `&VersionReq`, with no way to tell
-    /// `jsr:` from `npm:` apart, so both had to share one answer. That blindness is now
-    /// fixed, and it does not actually justify restricting `jsr:` on its own terms — unlike
-    /// npm's `deprecated`, JSR's `yanked` flag is a genuine per-version signal with no
-    /// package-level deprecation diagnostic (#205) for a range-requirement check to
-    /// conflate with. Keeping the restriction here is a deliberate scope decision, not a
-    /// technical constraint: relaxing it is out of scope for #448, which targets only the
-    /// `npm:` cross-ecosystem divergence. Tracked as a follow-up: #454.
-    fn yanked_diagnostic_applies_to(&self, dep: &dyn Dependency, requirement: &VersionReq) -> bool {
+    /// For `jsr:` specifiers, applies unconditionally (`true`), matching the trait default
+    /// that Cargo/PyPI/Dart already rely on (#454, dropping the exact-pin-only restriction
+    /// this hook carried before #448 made it scheme-aware). Unlike npm's `deprecated` — which
+    /// #436 found routinely applied to *every* published version at once, making this
+    /// diagnostic redundant with the package-level deprecation diagnostic (#205) — JSR's
+    /// `yanked` flag has no package-level counterpart to conflate with:
+    /// [`JsrVersion`](crate::types::JsrVersion)'s `impl_version!` invocation leaves
+    /// `deprecation` unset, so `Version::deprecation()` is structurally `None` for every JSR
+    /// version and #205 never fires for `jsr:` dependencies. There is also no data gap: JSR's
+    /// `meta.json` (`JsrRegistry::get_versions`) returns every version's `yanked` flag in one
+    /// fetch, identical whether the manifest requirement is a range or an exact pin.
+    fn yanked_diagnostic_applies_to(
+        &self,
+        dep: &dyn Dependency,
+        _requirement: &VersionReq,
+    ) -> bool {
         match split_scheme(dep.name().as_str()) {
             Some((Scheme::Npm, _)) => false,
             // `None` is unreachable in practice — every parser-produced `DenoDependency` name
             // is scheme-qualified (see `package_url`'s `warn_rejected_value` handling of the
-            // same case above) — folded into the `jsr:` exact-pin path as a harmless default.
-            Some((Scheme::Jsr, _)) | None => {
-                node_semver::Version::parse(requirement.as_str().trim()).is_ok()
-            }
+            // same case above) — folded into the `jsr:` unconditional-true path as a harmless
+            // default.
+            Some((Scheme::Jsr, _)) | None => true,
         }
     }
 
@@ -363,21 +368,19 @@ mod tests {
         }
     }
 
+    /// #454: drops the pre-#448-blindness exact-pin-only restriction — a `jsr:` range
+    /// requirement now surfaces the diagnostic just like an exact pin, matching
+    /// Cargo/PyPI/Dart (which never override this hook and so keep the trait default).
     #[test]
-    fn test_yanked_diagnostic_applies_to_jsr_exact_pin_only() {
+    fn test_yanked_diagnostic_applies_to_jsr_scheme_always_true() {
         let formatter = DenoFormatter;
-        assert!(formatter.yanked_diagnostic_applies_to(
-            &test_dep("jsr:@std/fs", "1.2.3"),
-            &VersionReq::new("1.2.3")
-        ));
-        assert!(!formatter.yanked_diagnostic_applies_to(
-            &test_dep("jsr:@std/fs", "^1.2.3"),
-            &VersionReq::new("^1.2.3")
-        ));
-        assert!(
-            !formatter
-                .yanked_diagnostic_applies_to(&test_dep("jsr:@std/fs", "*"), &VersionReq::new("*"))
-        );
+        for requirement in ["1.2.3", "^1.2.3", "~1.2.3", "*"] {
+            let dep = test_dep("jsr:@std/fs", requirement);
+            assert!(
+                formatter.yanked_diagnostic_applies_to(&dep, &VersionReq::new(requirement)),
+                "expected {requirement:?} to be accepted for jsr: scheme"
+            );
+        }
     }
 
     /// #448: fixes the #436 M1 cross-ecosystem divergence — an `npm:` specifier in

--- a/crates/deps-lsp/src/handlers/diagnostics.rs
+++ b/crates/deps-lsp/src/handlers/diagnostics.rs
@@ -865,9 +865,10 @@ serde = "1.0.0"
             );
         }
 
-        /// #448 companion: `jsr:` specifiers keep the pre-existing exact-pin-only behavior
-        /// (L1) — proves the scheme split actually discriminates end-to-end, not just in the
-        /// isolated `yanked_diagnostic_applies_to` unit tests.
+        /// #448/#454: an exact-pin `jsr:` specifier satisfiable only by a flagged version
+        /// fires the #247 diagnostic, proving the scheme split actually discriminates
+        /// `jsr:` from `npm:` end-to-end, not just in the isolated
+        /// `yanked_diagnostic_applies_to` unit tests.
         #[tokio::test]
         async fn test_handle_diagnostics_jsr_scheme_exact_pin_yanked_still_fires() {
             let state = Arc::new(ServerState::new());
@@ -908,6 +909,67 @@ serde = "1.0.0"
                 1,
                 "expected the #247 diagnostic to still fire for an exact-pin jsr: specifier, \
                  got {result:?}"
+            );
+            assert_eq!(
+                result[0].message,
+                format!(
+                    "{}; latest is 1.0.1",
+                    deps_deno::DenoFormatter.yanked_message()
+                )
+            );
+        }
+
+        /// #454: the actual bug fix, proven end-to-end — a `jsr:` *range* requirement
+        /// satisfiable only by yanked versions must now surface the #247
+        /// manifest-requirement diagnostic too, matching Cargo/PyPI/Dart's behavior for the
+        /// equivalent case (previously this was silent: `yanked_diagnostic_applies_to`
+        /// rejected any non-exact-pin `jsr:` requirement). Exactly one diagnostic fires,
+        /// confirming this does not double up with any package-level deprecation (#205)
+        /// signal — deno has no such diagnostic for `jsr:` in the first place.
+        #[tokio::test]
+        async fn test_handle_diagnostics_jsr_scheme_range_yanked_only_now_fires() {
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/deno.json");
+            let config = DiagnosticsConfig::default();
+
+            let ecosystem = state.ecosystem_registry.get("deno").unwrap();
+            let content = r#"{"imports": {"@std/fs": "jsr:@std/fs@^1.0.0"}}"#.to_string();
+            let parse_result = ecosystem
+                .parse_manifest(&content, &uri)
+                .await
+                .expect("Failed to parse manifest");
+
+            let mut doc_state =
+                DocumentState::new_from_parse_result(EcosystemId::Deno, content, parse_result);
+
+            let mut cached = std::collections::HashMap::new();
+            cached.insert(
+                "jsr:@std/fs".into(),
+                deps_core::PackageVersions {
+                    // Every version matching "^1.0.0" is yanked — the concrete #454 bug
+                    // scenario, which previously produced zero diagnostic signal.
+                    latest: "1.0.1".into(),
+                    available: std::sync::Arc::from(vec!["1.0.1".into(), "1.0.0".into()]),
+                    yanked: std::sync::Arc::from(vec![
+                        ("1.0.1".into(), deps_core::RemovalStatus::Yanked),
+                        ("1.0.0".into(), deps_core::RemovalStatus::Yanked),
+                    ]),
+                    published_at: None,
+                },
+            );
+            doc_state.update_cached_versions(cached);
+            // No `resolved_versions`/`yanked_versions` — isolates this assertion to the #247
+            // manifest-requirement path, same as the sibling exact-pin test.
+            state.update_document(uri.clone(), doc_state);
+
+            let (client, full_config) = create_test_client_and_config();
+            let result = handle_diagnostics(state, &uri, &config, client, full_config).await;
+
+            assert_eq!(
+                result.len(),
+                1,
+                "expected exactly one diagnostic for a jsr: range satisfiable only by yanked \
+                 versions (#454), got {result:?}"
             );
             assert_eq!(
                 result[0].message,

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -496,7 +496,10 @@ dependency, so only one yanked diagnostic is ever shown per dependency.
   Deno's `npm:` specifiers, which delegate to npm's own registry data (resolves #448). For
   Composer, evaluating a range requirement against it would flag every dependency on an
   abandoned package, so a bare exact pin (`"1.2.3"`, not `"^1.2.3"`) is unaffected by that
-  ambiguity and the check still applies there.
+  ambiguity and the check still applies there. Deno's `jsr:` specifiers are unrestricted (any
+  requirement shape): JSR's `meta.json` `yanked` flag is a true per-version signal with no
+  package-level deprecation payload to conflate with, unlike npm/Composer above (resolves
+  #454).
 
 **Ecosystem coverage, live-verified per registry rather than assumed from code:**
 
@@ -513,7 +516,7 @@ dependency, so only one yanked diagnostic is ever shown per dependency.
 | Gradle | No | reuses Maven Central's registry client, same hardcoded `false` |
 | NuGet | No | `NuGetVersion::is_yanked` is a hardcoded `false` constant |
 | Swift | No | `SwiftVersion.yanked` is a field that is always `false` for GitHub tags (no such concept in the source) |
-| Deno | `jsr:` yes, exact pins only; `npm:` no | JSR `meta.json` per-version `yanked` for `jsr:` specifiers; npm `deprecated` (unconditionally off, see restriction above) for `npm:` specifiers |
+| Deno | `jsr:` yes, any requirement shape; `npm:` no | JSR `meta.json` per-version `yanked` for `jsr:` specifiers; npm `deprecated` (unconditionally off, see restriction above) for `npm:` specifiers |
 
 5 of 12 ecosystems can produce this diagnostic today; npm is disabled by design rather than
 lacking a real signal (see restriction above), and that also covers Deno's `npm:` specifiers;


### PR DESCRIPTION
## Summary

- `DenoFormatter::yanked_diagnostic_applies_to` restricted the yanked diagnostic to exact-pin `jsr:` requirements, an inherited restriction from before #448 made the hook scheme-aware. Its original justification ("avoid conflating with the #205 package-level deprecation diagnostic") does not hold for JSR: `yanked` is a genuine per-version signal with no `deprecation()` payload for a range check to conflate with.
- `jsr:` now applies unconditionally (`true`), matching Cargo/PyPI/Dart's trait default. A `jsr:` range requirement satisfiable only by yanked versions (e.g. `jsr:@std/fs@^1.0.0` fully yanked) now surfaces the diagnostic instead of producing zero signal, closing a cross-ecosystem inconsistency.
- Updated the trait doc, `deps-deno/README.md`, and `ECOSYSTEM_GUIDE.md` to drop stale "exact-pin only" references for `jsr:`.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (3286 passed)
- [x] Rustdoc gate: `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New end-to-end test `test_handle_diagnostics_jsr_scheme_range_yanked_only_now_fires` covers the exact bug scenario
- [x] Verified `Version::deprecation()` is structurally `None` for every JSR version (no #205 double-fire risk)

Closes #454