### PR TITLE
docs(specs): migrate spec-driven-development archive to tracked specs/

### DIFF
--- a/specs/001-yaml-rust2-saphyr-eval/spec.md
+++ b/specs/001-yaml-rust2-saphyr-eval/spec.md
@@ -1,0 +1,181 @@
+---
+aliases:
+  - saphyr migration evaluation
+  - yaml-rust2 successor research
+tags:
+  - sdd
+  - spec
+  - research
+  - dependencies
+  - deps-dart
+created: 2026-08-19
+status: draft
+related:
+  - "[[constitution]]"
+---
+
+# Feature: Evaluate saphyr as eventual successor to yaml-rust2
+
+> [!info] Metadata
+> **Author**: rust-researcher (research session, 2026-08-19)
+> **Branch**: N/A (research finding, no implementation branch)
+
+## 1. Overview
+
+### Problem Statement
+
+`crates/deps-dart` depends on `yaml-rust2` (workspace-pinned `"0.11"`, root
+`Cargo.toml:52`) to parse `pubspec.yaml` and `pubspec.lock`. The yaml-rust2
+maintainers have publicly declared
+([issue #26](https://github.com/Ethiraric/yaml-rust2/issues/26)) that the
+crate will receive only basic maintenance going forward, and that all future
+API evolution and features will land exclusively in a sibling project,
+[`saphyr`](https://github.com/saphyr-rs/saphyr). This creates ambiguity about
+which crate the project should standardize on long-term, and the existing
+project rule (`.claude/rules/dependencies.md`) still names `yaml-rust2` as the
+canonical choice without acknowledging this split.
+
+This is not a bug — it is an open question about dependency direction that
+needs a documented decision so future dependency-monitoring sessions do not
+re-litigate it from scratch.
+
+### Goal
+
+Produce a documented, evidence-based decision on whether/when to migrate
+`deps-dart`'s YAML parsing from `yaml-rust2` to `saphyr`, backed by a concrete
+compatibility assessment, so the decision is a first-class, revisitable
+artifact rather than tribal knowledge.
+
+### Out of Scope
+
+- Actually performing the migration (no code changes — this is a `specify`-only
+  research spec; no `/sdd plan` or `/sdd tasks` phase).
+- Evaluating other YAML crates not in the yaml-rust2 lineage (e.g. `marked-yaml`,
+  `noyalib`, `serde-saphyr`) — out of scope unless a future scan reopens the
+  YAML-parser-choice question entirely.
+- Changing `.claude/rules/dependencies.md` (project rule files are not touched
+  by research sessions; a follow-up team decision is needed to update it if the
+  recommendation below is accepted).
+
+## 2. User Stories
+
+### US-001: Researcher tracks dependency direction risk
+AS A rust-researcher agent running periodic dependency-monitoring scans
+I WANT a recorded decision on the yaml-rust2 vs saphyr question
+SO THAT I don't re-research the same ecosystem split every cycle and can
+instead just check the stated re-evaluation triggers
+
+**Acceptance criteria:**
+```
+GIVEN a future research session scans crates.io for yaml-rust2/saphyr updates
+WHEN saphyr has not yet reached the re-evaluation trigger conditions (see FR-003)
+THEN the session records "no change" against this spec instead of re-deriving
+     the full compatibility analysis
+```
+
+### US-002: Maintainer decides whether to accept migration risk now
+AS A project maintainer reviewing research findings
+I WANT a clear effort estimate and blocking-API-differences list
+SO THAT I can decide immediately whether this is worth scheduling, without
+having to read yaml-rust2/saphyr source myself
+
+**Acceptance criteria:**
+```
+GIVEN this spec and its linked GitHub issue
+WHEN the maintainer reads the Functional Requirements and Data Model sections
+THEN they can determine the call-site count, the nature of the breaking
+     changes, and the recommended timeline without further investigation
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN a research session evaluates the yaml-rust2 dependency THE SYSTEM (research process) SHALL record whether saphyr has reached API stability (1.0) or yaml-rust2 has stopped receiving maintenance releases | must |
+| FR-002 | WHEN neither trigger in FR-001 has occurred THE SYSTEM SHALL classify this finding as "monitor only, no migration" and skip re-deriving the compatibility analysis | must |
+| FR-003 | WHEN either trigger in FR-001 occurs THE SYSTEM SHALL re-open this spec, re-verify the call-site list against current `deps-dart` source (line numbers drift with unrelated changes), and produce an updated effort estimate before recommending migration | must |
+| FR-004 | WHEN this spec is superseded by a migration decision THE SYSTEM SHALL update `.claude/rules/dependencies.md` as part of that decision (not as part of this research spec) | should |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Stability | Any adopted YAML parsing dependency must not require re-validating parsing correctness on every patch release; a crate shipping breaking changes in `0.0.x`/`0.x` releases at the observed cadence (yaml-rust2 issue #26: "rapidly...API-breaking changes...multiple times in a short timespan"; saphyr CHANGELOG: breaking changes in 0.0.5, 0.0.7, 0.0.9) does not meet this bar yet |
+| NFR-002 | Security | The chosen crate must have no open, unpatched RUSTSEC advisory (verified: neither yaml-rust2 nor saphyr currently has one) |
+| NFR-003 | MSRV | The chosen crate's MSRV must not exceed the project's MSRV (1.91, per `.claude/rules/rust-code.md`). Both yaml-rust2 and saphyr currently require 1.85.0 — not a blocker either way |
+
+## 5. Data Model
+
+Not applicable in the traditional sense (no persisted entities) — this section
+instead documents the concrete API surface delta between the two crates, since
+that delta *is* the decision-relevant "data."
+
+| Concept | yaml-rust2 (current, pinned `0.11`, latest `0.12.0`) | saphyr (`0.0.12`, pre-1.0) |
+|---|---|---|
+| Top-level type | Owned `Yaml` enum | `Yaml<'input>` — lifetime-parameterized, borrows from input; separate `YamlOwned` exists for fully-owned use |
+| Loader entry point | `YamlLoader::load_from_str(&str) -> Result<Vec<Yaml>, ScanError>` | `Yaml::load_from_str(&str)` via `LoadableYamlNode` trait (loader is now a trait method on the node type, not a separate struct) |
+| Mapping variant | `Yaml::Hash(LinkedHashMap<Yaml, Yaml>)` | `Yaml::Mapping(Mapping<'input>)` — renamed, still `hashlink::LinkedHashMap`-backed |
+| String scalar variant | `Yaml::String(String)` — direct match | No direct `String` variant. Either `Yaml::Representation(Cow<'input,str>, ScalarStyle, Option<Cow<Tag>>)` (raw/lazy) or `Yaml::Value(Scalar::String(Cow<str>))` (resolved) — a new `Scalar` enum (`String`/`Integer`/`FloatingPoint`/`Boolean`/`Null`) sits between `Yaml` and the primitive value |
+| Error type | `ScanError` | `LoadError`, `#[non_exhaustive]` since 0.0.7 |
+| Index access (`doc["key"]`) | Implemented via `Index`/`IndexMut`, returns `Yaml::BadValue` on miss | Present in saphyr too, but interacts with the `Representation`/`Value` split above |
+
+### Current `yaml-rust2` call sites in `deps-dart` (would all require rewriting)
+
+| File | Lines | Pattern |
+|---|---|---|
+| `crates/deps-dart/src/parser.rs` | 7 | `use yaml_rust2::{Yaml, YamlLoader};` |
+| `crates/deps-dart/src/parser.rs` | 52-53 | `YamlLoader::load_from_str(content)` |
+| `crates/deps-dart/src/parser.rs` | 84, 138, 175 | `Yaml::Hash(map)` pattern match |
+| `crates/deps-dart/src/parser.rs` | 127, 144, 153, 155, 168 | `Yaml::String(ver)` pattern match |
+| `crates/deps-dart/src/parser.rs` | 144, 149, 153, 155, 177-187 | `Yaml::String("key".into())` map-key construction, `Yaml::as_str` |
+| `crates/deps-dart/src/lockfile.rs` | 10 | `use yaml_rust2::{Yaml, YamlLoader};` |
+| `crates/deps-dart/src/lockfile.rs` | 46 | `YamlLoader::load_from_str(content)` |
+| `crates/deps-dart/src/lockfile.rs` | 56 | `Yaml::Hash(pkgs)` pattern match |
+| `crates/deps-dart/src/lockfile.rs` | 56-98 | `doc["packages"]`, `entry["version"]`, `entry["description"]["url"]` chained indexing |
+| Root `Cargo.toml` | 52 | `yaml-rust2 = "0.11"` workspace pin |
+| `crates/deps-dart/Cargo.toml` | 25 | `yaml-rust2 = { workspace = true }` |
+
+~15+ call sites across 2 source files, plus 2 manifest entries.
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| saphyr reaches 1.0 before yaml-rust2 is deprecated | Re-open FR-003, re-run the call-site audit (line numbers will have drifted), produce a fresh effort estimate before recommending migration |
+| yaml-rust2 stops receiving maintenance/security releases (no commits/releases for an extended period, or a RUSTSEC advisory is filed with no fix) | Treat as urgent — re-open FR-003 immediately regardless of saphyr's stability, and evaluate all YAML-parser alternatives (not just saphyr) |
+| A future `yaml-rust2` release changes MSRV above the project's MSRV | File a separate, standard dependency-update finding (not this spec — MSRV bumps are routine dependency monitoring, see `.claude/rules/continuous-improvement.md`) |
+| saphyr's `Representation`/`Value` lazy model turns out to require schema resolution the current code doesn't anticipate (e.g. `pubspec.lock` version strings that look numeric, like `"1.2"` unquoted) | Flag as an additional migration risk in the FR-003 re-audit — the resolved-vs-raw distinction did not exist in yaml-rust2 and needs explicit test coverage for pubspec's mixed quoted/unquoted scalar style |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Time to re-derive a migration decision when a trigger fires | Re-audit re-uses this spec's call-site table as a starting point rather than a from-scratch grep — should take materially less time than the original ~1 research session that produced this spec |
+| SC-002 | False re-migration attempts avoided | 0 migration PRs opened against this dependency before FR-001's trigger condition is met |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Re-verify crates.io versions and RUSTSEC status for both crates on each periodic dependency scan
+- Update this spec's Data Model table if the call-site line numbers have drifted due to unrelated `deps-dart` changes
+
+### Ask First
+- Proposing a `/sdd plan` phase for this spec (only once FR-001's trigger condition is met)
+- Changing `.claude/rules/dependencies.md`'s YAML parser recommendation
+
+### Never
+- Modify `crates/deps-dart/src/parser.rs`, `crates/deps-dart/src/lockfile.rs`, or any `Cargo.toml` as part of this research spec — this is a decision record only, per the research-protocol hard rule (researcher agents never modify source code)
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Should the team pre-emptively adopt `saphyr-parser` (the lower-level event-stream crate) instead of `saphyr` (the high-level `Yaml` object crate) if/when migration happens, to sidestep the `Representation`/`Value` lazy-resolution complexity entirely? This would mean building a custom YAML-to-`Yaml`-like mapping layer atop parser events — a materially different design than either full crate offers today, and is a decision for the eventual `/sdd plan` phase, not this `specify` phase.]
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[MOC-specs]] — all specifications
+- [yaml-rust2 issue #26 — "Status of this crate"](https://github.com/Ethiraric/yaml-rust2/issues/26)
+- [saphyr GitHub repository](https://github.com/saphyr-rs/saphyr)
+- [saphyr CHANGELOG](https://github.com/saphyr-rs/saphyr/blob/master/saphyr/CHANGELOG.md)
+- [yaml-rust2 CHANGELOG](https://github.com/Ethiraric/yaml-rust2/blob/master/CHANGELOG.md)
+- `.claude/rules/dependencies.md` — current project rule naming yaml-rust2 as the standard

--- a/specs/002-osv-vulnerability-diagnostics/plan.md
+++ b/specs/002-osv-vulnerability-diagnostics/plan.md
@@ -1,0 +1,316 @@
+---
+aliases:
+  - OSV vulnerability diagnostics plan
+tags:
+  - sdd
+  - plan
+  - research
+  - enhancement
+  - deps-core
+  - deps-lsp
+  - security
+created: 2026-08-19
+status: draft
+related:
+  - "[[spec]]"
+  - "[[constitution]]"
+---
+
+# Technical Plan: Vulnerability-aware diagnostics via OSV.dev batch API
+
+> [!info] References
+> **Spec**: [[spec]]
+> **Priority**: P2 — plan produced per this project's SDD-integration threshold
+> (P2–P3 enhancement = specify + plan; tasks/implementation deferred to a
+> dedicated `/rust-team` session, not this research cycle)
+
+> [!warning] Planning under open clarifications
+> The spec carries five `[NEEDS CLARIFICATION]` markers. Per research-session
+> rules, no code is written here, and this plan does not silently resolve
+> them — each is either (a) given a stated *working assumption* so the plan
+> can proceed, flagged for confirmation before `/sdd tasks`, or (b) left as a
+> hard blocker where guessing would be unsafe. See [[#10. Constitution
+> Compliance]] and [[#11. Risks and Mitigations]].
+
+## 1. Architecture
+
+### Approach
+
+Add vulnerability lookup as a **new, ecosystem-agnostic component in
+`deps-core`**, integrated into the existing diagnostics/hover/code-action
+pipeline at the same layer as `generate_diagnostics_from_cache`,
+`generate_hover`, and `generate_code_actions` (`crates/deps-core/src/lsp_helpers.rs`).
+This mirrors how those three functions are already shared across all 10
+ecosystem crates via default trait-method implementations on `Ecosystem`
+(`crates/deps-core/src/ecosystem.rs`) — no ecosystem crate needs its own OSV
+integration code, satisfying FR-002/US-005/NFR-003.
+
+The OSV batch query is triggered from the same place per-dependency registry
+version fetches already happen: `fetch_latest_versions_parallel`
+(`crates/deps-lsp/src/document/lifecycle.rs:97`). Rather than adding OSV as
+one more per-dependency task inside that function's existing fan-out, it is
+issued as a **single additional concurrent future** (one batch call for the
+whole dependency list) that is `tokio::join!`-ed alongside the existing
+per-dependency registry fetches, so the OSV round trip does not serialize
+behind — or block — the registry-fetch completion (NFR-001).
+
+Results are stored on `DocumentState` (`crates/deps-lsp/src/document/state.rs`)
+in a new field, structurally parallel to the existing `cached_versions:
+HashMap<String, String>` field, so the rendering functions
+(`generate_diagnostics_from_cache`, `generate_hover`, `generate_code_actions`)
+consume it the same way they already consume `cached_versions` and
+`resolved_versions` — read-only, from an already-populated cache, never
+making network calls themselves.
+
+### Component Diagram
+
+```mermaid
+graph TD
+    subgraph deps-lsp
+        A[document/lifecycle.rs<br/>handle_document_open / handle_document_change] --> B[fetch_latest_versions_parallel]
+        B --> C[per-dependency registry fetch<br/>existing, unchanged]
+        B --> D[NEW: osv_batch_fetch<br/>one call for all deps]
+        A --> E[DocumentState<br/>+ vulnerabilities: HashMap&lt;String, Vec&lt;OsvVulnerability&gt;&gt;]
+        D --> E
+    end
+    subgraph deps-core
+        D --> F[NEW: OsvClient<br/>querybatch + vulns fetch]
+        F --> G[HttpCache<br/>existing, reused unchanged]
+        H[Ecosystem trait<br/>generate_diagnostics / generate_hover / generate_code_actions] --> I[lsp_helpers.rs<br/>generate_diagnostics_from_cache<br/>generate_hover<br/>generate_code_actions]
+        E --> I
+        I --> J[NEW: osv_ecosystem_name&#40;ecosystem_id&#41;<br/>static mapping table]
+    end
+    F --> K[OSV.dev API<br/>POST /v1/querybatch<br/>POST /v1/query]
+```
+
+### Key Design Decisions
+
+| Decision | Choice | Rationale | Alternatives Considered |
+|----------|--------|-----------|--------------------------|
+| Integration layer | `deps-core`, not per-ecosystem crate | Only place that guarantees cross-ecosystem consistency (US-005, NFR-003); matches existing pattern for diagnostics/hover/code-actions | Per-ecosystem client in each of the 10 `deps-*` crates — rejected, direct violation of the project's cross-ecosystem-consistency rule |
+| HTTP transport | `reqwest` (already a workspace dependency) | No new HTTP client dependency needed | `ureq`/other lightweight client — rejected, adds a dependency for no benefit |
+| Caching | Reuse existing `HttpCache` (`crates/deps-core/src/cache.rs`) | FR-008; avoids the DRY violation already flagged in issue #120 by not adding a third caching implementation | Dedicated OSV-specific cache with a custom TTL — rejected, duplicates existing ETag/Last-Modified logic |
+| Batch vs per-dependency queries | Single `POST /v1/querybatch` per diagnostics cycle (chunked at 1000 per FR-009) | Matches OSV.dev's design intent and keeps request count flat regardless of manifest size (NFR-004) | N sequential `POST /v1/query` calls, one per dependency — rejected, defeats the batch endpoint's purpose and risks rate-limiting on large manifests |
+| Concurrency with registry fetch | OSV batch call runs concurrently (`tokio::join!`) with `fetch_latest_versions_parallel`'s existing per-dependency fetches, not appended after | Preserves NFR-001 — no added latency to the existing critical path in the common case | Sequential: fetch versions, then fetch OSV — rejected, doubles worst-case latency for no benefit |
+| Vulnerability detail fetch | Only for IDs returned by the batch call (FR-003) | Keeps the common "no vulnerabilities" case cheap — no extra request beyond the one batch call | Always fetch full vuln records — rejected, wasteful when 0 vulnerabilities are typically found |
+| Version-range matching for "is this version affected" | Delegate to OSV's own batch response (OSV performs the affected-range matching server-side; the batch endpoint already returns only vulnerabilities that match the queried version) | Avoids re-implementing per-ecosystem version-range semantics (semver, PEP 440, node-semver, etc.) a second time inside `deps-core` — OSV already does this correctly server-side | Fetch all advisories for a package name and match ranges client-side with each ecosystem's version-comparison crate — rejected, massive duplication of logic the project already has scattered across `semver`/`pep440_rs`/`node-semver`, and error-prone to reimplement generically |
+
+## 2. Project Structure
+
+```
+crates/deps-core/src/
+├── ecosystem.rs              (unchanged: Ecosystem trait keeps default-impl pattern)
+├── lsp_helpers.rs            (extended: generate_diagnostics_from_cache, generate_hover,
+│                               generate_code_actions read from new vulnerability map)
+├── cache.rs                  (unchanged: HttpCache reused as-is)
+└── osv/                      (NEW module)
+    ├── mod.rs                (OsvClient, batch query orchestration, chunking per FR-009)
+    ├── ecosystem_map.rs       (NEW: static ecosystem_id -> OSV ecosystem string table, FR-002)
+    └── types.rs               (NEW: OsvBatchQuery, OsvBatchResult, OsvVulnerability, serde types)
+
+crates/deps-lsp/src/document/
+├── state.rs                  (extended: DocumentState gains `vulnerabilities` field)
+└── lifecycle.rs              (extended: fetch_latest_versions_parallel gains a concurrent
+                                OSV batch future; new osv_batch_fetch helper)
+
+crates/deps-lsp/src/
+└── config.rs                 (extended: DiagnosticsConfig gains a vulnerability-scan toggle, FR-011)
+```
+
+## 3. Data Model
+
+```rust
+// crates/deps-core/src/osv/types.rs (sketch — exact serde field names to be
+// verified against the live OSV.dev schema before implementation)
+
+#[derive(serde::Serialize)]
+struct OsvBatchQuery<'a> {
+    package: OsvPackage<'a>,
+    version: &'a str,
+}
+
+#[derive(serde::Serialize)]
+struct OsvPackage<'a> {
+    ecosystem: &'a str, // from ecosystem_map.rs, e.g. "crates.io", "npm", "PyPI"
+    name: &'a str,
+}
+
+#[derive(serde::Deserialize)]
+struct OsvBatchResponse {
+    results: Vec<OsvBatchResult>, // order-matched to the request's `queries` list
+}
+
+#[derive(serde::Deserialize)]
+struct OsvBatchResult {
+    #[serde(default)]
+    vulns: Vec<OsvVulnId>,
+}
+
+#[derive(serde::Deserialize)]
+struct OsvVulnId {
+    id: String,
+    modified: String, // RFC3339 timestamp, used for cache/staleness reasoning
+}
+
+/// Full advisory, fetched only for IDs present in a batch result.
+#[derive(serde::Deserialize, Clone)]
+pub struct OsvVulnerability {
+    pub id: String,
+    pub summary: Option<String>,
+    pub severity: Vec<OsvSeverity>, // may be empty — see spec Open Questions
+    pub affected: Vec<OsvAffected>,
+}
+
+#[derive(serde::Deserialize, Clone)]
+pub struct OsvSeverity {
+    #[serde(rename = "type")]
+    pub kind: String, // e.g. "CVSS_V3"
+    pub score: String,
+}
+
+#[derive(serde::Deserialize, Clone)]
+pub struct OsvAffected {
+    pub ranges: Vec<OsvRange>,
+}
+
+#[derive(serde::Deserialize, Clone)]
+pub struct OsvRange {
+    pub events: Vec<OsvEvent>, // look for the `fixed` variant to derive fixed_version
+}
+
+#[derive(serde::Deserialize, Clone)]
+pub struct OsvEvent {
+    pub introduced: Option<String>,
+    pub fixed: Option<String>,
+}
+```
+
+```rust
+// crates/deps-lsp/src/document/state.rs — additive field on DocumentState
+pub vulnerabilities: HashMap<String, Vec<deps_core::osv::OsvVulnerability>>,
+// keyed the same way `cached_versions` is (normalized package name),
+// cloned the same way in `impl Clone for DocumentState`
+```
+
+### Migrations
+
+Not applicable — no persisted storage; all vulnerability data lives in
+in-memory `DocumentState` and the existing `HttpCache`, both already
+process-lifetime, non-persistent caches.
+
+## 4. API Design
+
+### Outbound (deps-lsp → OSV.dev)
+
+| Method | Path | Description | Request | Response |
+|--------|------|-------------|---------|----------|
+| POST | `https://api.osv.dev/v1/querybatch` | Batch-check all dependencies' declared versions against known advisories | `{"queries": [{"package": {"ecosystem": "crates.io", "name": "time"}, "version": "0.1.43"}, ...]}` (chunked at 1000 entries per FR-009) | `{"results": [{"vulns": [{"id": "RUSTSEC-2020-0071", "modified": "..."}]}, ...]}` |
+| POST | `https://api.osv.dev/v1/query` (batched by ID) or `GET /v1/vulns/{id}` | Fetch full advisory details for matched IDs only | `{"id": "RUSTSEC-2020-0071"}` or none (GET) | Full `OsvVulnerability` record — severity, summary, affected ranges, fixed version |
+
+No inbound API changes — this feature does not add or modify any LSP-facing
+request/response shape beyond the existing `Diagnostic`, `Hover`, and
+`CodeAction` payloads already produced by `generate_diagnostics_from_cache`,
+`generate_hover`, and `generate_code_actions`.
+
+## 5. Integration Points
+
+| System | Direction | Protocol | Notes |
+|--------|-----------|----------|-------|
+| OSV.dev | outbound | HTTPS (HTTP/2 recommended by OSV.dev for large batch responses) | Free, keyless, response capped at 32 MiB over HTTP/1.1 — no vault entry needed (NFR-006) |
+| `HttpCache` (`deps-core`) | internal, reused | in-process | Provides ETag/Last-Modified conditional requests for both the batch endpoint and per-ID vuln fetches |
+| `Ecosystem` trait default methods | internal | Rust trait dispatch | `generate_diagnostics`, `generate_hover`, `generate_code_actions` default impls extended to read the new `vulnerabilities` map — no per-ecosystem override needed for any of the 10 crates |
+
+## 6. Security
+
+- Authentication: none — OSV.dev API is public and keyless (NFR-006); no
+  secrets, no new Zeph vault entries.
+- Authorization: not applicable.
+- Input validation: dependency names/versions passed into the OSV batch query
+  are already-parsed, already-validated manifest data (same values already
+  sent to each ecosystem's own registry client) — no new untrusted-input
+  surface is introduced.
+- Sensitive data: none transmitted beyond package name + version, which is
+  not sensitive (same data already sent to public package registries for
+  version lookups).
+- Response handling: OSV responses are deserialized via `serde` into strongly
+  typed structs (not dynamically interpreted), and a malformed/oversized
+  response is treated as a fetch failure subject to FR-007's graceful
+  degradation, not a parse-time panic.
+
+## 7. Testing Strategy
+
+| Level | Framework | What to Test | Coverage Target |
+|-------|-----------|-------------|-----------------|
+| Unit | `cargo nextest` | `ecosystem_map.rs` mapping table (all 10 ecosystem IDs resolve to a non-empty OSV ecosystem string); severity-mapping fallback logic; fixed-version extraction from `OsvEvent` sequences | 100% of mapping table branches |
+| Unit | `mockito` (already in workspace, per `.claude/rules/testing.md`) | `OsvClient` against mocked `/v1/querybatch` and `/v1/vulns/{id}` responses — success, empty-result, malformed-JSON, timeout, non-200 status | All FR-007 degradation paths |
+| Integration | `cargo nextest` + `tempfile` fixtures | End-to-end: manifest with one known-vulnerable dependency (per spec SC-001, one fixture per ecosystem) produces the expected `Diagnostic` and hover content | 10/10 ecosystems (SC-001) |
+| Live/manual | per `.claude/rules/continuous-improvement.md` | Real OSV.dev batch query against a live known-vulnerable package per ecosystem, verified in a running LSP session with `RUST_LOG=debug`, per this project's Registry Integration Gate | Required before merge, not before spec/plan |
+| Snapshot (`insta`) | `cargo insta` | Diagnostic message format and hover markdown layout for a vulnerability match, to catch unintended formatting drift across ecosystems (reinforces NFR-003) | New snapshot per ecosystem fixture |
+
+## 8. Performance Considerations
+
+- Expected load: one batch request per diagnostics refresh cycle per open
+  document, chunked at 1000 dependencies (FR-009) — realistically 1 request
+  per document for the vast majority of manifests.
+- Bottleneck risk: OSV.dev round-trip time becomes the new tail latency for
+  diagnostics if it is slower than the slowest existing per-dependency
+  registry fetch; mitigated by running it concurrently (NFR-001) and applying
+  the same per-fetch timeout pattern already used in
+  `fetch_latest_versions_parallel` (`crates/deps-lsp/src/document/lifecycle.rs`).
+- Optimization: `HttpCache`'s conditional-request (ETag/If-None-Match) support
+  means repeated queries against an unchanged dependency set become cheap
+  304-status round trips rather than full payload transfers (NFR-005, SC-005).
+
+## 9. Rollout Plan
+
+Given P2 priority and the existing SDD-integration threshold rule (P2–P3 =
+specify + plan, implementation deferred to a dedicated `/rust-team` session):
+
+1. This plan is reviewed and the open `[NEEDS CLARIFICATION]` items (see
+   [[#11. Risks and Mitigations]]) are resolved with the maintainer.
+2. `/sdd tasks` breaks this plan into discrete, dependency-ordered tasks in a
+   dedicated implementation session (not this research cycle).
+3. Feature ships gated behind the new `DiagnosticsConfig` toggle (FR-011),
+   default value decided per the corresponding open question — allows an
+   opt-out rollout if OSV.dev integration proves noisy or unreliable in early
+   use.
+4. No phased/canary rollout infrastructure exists in this project today (no
+   feature-flag service) — the config toggle is the only rollout control
+   available, consistent with how existing diagnostics features are gated.
+
+## 10. Constitution Compliance
+
+`[NEEDS CLARIFICATION: .local/specs/constitution.md does not exist yet for
+this project (confirmed via file check) — this plan cannot verify formal
+constitution compliance and instead cross-checks against the project's
+existing enforced rules under .claude/rules/, which function as the
+project's de facto constitution today.]`
+
+| Principle (from `.claude/rules/`) | Status | Notes |
+|---|---|---|
+| Cross-ecosystem consistency (`continuous-improvement.md`) | Compliant by design | Single `deps-core` implementation, no per-ecosystem duplication (see [[#1. Architecture]]) |
+| Registry Integration Gate (`continuous-improvement.md`) | Addressed in [[#7. Testing Strategy]] | Live verification against real OSV.dev required before merge |
+| DRY / avoid duplicated caching logic | Compliant | Reuses `HttpCache` rather than adding a third cache implementation (avoids compounding the pattern already flagged in issue #120) |
+| Rust code conventions (`rust-code.md`) — `thiserror` typed errors, native async traits, no `unsafe`, `tracing` logging | Planned, not yet verified | To be enforced during implementation; `OsvClient` errors should extend or compose with existing `deps_core::error` types |
+| Testing conventions (`testing.md`) — `nextest`, `mockito`, `insta` | Planned | See [[#7. Testing Strategy]] |
+| Dependencies rule — check current versions via context7 mcp before adding | Not yet applicable | No new dependency anticipated (`reqwest`, `serde`, `serde_json` already in workspace) — to be confirmed at implementation time |
+
+## 11. Risks and Mitigations
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| OSV.dev ecosystem string for Swift Package Manager is wrong or has changed | High (feature silently returns zero results for one of 10 ecosystems) | Medium | Blocking `[NEEDS CLARIFICATION]` — verify against live OSV.dev ecosystem list before `/sdd tasks`; add a unit test asserting the mapping matches the documented list |
+| OSV advisories lacking a numeric severity field lead to inconsistent diagnostic severity | Medium (user-visible inconsistency, undermines NFR-003) | High (RUSTSEC/GHSA records commonly omit CVSS) | Blocking `[NEEDS CLARIFICATION]` — maintainer decides `WARNING` vs `HINT` default before implementation; document the decision in this plan once resolved |
+| Gradle/Maven `groupId:artifactId` name format mismatch with OSV's expected `name` field | Medium (silently missed vulnerabilities for Gradle/Maven) | Medium | Verify via a live query against a known-vulnerable Maven Central package (per Testing Strategy's live/manual row) before considering FR-010 complete |
+| OSV.dev batch endpoint rate-limits or throttles under heavy multi-document editing (many files open at once, each triggering its own batch call) | Medium (degraded UX, not a correctness bug) | Low–Medium | FR-008/NFR-005 caching mitigates repeat queries; if observed in live testing, consider debouncing or a shared per-workspace batch across open documents as a follow-up enhancement (not in this spec's scope) |
+| Feature adds latency perceived by users even though it runs concurrently (NFR-001), because `tokio::join!` waits for the slowest of the two futures | Low–Medium | Medium | Apply the same per-fetch timeout already used for individual registry fetches to the OSV future, so a slow/hanging OSV call cannot extend the diagnostics cycle beyond the existing timeout ceiling |
+| No project constitution exists to check formal compliance against | Low (process risk, not implementation risk) | Certain (confirmed) | Cross-checked against `.claude/rules/*.md` instead (see [[#10. Constitution Compliance]]); recommend running `/sdd init` before or alongside this feature's implementation session |
+
+## See Also
+
+- [[spec]] — feature specification
+- [[MOC-specs]] — all specifications
+- `crates/deps-core/src/ecosystem.rs`, `crates/deps-core/src/lsp_helpers.rs`, `crates/deps-core/src/cache.rs`
+- `crates/deps-lsp/src/document/lifecycle.rs`, `crates/deps-lsp/src/document/state.rs`
+- `crates/deps-gradle/src/ecosystem.rs` — Gradle-reuses-Maven precedent for FR-010
+- `.claude/rules/continuous-improvement.md`, `.claude/rules/testing.md`, `.claude/rules/rust-code.md`

--- a/specs/002-osv-vulnerability-diagnostics/spec.md
+++ b/specs/002-osv-vulnerability-diagnostics/spec.md
@@ -1,0 +1,271 @@
+---
+aliases:
+  - OSV vulnerability diagnostics
+  - vulnerability-aware diagnostics
+  - CVE/RUSTSEC/GHSA inline warnings
+tags:
+  - sdd
+  - spec
+  - research
+  - enhancement
+  - deps-core
+  - deps-lsp
+  - security
+created: 2026-08-19
+status: draft
+related:
+  - "[[constitution]]"
+---
+
+# Feature: Vulnerability-aware diagnostics via OSV.dev batch API
+
+> [!info] Metadata
+> **Author**: rust-researcher (continuous-improvement research session, 2026-08-19)
+> **Branch**: N/A (not yet started — see [[#8. Agent Boundaries]])
+> **Priority**: P2 (enhancement / capability gap)
+> **Source finding**: continuous-improvement research cycle, 2026-08-19; verified via `gh issue list --label research --state open` (empty) and review of open issues #118–#120 (all unrelated type/refactor findings)
+
+## 1. Overview
+
+### Problem Statement
+
+deps-lsp surfaces diagnostics for outdated, unknown, and yanked dependencies
+(`crates/deps-lsp/src/handlers/diagnostics.rs` delegating to
+`generate_diagnostics_from_cache` in `crates/deps-core/src/lsp_helpers.rs`, via
+the [[#Ecosystem trait|Ecosystem trait]] in `crates/deps-core/src/ecosystem.rs`),
+but has **no awareness of known security vulnerabilities** (CVEs, RUSTSEC
+advisories, GHSA advisories) in a user's declared dependencies. A repository-wide
+search for `advisor|vulnerab|osv|rustsec|cve` outside this research session
+returns zero matches — this is a genuine, unaddressed capability gap.
+
+Vulnerability awareness is now a baseline expectation for dependency tooling.
+`cargo audit` / `cargo deny check advisories` (already used in this project's
+own CI per `.claude/rules/continuous-improvement.md`), GitHub Dependabot, `npm
+audit`, and Snyk/Socket.dev all provide it — but as a background, CLI, or web
+check, not inline in the editor at the exact manifest line where a dependency
+is declared. Surfacing it as an LSP diagnostic, at edit time, before the
+dependency is even installed, is a meaningful differentiator that serves users
+of every one of deps-lsp's 10 supported ecosystems, not just Rust/Cargo.
+
+### Goal
+
+A user editing any supported manifest file (`Cargo.toml`, `package.json`,
+`requirements.txt`/`pyproject.toml`, `go.mod`, `Gemfile`, `pubspec.yaml`,
+`pom.xml`, `composer.json`, `build.gradle`/`build.gradle.kts`,
+`Package.swift`) sees an inline diagnostic when the declared dependency
+version has a known OSV.dev-tracked vulnerability, with hover content
+detailing the advisory and (when known) the fixed version to upgrade to.
+
+### Out of Scope
+
+- Vulnerability scanning of transitive/indirect dependencies beyond what
+  lock-file-resolved versions already expose via `resolved_versions`
+  (`crates/deps-lsp/src/document/state.rs`) — this spec covers only the
+  directly-declared dependencies already visited by
+  `generate_diagnostics_from_cache`.
+- A standalone `deps-lsp audit` CLI subcommand or workspace-wide vulnerability
+  report — this spec is scoped to the existing per-document LSP diagnostic
+  pipeline only.
+- Any vulnerability database other than OSV.dev (e.g. direct GHSA GraphQL API,
+  Snyk API, NVD) — OSV.dev already aggregates RUSTSEC, GHSA, PyPA, and
+  ecosystem-specific advisory databases, so a second source is redundant for
+  MVP.
+- Auto-fixing or auto-upgrading vulnerable dependencies without user action —
+  the existing "Update to latest version" code action pattern
+  (`generate_code_actions` in `crates/deps-core/src/lsp_helpers.rs`) is reused,
+  not replaced.
+- Vulnerability severity re-scoring or custom risk models — OSV/CVSS severity
+  as reported by the API is passed through, not recalculated.
+
+## 2. User Stories
+
+### US-001: Developer sees a known vulnerability inline
+AS A developer editing `Cargo.toml` (or any of the 9 other supported manifest
+types)
+I WANT to see when a dependency version I've declared has a known CVE/RUSTSEC/GHSA
+advisory
+SO THAT I can avoid introducing a vulnerable dependency before it's even
+installed, without leaving the editor or running a separate audit tool
+
+**Acceptance criteria:**
+```
+GIVEN a Cargo.toml with `time = "0.1.43"` (a version affected by RUSTSEC-2020-0071)
+WHEN diagnostics are generated for the document
+THEN a diagnostic appears at the dependency's version range referencing the
+     RUSTSEC advisory ID and severity
+```
+
+### US-002: Developer gets actionable remediation via hover
+AS A developer who sees a vulnerability diagnostic
+I WANT the hover panel to show the advisory summary and the fixed version
+SO THAT I know exactly what to upgrade to without leaving the editor to search
+the advisory database
+
+**Acceptance criteria:**
+```
+GIVEN a dependency flagged with a vulnerability diagnostic
+WHEN the user hovers over that dependency's name or version
+THEN the hover content includes the advisory ID, a one-line summary, severity,
+     and the fixed version (if the advisory declares one)
+```
+
+### US-003: Developer applies the fix via existing code action
+AS A developer who sees a vulnerability diagnostic with a known fixed version
+I WANT the existing "Update to latest version" code action to target the fixed
+version (or the latest version, whichever resolves the vulnerability)
+SO THAT remediation is a single click, consistent with how outdated-dependency
+fixes already work
+
+**Acceptance criteria:**
+```
+GIVEN a dependency with a vulnerability that has a fixed version F
+WHEN the user requests code actions at that dependency's location
+THEN a code action is offered that edits the manifest to a version >= F
+```
+
+### US-004: Developer working offline is not blocked
+AS A developer working without network access (e.g. on a plane, in a sandboxed
+CI runner)
+I WANT diagnostics for outdated/unknown/yanked dependencies to keep working
+even when the OSV.dev query fails
+SO THAT the loss of one data source doesn't degrade the rest of the LSP's
+functionality
+
+**Acceptance criteria:**
+```
+GIVEN OSV.dev is unreachable (network disabled or request times out)
+WHEN diagnostics are generated for a document
+THEN outdated/unknown/yanked diagnostics are still produced, and no
+     vulnerability diagnostic is shown (silently omitted, not an error state)
+```
+
+### US-005: Maintainer trusts consistent behavior across ecosystems
+AS A project maintainer enforcing the project's cross-ecosystem-consistency
+rule (`.claude/rules/continuous-improvement.md`)
+I WANT vulnerability diagnostics implemented once in `deps-core`, not
+per-ecosystem
+SO THAT the feature behaves identically (same diagnostic format, same hover
+layout, same severity mapping) across all 10 ecosystems, and a divergence is
+treated as a first-class bug rather than an acceptable per-ecosystem quirk
+
+**Acceptance criteria:**
+```
+GIVEN the same "known-vulnerable version" scenario reproduced once per
+      ecosystem (Cargo, npm, PyPI, Go, Bundler, Dart, Maven, Gradle, Composer,
+      Swift)
+WHEN diagnostics are generated for each manifest
+THEN the diagnostic message format, severity mapping, and hover layout are
+     identical across all ecosystems (only the OSV `ecosystem` query value and
+     manifest range differ)
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN diagnostics are generated for a document with one or more parsed dependencies THE SYSTEM SHALL query the OSV.dev batch endpoint (`POST /v1/querybatch`) with one `{package: {ecosystem, name}, version}` entry per dependency, in a single request per diagnostics refresh cycle | must |
+| FR-002 | WHEN mapping a deps-lsp ecosystem identifier to an OSV.dev `ecosystem` string THE SYSTEM SHALL use a single static mapping table owned by `deps-core` (see [[#5. Data Model]]), not duplicated per ecosystem crate, per the project's cross-ecosystem-consistency rule | must |
+| FR-003 | WHEN the OSV.dev batch response returns one or more vulnerability IDs for a dependency THE SYSTEM SHALL fetch full vulnerability details for only the matched IDs (via `POST /v1/query` or `GET /v1/vulns/{id}`) before rendering diagnostics or hover content | must |
+| FR-004 | WHEN a dependency's declared/resolved version matches at least one OSV advisory THE SYSTEM SHALL emit a `Diagnostic` at that dependency's version range (falling back to the name range if no version range exists), with severity derived per [[#5. Data Model|the severity mapping table]] | must |
+| FR-005 | WHEN a user requests hover for a dependency with one or more matched advisories THE SYSTEM SHALL append advisory ID(s), one-line summary, severity, and fixed version (if declared by OSV) to the existing hover content produced by `generate_hover` | must |
+| FR-006 | WHEN an OSV advisory declares a fixed version for an affected dependency THE SYSTEM SHALL make that version available to `generate_code_actions` so the existing "Update to latest version" action can target a version that resolves the vulnerability | should |
+| FR-007 | WHEN the OSV.dev batch request fails, times out, or returns a non-success HTTP status THE SYSTEM SHALL degrade gracefully — suppress vulnerability diagnostics/hover content for that refresh cycle without raising an LSP error and without blocking outdated/unknown/yanked diagnostics | must |
+| FR-008 | WHEN OSV.dev responses are received THE SYSTEM SHALL cache them via the existing `HttpCache` (ETag/Last-Modified conditional-request) infrastructure in `crates/deps-core/src/cache.rs`, rather than introducing a second caching mechanism | must |
+| FR-009 | WHEN a manifest declares more dependencies than the OSV.dev batch endpoint's per-request limit (1000 queries) THE SYSTEM SHALL split the dependency list into multiple sequential/parallel batch requests | should |
+| FR-010 | WHEN a Gradle manifest is parsed THE SYSTEM SHALL query OSV.dev using the `Maven` ecosystem value, consistent with `deps-gradle`'s existing reuse of `deps_maven::MavenCentralRegistry` (`crates/deps-gradle/src/ecosystem.rs`) for version resolution | must |
+| FR-011 | WHEN vulnerability diagnostics are enabled THE SYSTEM SHALL expose a configuration flag (default: enabled) allowing users to disable OSV queries entirely, consistent with the existing `DiagnosticsConfig` pattern in `crates/deps-lsp/src/config.rs` | should |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | Adding OSV batch queries must not measurably increase the latency of existing diagnostics for the common case (no vulnerabilities found) — the batch query runs in parallel with existing per-dependency registry fetches (`fetch_latest_versions_parallel`, `crates/deps-lsp/src/document/lifecycle.rs:97`), not sequentially after them |
+| NFR-002 | Reliability | OSV.dev unavailability must never prevent outdated/unknown/yanked diagnostics from being produced — see US-004 and FR-007 |
+| NFR-003 | Consistency | Diagnostic message format, severity mapping, and hover layout for vulnerabilities must be identical across all 10 ecosystems — implemented once in `deps-core`, verified via the project's cross-ecosystem consistency testing process (`.claude/rules/continuous-improvement.md`) |
+| NFR-004 | Network efficiency | The full manifest's dependency list must be queried in as few OSV.dev batch requests as possible (ideally one, per FR-001/FR-009), not one request per dependency, to respect OSV.dev's free/keyless rate limits |
+| NFR-005 | Caching | Repeated diagnostics refreshes for an unchanged dependency set must reuse cached OSV responses (ETag/Last-Modified) rather than re-querying on every keystroke-triggered diagnostics pass |
+| NFR-006 | Security | The OSV.dev integration introduces no new secret/credential handling — the API is free and keyless, consistent with the project's Zeph age vault policy (no new vault entries required) |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `OsvEcosystemMapping` | Static table mapping deps-lsp's internal ecosystem ID to the OSV.dev `ecosystem` query string | `cargo → crates.io`, `npm → npm`, `pypi → PyPI`, `go → Go`, `bundler → RubyGems`, `dart → Pub`, `maven → Maven`, `gradle → Maven`, `composer → Packagist`, `swift → [NEEDS CLARIFICATION: OSV.dev ecosystem value for Swift Package Manager — the finding's source material references "SwiftURL" but this must be verified against the current OSV.dev ecosystem list before implementation]` |
+| `OsvBatchQuery` | One entry in the batch request | `package.ecosystem` (string), `package.name` (string), `version` (string) |
+| `OsvBatchResult` | One entry in the batch response, order-matched to the query list | `vulns: Vec<{id: String, modified: DateTime}>` |
+| `OsvVulnerability` | Full advisory record fetched for matched IDs | `id`, `summary`, `severity` (CVSS vector/score or ecosystem-specific severity string), `affected` (version ranges per ecosystem), `fixed_version` (derived from `affected[].ranges[].events` where `event.fixed` is present) |
+| `VulnerabilityDiagnostic` | Rendered LSP diagnostic derived from `OsvVulnerability` matches for one dependency | `range` (dependency's version/name range), `severity` (`DiagnosticSeverity`, mapped from OSV/CVSS per [[#Severity mapping|severity mapping]]), `message` (advisory ID + one-line summary), `source: "deps-lsp"` |
+
+### Severity mapping
+
+| OSV/CVSS severity | LSP `DiagnosticSeverity` |
+|---|---|
+| Critical / High | `ERROR` |
+| Medium | `WARNING` |
+| Low / unspecified | `HINT` |
+
+`[NEEDS CLARIFICATION: some OSV advisories (notably RUSTSEC and GHSA-sourced) omit a numeric CVSS score entirely and only provide an ecosystem_specific severity string or no severity field at all — the exact fallback rule for "no severity reported" needs to be decided during /sdd plan: default to WARNING (safe-but-noisy) or HINT (quiet-but-easy-to-miss)?]`
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| OSV.dev batch request times out or network is unavailable | Diagnostics for outdated/unknown/yanked still render; vulnerability diagnostics silently omitted for this cycle (FR-007) |
+| Dependency has no version pinned (e.g. `latest`, `*`, git/path source) | Skip the OSV query for that dependency — OSV requires a concrete version string to match against affected ranges |
+| OSV batch response includes a vulnerability ID but the follow-up `/v1/vulns/{id}` fetch fails | Treat as "no vulnerability data available" for that dependency this cycle rather than surfacing a partial/malformed diagnostic |
+| Dependency's version matches an advisory, but the advisory has since been withdrawn/marked invalid at the source (rare, but OSV records can be updated) | Rely on OSV's own `modified` timestamp and cache invalidation (ETag) — do not implement separate "withdrawn advisory" filtering logic; if OSV stops returning the ID, the cache refresh will clear the diagnostic |
+| Manifest has 1000+ dependencies (exceeds OSV batch limit) | Split into multiple batch requests per FR-009 |
+| Same package name exists as a vulnerability match under a different OSV ecosystem string (e.g. name collision across ecosystems) | Not possible to conflate — the `ecosystem` field is always included in each query entry (FR-002), so OSV disambiguates internally |
+| User disables vulnerability diagnostics via config (FR-011) | No OSV requests are sent at all for that workspace/session — not just diagnostics suppressed, but the network call itself skipped |
+| Gradle dependency resolved via Maven coordinates has a group:artifact format that doesn't map cleanly to a single OSV `name` field | `[NEEDS CLARIFICATION: OSV.dev's Maven ecosystem expects "groupId:artifactId" as the name — confirm deps-gradle/deps-maven already expose dependency names in this exact format, or whether a transformation step is needed before querying]` |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Vulnerability detection accuracy | For a curated set of manifests each containing one known-vulnerable dependency version (one per ecosystem), the correct advisory ID is surfaced as a diagnostic in 10/10 cases |
+| SC-002 | Latency overhead (common case) | p95 time-to-diagnostics for a manifest with no vulnerable dependencies does not increase by more than the single parallel OSV batch round-trip (target: no more than the slowest existing per-dependency registry fetch, since OSV runs concurrently with it per NFR-001) |
+| SC-003 | Offline graceful degradation | 0 LSP errors/crashes and 0 missing outdated/unknown/yanked diagnostics when OSV.dev is unreachable, verified via the project's existing offline-testing playbook |
+| SC-004 | Cross-ecosystem consistency | 0 diagnostic-format or severity-mapping divergences found across the 10 ecosystems during the project's cross-ecosystem consistency testing pass |
+| SC-005 | Cache efficiency | Repeated diagnostics passes on an unchanged dependency set result in conditional (304-eligible) OSV requests, not full re-fetches, measured via `HttpCache` hit-rate logging |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Verify the OSV.dev `ecosystem` string list against the live API/documentation before finalizing the mapping table in [[#5. Data Model]] (particularly the two `[NEEDS CLARIFICATION]` items)
+- Reuse `HttpCache` (`crates/deps-core/src/cache.rs`) rather than introducing a new HTTP client or cache
+- Implement the feature once in `deps-core`, exposed through the `Ecosystem` trait's default-implementation pattern already used by `generate_diagnostics`/`generate_hover`/`generate_code_actions`, so all 10 ecosystem crates inherit it without per-crate duplication
+
+### Ask First
+- Adding `serde` derive types for the OSV request/response schema if it introduces a new dependency beyond what's already in the workspace (check `reqwest` + `serde_json` sufficiency first)
+- Changing the default value of the new `DiagnosticsConfig` flag (FR-011) — default should be discussed with the maintainer, not assumed
+- Any change to `.claude/rules/continuous-improvement.md`'s Registry Integration Gate to explicitly include OSV.dev as a "registry client" subject to live-verification-before-PR rules
+
+### Never
+- Implement vulnerability scanning per-ecosystem-crate instead of once in `deps-core` — this violates the project's cross-ecosystem-consistency rule and would itself become a `P2`-severity finding in a future continuous-improvement cycle
+- Silently swallow OSV.dev errors as a generic catch-all that also suppresses unrelated diagnostic types — the degradation in FR-007 must be scoped narrowly to vulnerability diagnostics only
+- Introduce a second vulnerability data source (GHSA API, Snyk, NVD) without a dedicated follow-up spec — out of scope per [[#Out of Scope]]
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: What is the current, exact OSV.dev `ecosystem` string for Swift Package Manager? The finding's source material states "SwiftURL" but this was not independently re-verified in this research session against the live OSV.dev ecosystem list — must be confirmed before `/sdd tasks`.]
+- [NEEDS CLARIFICATION: Fallback `DiagnosticSeverity` when an OSV advisory omits a numeric CVSS/severity field entirely (common for RUSTSEC/GHSA-sourced records) — default to `WARNING` or `HINT`? See [[#Severity mapping]].]
+- [NEEDS CLARIFICATION: Does OSV.dev's Maven ecosystem expect the dependency `name` field in `groupId:artifactId` format, and do `deps-maven`/`deps-gradle` already expose names in that exact format, or is a transformation needed?]
+- [NEEDS CLARIFICATION: Should the OSV batch query run only when a document is opened/changed (same cadence as `fetch_latest_versions_parallel`), or also on a periodic background timer independent of edits, so a dependency that becomes vulnerable *after* the file was last edited is still caught? MVP assumption in this spec is "same cadence as existing registry fetches" — confirm during `/sdd plan`.]
+- [NEEDS CLARIFICATION: Should the new config flag (FR-011) be a single global on/off switch, or per-ecosystem, mirroring any existing per-ecosystem config granularity in `crates/deps-lsp/src/config.rs`?]
+
+## 10. See Also
+
+- [[constitution]] — project principles (not yet created for this project)
+- [[MOC-specs]] — all specifications
+- [OSV.dev homepage](https://osv.dev/)
+- [OSV.dev GitHub repository](https://github.com/google/osv.dev)
+- [OSV API — `POST /v1/querybatch`](https://google.github.io/osv.dev/post-v1-querybatch/)
+- [Query OSV API — practical walkthrough](https://oneuptime.com/blog/post/2026-07-23-query-osv-api/view)
+- `crates/deps-core/src/ecosystem.rs` — `Ecosystem` trait, default-implementation pattern this feature extends
+- `crates/deps-core/src/lsp_helpers.rs` — `generate_diagnostics_from_cache`, `generate_hover`, `generate_code_actions`
+- `crates/deps-core/src/cache.rs` — `HttpCache`, existing ETag/Last-Modified conditional-request infrastructure
+- `crates/deps-lsp/src/handlers/diagnostics.rs` — diagnostics handler entry point
+- `crates/deps-lsp/src/document/lifecycle.rs` — `fetch_latest_versions_parallel`, existing parallel-fetch-with-timeout pattern
+- `crates/deps-gradle/src/ecosystem.rs` — confirms Gradle reuses `deps_maven::MavenCentralRegistry`
+- `.claude/rules/continuous-improvement.md` — Registry Integration Gate, Cross-Ecosystem Consistency Testing

--- a/specs/003-maven-legacy-version-sort/spec.md
+++ b/specs/003-maven-legacy-version-sort/spec.md
@@ -1,0 +1,261 @@
+---
+aliases:
+  - Maven Legacy Version Sort Bug
+  - r09 sorts above 33.7.1
+tags:
+  - sdd
+  - spec
+  - bug
+  - deps-maven
+  - deps-gradle
+  - version-sorting
+created: 2026-08-19
+status: draft
+related:
+  - "[[constitution]]"
+---
+
+# Feature: Fix Maven/Gradle Version Sort Corrupted by Legacy Non-Semver Versions
+
+> [!info] Metadata
+> **Author**: continuous-improvement cycle (deps-lsp)
+> **Branch**: fix/{issue-number}-maven-legacy-version-sort
+> **Priority**: P1
+> **Type**: bug
+
+## 1. Overview
+
+### Problem Statement
+
+`compare_versions()` in `crates/deps-maven/src/version.rs` (lines 36-66) is a
+hand-rolled version comparator: it splits a version string on `.` and `-` into
+segments, parses each segment as `u64`, and falls back to raw string (`Ord::cmp`)
+comparison whenever a segment fails to parse as a number.
+
+Legacy Maven artifacts occasionally shipped bare, qualifier-only version
+identifiers with no `.` or `-` separators at all — e.g. Guava's `r03`..`r09`
+releases from ~2012. For such a version, `split_version("r09")` yields a single
+segment `"r09"`, which fails `u64::parse`. `compare_segment` then falls back to
+`a.cmp(b)`, i.e. lexicographic string comparison, against numeric segments such
+as `"33"`. Because ASCII `'r'` (114) sorts above `'3'` (51), `"r09" > "33"`
+lexicographically — so `r09` permanently outranks every real, newer release
+regardless of how many stable versions have shipped since 2012.
+
+This broken comparator is used at `crates/deps-maven/src/registry.rs:221`
+(`versions.sort_by(|a, b| compare_versions(&b.version, &a.version))`) to sort
+the version list returned by the Maven Central registry client. Both
+`deps-maven` and `deps-gradle` (Gradle reuses the Maven Central registry client
+for library coordinates) consume this sorted list for hover rendering and
+completion rendering.
+
+The top-line "Latest" badge in the hover card was already fixed correctly by
+PR #93 / #91, which reads Maven metadata's authoritative `<release>` XML tag
+instead of relying on the sorted list. However, that fix is narrow: it did not
+touch `compare_versions` or the sort call itself, so every OTHER
+version-ordered surface remains broken:
+
+- The "Recent versions" list in the hover card (below the "Latest" badge)
+- The completion dropdown's item ordering
+- The completion dropdown's `(latest)` label, which is assigned purely by
+  index `0` into the same broken sort in
+  `crates/deps-core/src/completion.rs` (`build_version_completion` /
+  `VersionDisplayItem::new`), with no independent correctness check against
+  the authoritative release value
+
+The result is a hover card that contradicts itself in the same response
+(`**Latest**: 33.7.1-jre` on one line, `- r09 *(latest)*` two lines below), and
+a completion dropdown that offers a 14-year-old version as the default/first
+suggestion when the user invokes completion with an empty prefix — the common
+real-world case of opening the version field for the first time.
+
+This is worsened by the fact that the crate's own test suite documents the
+brokenness as accepted rather than asserting correctness:
+`crates/deps-maven/src/registry.rs::test_parse_metadata_xml_legacy_versions_release_wins`
+(~lines 442-469) only asserts `assert_ne!(versions[0].version, "33.5.0-jre", "sort
+puts r09 first")` — i.e. it confirms the sort produces something other than the
+correct top result, without asserting what the correct top result actually is.
+
+This also violates the project's own coding convention
+(`.claude/rules/rust-code.md`, "Registry Crates" section): "Version parsing:
+use ecosystem-specific crates (`semver`, `node-semver`, `pep440_rs`) — do not
+hand-roll version comparison logic." `compare_versions` is exactly such a
+hand-rolled comparator, and Maven's own de facto versioning scheme
+(Maven `ComparableVersion`, used by Maven Central itself) is not equivalent to
+strict semver, so a purely mechanical swap to the `semver` crate is not
+guaranteed to be sufficient on its own — see Open Questions.
+
+### Goal
+
+The version ordering used to render the "Recent versions" list in hover and
+the completion dropdown for Maven and Gradle packages agrees with the
+authoritative "Latest" determination (the `<release>` tag when present), and no
+legacy or malformed version identifier lacking numeric structure can ever
+outrank a well-formed, numerically-versioned release — regardless of how the
+underlying comparator is implemented.
+
+### Out of Scope
+
+- Changing how the "Latest" badge itself is computed (already correct via
+  `<release>` tag, PR #93/#91) — this spec covers the list/dropdown ordering
+  and the completion `(latest)` label logic that consumes that ordering
+- Non-Maven/Gradle ecosystems (Cargo, npm, PyPI, Go, Bundler, Dart, Composer,
+  Swift) — each already uses an ecosystem-specific version-parsing crate per
+  `.claude/rules/rust-code.md` and is not affected by this comparator
+- Redesigning the completion API surface (`build_version_completion`,
+  `VersionDisplayItem`) beyond what is required to source a correct
+  latest-version determination and a correct sort order
+- Retroactively fixing already-cached/persisted version lists (cache
+  invalidation strategy, if any, is an implementation detail for `/sdd plan`)
+
+## 2. User Stories
+
+### US-001: Correct hover "Recent versions" ordering
+
+AS A developer editing a `pom.xml` or `build.gradle` file
+I WANT the hover card's "Recent versions" list to show genuinely recent
+releases first, consistent with the "Latest" badge in the same card
+SO THAT I can trust the hover information without cross-checking it against
+Maven Central manually
+
+**Acceptance criteria:**
+```
+GIVEN a Maven artifact whose version history includes both legacy bare
+  qualifier identifiers (e.g. "r03".."r09") and well-formed numeric releases
+  (e.g. "14.0", "33.4.0-jre", "33.7.1-jre")
+WHEN the user hovers over the version field of a dependency using that
+  artifact
+THEN the "Latest" badge and the first entry of the "Recent versions" list
+  refer to the same version, and no legacy bare-qualifier identifier appears
+  above any well-formed numeric release in that list
+```
+
+### US-002: Correct completion default suggestion
+
+AS A developer typing or triggering completion on a dependency version field
+I WANT the first/default completion item (and the item labeled `(latest)`) to
+be the actual latest stable release
+SO THAT accepting the top suggestion never regresses my dependency to a
+14-year-old version
+
+**Acceptance criteria:**
+```
+GIVEN the same artifact as US-001
+WHEN the user triggers textDocument/completion with the cursor positioned at
+  the start of the version value (empty typed prefix)
+THEN the first completion item returned is the actual latest stable release
+  and is the only item labeled "(latest)"
+```
+
+### US-003: Consistency across Maven and Gradle
+
+AS A developer using either a Maven `pom.xml` or a Gradle `build.gradle` /
+`build.gradle.kts` file
+I WANT identical, correct version ordering behavior in both ecosystems for the
+same underlying Maven Central coordinate
+SO THAT the fix is not ecosystem-specific and does not need to be reapplied
+separately for Gradle
+
+**Acceptance criteria:**
+```
+GIVEN the same Maven Central artifact (e.g. com.google.guava:guava) is
+  referenced from a Gradle build.gradle file instead of a Maven pom.xml
+WHEN the user hovers or triggers completion on the version field
+THEN the observed ordering and "(latest)" labeling match the Maven case
+  exactly, since both consume the shared Maven Central registry client
+```
+
+## 3. Functional Requirements
+
+Use EARS notation. Prefix with FR-NNN.
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN the Maven Central registry client sorts a version list for display THE SYSTEM SHALL order it such that the item identified as "latest" is never outranked by a version segment that failed to parse numerically | must |
+| FR-002 | WHEN a version identifier contains one or more segments that cannot be parsed as a number (e.g. bare qualifiers like `r09`, or letter-prefixed identifiers) THE SYSTEM SHALL NOT allow raw lexicographic (`Ord::cmp` on `&str`) comparison of that segment to silently outrank a purely-numeric segment from another version | must |
+| FR-003 | WHEN Maven metadata provides an authoritative `<release>` tag THE SYSTEM SHALL ensure the sorted version list's first element and the completion dropdown's `(latest)`-labeled item are consistent with that `<release>` value | must |
+| FR-004 | WHEN Maven metadata does NOT provide a `<release>` tag (fallback path) THE SYSTEM SHALL determine "latest" using a version-ordering algorithm that also satisfies FR-001 and FR-002, so hover and completion remain internally consistent even without the authoritative tag | must |
+| FR-005 | WHEN the completion dropdown assigns the `(latest)` label and `sort_text` in `crates/deps-core/src/completion.rs` (`build_version_completion` / `VersionDisplayItem::new`) THE SYSTEM SHALL derive "latest" status independently verified against the authoritative determination (FR-003/FR-004), not purely from array index `0` of a potentially-incorrect sort | must |
+| FR-006 | WHEN a Gradle manifest (`build.gradle`, `build.gradle.kts`) references a Maven Central coordinate THE SYSTEM SHALL exhibit identical corrected ordering and labeling behavior as the Maven `pom.xml` case, since both share the same registry client | must |
+| FR-007 | WHEN the version list contains a mix of pre-release-qualified versions (SNAPSHOT/alpha/beta/rc/milestone, per existing `is_prerelease()`) and legacy non-numeric identifiers THE SYSTEM SHALL continue to apply existing pre-release exclusion/ranking rules without regression, in addition to fixing the legacy-identifier defect | should |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Correctness | The fixed comparator/sort MUST NOT be a hand-rolled ad hoc comparison per `.claude/rules/rust-code.md` ("do not hand-roll version comparison logic") — an ecosystem-appropriate approach (e.g. a maintained Maven-version-aware crate, or an explicit documented algorithm modeled on Maven's own `ComparableVersion` semantics) MUST be used or clearly justified if none exists |
+| NFR-002 | Regression safety | The existing test `test_parse_metadata_xml_legacy_versions_release_wins` MUST be strengthened from `assert_ne!` (asserts brokenness) to a positive assertion of the correct top-ranked version, and MUST NOT regress once the fix lands |
+| NFR-003 | Performance | Sorting MUST remain O(n log n) over the version list returned by the registry (typically tens to low hundreds of versions per artifact) with no observable hover/completion latency regression |
+| NFR-004 | Test coverage | New unit tests MUST cover: bare non-numeric identifiers (`r03`..`r09`), mixed numeric/non-numeric segment versions, and at least one other legacy Maven artifact pattern beyond Guava if one is identified during implementation |
+| NFR-005 | Cross-ecosystem consistency | Per `.claude/rules/continuous-improvement.md` ("Cross-Ecosystem Consistency Testing"), the fix MUST be implemented once in the shared Maven Central registry client / `deps-core` completion helper rather than duplicated separately for `deps-maven` and `deps-gradle` |
+
+## 5. Data Model
+
+No new persistent entities. The defect is confined to ordering logic over the
+existing `MavenVersion` list (`version: String`, `timestamp: Option<...>`)
+already produced by `parse_metadata_xml` in
+`crates/deps-maven/src/registry.rs`, and to the derived `VersionDisplayItem`
+in `crates/deps-core/src/completion.rs`.
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `MavenVersion` | One version entry parsed from Maven Central `maven-metadata.xml` | `version: String`, `timestamp: Option<...>` |
+| `VersionDisplayItem` | Derived completion-item view over a `Version`, including latest/index-based labeling | `version`, `package_name`, `index`, `is_latest` |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Version is a bare non-numeric qualifier with no `.`/`-` separators (e.g. `r09`) | Never sorts above a well-formed numeric release; does not receive the `(latest)` label unless it genuinely is the only/authoritative latest |
+| Version list contains ONLY legacy bare-qualifier identifiers (no numeric releases at all) | System falls back to a deterministic, documented ordering (e.g. registry publish order / lexicographic among like-typed segments) without crashing; `[NEEDS CLARIFICATION: exact fallback ordering rule when no numeric-leading version exists in the entire list]` |
+| Maven metadata has no `<release>` tag at all | "Latest" determination falls back to the corrected comparator (FR-004) and must still agree between hover and completion |
+| Mixed-type version list includes both classic semver-like Maven versions (`33.7.1-jre`) and dotted-numeric-only versions (`14.0`) | Fixed comparator ranks purely by numeric/qualifier semantics per Maven versioning rules, not accidentally by string length or lexicographic segment count |
+| Version list contains pre-release-qualified versions alongside the legacy identifiers (e.g. `34.0.0-jre-rc1` and `r09` in the same list) | Existing `is_prerelease()` exclusion/ranking behavior is preserved; legacy fix does not accidentally start treating pre-releases as latest |
+| Gradle manifest references the same coordinate as a Maven manifest in the same workspace | Both surfaces show identical ordering (shared registry client, FR-006) |
+| Registry returns an empty version list | No change from current behavior — out of scope for this fix, must not regress existing empty-list handling |
+
+## 7. Success Criteria
+
+Measurable metrics that prove the fix works:
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Hover "Recent versions" first entry matches "Latest" badge value for `com.google.guava:guava` (both `pom.xml` and `build.gradle`) | 100% match, verified via live LSP harness (`.local/testing/lsp_test.py`) per `continuous-improvement.md` live-testing principle |
+| SC-002 | `textDocument/completion` with empty version prefix returns the authoritative latest stable release as item 0, labeled `(latest)` | 100% match for `com.google.guava:guava` and at least one additional legacy-affected artifact if identified |
+| SC-003 | `test_parse_metadata_xml_legacy_versions_release_wins` (renamed/updated) asserts the correct top version positively, not just `assert_ne!` | Passing with positive assertion |
+| SC-004 | No regression in existing pre-release exclusion tests (`test_prerelease_detection` and related) | All existing tests continue to pass |
+| SC-005 | Full CI gate passes: `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo nextest run --workspace --all-features --no-fail-fast`, rustdoc gate | 0 failures |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Reproduce the bug live via the LSP harness (`.local/testing/lsp_test.py`) against a debug build before considering the fix verified, per `continuous-improvement.md`
+- Run the full local check suite before proposing a PR: `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo nextest run --workspace --all-features --no-fail-fast`, rustdoc gate
+- Update `CHANGELOG.md` under `[Unreleased]`
+- Update the existing test `test_parse_metadata_xml_legacy_versions_release_wins` to assert the correct behavior positively
+- Test both Maven (`pom.xml`) and Gradle (`build.gradle`) surfaces, since they share the registry client (cross-ecosystem consistency gate)
+
+### Ask First
+- Adding a new external crate dependency for Maven-aware version comparison (per NFR-001, if a mechanical hand-rolled fix is judged insufficient) — must be checked via context7 mcp for current versions per user's dependency policy
+- Changing the public signature of `compare_versions`, `MavenVersion`, or `VersionDisplayItem` if it affects other crates' call sites beyond `deps-maven`/`deps-gradle`/`deps-core`
+
+### Never
+- Modify the `<release>`-tag-based "Latest" badge logic that PR #93/#91 already fixed correctly, unless a regression in that logic is independently discovered and documented
+- Silently change ordering behavior for other ecosystems (Cargo/npm/PyPI/Go/etc.) as a side effect of this fix
+- Mark the fix complete based on unit tests alone — live LSP verification against real Maven Central data is required per the project's continuous-improvement testing gate
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Should the fix adopt a maintained Maven-version-comparison crate (if one with acceptable maturity/license exists), or is a corrected, well-documented hand-rolled algorithm acceptable given Maven's `ComparableVersion` scheme has no widely-adopted `semver`-compatible crate on crates.io? This determines whether `/sdd plan` needs a dependency-addition step.]
+- [NEEDS CLARIFICATION: Exact fallback ordering rule when a version list contains ONLY non-numeric/legacy identifiers and no `<release>` tag is present — is publish `timestamp` (already present as `Option<...>` on `MavenVersion` but currently unused for sorting) an acceptable tiebreaker/primary key in that degenerate case?]
+- [NEEDS CLARIFICATION: Beyond Guava's `r03`-`r09`, are there other known legacy Maven Central artifacts with similar bare-qualifier version identifiers that should be added to the regression test/regressions.md catalog? A search across popular artifacts may be warranted during `/sdd plan` or implementation.]
+- [NEEDS CLARIFICATION: Should `timestamp` (currently parsed but unused, per `MavenVersion.timestamp: Option<...>`) be wired into the corrected sort as a secondary/fallback signal, or left unused as before?]
+
+## 10. See Also
+
+- [[constitution]] — project principles (not yet created for this project)
+- [[MOC-specs]] — all specifications
+- `crates/deps-maven/src/version.rs` — `compare_versions`, `is_prerelease` (defect location)
+- `crates/deps-maven/src/registry.rs` — `parse_metadata_xml`, version sort call site, `test_parse_metadata_xml_legacy_versions_release_wins`
+- `crates/deps-core/src/completion.rs` — `build_version_completion`, `VersionDisplayItem::new` (consumer of the broken order)
+- `.claude/rules/rust-code.md` — "do not hand-roll version comparison logic" convention this defect violates
+- `.claude/rules/continuous-improvement.md` — live-testing principle and cross-ecosystem consistency gate applied to verification

--- a/specs/004-release-freshness-signal/plan-maven-gradle.md
+++ b/specs/004-release-freshness-signal/plan-maven-gradle.md
@@ -1,0 +1,327 @@
+---
+aliases:
+  - Maven/Gradle Release-Freshness Plan
+tags:
+  - sdd
+  - plan
+  - deps-maven
+  - deps-gradle
+created: 2026-08-24
+status: draft-pending-signoff
+parent: "[[004-release-freshness-signal/plan]]"
+issues: [221, 225]
+---
+
+# Implementation Plan: Release-Freshness for Maven/Gradle (issues #221, #225)
+
+Addendum to `plan.md`. Covers the Maven/Gradle ecosystem deferred in §0/§6 of the
+parent plan, plus the `MavenVersion.timestamp` dead-field cleanup (#225).
+
+## 0. Current state (verified 2026-08-24 against `main` @ 592d3074)
+
+PR1 of #145 has landed. Confirmed present:
+
+| Item | Location |
+|---|---|
+| `Version::published_at() -> Option<PublishTime>` (default `None`) | `crates/deps-core/src/registry.rs:218` |
+| `PublishTime` (+ `parse_rfc3339`, `from_unix_millis`, `age_secs_from`) | `crates/deps-core/src/freshness.rs:70-121` |
+| `FreshnessSettings { enabled, cooldown_secs }` (`Copy` DTO) | `crates/deps-core/src/freshness.rs:269` |
+| `FreshnessConfig` → `to_settings()`, `enabled` default **`true`** | `crates/deps-lsp/src/config.rs:489,523` |
+| Ch2 rendering: hover age suffix | `crates/deps-core/src/lsp_helpers.rs:983` (`version_age_suffix`) |
+| Ch2 rendering: completion `label_details` | `crates/deps-core/src/completion.rs:547-554` |
+
+Confirmed **absent** (PR2 of #145, not yet landed — out of this scope):
+`did_change_configuration`, `parse_config`, Ch1 widening (`LatestVersions`,
+`DocumentState.latest_published_at`, `VersionData::with_published`), the
+`**Latest**` age line, the cooldown callout, diagnostics differentiation.
+
+**Scope consequence:** this work targets **Ch2 only** — hover's "Recent versions"
+list and completion items. That is exactly the surface PR1 shipped for the other
+six ecosystems, so Maven/Gradle reach parity with them and nothing more. When PR2
+lands, Maven/Gradle inherit Ch1 for free *only* if PR2's `get_latest_matching`
+path is also wired (see §7 OQ3).
+
+### Registry sharing: `deps-gradle` inherits automatically
+
+`deps-gradle` re-exports the type (`crates/deps-gradle/src/types.rs:6`:
+`pub use deps_maven::MavenVersion as GradleVersion;`) and constructs its **own**
+instance of the same registry type (`crates/deps-gradle/src/ecosystem.rs:23`:
+`registry: Arc::new(MavenCentralRegistry::new(cache))`). There is exactly one
+`impl Version for MavenVersion` (`crates/deps-maven/src/types.rs:93`) and one
+`impl Registry for MavenCentralRegistry` (`crates/deps-maven/src/registry.rs:336`).
+
+→ **No `deps-gradle` source changes are required.** Both ecosystems already route
+`FreshnessSettings` into `complete_versions_generic`
+(`deps-maven/src/ecosystem.rs:123-130`, `deps-gradle/src/ecosystem.rs:42-49`) and
+neither overrides `generate_hover`, so both use `lsp_helpers::generate_hover`.
+`deps-gradle` needs only a `CHANGELOG`/README mention and live verification.
+
+---
+
+## 1. Data source — **solrsearch rejected, repo1 directory listing recommended**
+
+Issue #221 names Maven Central's `solrsearch?core=gav` endpoint. Live probing
+(2026-08-24, 24 requests) says do not build on it.
+
+### 1.1 Measurements
+
+| Source | Success rate | Latency (ok) | Payload (guava, 150 vers.) | Conditional GET | androidx | Gradle Plugin Portal |
+|---|---|---|---|---|---|---|
+| `search.maven.org/solrsearch/select?core=gav` | **6/12** and **6/12** in two runs (~50%) | 0.23–0.68 s | 53 KB | none observed | **`numFound: 0`** | indexed (77 GAVs) |
+| `repo1.maven.org/maven2/{g}/{a}/` (HTML listing) | **12/12** | **0.05–0.07 s** | 21 KB (44 KB for spring-core, 339 dirs) | **`Last-Modified` → 304 verified** | 404 | listing exists, **no dates** |
+
+Failures on solrsearch were silent 10 s read timeouts, not `429` — consistent with
+undocumented per-IP throttling. A ~50% failure rate on an interactive hover path
+is disqualifying: the feature would appear and disappear at random, which reads as
+a bug rather than as graceful degradation.
+
+### 1.2 Correctness cross-check
+
+`com.google.guava:guava:33.4.8-jre`
+- solrsearch `timestamp: 1744651522422` → `2025-04-14 17:25:22 UTC`
+- directory listing → `2025-04-14 17:25`
+
+The listing is **UTC, minute precision, truncated** (not rounded). `format_relative_age`'s
+smallest bucket is minutes, so the ≤59 s of lost precision is invisible at every
+rendered bucket boundary. 158 of 159 anchors carry a date; the only undated anchor
+is `../`.
+
+### 1.3 Recommendation
+
+Use the **directory listing of whichever repository base actually served
+`maven-metadata.xml`**, not a fixed host. This is the single most important
+correctness detail of the design:
+
+| Repo | Metadata source | Listing dates | Result |
+|---|---|---|---|
+| Maven Central (`repo1`) | ✅ | ✅ | ages rendered |
+| Google Maven (`dl.google.com`) | ✅ | 404 | `published_at() == None`, unchanged behavior |
+| Gradle Plugin Portal (fallback) | ✅ | listing has no date column | `published_at() == None`, unchanged behavior |
+
+Deriving the listing URL from the winning metadata URL means a Google-hosted or
+plugin-portal-only artifact never issues a doomed request against `repo1`.
+
+Coverage is therefore **not** 100% of Maven/Gradle dependencies — Android/AndroidX
+projects get no ages at all. This is US-003 graceful degradation, identical in
+shape to Go's documented partial coverage, and must be stated in
+`docs/ECOSYSTEM_GUIDE.md` rather than left implicit.
+
+---
+
+## 2. Config threading — **new defaulted `Registry` trait method** (recommended)
+
+### 2.1 The constraint, restated precisely
+
+`EcosystemRegistry` and all 11 ecosystems are built in `ServerState::new`
+(`crates/deps-lsp/src/document/state.rs:440-446`) via
+`register_ecosystems(&registry, cache)` (`crates/deps-lsp/src/lib.rs:205-217`),
+whose `register!` macro (`lib.rs:25-30`) calls `$ecosystem::new(Arc::clone($cache))`
+uniformly. `DepsConfig` is a *separate* `Arc<RwLock<_>>` on `Backend`
+(`crates/deps-lsp/src/server.rs:36`), first populated at `initialize`
+(`server.rs:282`) — i.e. **after** every registry already exists.
+
+But the settings already reach `deps-core` per request: PR1 threaded
+`FreshnessSettings` into `Ecosystem::generate_hover`/`generate_completions`, and
+both `deps-core` functions that fetch versions for a *freshness-rendering* surface
+already hold it in scope:
+
+- `lsp_helpers::generate_hover(..., freshness)` → `registry.get_versions(...)` at `lsp_helpers.rs:1008`
+- `completion::complete_versions_generic(..., freshness)` → `registry.get_versions(...)` at `completion.rs:781`
+
+### 2.2 Design
+
+Add one defaulted method to the `Registry` trait (`crates/deps-core/src/registry.rs`):
+
+```
+fn get_versions_with<'a>(&'a self, name, freshness: FreshnessSettings)
+    -> BoxFuture<'a, Result<Vec<Box<dyn Version>>>>
+{ self.get_versions(name) }        // default: ignore, existing behavior
+```
+
+`MavenCentralRegistry` is the only override. Exactly two call sites switch to it —
+`lsp_helpers.rs:1008` and `completion.rs:781` — and both already have the value.
+
+**`generate_code_actions` (`lsp_helpers.rs:1301-1357`) deliberately keeps plain
+`get_versions`.** It has no `freshness` parameter and renders no ages, so it must
+never pay for the listing fetch. The two-method split makes that correct by
+construction rather than by remembering to pass `enabled: false`.
+
+### 2.3 Why this over the alternatives
+
+| Option | Verdict |
+|---|---|
+| **A. `Arc<AtomicBool>` into `MavenCentralRegistry::new`** | Rejected. Requires plumbing the cell through `ServerState::new` → `register_ecosystems` → the `register!` macro → **all 11** `Ecosystem::new` signatures, for one ecosystem's benefit. Carries only `enabled`, not `cooldown_secs`, so it is a bespoke half-DTO that diverges from `FreshnessSettings` the moment a second field matters. Introduces shared mutable state where none exists today, and a second writer that PR2's `did_change_configuration` must remember to update — a silent-staleness bug waiting to happen. |
+| **B. Change `Registry::get_versions` for all 11** | Rejected. 10 registry files + their doctests and tests churn so 9 ecosystems can ignore the parameter forever. The defaulted-method variant buys identical type safety for ~10 lines. (Pre-1.0 means this is *allowed*, not that it is *warranted*.) |
+| **C. Defaulted `get_versions_with`** ✅ | Additive and object-safe (`FreshnessSettings` is `Copy + 'static`). Zero changes to 10 registries, to `register!`, to any `*::new`. Follows the precedent this codebase set twice already: `Registry::select_latest_matching` (#256) and `Version::published_at` (#145) are both defaulted opt-in trait methods. |
+
+**Live reload is free.** Because the value is read per request from the
+`Arc<RwLock<DepsConfig>>` snapshot in `handlers/hover.rs` / `handlers/completion.rs`,
+Maven/Gradle pick up a changed `freshness.enabled` the instant PR2's
+`did_change_configuration` lands — with no additional wiring, and without
+introducing any new lock or the C1 nested-read deadlock class described in
+parent-plan §7a.
+
+---
+
+## 3. Fetch and attach — `deps-maven` internals
+
+### 3.1 Flow
+
+```
+Registry::get_versions_with(name, freshness)              [maven, NEW override]
+ └─ get_versions_typed_with(name, freshness.enabled)      [NEW pub method]
+     ├─ get_metadata(name) -> (versions, release, base)   [1 req — EXISTING, +1 return value]
+     ├─ if enabled && base is Some:
+     │     fetch_publish_times(base) -> HashMap<String, PublishTime>   [1 req — NEW, GATED]
+     │       └─ any Err / non-200 / unparseable → empty map, tracing::debug!, never propagates
+     ├─ for v in &mut versions { v.published_at = map.get(&v.version).copied() }
+     └─ move_release_to_front(&mut versions, release)      [EXISTING]
+
+Registry::get_versions(name)  →  get_versions_typed(name)  →  byte-identical to today
+Registry::get_latest_matching →  untouched (Ch1, see §7 OQ3)
+```
+
+### 3.2 `get_metadata` must return the winning base URL
+
+`crates/deps-maven/src/registry.rs:148-169` loops over `metadata_urls(name)` and
+returns on the first `Ok`, discarding *which* URL won. Change its return type to
+`(Vec<MavenVersion>, Option<String>, Option<String>)` — or better, a small private
+struct — carrying the base directory of the successful fetch (the metadata URL
+minus the trailing `maven-metadata.xml`). `get_versions_typed` and
+`get_latest_matching_typed` (`registry.rs:171-188`) ignore the new field.
+
+### 3.3 Listing parse
+
+Line-oriented, no new dependency. For each line, require **both** an anchor
+`<a href="{v}/"` and a trailing `YYYY-MM-DD HH:MM` on that same line; a line with
+only one of the two yields nothing. This is what makes the parser safely return an
+empty map for the Gradle Plugin Portal's dateless `<pre><a href="X/">X/</a></pre>`
+format instead of guessing.
+
+Date → `PublishTime` **without new deps and without new `deps-core` API**: build
+`"{date}T{time}:00Z"` (`2011-09-28` + `16:04` → `2011-09-28T16:04:00Z`) and pass it
+to the existing `PublishTime::parse_rfc3339`. `time`'s RFC 3339 parser validates the
+field ranges, so a malformed line rejects rather than producing a bogus instant, and
+NFR-005 ("all date parsing goes through `time`") holds. `deps-maven` gains no
+`regex`, no `time`, no `chrono`.
+
+Bound the work: the listing is capped by `HttpCache`'s `MAX_RESPONSE_BYTES` already;
+the parse is a single pass. Largest observed real payload is 44 KB / 339 entries.
+
+### 3.4 Failure and caching behavior
+
+- Listing request fails, times out, 404s, or parses to nothing → every
+  `published_at()` is `None`; the version list is returned in full, unchanged.
+  The listing fetch is **never** allowed to fail `get_versions_with`.
+- `HttpCache::get_cached` handles the listing like any other URL. `Last-Modified`
+  is present and `304` was verified, so a repeat hover on the same artifact costs
+  a conditional request, exactly like `maven-metadata.xml` beside it.
+- Cache key is the URL, and the listing URL differs from every existing URL, so
+  no cache-key collision (`cache.rs:168-176` contract).
+
+---
+
+## 4. `MavenVersion.timestamp` — resolving #225
+
+`crates/deps-maven/src/types.rs:44-48`, currently `pub timestamp: Option<u64>`,
+never read, `None` at both construction sites.
+
+**Replace with `pub published_at: Option<PublishTime>`** and implement
+
+```
+fn published_at(&self) -> Option<PublishTime> { self.published_at }
+```
+
+on `impl deps_core::Version for MavenVersion` (`types.rs:93-114`).
+
+Rationale: matches the field name and eager-parse rule the parent plan §3 applied
+to all six landed ecosystems (`created_at`/`published`/`time` → `published_at:
+Option<PublishTime>`), so Maven does not become the one ecosystem storing a raw
+integer. Pre-1.0 → rename freely, record as a breaking change (parent plan §7a G4).
+
+Blast radius is contained: 29 construction sites, **all inside `deps-maven`**
+(3 in `types.rs`, 26 in `registry.rs`, nearly all `timestamp: None` in tests).
+`deps-gradle` constructs none. Mechanical rename.
+
+**Related dead code to resolve in the same PR:** `PublishTime::from_unix_millis`
+(`freshness.rs:91`) is documented as "kept for a future ecosystem whose registry
+reports millisecond timestamps (e.g. Maven's solrsearch `core=gav`)". If §1.3 is
+accepted, that method has no caller and its doc comment names an approach the
+project rejected. Either delete it (same dead-code class as #225 itself) or
+rewrite the comment — do not leave it citing a rejected design. Recommend
+deletion; it is trivially re-addable.
+
+---
+
+## 5. Files touched
+
+| File | Change |
+|---|---|
+| `crates/deps-core/src/registry.rs` | + defaulted `Registry::get_versions_with` (~12 lines incl. docs) |
+| `crates/deps-core/src/lsp_helpers.rs:1008` | `get_versions` → `get_versions_with(dep.name(), freshness)` |
+| `crates/deps-core/src/completion.rs:781` | same, in `complete_versions_generic` |
+| `crates/deps-core/src/freshness.rs:74-93` | delete `from_unix_millis` (or fix its doc) — see §4 |
+| `crates/deps-maven/src/types.rs` | `timestamp: Option<u64>` → `published_at: Option<PublishTime>`; `impl Version::published_at` |
+| `crates/deps-maven/src/registry.rs` | `get_metadata` returns winning base; new `fetch_publish_times` + listing parser; new `get_versions_typed_with`; `impl Registry::get_versions_with`; ~26 test construction sites renamed |
+| `crates/deps-gradle/**` | **none** (inherits) |
+| `CHANGELOG.md` | `[Unreleased]`: feature + breaking field rename + `from_unix_millis` removal |
+| `docs/ECOSYSTEM_GUIDE.md` | freshness coverage row: Central ✅ / Google Maven ✗ / Plugin Portal ✗ |
+| `crates/deps-maven/README.md`, `crates/deps-gradle/README.md` | brief mention if they document version metadata |
+
+Estimated ~250 lines including tests. No new workspace or crate dependency.
+
+## 6. Test plan
+
+- **Listing parser** (pure, no network): real `repo1` fixture (guava excerpt, incl.
+  the `r03`-style legacy dirs and the `../` anchor); Gradle Plugin Portal dateless
+  fixture → empty map; malformed date (`2011-13-45 99:99`) → that entry absent, the
+  rest still parsed; HTML with no `<pre>` at all → empty map; empty body → empty map.
+- **Gating** (`mockito`): `enabled: false` → mock asserts the listing endpoint gets
+  **zero** hits and every `published_at()` is `None`; `enabled: true` → one hit,
+  timestamps attached to the matching versions.
+- **Degradation** (`mockito`): listing returns 404 / 500 / times out → the version
+  list is still complete and correctly ordered, all `published_at()` are `None`,
+  no error surfaces.
+- **Version/date pairing**: a listing containing a version absent from
+  `maven-metadata.xml` and vice versa → no panic, no cross-assignment; ordering
+  after `move_release_to_front` is byte-identical to the pre-feature output
+  (FR-006 regression guard).
+- **`deps-gradle`**: one test asserting `GradleVersion::published_at()` is wired,
+  since it inherits rather than implements.
+- **Live (NFR-006, blocking)**: `pom.xml` and `build.gradle.kts` each with (a) a
+  Central artifact with a release in the last ~72 h, (b) an `androidx.*` artifact,
+  (c) a Gradle plugin resolved via the portal fallback. Verify (a) renders ages and
+  (b)/(c) render exactly as before. Record in `.local/testing/coverage.md` and a
+  `journal/ci-NNN.md` entry.
+- **Full gate**: `cargo +nightly fmt --all -- --check`, `cargo clippy --workspace
+  --all-targets --all-features -- -D warnings`, `cargo nextest run --workspace
+  --all-features --no-fail-fast`, rustdoc gate.
+
+## 7. Open questions — need sign-off before implementation
+
+- **OQ1 (blocking) — data source reversal.** Issue #221 specifies solrsearch. §1
+  measures it at ~50% silent-timeout failure and zero coverage for Google Maven,
+  and finds the `repo1` directory listing strictly better on every axis
+  (reliability 12/12, ~7× faster, cache-validated, same host as the metadata fetch).
+  Recommend switching, and editing #221 to record why. Only `fetch_publish_times`'
+  internals differ if the team insists on solrsearch — the rest of this plan is
+  source-agnostic — but the parse would then need `serde` structs instead of the
+  line scanner, and `from_unix_millis` would stay alive.
+- **OQ2 (decision point) — `freshness.enabled` defaults to `true`
+  (`config.rs:489`),** so by default every Maven/Gradle **hover and version
+  completion** issues one extra request. It is the same CDN host already being hit,
+  ~60 ms cold and a 304 warm, and it does **not** touch document-open/diagnostics
+  (Ch1 is untouched). Recommend **keeping the default `true`**: it gives Maven and
+  Gradle the same out-of-the-box behavior as the other six ecosystems (US-004), and
+  `freshness.enabled: false` is the documented opt-out. The alternative — a
+  Maven-specific `freshness.maven_publish_times` defaulting to `false` — violates
+  FR-010 ("uniform, no per-ecosystem override") and is not recommended.
+- **OQ3 (scope boundary) — Ch1.** `get_latest_matching` is deliberately left alone,
+  so when PR2 of #145 lands, hover's `**Latest**` line and the cooldown callout will
+  show **no** age for Maven/Gradle even though the "Recent versions" list below does.
+  Confirm this asymmetry is acceptable for now (it mirrors Go's documented Ch1/Ch2
+  split), or fold a `get_latest_matching_with` into PR2 instead.
+- **OQ4 (minor)** — the parent plan's follow-up list (§6) still says "Maven/Gradle —
+  solrsearch … extra request" and "Cleanup: delete the dead `MavenVersion.timestamp`
+  field" as two separate items. This plan merges them, which is what #225 asks for.
+  Confirm #225 is closed by this PR rather than by a separate deletion.

--- a/specs/004-release-freshness-signal/plan.md
+++ b/specs/004-release-freshness-signal/plan.md
@@ -1,0 +1,569 @@
+---
+aliases:
+  - Release Freshness Signal Plan
+tags:
+  - sdd
+  - plan
+  - deps-core
+created: 2026-08-23
+status: approved
+spec: "[[004-release-freshness-signal/spec]]"
+---
+
+# Implementation Plan: Release-Freshness Signal (issue #145)
+
+> **Sign-off status (2026-08-23):** all six open items (G1–G6) resolved by the
+> user via team-lead. v1 scope is **6 ecosystems**; `did_change_configuration`
+> is **in scope** for this PR. See §7 for the decision record.
+
+## 0. Scope correction — spec assumptions verified live (2026-08-23)
+
+The spec's Current State table and NFR-001 are **factually wrong for 6 of 11
+ecosystems**. Verified by reading the crates' serde structs *and* by live
+`curl` against every registry.
+
+| Ecosystem | Timestamp in the payload the crate *already fetches*? | Verified how | v1 |
+|---|---|---|---|
+| deps-cargo | **YES** — sparse index NDJSON now carries `pubtime`, 100% coverage (195/195 for `tokio`, incl. 2016 releases). Format `2026-07-18T23:05:13Z` | `curl index.crates.io/se/rd/serde`, `/to/ki/tokio` | ✅ |
+| deps-pypi | **YES** — PEP 700 `files[].upload-time` in the already-requested PEP 691 JSON (api-version 1.4). Format `2026-05-14T19:25:27.735762Z`. Per **file**, not per version | `curl -H 'Accept: application/vnd.pypi.simple.v1+json' pypi.org/simple/requests/` | ✅ |
+| deps-composer | **YES** — p2 payload has `time` on every entry. Format `2026-01-02T08:56:05+00:00` (numeric offset). Also a `published-time` sibling | `curl repo.packagist.org/p2/monolog/monolog.json` (87/87 entries) | ✅ |
+| deps-bundler | **YES** — `created_at` already parsed into `BundlerVersion` and discarded | code | ✅ |
+| deps-dart | **YES** — `published` already parsed into `DartVersion` and discarded | code | ✅ |
+| deps-go | **PARTIAL** — `/@latest` returns `Time` and `parse_version_info` already stores it; `/@v/list` (used by `get_versions`) is plain text with no dates | `curl proxy.golang.org/.../@latest` | ⚠️ partial |
+| deps-npm | **NO** — the abbreviated packument (`application/vnd.npm.install-v1+json`) omits the top-level `time` object. Top keys are exactly `dist-tags, modified, name, versions`. Full packument is **2.37×** larger (804 975 vs 339 376 B for `express`) | `curl` both variants | ❌ defer |
+| deps-maven / deps-gradle | **NO** — `maven-metadata.xml` has no per-version dates (only `<lastUpdated>` per artifact). `MavenVersion.timestamp: Option<u64>` is **dead code**: both construction sites pass `None` | `curl repo1.maven.org/.../guava/maven-metadata.xml` | ❌ defer |
+| deps-nuget | **NO** — flat container `index.json` is a bare `{"versions": [...]}`. `published` lives in the registration hive, which `ServiceIndex::resolve` does not fetch (deliberately deferred, `registry.rs:4-6`) and which is paged | `curl api.nuget.org/v3-flatcontainer/newtonsoft.json/index.json` | ❌ defer |
+| deps-swift | **NO** — version data comes from the GitHub **tags** API, which has no date field at all. Needs N commit lookups or a switch to the releases API (misses tag-only packages). Crate is already rate-limit sensitive | code + GitHub API shape | ❌ defer |
+
+**Consequences (all confirmed by the user 2026-08-23 — see §7):**
+- v1 covers **6 ecosystems** (5 full + Go partial), not 10–11. npm, Maven/Gradle,
+  NuGet and Swift are **out of this PR**; team-lead files one follow-up issue per
+  ecosystem after it lands.
+- **FR-008 is unsatisfiable for Maven** (the field it says to "wire" is never set) and only partially for Go.
+- **FR-007 is satisfiable for Cargo, PyPI and Composer at zero network cost** — better than the spec assumed. It is *not* satisfiable for npm/NuGet/Swift without a real cost.
+- **SC-001's "100% of ecosystems" target must be restated** as "100% of ecosystems where the timestamp is available without an added network round trip".
+- NFR-001 (no added round trips) is therefore what *defines* v1 scope, and it holds unconditionally.
+
+### Two data channels (critical, not mentioned in the spec)
+
+| Channel | Source | Feeds | Shape |
+|---|---|---|---|
+| **Ch1** | `Registry::get_latest_matching` → `fetch_latest_versions_parallel` (`deps-lsp/src/document/lifecycle.rs:137-205`) | diagnostics, inlay hints, hover's `**Latest**:` line | **lossy** — `Box<dyn Version>` collapsed to `String` at `lifecycle.rs:161-167`, stored in `DocumentState::cached_versions: HashMap<String,String>` (`state.rs:45`) |
+| **Ch2** | `Registry::get_versions` called live per request (`lsp_helpers.rs:536`, `completion.rs:680`, `lsp_helpers.rs:646`) | hover's "Recent versions" list, completion, code actions | full `Vec<Box<dyn Version>>` |
+
+Ch2 needs only the new trait method. **Ch1 needs a widening of `DocumentState`
+and `VersionData`** — this is the single largest structural cost of the feature
+and the spec does not mention it. Go is Ch1-only.
+
+---
+
+## 1. Core design — `deps-core`
+
+### 1.1 New dependency
+
+Add to `[workspace.dependencies]` and to **`crates/deps-core/Cargo.toml` only**:
+
+```toml
+time = { version = "0.3", default-features = false, features = ["std", "parsing"] }
+```
+
+- Latest observed is **0.3.55**, published 2026-08-01 → actively maintained.
+  **Developer MUST re-check the current version via context7 mcp before adding
+  it** (project dependency policy) — do not copy `0.3.55` on faith.
+- Required deps are `deranged`, `num-conv`, `powerfmt`, `time-core` — all tiny/no-std.
+- `Rfc3339` parses every format we need: bare `Z`, arbitrary fractional digits,
+  and numeric offsets (`+00:00`) — covers Cargo, PyPI, Composer, Bundler, Dart, Go.
+- Rejected `chrono` (heavier, tz machinery we do not need, historic `localtime_r`
+  advisory) and `jiff` (excellent but ships a tzdb — overkill for "parse RFC3339").
+- **We do not use `time` for "now"** — `std::time::SystemTime` is used instead, so
+  no `wasm-bindgen`/`local-offset` feature is ever needed.
+- ACTION: developer must re-verify the version via context7 mcp per the user's
+  dependency policy before adding it.
+
+### 1.2 New module `crates/deps-core/src/freshness.rs`
+
+Deliberately minimal — three items, no policy struct, no builder.
+
+```rust
+/// Dependabot's default cooldown (3 days) in seconds.
+pub const DEFAULT_COOLDOWN_SECS: u64 = 3 * 24 * 60 * 60;
+
+/// A release publish instant, normalized to Unix epoch seconds (UTC).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PublishTime(i64);
+
+impl PublishTime {
+    pub fn now() -> Self;                                   // SystemTime, saturating
+    pub const fn from_unix_secs(secs: i64) -> Self;
+    pub fn from_unix_millis(ms: i64) -> Self;               // for future Maven/solrsearch
+    pub fn parse_rfc3339(s: &str) -> Option<Self>;          // None on any parse failure
+    pub const fn as_unix_secs(self) -> i64;
+    /// Age in seconds; a future timestamp (clock skew) saturates to 0.
+    pub const fn age_secs_from(self, now: Self) -> u64;
+}
+
+/// `age < cooldown` — exclusive upper bound, the single documented rule.
+pub const fn is_within_cooldown(age_secs: u64, cooldown_secs: u64) -> bool;
+
+/// "just now" | "5 minutes ago" | "2 hours ago" | "3 days ago" |
+/// "2 weeks ago" | "5 months ago" | "2 years ago"
+pub fn format_relative_age(age_secs: u64) -> String;
+```
+
+Rules, applied uniformly (resolves three spec Open Questions):
+- **Clock skew**: `published > now` → age clamps to `0` → renders "just now" and
+  **counts as within cooldown**. Chosen over suppression because a
+  slightly-ahead registry clock is exactly the just-published case the feature
+  exists for; suppressing would silently lose the signal when it matters most.
+- **Boundary**: `age_secs < cooldown_secs` is fresh; `age == cooldown` is not.
+- **Parse failure**: `None`, logged at `trace`, never an error (FR-005).
+- `format_relative_age` operates on a `u64` of seconds — plain duration bucketing,
+  **not** date arithmetic, so NFR-005 is respected (all date parsing goes through
+  `time`).
+
+Export from `crates/deps-core/src/lib.rs` alongside the existing re-exports.
+
+### 1.3 `Version` trait extension — `crates/deps-core/src/registry.rs:135`
+
+```rust
+/// When this version was published, if the registry exposes it.
+///
+/// Default `None` — ecosystems without publish metadata degrade to
+/// pre-feature behavior (US-003).
+fn published_at(&self) -> Option<PublishTime> { None }
+```
+
+Purely additive default method → NFR-003 and SC-004 hold; the 5 not-yet-migrated
+ecosystems compile untouched. `PublishTime` is `Copy`, so no lifetime or
+borrow complications and `Box<dyn Version>` stays object-safe.
+
+`find_latest_stable` (`registry.rs:202`) is **not** touched — freshness never
+influences selection (spec §8 "Never").
+
+### 1.4 `impl_version!` macro — `crates/deps-core/src/macros.rs:110`
+
+The macro is fixed-arity (`version:`, `yanked:`). Add a **second arm** accepting
+an optional `published_at: $field:ident`. Two fully-written arms (~12 duplicated
+lines) beats a `()`-sentinel trick for readability. Used by deps-npm, deps-pypi,
+deps-composer, deps-swift.
+
+---
+
+## 2. Configuration
+
+`crates/deps-lsp/src/config.rs`, following the `CacheConfig` pattern verbatim
+(`config.rs:154-183` + validating deserializer `config.rs:283-337`):
+
+```rust
+#[derive(Debug, Clone, Deserialize)]
+pub struct FreshnessConfig {
+    #[serde(default = "default_freshness_enabled")]
+    pub enabled: bool,                 // default true
+    #[serde(default = "default_cooldown_secs", deserialize_with = "deserialize_cooldown")]
+    pub cooldown_secs: u64,            // default 259_200 (3 days)
+}
+```
+
+- Clamp to `MIN_COOLDOWN_SECS = 0 ..= MAX_COOLDOWN_SECS = 30 days`, `tracing::warn!`
+  on clamp (same shape as `deserialize_fetch_timeout`).
+- `cooldown_secs: 0` disables the cooldown *callout* but keeps age display;
+  `enabled: false` suppresses **all** freshness rendering. Cheap escape hatch.
+- Add `#[serde(default)] pub freshness: FreshnessConfig` to `DepsConfig`
+  (`config.rs:25-37`).
+- Uniform across ecosystems, no per-ecosystem override (FR-010).
+
+**Transport to `deps-core`.** Introduce a `Copy` DTO in `deps-core` (do **not**
+overload `EcosystemConfig`, which is inlay-hint-specific):
+
+```rust
+#[derive(Debug, Clone, Copy)]
+pub struct FreshnessSettings { pub enabled: bool, pub cooldown_secs: u64 }
+impl Default for FreshnessSettings { /* true, DEFAULT_COOLDOWN_SECS */ }
+```
+
+Threaded as a new parameter to **only two** entry points, chosen to minimize churn:
+
+| Entry point | Change | Override count to fix |
+|---|---|---|
+| `Ecosystem::generate_hover` (`ecosystem.rs:372-389`) | + `FreshnessSettings` param | **0** — no ecosystem overrides it |
+| `Ecosystem::generate_diagnostics` (`ecosystem.rs:418-431`) | + `FreshnessSettings` param | verify with `rg 'fn generate_diagnostics' crates/deps-*/src/` before starting |
+| `Ecosystem::generate_completions` | **unchanged** | 13 ecosystems override it — deliberately avoided |
+
+Completion therefore renders **relative age only, no cooldown verdict** — it needs
+no config. This is also better UX (no arbitrary cliff mid-list) and still
+satisfies FR-004, which lets `/sdd plan` pick the mechanism per surface.
+
+Call sites already hold `Arc<RwLock<DepsConfig>>` and use the
+snapshot-before-await idiom: `handlers/hover.rs:22`, `handlers/diagnostics.rs:15`.
+
+**Also fix (2 lines, in scope because we add a config field):**
+`server.rs:236` uses `if let Ok(config) = serde_json::from_value::<DepsConfig>(...)`
+which **silently discards the entire user config** on any deserialization error.
+Add an `Err` arm with `tracing::warn!`. Adding a field widens this bug's blast
+radius, so it belongs here.
+
+### 2.1 Live reload — `workspace/didChangeConfiguration` (IN SCOPE, user-requested)
+
+No such handler exists anywhere in the repo today; config is read exactly once at
+`initialize`. Build it as part of **T1**, since it is server-wide wiring rather
+than ecosystem-specific work.
+
+1. **Shared parse helper.** Extract the `initialize` body at `server.rs:230-252`
+   into one function used by *both* entry points, so the `Err`-arm warning above
+   exists in a single place:
+   ```rust
+   fn parse_config(value: serde_json::Value) -> Option<DepsConfig>  // warns on Err
+   ```
+2. **Handler** on `Backend` (`server.rs`, alongside `did_change_watched_files` at
+   `:335`):
+   ```rust
+   async fn did_change_configuration(&self, params: DidChangeConfigurationParams) {
+       let Some(config) = parse_config(params.settings) else { return };  // keep previous on error
+       *self.config.write().await = config;
+       // nudge the client to re-pull, capability permitting
+   }
+   ```
+   Replace-whole-config semantics, matching `initialize`. On a parse error the
+   **previous** config is kept — never silently reset to defaults.
+3. **Refresh the affected surfaces.** Hover, completion and code actions are
+   computed on demand and pick the new value up for free. **Diagnostics are
+   pull-based** (`Backend::diagnostic`, `server.rs:424`), so the client must be
+   told to re-pull: send `workspace/diagnostic/refresh`, guarded by
+   `client_capabilities.workspace.diagnostics.refresh_support` (already stored at
+   `server.rs:233`). Inlay hints are unaffected by freshness — do not refresh them.
+4. **Client divergence to handle:** some clients send the full settings object in
+   `params.settings`, others send `null` and expect the server to pull via
+   `workspace/configuration`. v1 handles only the push form; a `null`/absent
+   payload is a no-op logged at `debug`. Do **not** implement the pull form or
+   dynamic registration in this PR.
+
+Scope guarantee: the acceptance bar is that a changed `freshness.cooldown_secs`
+takes effect without restarting the editor. Reloading the rest of `DepsConfig`
+comes free from the same code path but is not separately guaranteed — note in
+the PR that `CacheConfig` changes still only affect subsequently-fetched
+documents.
+
+---
+
+## 3. Ecosystem wiring
+
+Common rule: **parse eagerly at construction** into `published_at: Option<PublishTime>`.
+Never store the raw string and parse inside `published_at()` — hover re-renders
+would re-parse on every keystroke.
+
+Pre-1.0, so **replace** the existing raw-string fields rather than adding
+alongside (user's CLAUDE.md: no back-compat shims before 1.0). Record as a
+breaking change in `CHANGELOG.md`.
+
+| Crate | Struct change | Parse site | `impl Version` site |
+|---|---|---|---|
+| deps-cargo | `CargoVersion` (`types.rs:99`) **+** `published_at: Option<PublishTime>`; `IndexEntry` (`registry.rs:232-241`) **+** `#[serde(default)] pubtime: Option<String>` | `registry.rs:254` | `types.rs:170` (hand-written) |
+| deps-pypi | `PypiVersion` (`types.rs:111`) **+** field; `SimpleFile` (`registry.rs:357-361`) **+** `#[serde(rename = "upload-time", default)] upload_time: Option<String>` | near `build_yanked_map` (`registry.rs:466`) — reuse the existing filename→version resolution, take the **minimum** `upload-time` across a version's files | `types.rs:149` (macro, new arm) |
+| deps-composer | `ComposerVersion` (`types.rs:78`) **+** field; `MinifiedVersion` (`registry.rs:129`) **+** `time: Option<String>` | `expand_minified_versions` (`registry.rs:142-183`) — **do NOT inherit** `time` through the minified chain; take it only from the entry itself, `None` if absent | `types.rs:84` (macro, new arm) |
+| deps-bundler | `BundlerVersion.created_at: Option<String>` (`types.rs:43`) → `published_at: Option<PublishTime>` | `registry.rs:101` | `registry.rs:171` (hand-written) |
+| deps-dart | `DartVersion.published: Option<String>` (`types.rs:33`) → `published_at: Option<PublishTime>` | `registry.rs:122` | `registry.rs:152` (hand-written) |
+| deps-go | `GoVersion.time: Option<String>` (`types.rs:43`) → `published_at: Option<PublishTime>` | `parse_version_info` (`registry.rs:387/397`) sets it; `parse_version_list` (`registry.rs:350`) keeps `None` | `types.rs:100` (hand-written) |
+
+**deps-maven / deps-gradle / deps-npm / deps-nuget / deps-swift: no change in v1.**
+`MavenVersion.timestamp: Option<u64>` stays dead — wiring it would ship a
+guaranteed-`None` accessor. Flag it for a separate cleanup issue (it fits the
+direction of #198/#200).
+
+Composer note: `time` was present on 87/87 entries live, so the
+no-inheritance rule is safe in practice, but it must still be written that way —
+inheriting a previous version's publish date would be a correctness bug.
+
+---
+
+## 4. LSP surface rendering
+
+### 4.1 Ch1 widening (required for diagnostics + hover's `**Latest**` line)
+
+Minimal-diff approach — a **parallel map**, matching the existing
+`VersionData { cached, resolved }` two-parallel-maps pattern rather than
+reshaping `HashMap<String,String>` (which 13 ecosystems' formatters read):
+
+1. `deps-lsp/src/document/lifecycle.rs:137-205` — `fetch_latest_versions_parallel`
+   returns a named struct instead of one map:
+   ```rust
+   pub(crate) struct LatestVersions {
+       pub versions: HashMap<String, String>,
+       pub published_at: HashMap<String, PublishTime>,
+   }
+   ```
+   Populate `published_at` from `v.published_at()` at `lifecycle.rs:161-167`,
+   right where the `Box<dyn Version>` is currently discarded.
+2. `deps-lsp/src/document/state.rs` — add
+   `latest_published_at: HashMap<String, PublishTime>` (next to `:45`/`:47`)
+   plus its setter (next to `update_cached_versions` at `:218`).
+3. `deps-core/src/lsp_helpers.rs:35-60` — `VersionData` gains
+   `published: Option<&'a HashMap<String, PublishTime>>`.
+   `VersionData::new` keeps its **2-argument signature** (sets `None`) and gains
+   `with_published(self, map)`. Source-compatible for every existing call site
+   and doctest; `Copy` is preserved.
+
+### 4.2 Hover — `lsp_helpers.rs:519-621`
+
+Two insertions, no reordering, no removals.
+
+**(a) The `**Latest**:` line (Ch1)** — append the age when known:
+```
+**Latest**: `1.2.3` *(published 2 hours ago)*
+```
+Followed, when the release is within cooldown and `enabled`, by a callout:
+```
+> ⏳ **Recently published** — this release is still within the cooldown window.
+> It may still be yanked or superseded; consider verifying before upgrading.
+```
+The window duration is deliberately **not** interpolated into the text, so no
+awkward duration formatting is needed.
+
+**(b) The "Recent versions" list (Ch2)** — annotate entries whose
+`published_at()` is known, preserving the existing `*(latest)*` and
+`yanked_label()` markers:
+```
+- `1.2.3` *(latest)* — 2 hours ago
+- `1.2.2` — 3 months ago
+- `1.2.1` *(yanked)* — 5 months ago
+```
+This is what makes US-002's "the previous stable version outside the cooldown
+window remains visible as an alternative" true **without touching ordering or
+filtering** (FR-006).
+
+Constraints: reuse `escape_markdown` / `markdown_code_span`; the age string is
+generated internally so it needs no escaping, but must not be concatenated into
+a code span. **No `EcosystemFormatter` hook** for freshness — NFR-002/US-004
+require one uniform rendering, unlike `yanked_label()`.
+
+### 4.3 Diagnostics — `lsp_helpers.rs:689-744` (`generate_diagnostics_from_cache`)
+
+- **Severity stays `HINT` in both cases.** Rationale: `HINT` is already the floor,
+  so there is nothing "softer"; raising it adds noise; suppressing the diagnostic
+  would hide the recommendation, against the spec's intent.
+- **Message-only differentiation:**
+  - established (or unknown age): `Newer version available: 1.2.3` — unchanged
+  - within cooldown: `Newer version available: 1.2.3 (published 2 hours ago — still within the release cooldown window)`
+- Do **not** wire `DiagnosticsConfig::{outdated,unknown,yanked}_severity`. Those
+  three fields are parsed and then dropped at `handlers/diagnostics.rs:15`
+  (`_config`), i.e. dead code. Fixing that is a separate issue — out of scope here.
+- Apply the same change to `generate_diagnostics` (`lsp_helpers.rs:753-817`) only
+  if trivial; it has no in-workspace callers.
+
+### 4.4 Completion — `completion.rs:474-535`
+
+- `VersionDisplayItem` **+** `pub published_at: Option<PublishTime>`, populated in
+  `VersionDisplayItem::new` from the `&dyn Version` it already receives
+  (`completion.rs:520`) — this is the one chokepoint where per-version metadata
+  is still live.
+- `build_version_completion` fills the currently-unused `label_details` slot
+  (`CompletionItemLabelDetails` appears nowhere in the repo today):
+  ```rust
+  label_details: Some(CompletionItemLabelDetails {
+      detail: Some(format!("  {}", format_relative_age(age))),
+      description: None,
+  }),
+  ```
+  It renders greyed next to the label in VS Code/Zed and, unlike `label`, does
+  not participate in filter matching.
+- **Unchanged: `label`, `sort_text`, `preselect`, and
+  `prepare_version_display_items`' filtering/ordering** — FR-006 is a hard
+  invariant here.
+- `generate_code_actions` (`lsp_helpers.rs:650`) shares
+  `prepare_version_display_items` and simply ignores the new field.
+
+---
+
+## 5. Test plan
+
+**deps-core `freshness.rs`** — the six real-world formats as fixtures:
+`2026-07-18T23:05:13Z` (cargo), `2026-05-14T19:25:27.735762Z` (pypi, 6-digit
+fraction), `2026-01-02T08:56:05+00:00` (composer, numeric offset),
+`2024-01-15T10:30:00.000Z` (bundler), pub.dev fractional form, and Go's bare `Z`
+form. Plus: garbage input → `None`; empty string → `None`; future timestamp →
+age `0` and within-cooldown `true`; `age == cooldown` → `false`;
+`age == cooldown - 1` → `true`; every `format_relative_age` bucket boundary.
+
+**Per ecosystem crate (NFR-004)** — three mockito tests each, following
+`deps-bundler`'s existing `test_parse_versions_response_with_created_at`:
+present / absent-or-null / malformed. Six crates × 3 = 18 tests.
+PyPI additionally: a version whose files have differing `upload-time` values →
+the minimum is chosen. Composer additionally: an entry with no `time` must yield
+`None`, **not** the previous entry's value.
+
+**LSP surface** — hover markdown assertions (age line present / callout present
+within cooldown / both absent when `published_at()` is `None` / both absent when
+`enabled: false`); diagnostic message variants; completion `label_details`
+present-and-absent plus an assertion that `sort_text`/`preselect`/item count are
+byte-identical to the pre-feature output (FR-006 regression guard).
+
+**Config** — defaults, partial JSON, clamping above 30 days, `enabled: false`.
+
+**Live reload (§2.1)** — `parse_config` returns `None` and logs on malformed
+input; `did_change_configuration` with a valid payload replaces the stored
+config; with a malformed payload **keeps the previous config** rather than
+resetting to defaults; with `null` settings is a no-op. Plus an end-to-end
+assertion that a diagnostic's message flips between the plain and the
+within-cooldown variant when only `cooldown_secs` changes.
+
+**Live verification (NFR-006, blocking)** — `.local/testing/lsp_test.py`, one
+package with a release published in the last ~72 h per v1 ecosystem
+(cargo/pypi/composer/bundler/dart) plus Go on the Ch1 path only. Record results
+in `.local/testing/coverage.md` and a `journal/ci-NNN.md` entry.
+
+**Full gate** — `cargo +nightly fmt --all -- --check`,
+`cargo clippy --workspace --all-targets --all-features -- -D warnings`,
+`cargo nextest run --workspace --all-features --no-fail-fast`, rustdoc gate.
+Every new `pub` item needs `///` docs and the non-trivial ones a runnable
+`# Examples` doc-test (user's CLAUDE.md).
+
+---
+
+## 6. Task decomposition — recommended split
+
+```
+T1  foundation (SERIAL, blocks everything)
+    time dep (context7 check first) + deps-core/src/freshness.rs
+    + Version::published_at + impl_version! second arm
+    + FreshnessConfig/FreshnessSettings
+    + parse_config helper & did_change_configuration handler (§2.1)
+    + unit tests
+    ~250 lines, 6 files
+
+        ├── T2  ecosystem wiring (6 fully independent subtasks, no shared files)
+        │       T2a cargo   T2b pypi   T2c composer
+        │       T2d bundler T2e dart   T2f go
+        │       ~30 lines + 3 tests each
+        │
+        └── T3  LSP surface (independent of T2 — develop against a mock Version)
+                LatestVersions/DocumentState + VersionData.published
+                + hover + diagnostics + completion
+                ~180 lines, 7 files
+
+T4  integration (SERIAL, after T2 ∥ T3)
+    live verification, CHANGELOG, README config table, ECOSYSTEM_GUIDE
+```
+
+**T2 and T3 are genuinely parallelizable** — disjoint file sets, and T3 only
+depends on the T1 trait method, not on any ecosystem implementing it. With a
+single developer the same ordering works serially. T2a–T2f are six independent
+one-crate tasks if more parallelism is wanted.
+
+**Superseded 2026-08-23 by critic review + user sign-off — see §7a.** The
+"one PR" recommendation below is kept for historical context only; the
+"already-parsed vs needs-parsing" rejection still stands (network cost, not
+parse state, is the real axis), but the PR-count conclusion built on top of it
+did not survive critique: the critic's recount put the true size at ~1700
+lines (not ~900), found that a rendering-only split *is* live-verifiable
+(contrary to the claim below), and surfaced three concrete defects (C1–C3,
+§7a) that are cheaper to isolate in their own PR than to mix into the
+mechanical ecosystem wiring. **Actual split: PR1 = T1 (minus live-reload) + T2
++ Ch2 rendering only; PR2 = Ch1 widening + did_change_configuration + C1–C3
+fixes.** Original text follows, unchanged:
+
+Recommendation: one PR, not two. The spec's Open Question proposes splitting
+along "already-parsed (FR-008)" vs "needs parsing (FR-007)". Reject that axis —
+live verification shows it does not correlate with anything that matters:
+Cargo/PyPI/Composer are *not* pre-parsed yet are free, while Maven/Go *are*
+pre-parsed yet are dead or partial. The meaningful axis is **network cost**, and
+every zero-cost ecosystem belongs in v1 together. Splitting T1+T2 into their own
+PR would ship a foundation with zero user-visible behavior, which cannot satisfy
+NFR-006's live-verification gate. Estimated total ≈ 900 lines including tests —
+large but reviewable. Fallback if the reviewer objects: PR1 = T1+T2, PR2 = T3+T4.
+
+**Follow-up issues to file (one per deferred ecosystem, each carrying its own
+cost decision):**
+- npm — full packument is 2.37× the abbreviated one; a product tradeoff needing
+  user input, not an engineering default.
+- Maven/Gradle — solrsearch `core=gav` returns per-GAV `timestamp` as unix
+  millis (matching the existing dead `Option<u64>` field's type); extra request.
+- NuGet — requires resolving `RegistrationsBaseUrl` and paging the registration
+  hive.
+- Swift — GitHub tags carry no dates; needs the releases API (misses tag-only
+  packages) or N commit lookups against an already rate-limited endpoint.
+- Go Ch2 — `/@v/list` has no dates; would need one `.info` request per version.
+- Cleanup: delete the dead `MavenVersion.timestamp` field.
+
+---
+
+## 7. Open questions — resolved, and gaps needing sign-off
+
+### Resolved here
+| Spec question | Decision |
+|---|---|
+| UX treatment | hover: age suffix + blockquote callout; diagnostics: message-only, severity unchanged at `HINT`; completion: `label_details` age, no cooldown verdict (§4) |
+| Where cooldown is configured | `DepsConfig.freshness` via `initializationOptions`, 3-day default, clamped 0..30 d; live-reloadable via `did_change_configuration` (§2.1) |
+| Trait signature / date crate | `fn published_at(&self) -> Option<PublishTime>` with a `deps-core` newtype over `i64` Unix seconds; `time 0.3` in `deps-core` only — ecosystem crates never touch a date crate |
+| Clock skew | clamp age to 0 → "just now", counts as within cooldown |
+| Cooldown boundary | `age < cooldown` (exclusive), documented once, uniform |
+| Does freshness apply to the locked/installed version? | **No.** Only the recommendation target (`**Latest**`) and the version list. Lockfiles carry no timestamps, and a pinned version's age is not actionable. The `**Current**:` line is untouched |
+| Swift non-GitHub hosts | moot — Swift is deferred entirely; the GitHub tags API has no dates for *any* host |
+| FR-007/FR-008 PR split | rejected as an axis; split by network cost instead (§6) |
+| OSV/002 coordination | out of scope; noted only |
+
+### Decision record — G1–G6, all resolved 2026-08-23
+
+| # | Item | Decision |
+|---|---|---|
+| **G1** | New `time` dependency | **Proceed.** Developer must run a context7 version check before adding it to `Cargo.toml` (project policy) — `0.3.55` above is an observation, not an instruction |
+| **G2** | v1 ships 6 ecosystems, not 10–11 | **Confirmed.** npm, Maven/Gradle, NuGet, Swift are out of this PR; team-lead files one follow-up issue per ecosystem after it lands, using the cost findings in §0. Spec's Current State / NFR-001 / SC-001 updated accordingly |
+| **G3** | FR-008 unsatisfiable for Maven, partial for Go | **Confirmed** as part of G2. Spec FR-007/FR-008 restated around network cost |
+| **G4** | Pre-1.0 breaking struct changes | **Pre-approved** by standing policy (CLAUDE.md: no backward-compat concerns before v1.0.0). No further sign-off needed |
+| **G5** | Config live-reload | **Reversed — now IN SCOPE.** `did_change_configuration` is implemented in this PR (§2.1), not deferred. Acceptance bar: changing `freshness.cooldown_secs` takes effect without an editor restart |
+| **G6** | Ch1 `DocumentState`/`VersionData` widening | **Architect/developer's call** — proceed as designed (§4.1) |
+
+US-004 note carried forward: cross-ecosystem consistency holds for *rendering*
+(one implementation in `deps-core`, no `EcosystemFormatter` hook) but not for
+*coverage*. The 5 deferred ecosystems fall back to US-003 graceful degradation,
+which is byte-identical to pre-feature behavior.
+
+### Adjacent bugs — dispositions confirmed
+- Config silently discarded on deserialize error (`server.rs:236`) — **bundled
+  here** as the shared `parse_config` helper (§2.1), since this PR touches config
+  and adds a field that widens the blast radius. **Now PR2-only — see §7a C2.**
+- `DiagnosticsConfig::{outdated,unknown,yanked}_severity` are parsed then dropped
+  at `handlers/diagnostics.rs:15` (`_config`) — **out of scope**; team-lead files
+  a separate issue. Do not wire them while implementing §4.3.
+
+## 7a. Critic findings (2026-08-23) — three confirmed defects, PR split final
+
+Critic verdict: core design (`PublishTime`, trait default, v1 scope) is sound.
+Three defects confirmed against source (not inferred) block T1 as originally
+scoped; user confirmed the 2-PR split as the resolution (below), superseding
+§6's "one PR" recommendation.
+
+### Confirmed blockers
+
+| # | Defect | Where | Fix | PR |
+|---|---|---|---|---|
+| **C1** | `did_change_configuration` activates a latent deadlock: `server.rs:166` holds a `config.read()` guard across a loop that calls into `ensure_document_loaded` → `config.read()` (`lifecycle.rs:699`) — nested read on one write-preferring tokio `RwLock`, same task. Harmless today (only `write()` call is in `initialize`, before any requests); the new handler makes a concurrent `write()` reachable, which can permanently block the inner read | `server.rs:166` | Snapshot-and-drop the guard before the loop, matching the existing pattern at `:386`/`:432` (2-line fix) | **PR2** — only reachable via `did_change_configuration` |
+| **C2** | The "malformed payload keeps previous config" guard in §2.1 does not fire: `DepsConfig` is all-`#[serde(default)]`, so a section-wrapped payload (e.g. `{"deps-lsp": {...}}`, which real clients send) deserializes *successfully* into an all-defaults struct — the `Err` arm never triggers, so the user's entire configuration is silently replaced with defaults. Data-loss bug, not a half-implementation | `parse_config` helper (§2.1) | Add a positive-signal check: reject/unwrap based on a known top-level key rather than trusting `Result::is_ok` | **PR2** — `parse_config`/`did_change_configuration` don't exist until PR2 |
+| **C3** | The Ch1 "parallel map" (§4.1) desyncs: `lifecycle.rs:272` overwrites `cached_versions` with lockfile-resolved versions for instant display, but `preserve_cache` carries the *old* `published_at` map forward unchanged. Result: hover's `**Latest**` line can show `<locked version> (published 2 hours ago)` where the age belongs to a different version entirely. Silent, timing-window-only, invisible to unit tests | `lifecycle.rs:272` + all mirror sites of `cached_versions` mutation (6 total) | Replace the two parallel maps with one `HashMap<String, LatestVersion { version, published_at }>` so version and age can never drift apart | **PR2** — only affects Ch1 (diagnostics + `**Latest**` line), which is entirely PR2 scope |
+
+### Plan corrections (non-blocking, apply wherever the relevant work lands)
+
+- **M1** — §2's "only two entry points" undercounts diagnostics: `generate_diagnostics_internal(state, uri)` carries no config and has 4 call sites (3 background spawns in `lifecycle.rs`); `ServerState` holds no `DepsConfig` today. Threading `FreshnessSettings` through diagnostics is more than the table implies. (Confirmed accurate: `generate_hover`/`generate_diagnostics` have zero ecosystem overrides.) — **PR2**
+- **M2** — diagnostics are push *and* pull (`client.publish_diagnostics` at `server.rs:182`, plus 3 lifecycle background spawns); `workspace/diagnostic/refresh` only reaches pull-capable clients, so §2.1's refresh nudge does not cover push-only clients. Document this as a known v1 gap in spec §1 non-goals rather than silently under-covering it. — **PR2**
+- **M3** — clients gate `didChangeConfiguration` notifications on `workspace.didChangeConfiguration.dynamicRegistration`; without `client.register_capability` in `initialized` (~10 lines, available in `tower-lsp-server` 0.23) some clients never send the notification, making FR-012 unverifiable under NFR-006's live gate. Add the ~10-line registration alongside §2.1. — **PR2**
+- **M4** — render helpers must take `now: PublishTime` as a parameter rather than calling `PublishTime::now()` internally; otherwise bucket-boundary assertions are wall-clock dependent and a single request can straddle a boundary between hover and diagnostics. — applies to **both PRs** (any code computing age from `published_at()`)
+
+### `PublishTime` nits (apply in T1, PR1)
+
+- `age_secs_from` as `const fn` overflows at `i64::MIN`; use `saturating_sub(...).max(0)` instead of raw subtraction.
+- `is_within_cooldown(age_secs: u64, cooldown_secs: u64)` has two swappable same-typed params — mild inconsistency with the newtype direction from #191/#200, but not worth a wrapper type for two call sites. Document parameter order clearly in the doc comment instead.
+
+### Final PR split (supersedes §6)
+
+**PR1 — mechanical, fully live-verifiable, low risk:**
+- T1 minus §2.1 (no `did_change_configuration`, no `parse_config` helper, no live-reload) — just `freshness.rs`, `Version::published_at`, `impl_version!` second arm, `FreshnessConfig`/`FreshnessSettings` (config field exists and is read at `initialize` as today; just not live-reloadable yet).
+- T2 — all 6 ecosystem wiring subtasks (cargo, pypi, composer, bundler, dart, go-partial).
+- Ch2-only rendering — hover's "Recent versions" list ages (§4.2b) and completion's `label_details` age (§4.4). **No** Ch1 widening, **no** `**Latest**` age/callout, **no** diagnostics changes.
+- Apply the `PublishTime` nits and M4 (inject `now`) here.
+- Live-verifiable per NFR-006 on the 5 full ecosystems + Go's Ch2 path (hover/completion only).
+
+**PR2 — risk-isolated, built on PR1:**
+- Ch1 widening (§4.1: `LatestVersions`/`DocumentState`/`VersionData.published`) using the corrected single-map design from C3, not the original parallel-map design.
+- Hover's `**Latest**` age + cooldown callout (§4.2a), diagnostics message differentiation (§4.3).
+- `did_change_configuration` (§2.1) + `parse_config` helper, with C1 (deadlock), C2 (config-loss), and M2/M3 (refresh coverage, dynamic registration) all fixed as part of this work, not deferred further.
+- Update spec §1 to state the push-only/no-dynamic-pull-form boundary explicitly as a non-goal (per critic's did_change_configuration verdict: "push-only is an acceptable v1 boundary; the silence about it is not").
+
+Both PRs target branch `feat/145-release-freshness-signal`; PR1 merges first, PR2 branches from post-merge `main` (or is rebased onto it) and closes issue #145. PR1 alone does not close the issue.

--- a/specs/004-release-freshness-signal/spec.md
+++ b/specs/004-release-freshness-signal/spec.md
@@ -1,0 +1,395 @@
+---
+aliases:
+  - Release Freshness Signal
+  - Cooldown-Aware Version Recommendations
+  - Publish Recency Risk Signal
+tags:
+  - sdd
+  - spec
+  - research
+  - deps-core
+  - supply-chain-risk
+  - cross-ecosystem
+created: 2026-08-20
+updated: 2026-08-23
+status: approved
+related:
+  - "[[constitution]]"
+---
+
+> [!note] Revision 2026-08-23
+> Current State, FR-007/FR-008, NFR-001 and SC-001 were revised after every
+> registry was verified live; FR-011 and FR-012 were added. All Open Questions
+> (§9) are resolved in `plan.md`. v1 scope is **six ecosystems**.
+
+# Feature: Release-Freshness Signal for Version Recommendations
+
+> [!info] Metadata
+> **Author**: continuous-improvement cycle (deps-lsp)
+> **Branch**: feat/{issue-number}-release-freshness-signal
+> **Priority**: P2
+> **Type**: research / parity gap
+
+## 1. Overview
+
+### Problem Statement
+
+deps-lsp's hover, diagnostics, and completion features recommend the "latest"
+version of a dependency as soon as a registry reports it, with no awareness of
+how recently that version was published. Two reference projects in the
+dependency-tooling space have converged on treating "very recently published"
+as a risk signal rather than a pure positive:
+
+- GitHub Dependabot (as of 2026-07-14) now defaults to a 3-day "cooldown"
+  period before opening a version-update PR for a newly published release —
+  security updates are exempted and still surface immediately.
+  ([source](https://github.blog/changelog/2026-07-14-dependabot-version-updates-introduce-default-package-cooldown/))
+- Socket.dev's supply-chain risk scoring flags packages/releases with
+  characteristics like "very new", "new maintainer/author", or otherwise low
+  publication history as elevated-risk signals, independent of known-CVE
+  status.
+
+Rationale: a version published minutes or hours ago carries meaningfully
+higher risk of being yanked, containing a build mistake, or — rarer but
+higher-impact — being a compromised/malicious publish that has not yet been
+caught, compared to a version that has been live for days. Today deps-lsp has
+no concept of "time since publish" surfaced anywhere in hover, diagnostics, or
+completion, so it cannot distinguish "safe, well-established latest" from
+"just published 10 minutes ago" when it tells a user "you're outdated, upgrade
+to X".
+
+### Current State (verified against the codebase, 2026-08-20)
+
+The shared `Version` trait
+(`crates/deps-core/src/registry.rs:135`, implemented by every ecosystem crate)
+has no publish-timestamp accessor. `find_latest_stable`
+(`crates/deps-core/src/registry.rs:202`) — the single shared function that
+selects "latest" for hover, diagnostics (`crates/deps-core/src/lsp_helpers.rs`,
+`generate_diagnostics` / `generate_diagnostics_from_cache`), and completion
+(`crates/deps-core/src/completion.rs`) — only considers `is_yanked()` and
+`is_prerelease()`. Publish recency plays no role in ranking or in the
+`DiagnosticSeverity` chosen (`WARNING` for unknown package, `HINT` for
+outdated, per `lsp_helpers.rs:474/494/524/550/563`).
+
+At the per-ecosystem level, the picture is mixed rather than uniformly
+absent — some ecosystem `Version` structs already parse a raw publish
+timestamp from the registry response, but the value is dead data: parsed,
+stored, and never read by any hover/diagnostic/completion code path.
+
+> [!warning] Revised 2026-08-23 after live verification
+> The table below was originally derived from code reading alone and was wrong
+> for 6 of 11 ecosystems, in **both** directions. It has been replaced with
+> results verified by live `curl` against every registry. Raw evidence in
+> `plan.md` §0.
+
+The decisive question is not "does the registry expose a timestamp somewhere"
+(all of them do) but "is it in the payload the crate **already fetches**".
+
+| Ecosystem crate | `*Version` struct | In the already-fetched payload? | Format / notes |
+|---|---|---|---|
+| `deps-cargo` | `CargoVersion` (`types.rs:99`) | **YES** | Sparse index NDJSON now carries `pubtime`, 100% coverage (195/195 for `tokio`, back to 2016). `2026-07-18T23:05:13Z`. **No separate crates.io API call needed** — contrary to the original finding |
+| `deps-pypi` | `PypiVersion` (`types.rs:111`) | **YES** | PEP 700 `files[].upload-time` inside the already-requested PEP 691 JSON (api-version 1.4). `2026-05-14T19:25:27.735762Z`. Per **file**, so a version's time is the minimum across its files |
+| `deps-composer` | `ComposerVersion` (`types.rs:78`) | **YES** | Packagist p2 `time` on every entry (87/87 for `monolog/monolog`). `2026-01-02T08:56:05+00:00` (numeric offset) |
+| `deps-bundler` | `BundlerVersion` (`types.rs:39`) | **YES** | `created_at` already parsed and discarded |
+| `deps-dart` | `DartVersion` (`types.rs:30`) | **YES** | `published` already parsed and discarded |
+| `deps-go` | `GoVersion` (`types.rs:39`) | **PARTIAL** | `/@latest` returns `Time` (feeds diagnostics); `/@v/list`, used by `get_versions` for hover/completion, is plain text with no dates. The `time` field exists but `parse_version_list` hardcodes `None` |
+| `deps-npm` | `NpmVersion` (`types.rs:89`) | **NO** | The abbreviated packument deliberately used by the crate omits the top-level `time` object entirely. The full packument is **2.37×** larger (804 975 vs 339 376 B for `express`) |
+| `deps-maven` / `deps-gradle` | `MavenVersion` (`types.rs:45`) | **NO** | `maven-metadata.xml` has **no per-version dates** at all (only `<lastUpdated>` per artifact). `timestamp: Option<u64>` is **dead code** — both construction sites pass `None`. Per-version dates need the solrsearch `core=gav` API or a `HEAD` per version |
+| `deps-nuget` | `NuGetVersion` (`types.rs:54`) | **NO** | Flat container `index.json` is a bare `{"versions": [...]}`. `published` lives in the registration hive, which the crate deliberately does not resolve and which is paged |
+| `deps-swift` | `SwiftVersion` (`types.rs:76`) | **NO** | Version data comes from the GitHub **tags** API, which has no date field for any host. Needs N commit lookups or the releases API (which misses tag-only packages), against an already rate-limited endpoint |
+
+This supersedes the original finding's "zero hits" characterization in both
+directions. Three ecosystems (Cargo, PyPI, Composer) are **cheaper** than
+assumed — their timestamps are already on the wire, merely not deserialized.
+Four (npm, Maven/Gradle, NuGet, Swift) are **more expensive** than assumed — the
+timestamp is not in the fetched payload at all, so the spec's premise that every
+registry "already fetches" it does not hold. What is genuinely true across the
+board is that no timestamp ever reaches the shared `Version` trait or any
+hover/diagnostic/completion decision: the freshness *signal* does not exist
+anywhere in `deps-core`.
+
+**v1 scope (confirmed by the user 2026-08-23):** the six ecosystems with a
+zero-cost timestamp — Cargo, PyPI, Composer, Bundler, Dart, and Go (diagnostics
+path only). npm, Maven/Gradle, NuGet and Swift are deferred to one follow-up
+issue each, because each carries a distinct, non-trivial network cost that
+deserves its own decision rather than a blanket one.
+
+### Goal
+
+deps-lsp can express, per version, "how long has this been published" as a
+first-class signal available to hover, diagnostics, and completion, so that a
+just-published "latest" version can be visually and semantically
+distinguished from an established one — without ever hiding, blocking, or
+demoting the version below other choices if the user wants to pick it anyway.
+
+### Out of Scope
+
+- Choosing the final UX treatment (color, icon, severity level, exact
+  wording) for the freshness signal in hover/diagnostics/completion — this
+  spec defines the capability and the signal; `/sdd plan` decides rendering
+  details in collaboration with the user
+- Blocking, auto-rejecting, or filtering out recently-published versions from
+  any list — Dependabot's cooldown delays the *update PR*; deps-lsp has no PR
+  concept, so at most this delays/softens a *recommendation*, never removes a
+  version from what the user can see or select
+- Fetching additional network calls per version where the timestamp is not
+  already part of an already-fetched payload (see Data Model/NFR for the
+  per-ecosystem cost analysis) — if an ecosystem requires a materially more
+  expensive API call it may be deferred, flagged as a partial implementation
+  in `/sdd plan`
+- Any determination about maintainer reputation, publish-history depth, or
+  other Socket.dev-style supply-chain signals beyond publish-recency of the
+  specific version — those are a distinct, larger research topic
+- Security-update exemption logic equivalent to Dependabot's — deps-lsp does
+  not currently have a vulnerability-aware diagnostics pathway merged (see
+  [[002-osv-vulnerability-diagnostics/spec|002]], still in `plan` phase with
+  open clarifications); wiring freshness-exemption-for-security-updates
+  together with 002 is a follow-up, not this spec
+
+## 2. User Stories
+
+### US-001: See publish recency in hover
+
+AS A developer hovering over a dependency version in my manifest
+I WANT the hover card to tell me how recently the "latest" version was
+published (e.g. "published 2 hours ago" vs. "published 4 months ago")
+SO THAT I can judge whether it is safe to jump straight to it or whether I
+should wait
+
+**Acceptance criteria:**
+```
+GIVEN a dependency whose registry-reported latest version has a known publish
+  timestamp
+WHEN the user hovers over that dependency's version field
+THEN the hover card shows a human-readable "published <relative time> ago"
+  line for the latest version, in addition to the existing version number
+```
+
+### US-002: Softer signal for very recent releases
+
+AS A developer relying on deps-lsp's outdated-version diagnostics
+I WANT a version published within a short, configurable window (default
+mirrors Dependabot's 3-day default) to be flagged distinctly from an
+established outdated recommendation
+SO THAT I am not nudged to adopt a release that might still be yanked or
+buggy within its first hours/days
+
+**Acceptance criteria:**
+```
+GIVEN the registry-reported latest version was published less than the
+  configured cooldown window ago
+WHEN deps-lsp generates a diagnostic or hover recommendation for that
+  dependency
+THEN the recommendation is visually/semantically distinguished from a
+  standard "outdated, upgrade now" recommendation (exact treatment decided in
+  /sdd plan), and the previous stable version outside the cooldown window
+  remains visible as an alternative
+```
+
+### US-003: Graceful degradation when publish data is unavailable
+
+AS A developer using an ecosystem where publish-timestamp data cannot be
+retrieved (e.g. a non-GitHub-hosted Swift package registry, or a transient
+registry error)
+I WANT deps-lsp to behave exactly as it does today — no freshness signal
+shown, no error, no blocked recommendation
+SO THAT the new capability never regresses existing behavior for ecosystems
+or edge cases where the data genuinely is not available
+
+**Acceptance criteria:**
+```
+GIVEN a version's publish timestamp cannot be determined (parse failure,
+  missing field, or ecosystem where the API does not expose it)
+WHEN deps-lsp renders hover, diagnostics, or completion for that version
+THEN it falls back to current (pre-feature) behavior with no freshness line,
+  no error surfaced to the user, and no change in severity/ranking
+```
+
+### US-004: Consistent behavior across ecosystems
+
+AS A developer who works across multiple ecosystems in the same or different
+projects (e.g. Cargo and npm)
+I WANT the freshness signal to look and behave the same way regardless of
+which of the 10+ supported ecosystems I am using
+SO THAT the feature is predictable and not something I have to re-learn per
+manifest type
+
+**Acceptance criteria:**
+```
+GIVEN two dependencies in different ecosystems whose latest versions were
+  both published 1 hour ago
+WHEN the user hovers over either dependency
+THEN both hover cards present the freshness signal in the same format and
+  with the same cooldown-window semantics, per the cross-ecosystem
+  consistency principle in .claude/rules/continuous-improvement.md
+```
+
+## 3. Functional Requirements
+
+Use EARS notation. Prefix with FR-NNN.
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN an ecosystem registry response for a version already includes a publish timestamp THE SYSTEM SHALL parse it into a structured, ecosystem-independent time value accessible via the shared `Version` trait (`crates/deps-core/src/registry.rs`) | must |
+| FR-002 | WHEN the shared `Version` trait exposes a publish timestamp for a version THE SYSTEM SHALL make it available to hover rendering, diagnostic generation (`generate_diagnostics`, `generate_diagnostics_from_cache`), and completion (`build_version_completion`) without ecosystem-specific branching in `deps-core` | must |
+| FR-003 | WHEN a version's publish timestamp is known and hover is requested for that dependency THE SYSTEM SHALL include a human-readable relative-time indicator (e.g. "published 2 hours ago") in the hover content for that version | must |
+| FR-004 | WHEN the latest version's publish timestamp is within a configurable cooldown window (default 3 days, mirroring Dependabot's default) THE SYSTEM SHALL distinguish the resulting recommendation from a recommendation for a version outside the cooldown window, via: a hover age suffix plus a cooldown callout, and a distinct diagnostic **message** with severity unchanged at `HINT` (mechanism decided in `plan.md` §4; completion carries relative age only, no cooldown verdict) | must |
+| FR-005 | WHEN a version's publish timestamp cannot be parsed or is absent from the registry response THE SYSTEM SHALL fall back to current pre-feature behavior for that version with no error surfaced to the user | must |
+| FR-006 | WHEN the cooldown window influences a recommendation THE SYSTEM SHALL NOT remove, hide, or block the recently-published version from being visible or selectable in hover or completion — only the recommendation framing changes | must |
+| FR-007 | WHEN an ecosystem's publish timestamp is present in the payload the crate already fetches but is not yet deserialized (Cargo `pubtime`, PyPI `files[].upload-time`, Composer `time`, per Current State table) THE SYSTEM SHALL add that deserialization without introducing an additional network round trip | must |
+| FR-008 | WHEN an ecosystem crate already parses a publish timestamp but discards it (Dart `published`, Bundler `created_at`, Go `time`, per Current State table) THE SYSTEM SHALL wire the existing field into the shared `Version` trait rather than re-parsing or re-fetching it | must |
+| FR-009 | WHEN the cooldown window is not explicitly configured by the user THE SYSTEM SHALL apply a default of 3 days | should |
+| FR-010 | WHEN a user configures a custom cooldown window THE SYSTEM SHALL apply it uniformly across all ecosystems (no per-ecosystem override), consistent with the cross-ecosystem consistency principle | should |
+| FR-011 | WHEN an ecosystem's publish timestamp is NOT in the already-fetched payload (npm, Maven/Gradle, NuGet, Swift) THE SYSTEM SHALL leave that ecosystem unmodified in v1, falling back to FR-005 graceful degradation, and defer the cost decision to a per-ecosystem follow-up issue | must |
+| FR-012 | WHEN the user changes the cooldown configuration at runtime THE SYSTEM SHALL apply the new value without requiring an editor or server restart, via `workspace/didChangeConfiguration` | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | Parsing and exposing the publish timestamp MUST NOT add any network round trip, nor enlarge any existing request/response, for the six ecosystems whose timestamp is already on the wire (Cargo, PyPI, Composer, Bundler, Dart, Go-partial). This constraint **defined** v1 scope, deferring the four ecosystems whose timestamp is not already on the wire (npm, Maven/Gradle, NuGet, Swift) rather than making them more expensive. **Amended for Maven/Gradle (issues #221, #225):** after live probing found no zero-cost data source (see `plan-maven-gradle.md` §1), the team accepted a scoped, documented, opt-out-able exception for Maven/Gradle specifically — `freshness.enabled` (default `true`) issues one extra conditional GET per hover/completion to the CDN host already serving `maven-metadata.xml` (~130–170ms cold, a 304 on repeat; document-open/diagnostics untouched), with `freshness.enabled: false` restoring the original zero-extra-request behavior. npm, NuGet, and Swift remain deferred under the original, unamended constraint. No observable hover/completion latency regression for the six ecosystems this constraint still applies to unmodified |
+| NFR-002 | Cross-ecosystem consistency | Per `.claude/rules/continuous-improvement.md` ("Cross-Ecosystem Consistency Testing"), the freshness signal MUST be implemented once in `deps-core` (shared `Version` trait, hover/diagnostic/completion helpers) rather than duplicated per ecosystem crate |
+| NFR-003 | Backward compatibility (pre-1.0) | Adding a timestamp accessor to the `Version` trait MUST be done via a default trait method (returning `None`) so existing ecosystem implementations compile unchanged until each is migrated, avoiding a big-bang breaking change across all 11+ ecosystem crates in one PR |
+| NFR-004 | Test coverage | Each ecosystem crate that gains timestamp parsing MUST have unit tests covering: present timestamp, missing/null timestamp, and malformed/unparseable timestamp, per the existing test patterns already used for `created_at`/`time` fields (e.g. `crates/deps-bundler/src/registry.rs::test_parse_versions_response_with_created_at`) |
+| NFR-005 | Correctness | Timestamp parsing and relative-time formatting MUST use an existing, maintained date/time crate already in the workspace dependency tree or added per the project's dependency-addition policy (context7 mcp check) — no hand-rolled date arithmetic |
+| NFR-006 | Live verification | Per the project's live-testing principle, the freshness signal MUST be verified against at least one real, currently-recent release per ecosystem (a package that published a version within the last few days) before the feature is considered complete — not just unit-tested with fixture data |
+
+## 5. Data Model
+
+No new persistent entities; this extends the existing per-ecosystem `*Version`
+structs and the shared `Version` trait with an optional timestamp.
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `Version` (trait, `deps-core`) | Shared abstraction every ecosystem's version type implements | existing: `version_string()`, `is_yanked()`, `is_prerelease()`; new: `published_at() -> Option<DateTime<Utc>>` (default `None`) `[NEEDS CLARIFICATION: exact method name/signature — decided in /sdd plan]` |
+| `MavenVersion` / `DartVersion` / `BundlerVersion` / `GoVersion` | Already carry a raw timestamp field (`timestamp: Option<u64>`, `published: Option<String>`, `created_at: Option<String>`, `time: Option<String>`) | Wire existing field into `Version::published_at()` |
+| `CargoVersion` / `NpmVersion` / `PypiVersion` / `ComposerVersion` / `SwiftVersion` / `NuGetVersion` | Do not currently carry a timestamp | Add a field sourced from the registry response field identified in the Current State table |
+| Cooldown configuration | New, currently undefined | Default 3-day window; storage location (LSP client settings? `deps-lsp` config file? hardcoded constant for v1?) `[NEEDS CLARIFICATION: see Open Questions]` |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Registry response omits the timestamp field entirely | `published_at()` returns `None`; hover/diagnostics/completion behave exactly as pre-feature (US-003) |
+| Timestamp field present but malformed (unparseable date string) | Treated identically to absent — parse failure logged at `debug`/`trace`, never surfaced as a user-facing error or panic |
+| Version was published in the future relative to the local clock (clock skew, or registry timestamp bug) | Freshness signal MUST NOT show a negative/nonsensical duration; clamp to "just now" or suppress the signal — `[NEEDS CLARIFICATION: exact clamping behavior]` |
+| Latest version is exactly at the cooldown boundary (e.g. published 3 days minus 1 second ago) | Boundary is inclusive/exclusive per a single documented rule applied uniformly across all ecosystems |
+| All available versions for a package are within the cooldown window (package is brand new) | The freshest version is still shown as the best available choice — cooldown softens the recommendation, never leaves the user with nothing to install (consistent with FR-006) |
+| Multiple ecosystems return timestamps in different formats (Unix epoch `u64` for Maven, ISO 8601 string for most others) | Parsing normalizes all formats to one internal `DateTime<Utc>` (or equivalent) representation in `deps-core` before any comparison logic runs |
+| User's editor/LSP client does not support whatever configuration mechanism is chosen for the cooldown window | Falls back to the 3-day default; feature still functions, just not customizable in that client |
+| A lockfile pins a version that is itself within the cooldown window (already installed, not a recommendation) | `[NEEDS CLARIFICATION: does the freshness signal apply to the currently-installed/locked version too, or only to the "latest" recommendation target?]` |
+
+## 7. Success Criteria
+
+Measurable metrics that prove the feature works:
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Hover shows a "published X ago" line for a package with a known-recent release, verified live for at least one package per ecosystem | 100% of the **six v1 ecosystems** — Cargo, PyPI, Composer, Bundler, Dart on both hover and diagnostics; Go on the diagnostics path only (its `**Latest**` hover line, not its "Recent versions" list). Verified via `.local/testing/lsp_test.py`. The four deferred ecosystems are explicitly expected to show **no** freshness line — that is SC-003, not a failure |
+| SC-002 | Diagnostics/hover for a version published within the cooldown window are distinguishable (per whatever mechanism `/sdd plan` selects) from one published outside it | Verified live with at least one real package published within the last 3 days |
+| SC-003 | No regression: ecosystems/edge cases without timestamp data behave identically to pre-feature baseline | 100% of existing hover/diagnostics/completion tests continue to pass unchanged |
+| SC-004 | `Version` trait extension is additive only | Zero call sites outside `deps-core` and the ecosystem crates being actively migrated require changes; existing ecosystem crates not yet migrated (per NFR-003) compile without modification |
+| SC-005 | Full CI gate passes | `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo nextest run --workspace --all-features --no-fail-fast`, rustdoc gate — 0 failures |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Reproduce the freshness signal live via the LSP harness against a debug
+  build for at least one real, recently-published package before considering
+  any implementation task complete, per `continuous-improvement.md`
+- Add unit tests for present/missing/malformed timestamp per ecosystem
+  touched
+- Preserve existing hover/diagnostic/completion behavior for ecosystems not
+  yet migrated (default trait method returns `None`)
+
+### Ask First
+- Adding a new date/time crate dependency if the workspace's current
+  dependency tree (`chrono`/`time`, whichever if either is already present)
+  is insufficient — must be checked via context7 mcp per user's dependency
+  policy
+- Choosing where cooldown-window configuration lives (LSP `initializationOptions`,
+  a config file, or a hardcoded constant for v1) — this is a UX/architecture
+  decision for `/sdd plan`, not an implementation default to silently pick
+- Changing the public signature of the `Version` trait in a way that is not
+  purely additive (i.e. anything beyond a new default method)
+
+### Never
+- Filter, hide, or block a recently-published version from any hover,
+  completion, or diagnostic output as a side effect of this feature
+  (violates FR-006 / US-002 intent — Dependabot delays PRs, it does not
+  delete releases from view)
+- Silently change `find_latest_stable`'s selection criteria (yanked/prerelease
+  exclusion) as a side effect of adding freshness data — freshness is an
+  additional signal, not a replacement for existing latest-selection logic,
+  unless explicitly scoped in `/sdd plan`
+- Mark the fix complete based on unit tests alone — live LSP verification
+  against a real, recently-published package per ecosystem is required per
+  the project's continuous-improvement testing gate
+
+## 9. Open Questions
+
+> [!success] All resolved 2026-08-23 — see `plan.md` §7 for the decision record
+> Summary: hover gets an age suffix plus a cooldown callout and per-entry ages;
+> diagnostics change message only, severity stays `HINT`; completion uses
+> `label_details` for age with no cooldown verdict. Cooldown lives in
+> `DepsConfig.freshness` (3-day default, clamped 0–30 d) and is **live-reloadable**
+> via `did_change_configuration` (FR-012). The trait method is
+> `published_at() -> Option<PublishTime>`, a `deps-core` newtype over `i64` Unix
+> seconds backed by the `time` crate, which stays confined to `deps-core`. Future
+> timestamps clamp to "just now" and count as within cooldown; the boundary rule
+> is `age < cooldown` (exclusive). Freshness applies only to the recommendation
+> target, never to the locked/installed version. Swift is deferred entirely, so
+> the non-GitHub-host question is moot. The FR-007/FR-008 PR split was rejected as
+> an axis in favour of splitting by network cost. OSV/002 coordination stays out
+> of scope.
+>
+> The original questions are retained below for provenance.
+
+- [NEEDS CLARIFICATION: Exact UX treatment for the cooldown-window signal —
+  softer diagnostic severity (e.g. `HINT` instead of `WARNING`), a distinct
+  hover badge/icon, a completion item detail suffix, or some combination?
+  Decided in `/sdd plan`.]
+- [NEEDS CLARIFICATION: Where does the cooldown-window duration get
+  configured — LSP `initializationOptions`, a `deps-lsp` config file, an
+  environment variable, or hardcoded to 3 days for v1 with configurability
+  deferred?]
+- [NEEDS CLARIFICATION: Exact `Version` trait method signature and return
+  type for the timestamp — `Option<DateTime<Utc>>` via `chrono`, or
+  `Option<OffsetDateTime>` via `time`, depending on which (if either) is
+  already a workspace dependency. Needs a dependency audit in `/sdd plan`.]
+- [NEEDS CLARIFICATION: Does the freshness signal apply only to the
+  registry-reported "latest" version, or also to the version currently
+  pinned/locked in the user's manifest or lockfile (relevant to
+  `crates/deps-core/src/lockfile.rs` consumers)?]
+- [NEEDS CLARIFICATION: Clamping/edge-case behavior for a publish timestamp
+  in the future relative to local clock — suppress the signal entirely, or
+  clamp to "just now"?]
+- [NEEDS CLARIFICATION: For Swift packages hosted on non-GitHub Swift Package
+  Registries (per the finding, "varies by host"), is a best-effort partial
+  implementation (GitHub-hosted only) acceptable for v1, with other hosts
+  falling back to US-003 graceful degradation?]
+- [NEEDS CLARIFICATION: Should FR-007 (adding timestamp parsing to Cargo,
+  npm, PyPI, Composer, Swift, NuGet) ship in the same PR as FR-008 (wiring
+  already-parsed timestamps for Maven, Dart, Bundler, Go), or should this be
+  split into two PRs — "wire what we already have" first, "add parsing where
+  missing" second — to keep each PR reviewable? Recommend the split in
+  `/sdd plan`.]
+- [NEEDS CLARIFICATION: Interaction with the still-in-progress
+  [[002-osv-vulnerability-diagnostics/spec|OSV vulnerability diagnostics]]
+  spec — should a security-relevant version be exempted from cooldown
+  softening, mirroring Dependabot's security-update exemption? Deferred as
+  explicitly out of scope above, but flagged here in case `/sdd plan` for
+  either feature wants to coordinate.]
+
+## 10. See Also
+
+- [[constitution]] — project principles (not yet created for this project)
+- [[MOC-specs]] — all specifications
+- [[002-osv-vulnerability-diagnostics/spec|OSV vulnerability diagnostics]] — related risk-signal spec, currently in `plan` phase
+- [[003-maven-legacy-version-sort/spec|Maven/Gradle legacy version sort fix]] — already flags Maven's unused `timestamp` field as a candidate sort tiebreaker
+- `crates/deps-core/src/registry.rs` — `Version` trait (`:135`), `find_latest_stable` (`:202`)
+- `crates/deps-core/src/lsp_helpers.rs` — `generate_diagnostics`, `generate_diagnostics_from_cache`, `DiagnosticSeverity` assignment
+- `crates/deps-core/src/completion.rs` — `build_version_completion`, `VersionDisplayItem`
+- `crates/deps-maven/src/types.rs`, `crates/deps-dart/src/types.rs`, `crates/deps-bundler/src/types.rs`, `crates/deps-go/src/types.rs` — ecosystems that already parse a publish timestamp but discard it
+- `.claude/rules/continuous-improvement.md` — live-testing principle and cross-ecosystem consistency gate
+- [GitHub Changelog: Dependabot version updates introduce default package cooldown](https://github.blog/changelog/2026-07-14-dependabot-version-updates-introduce-default-package-cooldown/) — source of the 3-day default cooldown reference

--- a/specs/005-completion-search-blocking-timeout/spec.md
+++ b/specs/005-completion-search-blocking-timeout/spec.md
@@ -1,0 +1,248 @@
+---
+aliases:
+  - Completion Search Blocking Timeout
+  - Fallback Completion Latency Fix
+tags:
+  - sdd
+  - spec
+  - bug
+  - lsp
+  - completion
+  - performance
+created: 2026-08-20
+status: draft
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+---
+
+# Feature: Bound Latency of Package-Name Completion Fallback Search
+
+> [!info] Metadata
+> **Author**: k05h31@gmail.com
+> **Branch**: fix/{issue-number}-completion-search-timeout
+> **Priority**: P1 (bug)
+> **Source finding**: continuous-improvement session, 2026-08-20, deps-lsp v0.9.5 (commit `03c5a1b03`)
+
+## 1. Overview
+
+### Problem Statement
+
+`textDocument/completion` for a new package-name prefix (the "fallback completion" path)
+blocks the LSP request handler for as long as the live registry search takes — up to the
+generic 30-second `HTTP_TIMEOUT_SECS` (`crates/deps-core/src/cache.rs:11`) — instead of
+returning within an interactive latency budget.
+
+Root cause, traced through `crates/deps-lsp/src/handlers/completion.rs`:
+
+- `handle_completion` (line ~94/100) calls `fallback_completion(&state, ecosystem_id, position, &content).await`
+  **inline**, on the request-handling task, not delegated to `tokio::spawn`.
+- `fallback_completion` (line ~171) calls `search_packages(registry.as_ref(), ecosystem_kind, prefix).await`.
+- `search_packages` (line ~442) directly awaits `registry.search(query, 50).await` — a live
+  HTTP call to the ecosystem registry — with no dedicated shorter timeout for this
+  interactive path. It shares the same `HTTP_TIMEOUT_SECS` constant applied to the
+  underlying `reqwest::Client` (`crates/deps-core/src/registry.rs:145`,
+  `crates/deps-core/src/cache.rs:11`) that background hover/inlay-hint prefetches use —
+  paths that are not latency-sensitive because their results are cached ahead of the
+  request that needs them.
+- On any error (including timeout), `search_packages` catches it and silently returns
+  `vec![]` (line ~448) with only a `tracing::warn!` log line — no partial results, no
+  indication to the editor/user that the search timed out rather than genuinely finding
+  nothing.
+
+This directly violates the project's own documented convention in
+`.claude/rules/rust-code.md` under "LSP Layer (`crates/deps-lsp`)":
+*"Hover and completion responses must return quickly; delegate registry fetches to
+background tasks with caching."* The hover and inlay-hint paths already honor this
+(pre-fetched, cached, background-populated data); the package-name completion fallback
+path does not — it performs a synchronous, uncached, live registry search inline in the
+request handler.
+
+Confirmed live against Maven Central: a 2-character query (`gu`, the shortest prefix
+`fallback_completion` accepts — see `prefix.len() < 2` rejection at
+`crates/deps-lsp/src/handlers/completion.rs:157`) sent to
+`https://search.maven.org/solrsearch/select` can hang for the full 30s (h2 handshake
+completes, then no data frame arrives), versus ~0.2s for a longer, more specific query
+(`guava`). A raw `curl` control test against the same Solr endpoint reproduced the same
+first-attempt slowness independently of deps-lsp, confirming this is upstream registry
+behavior (Maven Central's Solr backend being flaky/slow for short, unqualified queries) —
+exactly the kind of registry latency variance the "delegate to background task"
+convention exists to protect the interactive completion request from. Gradle shares the
+same Maven registry client (`crates/deps-maven`) and is very likely to exhibit the same
+freeze, though this was not separately re-verified live for `build.gradle`.
+
+### Goal
+
+`textDocument/completion` on a package-name prefix returns within a short, bounded,
+interactive-latency window (target: within the existing `handle_completion` cold-start
+budget class, i.e. single-digit seconds, not 30s) regardless of how slow the underlying
+registry is for that particular query — by applying a short, dedicated timeout to the
+fallback-completion live-search path, returning promptly (empty or best-effort partial
+results) when that timeout is exceeded, distinct from the 30s `HTTP_TIMEOUT_SECS` used for
+background prefetches.
+
+### Out of Scope
+
+- Changing `HTTP_TIMEOUT_SECS` itself or any other background-fetch timeout (hover,
+  inlay hints, diagnostics) — those are correctly unbounded-ish because their results are
+  pre-fetched/cached ahead of the request that consumes them.
+- Fixing Maven Central's own Solr backend latency/flakiness — that is upstream, out of
+  deps-lsp's control.
+- Adding a warm-cache-on-timeout / "search continues in background, next keystroke sees
+  the result" mechanism, unless selected as the chosen approach in section 3 (see open
+  question OQ-1) — a minimal fix (bounded timeout + prompt empty return) satisfies the
+  Goal above on its own.
+- Re-verifying the Gradle-specific repro live — Gradle shares `deps-maven`'s registry
+  client, so the fix in `deps-maven`/`search_packages` covers it, but a dedicated
+  `build.gradle` short-query repro is not required to close this spec (may be covered by
+  the fix's test suite instead, see NFR-002 / edge cases table).
+
+## 2. User Stories
+
+### US-001: Fast completion regardless of registry slowness
+AS A developer editing a manifest file (e.g. `pom.xml`, `build.gradle`) in an editor with
+LSP support
+I WANT `textDocument/completion` for a new package name to respond quickly
+SO THAT I am not blocked mid-typing while the editor's UI freezes or the completion
+popup silently fails to appear for up to 30 seconds
+
+**Acceptance criteria:**
+```
+GIVEN a manifest file open in the editor with the cursor inside a dependencies section
+WHEN I type a short package-name prefix (e.g. 2 characters) that happens to trigger a
+     slow response from the ecosystem registry's search endpoint
+THEN the completion response returns within the bounded interactive timeout
+     (see NFR-001), even if that means returning an empty completion list because the
+     registry did not respond in time
+```
+
+### US-002: No silent multi-second UI freeze
+AS A developer
+I WANT the editor to remain responsive while I type
+SO THAT a slow registry does not make the entire editor session feel hung
+
+**Acceptance criteria:**
+```
+GIVEN the LSP server is processing a completion request whose fallback search is slow
+WHEN the bounded timeout for that search elapses
+THEN the LSP server returns a completion response (possibly empty) to the client instead
+     of leaving the `textDocument/completion` request outstanding
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN `fallback_completion` invokes `search_packages` for an interactive completion request THE SYSTEM SHALL apply a timeout to the registry search call that is strictly shorter than `HTTP_TIMEOUT_SECS` (30s) [NEEDS CLARIFICATION: exact bound — see OQ-2] | must |
+| FR-002 | WHEN the fallback-completion search timeout elapses before the registry responds THE SYSTEM SHALL return an empty completion list for that request rather than continuing to await the in-flight HTTP call | must |
+| FR-003 | WHEN the fallback-completion search times out THE SYSTEM SHALL log the timeout at a distinguishable level/message (e.g. `tracing::warn!` with an explicit "timed out" reason) separate from the existing generic search-failure log, so timeouts are distinguishable from genuine zero-result searches in `.local/testing/debug/session.log` | must |
+| FR-004 | WHEN applying the new bounded timeout THE SYSTEM SHALL apply it uniformly across all ecosystems that use `fallback_completion` (Cargo, Pypi, Npm, Composer, Maven, Go, Dart, and any ecosystem for which `is_in_dependencies_section` returns true), not only Maven | must |
+| FR-005 | THE SYSTEM SHALL NOT change the timeout used by background hover, inlay-hint, or diagnostic registry fetches (`HTTP_TIMEOUT_SECS` stays 30s for those paths) | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | `textDocument/completion` for a package-name prefix SHALL return within [NEEDS CLARIFICATION: target bound — candidates discussed in OQ-2, e.g. 3s, 5s] of request receipt, independent of registry response time, measured end-to-end via the existing `.local/testing/lsp_test.py` harness |
+| NFR-002 | Reliability | The fix SHALL NOT regress the existing control case (a longer/more specific query, e.g. `guava` against Maven Central, currently ~0.2s) — no added latency floor beyond negligible timer/task overhead |
+| NFR-003 | Observability | Timeout events on the fallback-completion path SHALL be visible in `RUST_LOG=debug` output with enough detail (ecosystem, query, elapsed time) to distinguish "registry timed out" from "registry returned zero matches" without re-running the request |
+| NFR-004 | Consistency | The bounded-timeout behavior SHALL be identical across all ecosystems sharing `fallback_completion`/`search_packages` — this is a `deps-core`/`deps-lsp` layer fix, not an ecosystem-specific one, per the project's cross-ecosystem-consistency convention |
+
+## 5. Data Model
+
+No new persistent entities. This is a control-flow/timeout change on an existing
+request path.
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| Fallback completion request | In-flight interactive search triggered by `fallback_completion` → `search_packages` → `registry.search()` | ecosystem id, query prefix, elapsed time, outcome (results / empty-timeout / empty-error) |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Registry responds within the new bounded timeout | Completion items returned as today (no behavior change) |
+| Registry never responds (network hang, upstream flakiness) within the bounded timeout | `search_packages` returns `vec![]`; `handle_completion` returns `Some(CompletionResponse::Array(vec![]))` or `None` per existing `items.is_empty()` branching (unchanged from current empty-result behavior, just reached faster) |
+| Registry returns a genuine HTTP error (4xx/5xx) before the bounded timeout | Unchanged: existing `Err(e) => { warn!; vec![] }` branch in `search_packages`, distinguishable in logs from a timeout per FR-003 |
+| Query prefix is 2 characters (minimum accepted length) against a registry backend known to be slow for short queries (e.g. Maven Central Solr) | Bounded timeout applies exactly as for any other query length; no separate short-prefix carve-out (see OQ-1) |
+| Multiple rapid keystrokes each triggering a new fallback-completion search before the previous one's timeout elapses | [NEEDS CLARIFICATION: does this spec require cancelling/superseding a still-in-flight prior search, or is it acceptable for prior in-flight bounded-timeout searches to simply run to completion/timeout in the background and be discarded? Current code has no such cancellation; out of scope unless explicitly requested — see OQ-3] |
+| Ecosystem's own `generate_completions` already returns non-empty results | Fallback path (and this fix) is never reached — unchanged |
+| Ecosystem with no raw-text dependencies-section boundary (Bundler, Swift, Gradle's TOML/Groovy/Kotlin manifests per `is_in_dependencies_section`) | Fallback completion already returns `vec![]` before reaching `search_packages` — unaffected by this fix, though FR-004 still requires the timeout to apply uniformly for ecosystems where the fallback path IS reached (e.g. Maven's `pom.xml`, which does have a raw-text `<dependencies>` boundary) |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | `textDocument/completion` wall-clock latency for a 2-char Maven prefix against a slow/hanging Solr response | Reduced from the reproduced ~36s to within the bounded timeout target (NFR-001), verified live via `.local/testing/lsp_test.py` per the repro steps in this finding |
+| SC-002 | Control-case latency (longer/specific query, e.g. `guava`) | Remains ~0.2s–low seconds, no regression |
+| SC-003 | Cross-ecosystem consistency | Same bounded-timeout behavior verified for at least Maven and one other ecosystem using `fallback_completion` (e.g. Cargo or Npm) with an artificially slow/mocked registry response in a unit/integration test |
+| SC-004 | Log distinguishability | A timed-out fallback search produces a log line distinguishable from a zero-result search when grepped in `.local/testing/debug/session.log` |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Run `cargo nextest run -p deps-lsp` (and `-p deps-core` / affected registry crates) after changes
+- Follow existing code patterns in `crates/deps-lsp/src/handlers/completion.rs` and
+  `crates/deps-core/src/cache.rs` / `registry.rs` for timeout/error handling style
+- Preserve existing public behavior for non-timeout cases (successful search, genuine
+  HTTP errors) exactly as documented in section 6
+
+### Ask First
+- Introducing a new constant name/location for the bounded completion-search timeout if
+  it isn't obviously implied by existing naming conventions (e.g. alongside
+  `HTTP_TIMEOUT_SECS` in `deps-core/src/cache.rs`, or local to `deps-lsp`)
+- Any change that also touches the 30s `HTTP_TIMEOUT_SECS` background-fetch timeout
+  (explicitly out of scope per FR-005 unless the user says otherwise)
+- Adding cancellation/supersession logic for rapid successive keystroke-triggered
+  searches (see OQ-3) — this is a larger behavioral change than the minimal bounded-
+  timeout fix
+
+### Never
+- Change registry API client logic unrelated to timeout handling (e.g. Maven Solr query
+  construction, result parsing)
+- Silently increase `HTTP_TIMEOUT_SECS` as a workaround instead of adding a dedicated
+  shorter timeout for the interactive path
+- Remove or weaken the existing `tracing::warn!` on search failure — only extend/clarify it
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: OQ-1 — Should there be a background "warm the cache" behavior
+  where, after the bounded timeout returns empty results to the editor, the live search
+  keeps running in the background so a follow-up keystroke on a similar/extended prefix
+  can hit a cache and return real results faster? The finding's "Expected behavior"
+  section mentions this as one of two acceptable approaches (the other being a bare
+  bounded timeout). Decide before `/sdd plan`.]
+- [NEEDS CLARIFICATION: OQ-2 — What is the exact timeout bound for the interactive
+  completion-search path? Candidates to consider: a fixed value (e.g. 2s, 3s, 5s)
+  independent of `HTTP_TIMEOUT_SECS`, or a fraction/derived value. The existing
+  cold-start document-load timeout in `handle_completion` uses 200ms for a much
+  cheaper local operation (disk load), which is not directly comparable to a live
+  cross-network registry search.]
+- [NEEDS CLARIFICATION: OQ-3 — Should rapid successive completion requests (each
+  triggering a new fallback search before the prior one's timeout elapses) cancel the
+  prior in-flight search, or is running multiple bounded-timeout searches concurrently
+  acceptable? No existing cancellation mechanism exists in `fallback_completion` today.]
+- [NEEDS CLARIFICATION: whether the bounded timeout should be implemented via
+  `tokio::time::timeout` wrapping the `registry.search()` call in `search_packages`
+  (simplest, most local to the fix), or via a `reqwest::Client`-level per-request
+  timeout override passed down through the `Registry` trait (more invasive, touches
+  `crates/deps-core/src/registry.rs` trait signature and every ecosystem's
+  implementation). Recommend the former unless plan-phase investigation shows the
+  `Registry` trait already supports per-call timeout overrides.]
+
+## 10. See Also
+
+- [[constitution]] — project principles (not yet created for this project)
+- [[MOC-specs]] — all specifications
+- `.claude/rules/rust-code.md` — "LSP Layer" convention this bug violates
+- `.claude/rules/continuous-improvement.md` — testing/anomaly-reporting process this
+  finding originated from
+- `crates/deps-lsp/src/handlers/completion.rs` — `handle_completion`,
+  `fallback_completion`, `search_packages` (lines ~19, ~115, ~429)
+- `crates/deps-core/src/cache.rs:11` — `HTTP_TIMEOUT_SECS` constant (background-fetch
+  timeout, unaffected by this fix per FR-005)
+- `crates/deps-core/src/registry.rs:117,145` — `Registry::search` trait method and
+  `HTTP_TIMEOUT_SECS` application to the underlying `reqwest::Client`
+- `crates/deps-maven/src/registry.rs:18,133` — `MAVEN_SEARCH_BASE`
+  (`https://search.maven.org/solrsearch/select`), `search_typed` — concrete repro path
+  for the Maven Central Solr slowness

--- a/specs/006-completion-prefix-quote-stripping/spec.md
+++ b/specs/006-completion-prefix-quote-stripping/spec.md
@@ -1,0 +1,198 @@
+---
+aliases:
+  - Completion Prefix Quote Stripping
+  - JSON Completion Quote Bug
+tags:
+  - sdd
+  - spec
+  - bug
+  - completion
+  - npm
+  - composer
+created: 2026-08-20
+status: draft
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+---
+
+# Feature: Strip JSON String-Delimiter Quote from Fallback Completion Prefix
+
+> [!info] Metadata
+> **Author**: k05h31@gmail.com
+> **Branch**: fix/completion-prefix-quote-stripping
+> **Priority**: P2
+> **Type**: bug
+
+## 1. Overview
+
+### Problem Statement
+
+`fallback_completion` in `crates/deps-lsp/src/handlers/completion.rs` (lines 149-152)
+extracts the user's in-progress package-name prefix as:
+
+```rust
+let prefix_end = std::cmp::min(position.character as usize, line.len());
+let prefix = &line[..prefix_end];
+let prefix = prefix.trim();
+```
+
+`prefix.trim()` only strips whitespace. For JSON-based manifests (`package.json`
+for npm, `composer.json` for Composer), `is_in_json_dependencies` (line 264)
+confirms the cursor line is inside a `dependencies` / `require` / `require-dev`
+block, but the raw line text still contains the opening `"` of the JSON string
+literal the user is mid-typing (e.g. `"expr` while typing `"expr-eval"` inside
+`"dependencies": { "expr`). That leading `"` is not stripped, so it is passed
+straight through as the search query.
+
+This query flows unmodified into `search_packages(registry, ecosystem_id, prefix)`
+(line 430) and then into the registry's `search()` implementation, which URL-encodes
+it verbatim and sends it to the live registry search API:
+
+- npm: `format!("{}/-/v1/search?text={}&size={}", REGISTRY_BASE, urlencoding::encode(query), limit)`
+  (`crates/deps-npm/src/registry.rs:143-149`) — sends `text=%22expr` (`"expr`) instead
+  of `text=expr`.
+- Composer/Packagist: `format!("{}?q={}&per_page={}", PACKAGIST_SEARCH, urlencoding::encode(query), limit)`
+  (`crates/deps-composer/src/registry.rs:84-90`) — same defect pattern, same root cause
+  (`is_in_json_dependencies` is also used for Composer's `require`/`require-dev`
+  sections per `is_in_dependencies_section`, lines ~200-210).
+
+Live verification against npm's real `/-/v1/search` endpoint confirms this is not
+a caching or ranking-noise artifact but a genuine relevance regression: querying
+with the stray leading quote (`%22expr`) omits the exact-name match package `expr`
+from the top-5 results entirely, while querying without it (`expr`) returns `expr`
+as the top-ranked result. See Reproduction below for the full comparison.
+
+This is a longstanding, pre-existing defect (present since the original completion
+feature, commit `ac0646e`, #36) — not introduced by the recent `EcosystemId` enum
+refactor (#135) — but it directly degrades package-name completion quality for
+npm and Composer, the two most commonly used JSON-manifest ecosystems, and had
+gone undetected until this cycle's live end-to-end completion test because it was
+not covered by any existing `journal.md`/`regressions.md` playbook entry.
+
+### Goal
+
+For JSON-based ecosystems (npm, Composer), the prefix passed to
+`search_packages`/`registry.search` contains only the bare package-name text the
+user has typed so far — with any leading and/or trailing JSON string-delimiter
+quote (`"`) stripped in addition to whitespace — so registry search relevance
+matches what a normal, well-formed query would return.
+
+### Out of Scope
+
+- Changes to non-JSON ecosystems (Cargo, PyPI, Maven, Go, Dart, Bundler, Swift,
+  Gradle) — their raw-text prefix extraction does not involve a JSON string
+  delimiter and is unaffected by this defect.
+- Changes to `is_in_dependencies_section` / `is_in_json_dependencies` section-boundary
+  detection logic itself — this spec only concerns prefix *content* extraction,
+  not section detection.
+- Changes to registry `search()` implementations (`deps-npm`, `deps-composer`) —
+  the fix is upstream of them, in the prefix extraction shared by all ecosystems.
+- Ranking/relevance tuning on the registry side — out of deps-lsp's control.
+- Any parsed-completion path (`ecosystem.generate_completions`) — this only affects
+  the raw-text `fallback_completion` fallback path used while the manifest is
+  mid-typing and fails to parse.
+
+## 2. User Stories
+
+### US-001: Accurate package suggestions while typing a new npm/Composer dependency
+
+AS A developer editing `package.json` or `composer.json`
+I WANT completion suggestions to reflect what I actually typed, not a mangled query
+SO THAT the package I'm typing (e.g. `expr`) appears near the top of the suggestion
+list instead of being pushed out by irrelevant results
+
+**Acceptance criteria:**
+```
+GIVEN a package.json with an unterminated dependency entry `"dependencies": { "expr`
+WHEN completion is requested with the cursor immediately after "expr"
+THEN the search query sent to the npm registry is `expr` (no leading quote)
+AND the completion list includes the exact-name match `expr` package among the
+    top results (subject to registry-side ranking, not degraded by a stray query
+    character)
+```
+
+```
+GIVEN a composer.json with an unterminated require entry `"require": { "monolog/lo`
+WHEN completion is requested with the cursor immediately after "monolog/lo"
+THEN the search query sent to Packagist is `monolog/lo` (no leading quote)
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN `fallback_completion` extracts the raw-text prefix for a JSON-based ecosystem (npm, Composer) THE SYSTEM SHALL strip a leading `"` character from the prefix, if present, before using it as the search query | must |
+| FR-002 | WHEN `fallback_completion` extracts the raw-text prefix for a JSON-based ecosystem THE SYSTEM SHALL strip a trailing `"` character from the prefix, if present (e.g. cursor positioned just after a fully-closed string literal), before using it as the search query | must |
+| FR-003 | WHEN the prefix, after quote-stripping, is empty or shorter than the existing minimum-length threshold (2 chars) THE SYSTEM SHALL reject it and return no completions, per existing behavior at line 157 | must |
+| FR-004 | WHEN the ecosystem is not JSON-based (Cargo, PyPI, Maven, Go, Dart) THE SYSTEM SHALL NOT alter its existing prefix-extraction behavior | must |
+| FR-005 | WHEN the stripped prefix still contains an internal `=` character (existing reject condition at line 157) THE SYSTEM SHALL continue to reject it as before | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Correctness | The fix must not change behavior for any ecosystem other than npm and Composer (or more generally, any ecosystem routed through `is_in_json_dependencies`) |
+| NFR-002 | Performance | The added quote-stripping is a constant-time string operation on an already-bounded-length line prefix; no measurable latency impact on the completion hot path |
+| NFR-003 | Testability | The fix must be covered by a unit test that reproduces the exact scenario in the finding (unterminated `"expr` inside `package.json` dependencies) and asserts the extracted prefix is `expr`, not `"expr` |
+
+## 5. Data Model
+
+No data model changes. This is a pure string-processing fix within
+`fallback_completion`; no new entities, persisted state, or schema changes.
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| N/A | No entities introduced or modified | — |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Prefix is exactly `"` (only the opening quote typed, nothing after) | After stripping, prefix is empty string; rejected by existing empty-check (FR-003), no completions returned |
+| Prefix has quote on both ends, e.g. cursor lands right after a closed string `"expr"` | Both leading and trailing `"` stripped per FR-001/FR-002, leaving `expr` |
+| Prefix has no quote at all (e.g. cursor is mid-value after `=`, non-JSON ecosystem, or user is inside a bare key) | No-op — quote-stripping only removes `"` if present at the boundary; unaffected inputs pass through unchanged |
+| Prefix contains an escaped quote inside the value, e.g. `"expr\"` (unlikely for package names but theoretically typable) | `[NEEDS CLARIFICATION: should escaped-quote sequences inside the prefix be unescaped/handled specially, or is a simple leading/trailing `"` strip sufficient given package names practically never contain quote characters?]` — default assumption: simple boundary strip is sufficient since npm/Composer package names cannot contain `"` per registry naming rules |
+| Non-JSON ecosystem line that happens to contain a literal `"` character in the prefix (e.g. TOML value context) | Not affected — quote-stripping is gated on `ecosystem_kind` being JSON-based (npm/Composer), per FR-004 |
+| Multiple consecutive leading quotes (malformed input, e.g. `""expr`) | `[NEEDS CLARIFICATION: strip only one leading quote or all consecutive leading quotes?]` — default assumption: strip only one leading and one trailing quote (matches the realistic single-string-literal case); pathological multi-quote input is not expected from normal typing |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Query sent to npm/Composer registry search for a mid-typed JSON dependency name | Contains no leading/trailing `"` character |
+| SC-002 | Regression test reproducing the finding's exact scenario (`"expr` in `package.json`) | Passes: extracted prefix equals `expr` |
+| SC-003 | Existing completion test suite (lines ~1040-1090 and surrounding fallback-completion tests in `completion.rs`) | Continues to pass unchanged |
+| SC-004 | Live end-to-end verification via `.local/testing/lsp_test.py` against real npm registry, matching the finding's reproduction steps | Top completion results now include the exact-name match package (e.g. `expr` for query `expr`) |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Run `cargo +nightly fmt --check`, `cargo clippy --all-targets --all-features --workspace -- -D warnings`, and `cargo nextest run --workspace --all-features --lib --bins` before considering the fix complete
+- Add a unit test reproducing the exact finding scenario
+- Follow existing code patterns in `completion.rs` (the file already has helper functions like `is_in_json_dependencies`, `is_in_toml_dependencies`, etc. — keep the fix consistent with that style)
+- Update `CHANGELOG.md` under `[Unreleased]`
+
+### Ask First
+- Any change to `is_in_dependencies_section` dispatch logic beyond what's needed to gate quote-stripping to JSON ecosystems
+- Any change to registry `search()` signatures in `deps-npm`/`deps-composer`
+
+### Never
+- Modify non-JSON ecosystem prefix-extraction paths (Cargo, PyPI, Maven, Go, Dart, Bundler, Swift, Gradle)
+- Perform live registry end-to-end verification during a code-writing/fix session — per `.claude/rules/continuous-improvement.md`, live testing against real registries is scoped to dedicated testing sessions, not fix implementation sessions (unit test coverage per SC-002/SC-003 is sufficient to close this spec; SC-004 live verification is a follow-up testing-session activity)
+- Commit secrets or credentials
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: should escaped-quote sequences inside the prefix (e.g. `"expr\"`) be unescaped/handled specially, or is a simple leading/trailing `"` boundary strip sufficient? Default assumption: simple strip is sufficient since npm/Composer package names cannot contain `"`.]
+- [NEEDS CLARIFICATION: for malformed input with multiple consecutive leading quotes (e.g. `""expr`), strip only one or all? Default assumption: strip only one leading and one trailing quote.]
+
+## 10. See Also
+
+- [[constitution]] — project principles (not yet created for this project)
+- [[MOC-specs]] — all specifications
+- `crates/deps-lsp/src/handlers/completion.rs` — `fallback_completion`, `is_in_json_dependencies`, `search_packages`
+- `crates/deps-npm/src/registry.rs` — npm `search()` implementation
+- `crates/deps-composer/src/registry.rs` — Composer/Packagist `search()` implementation
+- Issue #36 (`ac0646e`) — original completion feature introducing this defect
+- PR #135 — `EcosystemId` enum refactor (unrelated to this defect, but touches the same dispatch logic)

--- a/specs/007-lightweight-registry-metadata/plan.md
+++ b/specs/007-lightweight-registry-metadata/plan.md
@@ -1,0 +1,359 @@
+---
+aliases:
+  - Lightweight Registry Metadata plan
+tags:
+  - sdd
+  - plan
+  - enhancement
+  - performance
+  - npm
+  - pypi
+created: 2026-08-20
+status: draft
+related:
+  - "[[spec]]"
+  - "[[constitution]]"
+---
+
+# Technical Plan: Adopt Lightweight Registry Metadata Formats for npm and PyPI Version Lookups
+
+> [!info] References
+> **Spec**: [[spec]]
+> **Priority**: P2 — plan produced per this project's SDD-integration threshold
+> (P2–P3 enhancement = specify + plan; `/sdd tasks`/implementation deferred to
+> a dedicated `/rust-team` session, not this research cycle)
+
+> [!warning] Planning under open clarifications
+> The spec carries two `[NEEDS CLARIFICATION]` markers (filename-based version
+> derivation for PyPI, ETag-only caching on the Simple API). Neither blocks
+> planning — both are given a concrete working design below — but both must
+> be verified live (per the Testing Strategy) before this plan is considered
+> ready for `/sdd tasks`.
+
+## 1. Architecture
+
+### Approach
+
+This is a narrow, surgical change confined to two functions:
+`NpmRegistry::get_versions` (`crates/deps-npm/src/registry.rs`) and
+`PypiRegistry::get_versions` (`crates/deps-pypi/src/registry.rs`). No new
+crate, module, or `deps-core` abstraction is introduced — both changes reuse
+the existing `HttpCache::get_cached_with_headers` method
+(`crates/deps-core/src/cache.rs:204`), which already supports injecting
+arbitrary request headers (originally added for Authorization use cases) and
+already keys its cache purely by URL, so switching to a header-negotiated
+lighter response for the *same* npm URL does not collide with any other
+cached entry.
+
+**npm**: the request changes (add `Accept:
+application/vnd.npm.install-v1+json`); the response *parsing* does not. The
+abbreviated packument is a strict field-subset of the full packument for
+every field the existing `PackageMetadata`/`VersionMetadata` structs already
+deserialize (`version` key implicit in the map, `deprecated` per entry) —
+`serde`'s default "ignore unknown fields" behavior means the existing structs
+work unchanged against the new response shape. This was confirmed live (see
+[[spec#Overview|spec Overview]]).
+
+**PyPI**: both the request *and* the response shape change, because the
+Simple JSON API's top-level structure (`versions: [String]`, `files:
+[{filename, yanked, ...}]`) is fundamentally different from the full JSON
+API's `releases: {version: [files]}` grouping. A new set of internal
+deserialization types replaces `PypiResponse`/`PypiRelease` *only* inside
+`get_versions`'s call path; `get_package_metadata` keeps using the old
+`PypiResponse`/`PypiInfo` types against the unchanged full-JSON-API endpoint.
+
+The one genuine technical gap: PEP 691's `files` array carries no explicit
+per-file `version` field (the full JSON API's `releases` map, by contrast,
+groups files by version key already). `get_versions`'s current semantics —
+"a version is yanked if any of its release files is yanked" — require
+mapping each file back to a version. This plan resolves it with a
+filename-based matching pass against the already-known `versions` list (see
+[[#3. Data Model]]), not a new dependency.
+
+### Component Diagram
+
+```mermaid
+graph TD
+    subgraph deps-npm
+        A[NpmRegistry::get_versions] --> B[HttpCache::get_cached_with_headers<br/>Accept: vnd.npm.install-v1+json]
+        B --> C[registry.npmjs.org/{package}<br/>SAME URL as before]
+        C --> D[parse_package_metadata<br/>UNCHANGED structs]
+    end
+    subgraph deps-pypi
+        E[PypiRegistry::get_versions] --> F[HttpCache::get_cached_with_headers<br/>Accept: vnd.pypi.simple.v1+json]
+        F --> G[pypi.org/simple/{name}/<br/>NEW URL]
+        G --> H[NEW: parse_simple_api_response<br/>SimpleApiResponse / SimpleApiFile]
+        H --> I[NEW: match_files_to_versions<br/>filename -&gt; version derivation]
+        J[PypiRegistry::get_package_metadata] --> K[HttpCache::get_cached_with_headers<br/>unchanged, no Accept override]
+        K --> L[pypi.org/pypi/{name}/json<br/>UNCHANGED URL]
+        L --> M[parse_package_info<br/>UNCHANGED, uses existing PypiResponse/PypiInfo]
+    end
+```
+
+### Key Design Decisions
+
+| Decision | Choice | Rationale | Alternatives Considered |
+|----------|--------|-----------|--------------------------|
+| HTTP mechanism for content negotiation | Reuse `HttpCache::get_cached_with_headers` with an `Accept` header | Already exists, already supports arbitrary headers, no new HTTP client code | Add a new `HttpCache` method dedicated to Accept headers — rejected, `get_cached_with_headers` is already generic enough |
+| npm response parsing | No change to `PackageMetadata`/`VersionMetadata` structs | Abbreviated packument is a superset of the fields already deserialized; serde ignores unknown fields by default | Define new `AbbreviatedPackageMetadata` structs mirroring the new schema exactly — rejected, unnecessary duplication for identical field names |
+| PyPI cache key / URL | Switch `get_versions` to `https://pypi.org/simple/{name}/`, distinct from `get_package_metadata`'s `https://pypi.org/pypi/{name}/json` | `HttpCache` keys strictly by URL (`crates/deps-core/src/cache.rs:133`), so the two functions naturally get independent cache entries with no collision risk | Reuse the same URL for both with different Accept headers — rejected, `HttpCache`'s cache key is URL-only, so two different Accept-negotiated bodies for one URL would collide and one would silently serve stale/wrong-shaped data to the other caller |
+| PyPI per-version yanked derivation | Match each Simple API file to a version by filename, using the already-known `versions` list as the candidate set (longest-match-first prefix matching after underscore/hyphen normalization) | No per-file `version` field exists in PEP 691; the `versions` list gives a small, authoritative candidate set to match against, avoiding a full wheel/sdist filename-parsing library | Add a wheel-filename-parsing crate (e.g. a PEP 427/625 parser) — rejected as over-engineering for extracting one field; hand-rolled matching against a known-versions set is simpler and sufficient |
+| Yanked field decoding on Simple API | Custom deserializer accepting both `false`/`true` (bool) and a string (yank reason) — PEP 691 allows either | The full JSON API uses a plain `bool`, but PEP 691's `yanked` field is `false \| string`; a plain `bool` deserializer would fail to parse a yank-reason string | Deserialize as `serde_json::Value` inline without a helper — rejected, less testable and repeats logic if reused |
+| `get_package_metadata` endpoint | Left unchanged, still full JSON API | It needs `summary`/`project_urls`, which the Simple API does not provide (FR-005, NFR-004) | Migrate everything to Simple API and drop hover summary — rejected, explicitly out of scope and would degrade an existing feature |
+
+## 2. Project Structure
+
+```
+crates/deps-npm/src/
+└── registry.rs        (modified: get_versions adds Accept header via
+                         get_cached_with_headers; no struct changes)
+
+crates/deps-pypi/src/
+└── registry.rs         (modified:
+                          - get_versions: new URL (pypi.org/simple/{name}/),
+                            new Accept header, new response types
+                            (SimpleApiResponse, SimpleApiFile), new
+                            filename-to-version matching helper
+                          - get_package_metadata: UNCHANGED
+                          - parse_package_info: UNCHANGED, still parses
+                            PypiResponse from the full JSON API
+                          - NEW private fn: parse_simple_api_response
+                          - NEW private fn: match_files_to_versions
+                            (or equivalent filename-matching helper)
+```
+
+No changes anywhere in `deps-core`, `deps-lsp`, or any other ecosystem crate.
+
+## 3. Data Model
+
+```rust
+// crates/deps-npm/src/registry.rs — NO CHANGES to existing types.
+// Only the request changes:
+pub async fn get_versions(&self, name: &str) -> Result<Vec<NpmVersion>> {
+    let url = format!("{REGISTRY_BASE}/{name}");
+    let data = self
+        .cache
+        .get_cached_with_headers(
+            &url,
+            &[(header::ACCEPT, "application/vnd.npm.install-v1+json")],
+        )
+        .await?;
+    parse_package_metadata(&data) // unchanged function, unchanged structs
+}
+```
+
+```rust
+// crates/deps-pypi/src/registry.rs — NEW types, scoped to get_versions only.
+
+/// PEP 691 Simple JSON API response for a single project.
+#[derive(Debug, Deserialize)]
+struct SimpleApiResponse {
+    versions: Vec<String>,
+    files: Vec<SimpleApiFile>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SimpleApiFile {
+    filename: String,
+    #[serde(default, deserialize_with = "deserialize_yanked")]
+    yanked: bool,
+}
+
+/// PEP 691 allows `yanked` to be `false` or a string (the yank reason).
+/// Any string value means "yanked"; `false`/absent means "not yanked".
+fn deserialize_yanked<'de, D>(deserializer: D) -> std::result::Result<bool, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(match serde_json::Value::deserialize(deserializer)? {
+        serde_json::Value::Bool(b) => b,
+        serde_json::Value::String(_) => true,
+        _ => false,
+    })
+}
+
+pub async fn get_versions(&self, name: &str) -> Result<Vec<PypiVersion>> {
+    let normalized = normalize_package_name(name);
+    let url = format!("https://pypi.org/simple/{normalized}/");
+    let data = self
+        .cache
+        .get_cached_with_headers(
+            &url,
+            &[(header::ACCEPT, "application/vnd.pypi.simple.v1+json")],
+        )
+        .await
+        .map_err(/* unchanged 404 -> PackageNotFound mapping */)?;
+
+    parse_simple_api_response(name, &normalized, &data)
+}
+
+/// Derives per-version yanked status from the flat `files` list by matching
+/// each filename against the known `versions` set (longest-match-first,
+/// underscore/hyphen normalized), since PEP 691 files carry no explicit
+/// `version` field.
+fn parse_simple_api_response(
+    package_name: &str,
+    normalized_name: &str,
+    data: &[u8],
+) -> Result<Vec<PypiVersion>> {
+    let response: SimpleApiResponse = serde_json::from_slice(data)
+        .map_err(|e| PypiError::api_response_error(package_name, e))?;
+
+    // Longest version strings first, so "1.0.10" is preferred over a
+    // false-positive prefix match against "1.0.1".
+    let mut candidates: Vec<&str> = response.versions.iter().map(String::as_str).collect();
+    candidates.sort_unstable_by_key(|v| std::cmp::Reverse(v.len()));
+
+    let mut yanked_by_version: std::collections::HashMap<&str, bool> =
+        response.versions.iter().map(|v| (v.as_str(), false)).collect();
+
+    for file in &response.files {
+        if let Some(version) = match_filename_to_version(&file.filename, normalized_name, &candidates) {
+            let entry = yanked_by_version.entry(version).or_insert(false);
+            *entry = *entry || file.yanked;
+        }
+    }
+
+    // Parse + sort exactly as before, now sourced from `versions` + the map above.
+    let mut versions_with_parsed: Vec<(PypiVersion, Version)> = response
+        .versions
+        .into_iter()
+        .filter_map(|version_str| {
+            let yanked = yanked_by_version.get(version_str.as_str()).copied().unwrap_or(false);
+            Version::from_str(&version_str).ok().map(|parsed| {
+                (PypiVersion { version: version_str, yanked }, parsed)
+            })
+        })
+        .collect();
+
+    versions_with_parsed.sort_by(|a, b| b.1.cmp(&a.1));
+    Ok(versions_with_parsed.into_iter().map(|(v, _)| v).collect())
+}
+```
+
+### Migrations
+
+Not applicable — no persisted storage; all data lives in `HttpCache`'s
+in-memory, process-lifetime entries, unchanged in structure (`CachedResponse
+{ body, etag, last_modified, fetched_at }`).
+
+## 4. API Design
+
+### Outbound (deps-npm/deps-pypi → registries)
+
+| Method | Path | Description | Request Headers | Response (relevant fields) |
+|--------|------|-------------|------------------|------------------------------|
+| GET | `https://registry.npmjs.org/{package}` | npm version lookup (changed: header only, URL unchanged) | `Accept: application/vnd.npm.install-v1+json` (new) | `{ versions: { [v]: { version, dist, engines, deprecated } }, dist-tags, modified }` |
+| GET | `https://pypi.org/simple/{name}/` | PyPI version lookup (changed: new URL + header) | `Accept: application/vnd.pypi.simple.v1+json` (new) | `{ name, versions: [String], files: [{ filename, yanked, hashes, ... }], meta }` |
+| GET | `https://pypi.org/pypi/{name}/json` | PyPI hover metadata (`get_package_metadata`) — **unchanged** | none (unchanged) | `{ info: { summary, project_urls, version }, releases }` |
+
+No inbound (LSP-facing) API changes — `Hover`, `CompletionItem`, and
+`Diagnostic` payloads produced downstream are unaffected; this feature only
+changes what each registry client fetches internally.
+
+## 5. Integration Points
+
+| System | Direction | Protocol | Notes |
+|--------|-----------|----------|-------|
+| `registry.npmjs.org` | outbound | HTTPS | Same host/path as today, different `Accept` header |
+| `pypi.org/simple/{name}/` | outbound, NEW endpoint for this crate | HTTPS | Public, keyless, PEP 691 |
+| `pypi.org/pypi/{name}/json` | outbound, unchanged | HTTPS | Still used by `get_package_metadata` |
+| `HttpCache` (`deps-core`) | internal, reused unchanged | in-process | `get_cached_with_headers` already supports the header-injection this feature needs; cache keying by URL already isolates the two PyPI endpoints from each other |
+
+## 6. Security
+
+- Authentication: none — both endpoints are public and keyless, same as
+  today.
+- Authorization: not applicable.
+- Input validation: `name`/`normalized_name` are already validated/normalized
+  by existing `normalize_package_name` (PEP 503) before being interpolated
+  into the URL; no new untrusted-input surface.
+- Response handling: both new response shapes are deserialized via `serde`
+  into strongly typed structs; a malformed or oversized response is treated
+  as a fetch/parse failure (FR-006), not a panic. `HttpCache`'s existing
+  `MAX_RESPONSE_BYTES` cap (`crates/deps-core/src/cache.rs`) applies
+  unchanged to both new endpoints.
+- Sensitive data: none — no change to what's transmitted (package name only).
+
+## 7. Testing Strategy
+
+| Level | Framework | What to Test | Coverage Target |
+|-------|-----------|-------------|-----------------|
+| Unit | `cargo nextest` | npm: existing `test_parse_package_metadata` continues to pass unchanged (structs unchanged); add a fixture using the *actual* abbreviated-packument shape (captured live) to prove forward-compatibility | Existing + 1 new fixture-based test |
+| Unit | `cargo nextest` | PyPI: `parse_simple_api_response` against a fixture matching the real PEP 691 shape — cases: version with all files yanked, version with no files yanked, version with a `yanked` string reason (not just bool), version absent from `files` entirely, malformed/unmatchable filename | 5+ new test cases replacing/extending `test_parse_package_metadata` |
+| Unit | `cargo nextest` | `match_filename_to_version` (or equivalent helper) — sdist filenames (`.tar.gz`, `.zip`), wheel filenames (with/without build tag), a version that is a strict prefix of another version's filename (e.g. `1.0.1` inside `1.0.10`) to prove longest-match-first correctness | Dedicated unit tests for the matching algorithm |
+| Unit | `mockito` (already in workspace) | `HttpCache::get_cached_with_headers` is called with the correct `Accept` header for both `NpmRegistry::get_versions` and `PypiRegistry::get_versions`; `get_package_metadata` is verified to NOT send the new Accept header / NOT hit the Simple API URL | Regression guard for NFR-004/FR-005 |
+| Live/manual | per `.claude/rules/continuous-improvement.md` Registry Integration Gate | Real requests to `registry.npmjs.org` (e.g. `express`) and `pypi.org/simple/` (e.g. `django`) — confirm payload size reduction (SC-001/SC-002), identical version-list output vs. current production code (SC-004), and that a second call returns `304 Not Modified` (SC-005, resolves the ETag-only ` [NEEDS CLARIFICATION]`) | Required before merge, not before spec/plan |
+| Regression | existing suite | `get_latest_matching` tests for both crates continue passing unchanged (FR-007) | 100% pass |
+
+## 8. Performance Considerations
+
+- Expected load: identical request *count* — one request per `get_versions`
+  call, unchanged from today; only the response *size* decreases.
+- Bottleneck risk: none introduced — no new round trips, no new
+  serialization complexity beyond the filename-matching pass, which is O(number
+  of files) per package (bounded, typically well under a few hundred for
+  even large PyPI/npm packages) and runs once per fetch (not per hover
+  keystroke), same as today's existing parse step.
+- Benefit: smaller payloads reduce both network transfer time (directly
+  improving hover/completion latency for large-history packages, per
+  `.claude/rules/rust-code.md`'s "must return quickly" requirement) and
+  `HttpCache`'s per-entry memory footprint, which increases effective cache
+  capacity for the same byte budget — relevant to the still-open issue #142
+  (`HttpCache` retained memory bounded by entry count, not bytes), though this
+  feature does not implement byte-based eviction itself.
+
+## 9. Rollout Plan
+
+Given P2 priority and this project's SDD-integration threshold rule (P2–P3 =
+specify + plan; implementation deferred to a dedicated `/rust-team` session):
+
+1. This plan is reviewed and the two open `[NEEDS CLARIFICATION]` items are
+   confirmed via the Live/manual testing row above before `/sdd tasks` is run.
+2. `/sdd tasks` breaks this plan into discrete tasks in a dedicated
+   implementation session (not this research cycle).
+3. No feature flag needed — this is an internal fetch-format change with no
+   externally observable behavior change beyond payload size and latency, so
+   there is no user-facing toggle to gate. If a regression is discovered
+   post-merge, revert is a single-commit rollback per crate (npm change and
+   PyPI change are independent and can be reverted separately).
+4. No phased/canary rollout infrastructure exists in this project — ship
+   directly once live verification (Testing Strategy) passes.
+
+## 10. Constitution Compliance
+
+`[NEEDS CLARIFICATION: .local/specs/constitution.md does not exist yet for
+this project (confirmed via file check) — this plan cross-checks against the
+project's existing enforced rules under .claude/rules/, which function as the
+project's de facto constitution today.]`
+
+| Principle (from `.claude/rules/`) | Status | Notes |
+|---|---|---|
+| Registry Integration Gate (`continuous-improvement.md`) | Addressed in [[#7. Testing Strategy]] | Live verification against real npm/PyPI required before merge |
+| Hover/completion must return quickly (`rust-code.md`) | Directly served by this feature | Smaller payloads reduce the dominant latency cost (network transfer) on the hot path |
+| Registry crates use ecosystem-specific version-parsing crates, not hand-rolled | Compliant | No change — `node_semver`/`pep440_rs` usage is untouched, this feature only changes the JSON source, not version comparison logic |
+| `thiserror` typed errors (`rust-code.md`) | Compliant | No new error variants — FR-006 keeps existing `DepsError`/`PypiError` types |
+| Testing conventions (`testing.md`) — `nextest`, `mockito` | Planned | See [[#7. Testing Strategy]] |
+| Dependencies rule — check current versions via context7 mcp before adding | Not applicable | No new dependency — `reqwest`, `serde`, `serde_json` already in workspace; filename matching is hand-rolled, no crate added |
+
+## 11. Risks and Mitigations
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| Filename-to-version matching produces a false match or misses a match for an unusual sdist/wheel naming pattern (e.g. legacy pre-PEP 625 sdist, `.egg`, `.tar.bz2`) | Medium (a yanked version could be reported as not-yanked, or vice versa) | Low–Medium | Longest-match-first against the known `versions` set (not free-form parsing) minimizes false positives; unmatched files simply don't contribute a yanked signal (fail-safe toward "not yanked", same as today's behavior for a release with zero files) — covered by dedicated unit tests (Testing Strategy) |
+| PyPI's Simple JSON API omits `Last-Modified` (confirmed live) — if any part of `HttpCache` implicitly assumed both headers are present together | Low | Low | `HttpCache`'s `last_modified` field is already `Option<String>` and only sent as `If-Modified-Since` when `Some` (`crates/deps-core/src/cache.rs:258-260`) — no code change needed; confirmed via live 304 test (SC-005) |
+| npm abbreviated packument silently drops a field the current struct relies on that wasn't caught by this analysis | Low (grep-confirmed only `deprecated` is read; risk is a missed private/internal usage) | Low | Existing unit test suite plus a new live-fixture test (Testing Strategy) catch any parse failure immediately since `serde` would error on a genuinely required-but-missing field |
+| PEP 691 `yanked` field's two-shape (`bool \| string`) is mis-decoded if the custom deserializer has a bug | Medium (yanked status silently wrong) | Low | Dedicated unit test cases for both shapes (bool `false`/`true` and string reason) in the Testing Strategy |
+| No project constitution exists to check formal compliance against | Low (process risk, not implementation risk) | Certain (confirmed) | Cross-checked against `.claude/rules/*.md` instead (see [[#10. Constitution Compliance]]) |
+
+## See Also
+
+- [[spec]] — feature specification
+- [[MOC-specs]] — all specifications
+- `crates/deps-npm/src/registry.rs` — `NpmRegistry::get_versions`, `parse_package_metadata`
+- `crates/deps-pypi/src/registry.rs` — `PypiRegistry::get_versions`, `get_package_metadata`, `parse_package_metadata`, `parse_package_info`
+- `crates/deps-core/src/cache.rs` — `HttpCache::get_cached_with_headers`
+- [npm registry package metadata responses](https://github.com/npm/registry/blob/main/docs/responses/package-metadata.md)
+- [PEP 691 – JSON-based Simple API for Python Package Indexes](https://peps.python.org/pep-0691/)
+- `.claude/rules/continuous-improvement.md`, `.claude/rules/testing.md`, `.claude/rules/rust-code.md`
+- Issue #142 — `HttpCache` retained memory bounded by entry count, not bytes

--- a/specs/007-lightweight-registry-metadata/spec.md
+++ b/specs/007-lightweight-registry-metadata/spec.md
@@ -1,0 +1,267 @@
+---
+aliases:
+  - Lightweight Registry Metadata for npm/PyPI
+  - Abbreviated Packument and Simple JSON API Adoption
+tags:
+  - sdd
+  - spec
+  - enhancement
+  - performance
+  - npm
+  - pypi
+created: 2026-08-20
+status: draft
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+---
+
+# Feature: Adopt Lightweight Registry Metadata Formats for npm and PyPI Version Lookups
+
+> [!info] Metadata
+> **Author**: k05h31@gmail.com
+> **Branch**: feat/lightweight-registry-metadata
+> **Priority**: P2
+> **Type**: enhancement
+
+## 1. Overview
+
+### Problem Statement
+
+`deps-npm` and `deps-pypi`'s version-lookup hot path is called on every hover,
+completion, and diagnostic refresh (per `.claude/rules/rust-code.md`'s
+requirement that hover/completion responses return quickly). Both clients
+currently fetch the **heaviest** payload their registry offers, even though
+each registry provides an official lightweight alternative that carries every
+field the hot path actually parses.
+
+**npm** — `NpmRegistry::get_versions` (`crates/deps-npm/src/registry.rs:69-74`)
+fetches `https://registry.npmjs.org/{package}` with no `Accept` header,
+returning the full packument (complete README, full per-version dependency
+graphs, `maintainers`, `time`, etc.). The parser (`VersionMetadata`,
+`crates/deps-npm/src/registry.rs:162-167`) only reads `deprecated` per
+version. npm's registry has supported an abbreviated packument since 2018 via
+`Accept: application/vnd.npm.install-v1+json`
+([registry metadata docs](https://github.com/npm/registry/blob/main/docs/responses/package-metadata.md)).
+Verified live:
+
+```
+curl -s -o /dev/null -w "%{size_download}\n" https://registry.npmjs.org/express
+# 804975
+curl -s -H "Accept: application/vnd.npm.install-v1+json" \
+     -o /dev/null -w "%{size_download}\n" https://registry.npmjs.org/express
+# 339376  (58% smaller)
+```
+
+The abbreviated packument was fetched live and confirmed to contain, per
+version, exactly `{name, version, directories, dist, engines, deprecated}` —
+a strict superset of the one field (`deprecated`) `parse_package_metadata`
+consumes, plus `dist-tags`, `modified`, and standard ETag/Last-Modified
+response headers unchanged.
+
+**PyPI** — `PypiRegistry::get_versions` (`crates/deps-pypi/src/registry.rs:113-127`)
+fetches `https://pypi.org/pypi/{package}/json` (the full JSON API), returning
+the complete `info` block (description, classifiers, project URLs) plus the
+full `releases` map with every historical file's metadata. The parser
+(`PypiRelease`, `crates/deps-pypi/src/registry.rs:317-320`) only reads
+`yanked` per release file. PyPI's PEP 691 Simple JSON API
+(`https://pypi.org/simple/{package}/`, `Accept:
+application/vnd.pypi.simple.v1+json`) is purpose-built for version and
+file-availability lookups. Verified live:
+
+```
+curl -s -o /dev/null -w "%{size_download}\n" https://pypi.org/pypi/django/json
+# 619755
+curl -s -H "Accept: application/vnd.pypi.simple.v1+json" \
+     -o /dev/null -w "%{size_download}\n" https://pypi.org/simple/django/
+# 411376  (34% smaller)
+```
+
+The Simple JSON API response was fetched live and confirmed to expose a
+top-level `versions: [String]` array (the full, deduplicated version list —
+exactly what `get_versions` needs to build its result) plus a `files` array
+where each file carries a `yanked: bool` field, matching the semantics
+`get_versions` already consumes. It does **not** carry a per-file `version`
+field, which is a real difference from the current `releases: { version:
+[files] }` grouping and is addressed as a design decision in the plan (see
+[[007-lightweight-registry-metadata/plan|plan]]).
+
+A **separate** function, `PypiRegistry::get_package_metadata`
+(`crates/deps-pypi/src/registry.rs:220-234`, using the `PypiInfo` struct at
+line 310-315: `summary`, `project_urls`), genuinely needs the full JSON API's
+`info` block for hover display and must **not** be changed by this feature.
+
+Other ecosystem clients were surveyed and found to already use lean registry
+endpoints: cargo (sparse index), composer (`p2` metadata endpoint), nuget
+(v3 flat-container), go (module proxy protocol, inherently lean), maven/gradle
+(repository XML metadata), dart (`pub.dev/api`), bundler (rubygems `api/v1`,
+no lighter alternative exists). This feature is scoped to npm and PyPI only.
+
+### Goal
+
+`deps-npm::registry::NpmRegistry::get_versions` and
+`deps-pypi::registry::PypiRegistry::get_versions` fetch the lightest payload
+their registry offers that still satisfies every field currently consumed,
+with no change to `PypiRegistry::get_package_metadata` or any other
+ecosystem's registry client, and no loss of currently-produced `NpmVersion` /
+`PypiVersion` data.
+
+### Out of Scope
+
+- Any registry client other than `deps-npm::registry::get_versions` and
+  `deps-pypi::registry::get_versions` (cargo, go, bundler, dart, maven,
+  composer, gradle, swift, nuget are already lean; `deps-pypi`'s
+  `get_package_metadata` and `deps-npm`'s `search` are unaffected).
+- Adding npm registry search-result trimming — `search()`
+  (`crates/deps-npm/src/registry.rs:143-153`) already uses the lean
+  `-/v1/search` endpoint and is not part of this finding.
+- Byte-based `HttpCache` capacity accounting (tracked separately in issue
+  #142) — this feature reduces per-entry byte size, which improves #142's
+  effective headroom, but does not implement byte-based eviction itself.
+- Adding configurable/self-hosted registry URLs for npm or PyPI — both
+  `REGISTRY_BASE` and `PYPI_BASE` remain hardcoded to the public registries;
+  content-negotiation compatibility with third-party mirrors is not addressed.
+- Changing the `NpmVersion` / `PypiVersion` public struct shape, or the
+  `deps_core::Registry` / `deps_core::Version` trait implementations for
+  either ecosystem.
+
+## 2. User Stories
+
+### US-001: Faster hover/completion for packages with large version history
+
+AS A developer with `express`, `lodash`, `django`, or `numpy` (or any
+package with a long release history) in their manifest
+I WANT hover, completion, and diagnostic checks to fetch only the version
+data actually needed
+SO THAT I see results sooner and my editor's LSP session spends less
+bandwidth and memory on data it never displays
+
+**Acceptance criteria:**
+```
+GIVEN an open package.json with "express" as a dependency
+WHEN deps-lsp resolves hover/completion/diagnostics for "express"
+THEN the HTTP request sent to registry.npmjs.org carries
+     `Accept: application/vnd.npm.install-v1+json`
+AND the response body is the abbreviated packument (smaller than the full
+    packument), not the full packument
+AND the resulting version list (versions, deprecated flags) is identical to
+    what the full-packument code path would have produced
+```
+
+```
+GIVEN an open requirements.txt or pyproject.toml with "django" as a dependency
+WHEN deps-lsp resolves hover/completion/diagnostics for "django"
+THEN the HTTP request sent is to https://pypi.org/simple/django/ with
+     `Accept: application/vnd.pypi.simple.v1+json`, not to
+     https://pypi.org/pypi/django/json
+AND the resulting version list (versions, yanked flags) is identical to what
+    the full-JSON-API code path would have produced
+```
+
+### US-002: Hover metadata (summary, project URLs) is unaffected
+
+AS A developer viewing hover text for a PyPI package
+I WANT the hover panel to keep showing the package summary and project URLs
+SO THAT switching `get_versions` to a lighter endpoint does not degrade any
+user-visible feature
+
+**Acceptance criteria:**
+```
+GIVEN an open pyproject.toml with "flask" as a dependency
+WHEN hover is requested and deps-lsp calls get_package_metadata("flask")
+THEN the request still goes to https://pypi.org/pypi/flask/json (full JSON API)
+AND the hover panel still shows summary and project URLs, unchanged from
+    current behavior
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN `NpmRegistry::get_versions` fetches package metadata THE SYSTEM SHALL send an `Accept: application/vnd.npm.install-v1+json` header on the request to `https://registry.npmjs.org/{package}` | must |
+| FR-002 | WHEN `NpmRegistry::get_versions` parses the abbreviated packument response THE SYSTEM SHALL continue to extract `version` and `deprecated` per entry and produce the same `Vec<NpmVersion>` shape and sort order (newest-first) as before | must |
+| FR-003 | WHEN `PypiRegistry::get_versions` fetches version data THE SYSTEM SHALL request `https://pypi.org/simple/{normalized_name}/` with `Accept: application/vnd.pypi.simple.v1+json` instead of `https://pypi.org/pypi/{normalized_name}/json` | must |
+| FR-004 | WHEN `PypiRegistry::get_versions` parses the Simple JSON API response THE SYSTEM SHALL derive the full version list from the top-level `versions` array and the per-version `yanked` flag from the `files` array (any file belonging to a version being yanked marks that version yanked), matching current any-file-yanked semantics | must |
+| FR-005 | WHEN `PypiRegistry::get_package_metadata` fetches package info for hover display THE SYSTEM SHALL continue to use the full JSON API endpoint (`https://pypi.org/pypi/{name}/json`) unchanged | must |
+| FR-006 | WHEN either new endpoint returns a non-2xx status, malformed JSON, or a network error THE SYSTEM SHALL surface the same error types as before (`DepsError::RegistryError`, `PypiError::PackageNotFound`, `PypiError::registry_error`) with no new failure modes | must |
+| FR-007 | WHEN `NpmRegistry::get_latest_matching` and `PypiRegistry::get_latest_matching` call the now-changed `get_versions` THE SYSTEM SHALL continue to produce identical matching results, since neither function's own logic changes | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | npm `get_versions` response payload for a representative large package (e.g. `express`) is measurably smaller than the current full-packument payload (58% smaller observed live); PyPI `get_versions` response payload for a representative large package (e.g. `django`) is measurably smaller than the current full-JSON-API payload (34% smaller observed live) |
+| NFR-002 | Correctness | Zero loss of currently-consumed fields: `deprecated` (npm) and `yanked` (PyPI) must be derivable from the new payloads with identical resulting values for the same package, across representative fixture and live packages |
+| NFR-003 | Caching | `HttpCache`'s ETag (`If-None-Match`) and Last-Modified (`If-Modified-Since`) conditional-request flow (`crates/deps-core/src/cache.rs`) must continue to function against both new endpoints — repeated requests for an unchanged package must still receive `304 Not Modified` and reuse the cached body |
+| NFR-004 | Compatibility | `NpmVersion` and `PypiVersion` public struct shapes, and the `deps_core::Registry` / `deps_core::Version` trait implementations for both ecosystems, are unchanged — this is an internal fetch-format change only, invisible to callers |
+| NFR-005 | Testability | Both changed parsers must be covered by unit tests using fixture payloads that match the *actual* shape of the new endpoints (abbreviated packument / PEP 691 Simple JSON), not the old shape, to catch any latent assumption mismatch |
+
+## 5. Data Model
+
+No changes to `NpmVersion` or `PypiVersion` (both remain `{version: String,
+deprecated/yanked: bool}`). This feature changes only the *source* JSON shape
+parsed inside each registry client's private response types.
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `NpmVersion` | Existing, unchanged | `version`, `deprecated` |
+| `PypiVersion` | Existing, unchanged | `version`, `yanked` |
+| npm abbreviated packument (new internal parse target) | npm's lightweight package-metadata response, replaces the full packument as `get_versions`'s input | `versions: { [version]: { version, dist, engines, deprecated } }`, `dist-tags`, `modified` |
+| PyPI PEP 691 Simple JSON response (new internal parse target) | PyPI's lightweight per-project index response, replaces the full JSON API as `get_versions`'s input | `name`, `versions: [String]`, `files: [{ filename, yanked, hashes, ... }]`, `meta` |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| PyPI Simple JSON API's `files` entries have no explicit per-file `version` field (unlike the current `releases` map, which is already grouped by version) | `get_versions` must derive each file's version by parsing the filename (sdist/wheel naming conventions) to match it against an entry in the top-level `versions` array — see plan for the exact parsing approach |
+| Package has zero published versions | Both endpoints return an empty version collection; `get_versions` returns an empty `Vec`, same as current behavior |
+| npm package has no `deprecated` field on a version | Same as today — `#[serde(default)]` treats it as `None`/not deprecated |
+| PyPI Simple JSON response's `files` array is empty for a version present in `versions` (edge case: version exists in the index but has no distributable files) | Version is treated as not yanked (no yanked file found) — the same result the current "any release file yanked" logic would produce for a release with zero files |
+| A version string in PyPI's `versions` array fails PEP 440 parsing | Filtered out silently, matching current behavior in `parse_package_metadata`'s `filter_map` |
+| Either endpoint is unreachable or returns a transient 5xx | Existing `HttpCache` stale-while-revalidate fallback applies unchanged — cached data (if any) is served, otherwise the existing error path (FR-006) triggers |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | npm `get_versions` response payload size for `express` (live) | ≤ 50% of current full-packument size (58% reduction observed) |
+| SC-002 | PyPI `get_versions` response payload size for `django` (live) | ≤ 70% of current full-JSON-API size (34% reduction observed) |
+| SC-003 | Unit tests for `parse_package_metadata` (both crates) using fixtures matching the real new payload shapes | 100% passing, including the existing deprecated/yanked assertions |
+| SC-004 | Live end-to-end: version list (set of versions + deprecated/yanked flags) for `express` and `django` before vs. after the change | Identical output |
+| SC-005 | Live end-to-end: repeated `get_versions` call for an unchanged package against both new endpoints | Second call observes `304 Not Modified` via `HttpCache` |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Reuse `HttpCache::get_cached_with_headers` (`crates/deps-core/src/cache.rs:204`), which already supports injecting an `Accept` header — no new HTTP client code needed
+- Add/update unit test fixtures to match the real abbreviated-packument and PEP 691 Simple JSON shapes (captured live in this spec's Overview)
+- Run `cargo +nightly fmt --check`, `cargo clippy --all-targets --all-features --workspace -- -D warnings`, `cargo nextest run --workspace --all-features --lib --bins` before considering the change complete
+- Update `CHANGELOG.md` under `[Unreleased]`
+- Follow the Registry Integration Gate (`.claude/rules/continuous-improvement.md`) — verify against the live npm and PyPI endpoints before filing the implementation PR
+
+### Ask First
+- Any change to `PypiVersion` / `NpmVersion` public struct shape
+- Introducing a new dependency for filename parsing (wheel/sdist filename conventions) if hand-rolled parsing proves insufficient
+- Any change to `PypiRegistry::get_package_metadata` or `NpmRegistry::search`
+
+### Never
+- Change `get_package_metadata`'s endpoint away from the full JSON API
+- Touch registry clients for cargo, go, bundler, dart, maven, composer, gradle, swift, or nuget — already confirmed lean by this finding's survey
+- Add configurable/self-hosted registry base URLs as part of this change
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: PEP 691's `files` array has no explicit per-file `version` field, so deriving per-version `yanked` status requires parsing sdist/wheel filenames to extract the version segment and match it against the `versions` list. Should this be a minimal hand-rolled parser scoped only to extracting the version segment (default assumption — a full wheel-filename-parsing crate would be over-engineering for one field), or is there an existing workspace dependency that already does this?]
+- [NEEDS CLARIFICATION: PyPI's Simple JSON API response was observed live to return only an `ETag` header, no `Last-Modified` header (unlike the full JSON API). `HttpCache`'s conditional-request logic already treats `last_modified` as `Option<String>`, so this should work unchanged — confirm via live 304 test (SC-005) rather than assuming.]
+
+## 10. See Also
+
+- [[constitution]] — project principles (not yet created for this project)
+- [[MOC-specs]] — all specifications
+- [[007-lightweight-registry-metadata/plan|plan]] — technical plan
+- `crates/deps-npm/src/registry.rs` — `NpmRegistry::get_versions`, `parse_package_metadata`
+- `crates/deps-pypi/src/registry.rs` — `PypiRegistry::get_versions`, `get_package_metadata`, `parse_package_metadata`, `parse_package_info`
+- `crates/deps-core/src/cache.rs` — `HttpCache::get_cached_with_headers`
+- [npm registry package metadata responses](https://github.com/npm/registry/blob/main/docs/responses/package-metadata.md)
+- [PEP 691 – JSON-based Simple API for Python Package Indexes](https://peps.python.org/pep-0691/)
+- Issue #142 — `HttpCache` retained memory bounded by entry count, not bytes

--- a/specs/008-codelens-update-all-outdated/spec.md
+++ b/specs/008-codelens-update-all-outdated/spec.md
@@ -1,0 +1,247 @@
+---
+aliases:
+  - CodeLens Update All Outdated Dependencies
+  - Workspace-wide Update All
+tags:
+  - sdd
+  - spec
+  - research
+  - parity-gap
+  - lsp-protocol
+  - priority/p2
+created: 2026-08-20
+status: draft
+related:
+  - "[[MOC-specs]]"
+---
+
+# Feature: CodeLens support for "update all outdated dependencies" action
+
+> [!info] Metadata
+> **Author**: continuous-improvement cycle 005 (research finding)
+> **Branch**: [NEEDS CLARIFICATION: assign issue number before branching, e.g. `feat/<issue>-codelens-update-all`]
+> **Type**: research / competitive-parity gap — this spec documents WHAT is missing and WHY;
+> the HOW (exact wiring, placement, batching strategy) is deferred to a future `/sdd plan` session.
+
+## 1. Overview
+
+### Problem Statement
+
+deps-lsp implements only a subset of the LSP 3.17 surface relevant to dependency tooling:
+`hover`, `completion`, `inlay_hint`, `code_action` (per-line), `diagnostic` (pull model), and
+`execute_command`. It does **not** implement `textDocument/codeLens` (or `workspace/codeLens`),
+`workspace/symbol`, or `textDocument/semanticTokens`.
+
+Verified this cycle (2026-08-20) via:
+```
+rg -n "code_lens|codeLens|CodeLens|workspace_symbol|workspaceSymbol|semantic_tokens|semanticTokens" crates/deps-lsp/src/ --type rust
+# => no output (zero hits)
+```
+`ServerCapabilities` construction in `crates/deps-lsp/src/server.rs:194-220` sets
+`text_document_sync`, `completion_provider`, `hover_provider`, `inlay_hint_provider`,
+`code_action_provider`, and `execute_command_provider` — there is no `code_lens_provider` field
+set.
+
+IDE-native dependency-update UIs (VS Code's built-in npm/Cargo tooling patterns, JetBrains
+package-update panels, GitHub Dependabot-adjacent editor integrations) commonly surface an
+**aggregate** "N dependencies are outdated — update all" affordance at the top of a manifest
+file, in addition to per-dependency hints. deps-lsp currently only offers the per-line
+interaction: a user must act on each outdated dependency individually via hover-triggered code
+action / `deps-lsp.updateVersion` command.
+
+This gap has been observed in the competitive-parity research playbook
+(`.local/testing/playbooks/competitive-parity.md`) across three consecutive prior continuous-
+improvement cycles (002, 003, 004) but was never spec'd or filed as an issue — each cycle
+deferred it in favor of a higher-confidence finding. The most recent research handoff
+(`.local/handoff/2026-08-20T03-50-54-researcher.md`) explicitly recommended acting on it this
+cycle (005) instead of deferring a fourth time.
+
+### Goal
+
+deps-lsp advertises `textDocument/codeLens` capability and, for any open manifest with one or
+more outdated dependencies, renders at least one CodeLens entry summarizing the aggregate count
+and offering a single action that updates all outdated dependencies in that manifest, reusing
+the existing per-dependency version-comparison data and `WorkspaceEdit` update mechanism.
+
+### Out of Scope
+
+- Redesigning or replacing the existing per-line `code_action` / `deps-lsp.updateVersion`
+  interaction — CodeLens is additive, not a replacement.
+- `workspace/symbol` and `textDocument/semanticTokens` — separate, unrelated LSP-surface gaps
+  noted by the same grep sweep; not covered by this spec.
+- Vulnerability-severity-aware batching (e.g., "update only vulnerable deps") — that depends on
+  the separate OSV vulnerability-diagnostics effort ([[002-osv-vulnerability-diagnostics/spec]])
+  and is not assumed to exist yet.
+- Cross-file / true `workspace/codeLens` aggregation (e.g., one CodeLens summarizing outdated
+  counts across an entire multi-manifest workspace) — this spec scopes to per-document
+  `textDocument/codeLens` only; workspace-wide aggregation is a possible future extension.
+- Exact UI placement, resolve-lazy vs eager CodeLens computation, and batching/undo semantics
+  for the bulk edit — these are HOW decisions for `/sdd plan`.
+
+## 2. User Stories
+
+### US-001: See and act on an aggregate outdated count
+
+AS A developer with a manifest file containing many outdated dependencies (e.g., a `Cargo.toml`
+or `package.json` with 20+ dependencies, several of which are outdated)
+I WANT a single, visible annotation showing how many dependencies are outdated and a way to
+update them all at once
+SO THAT I don't have to hover and trigger the update command individually for each outdated
+dependency, one at a time.
+
+**Acceptance criteria:**
+```
+GIVEN an open manifest file with N outdated dependencies (N >= 1)
+WHEN the editor requests textDocument/codeLens for that document
+THEN the server SHALL return at least one CodeLens entry whose title communicates the count
+     (e.g., "Update N outdated dependencies") and whose command, when invoked, updates all N
+     outdated dependencies in that manifest via a WorkspaceEdit
+```
+
+### US-002: No noise when everything is current
+
+AS A developer with a manifest file where all dependencies are already up to date
+I WANT no "update all" CodeLens to appear
+SO THAT the CodeLens surface doesn't add visual clutter when there is nothing actionable.
+
+**Acceptance criteria:**
+```
+GIVEN an open manifest file with zero outdated dependencies
+WHEN the editor requests textDocument/codeLens for that document
+THEN the server SHALL return an empty CodeLens list (or omit the aggregate entry) for that
+     document
+```
+
+### US-003: Consistent behavior across every supported ecosystem
+
+AS A developer using deps-lsp with any of the 10 supported ecosystems (Cargo, npm, PyPI, Go,
+Bundler, Dart, Maven, Composer, Gradle, Swift, NuGet manifest formats)
+I WANT the "update all outdated dependencies" CodeLens to behave identically regardless of which
+manifest format I'm editing
+SO THAT I don't have to learn ecosystem-specific quirks in the update workflow.
+
+**Acceptance criteria:**
+```
+GIVEN two open manifests from different ecosystems (e.g., Cargo.toml and package.json), each
+     with an equivalent number of outdated dependencies
+WHEN textDocument/codeLens is requested for each
+THEN the CodeLens title format, aggregate-count logic, and update-all command behavior SHALL be
+     equivalent across both, per the project's cross-ecosystem-consistency rule
+     (`.claude/rules/continuous-improvement.md#Cross-Ecosystem Consistency Testing`)
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | THE SYSTEM SHALL advertise `code_lens_provider` in `ServerCapabilities` (`crates/deps-lsp/src/server.rs`, alongside the existing `inlay_hint_provider` / `code_action_provider` / `execute_command_provider` entries around line 194) | must |
+| FR-002 | WHEN the client sends `textDocument/codeLens` for an open manifest THE SYSTEM SHALL compute the count of outdated dependencies in that document by reusing the existing version-comparison logic already used for diagnostics and inlay hints (not a duplicate implementation) | must |
+| FR-003 | WHEN the outdated-dependency count for a manifest is greater than zero THE SYSTEM SHALL return at least one CodeLens entry whose command title communicates the count (e.g., "Update N outdated dependencies") | must |
+| FR-004 | WHEN the outdated-dependency count for a manifest is zero THE SYSTEM SHALL return no aggregate "update all" CodeLens entry for that document | must |
+| FR-005 | THE SYSTEM SHALL expose a workspace/document-scoped command (new, or an extension of the existing `deps-lsp.updateVersion` command defined in `crates/deps-lsp/src/server.rs` `mod commands`) that, when invoked, applies a `WorkspaceEdit` updating all outdated dependencies in the target manifest to their latest resolvable version | must |
+| FR-006 | THE SYSTEM SHALL produce equivalent CodeLens behavior (capability advertisement, count computation, command wiring) across all 10 supported ecosystem crates (`deps-cargo`, `deps-npm`, `deps-pypi`, `deps-go`, `deps-bundler`, `deps-dart`, `deps-maven`, `deps-composer`, `deps-gradle`, `deps-swift`, `deps-nuget`), per the cross-ecosystem-consistency rule | must |
+| FR-007 | THE SYSTEM SHALL route the update-all command through the existing `execute_command` handler pathway (`crates/deps-lsp/src/server.rs`, around line 450-460) rather than introducing a parallel execution mechanism | should |
+| FR-008 | WHEN a manifest is edited after CodeLens was computed (e.g., a dependency version line changes) THE SYSTEM SHALL recompute the CodeLens on the next `textDocument/codeLens` request rather than serving stale counts | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | Computing the CodeLens SHALL NOT trigger additional registry (network) fetches beyond what diagnostics/inlay hints already perform for the same document — it SHALL reuse already-cached per-dependency version-comparison state |
+| NFR-002 | Performance | `textDocument/codeLens` response time SHALL be dominated by in-memory aggregation over already-computed per-dependency state, not by new I/O; target latency in the same order of magnitude as the existing `textDocument/inlayHint` handler for an equivalently sized manifest |
+| NFR-003 | Consistency | CodeLens title format and update-all semantics SHALL be identical across all 10 ecosystems — any ecosystem-specific divergence is a first-class bug per `.claude/rules/continuous-improvement.md#Cross-Ecosystem Consistency Testing` |
+| NFR-004 | Compatibility | Advertising `code_lens_provider` SHALL NOT alter existing `hover`, `completion`, `inlay_hint`, `code_action`, `diagnostic`, or `execute_command` behavior — this is an additive capability |
+| NFR-005 | Reliability | If the update-all command partially fails (e.g., one dependency's latest version cannot be resolved), the system SHALL NOT leave the manifest in a corrupted/partially-edited state — [NEEDS CLARIFICATION: exact atomicity/rollback guarantee for partial-failure batch edits] |
+
+## 5. Data Model
+
+No new persistent entities. This feature aggregates existing per-dependency version-comparison
+results (already computed for diagnostics/inlay hints) into a document-level summary.
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| Outdated dependency count (derived) | Per-document aggregate of dependencies whose current version is behind the latest resolvable version | document URI, count of outdated deps, [NEEDS CLARIFICATION: does the count include yanked/unknown-status deps or only strictly "outdated"?] |
+| Update-all command payload | Input to the workspace-scoped update command | document URI, list of (dependency identifier, target version) pairs to apply as a single `WorkspaceEdit` |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Manifest has zero dependencies | No CodeLens returned (empty list) |
+| Manifest has zero outdated dependencies | No aggregate "update all" CodeLens returned (per US-002 / FR-004) |
+| Manifest has one outdated dependency | CodeLens SHALL still appear (singular vs plural title wording is a HOW detail for `/sdd plan`) — [NEEDS CLARIFICATION: singular phrasing, e.g. "Update 1 outdated dependency"] |
+| Registry/version data for some dependencies is stale or unavailable (e.g., offline) | CodeLens count SHALL reflect only dependencies with resolvable comparison state; system SHALL degrade gracefully, consistent with how diagnostics/inlay hints already degrade under the same condition |
+| User invokes update-all while manifest has unsaved edits | [NEEDS CLARIFICATION: does the update-all command operate on the last-synced document state via `WorkspaceEdit`, consistent with how `deps-lsp.updateVersion` already handles this for single updates?] |
+| Manifest contains a mix of outdated + yanked + unknown-status dependencies | [NEEDS CLARIFICATION: does "update all outdated" only target strictly-outdated entries, or also attempt to resolve yanked/unknown entries?] |
+| Very large manifest (hundreds of dependencies, many outdated) | CodeLens computation SHALL NOT introduce new registry calls (NFR-001); update-all command SHALL apply as a single batched `WorkspaceEdit`, not N sequential edits |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | `code_lens_provider` present in `ServerCapabilities` | Advertised for all supported manifest file types |
+| SC-002 | CodeLens count matches diagnostic/inlay-hint outdated count | 100% agreement between the CodeLens aggregate count and the count of "outdated" diagnostics for the same document at the same point in time |
+| SC-003 | No duplicate registry fetches introduced by CodeLens computation | 0 additional outbound registry HTTP calls attributable to `textDocument/codeLens` beyond what diagnostics/inlay hints already perform, verified via debug log inspection per the project's live-testing protocol |
+| SC-004 | Cross-ecosystem consistency | CodeLens title format and update-all command behavior verified equivalent across all 10 ecosystem manifest types in a live-testing session, logged in `.local/testing/coverage.md`'s LSP Feature Matrix |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Follow existing patterns in `crates/deps-lsp/src/server.rs` for capability advertisement and
+  command wiring (reuse `execute_command` pathway, `mod commands` constants).
+- Reuse `deps-core`'s existing version-comparison logic; do not duplicate it in a new module.
+- Run the full check suite (`cargo +nightly fmt --check`, `cargo clippy --all-targets
+  --all-features --workspace -- -D warnings`, `cargo nextest run --workspace --all-features`)
+  before considering any implementation of this spec complete.
+
+### Ask First
+- Introducing a new LSP command identifier distinct from `deps-lsp.updateVersion` (vs. extending
+  the existing one with a batch mode).
+- Any change to the `WorkspaceEdit` batching/atomicity strategy that could affect the existing
+  single-dependency update command's behavior.
+- Adding a new dependency to support CodeLens rendering, if one is deemed necessary.
+
+### Never
+- Modify the existing per-line `code_action` / `updateVersion` interaction as a side effect of
+  adding CodeLens — it must remain fully functional and unchanged in behavior.
+- Introduce ecosystem-specific CodeLens behavior that diverges from the other 9 ecosystems
+  without an explicit, documented rationale.
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Exact CodeLens placement — top of file (single document-level CodeLens)
+  vs. per-dependency-block (e.g., one per `[dependencies]` table in Cargo.toml, one per
+  `dependencies`/`devDependencies` object in package.json)? The finding does not prescribe this;
+  it is a `/sdd plan` decision.]
+- [NEEDS CLARIFICATION: Should the update-all command target only strictly "outdated" status, or
+  also include "yanked" / "unknown" status dependencies where a safe upgrade target exists?]
+- [NEEDS CLARIFICATION: Atomicity/rollback guarantee when the batch update partially fails
+  (NFR-005) — should the `WorkspaceEdit` be all-or-nothing, or best-effort with a follow-up
+  diagnostic listing what couldn't be resolved?]
+- [NEEDS CLARIFICATION: Should CodeLens support `workspace/codeLens` (cross-file aggregation)
+  in a later iteration, or remain strictly per-document (`textDocument/codeLens`) as scoped
+  here?]
+- [NEEDS CLARIFICATION: Singular vs. plural title wording for the N=1 case.]
+- [NEEDS CLARIFICATION: Should this feature be gated behind a client capability check (i.e.,
+  only advertise `code_lens_provider` if the connecting client declares CodeLens support in
+  `ClientCapabilities`), consistent with how other optional capabilities are or aren't
+  negotiated in `crates/deps-lsp/src/server.rs`?]
+- [NEEDS CLARIFICATION: No project constitution exists yet at `.local/specs/constitution.md`
+  — this spec cannot yet be checked against project-wide architectural principles. Recommend
+  running `/sdd init` before `/sdd plan` for this feature.]
+
+## 10. See Also
+
+- `crates/deps-lsp/src/server.rs` — `ServerCapabilities` construction (~line 194), `mod commands`
+  and `UPDATE_VERSION` constant (~line 22-24), `execute_command_provider` /
+  `ExecuteCommandOptions` wiring (~line 214), `execute_command` handler (~line 450-460)
+- [LSP 3.17 specification — `textDocument/codeLens`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_codeLens)
+- `.local/testing/playbooks/competitive-parity.md` — original finding, unfiled across cycles
+  002, 003, 004
+- `.local/handoff/2026-08-20T03-50-54-researcher.md` — prior cycle's handoff recommending this
+  finding be acted on in cycle 005
+- [[MOC-specs]] — all specifications
+- [[002-osv-vulnerability-diagnostics/spec]] — related diagnostics work using the same
+  per-dependency version-comparison data
+- [[007-lightweight-registry-metadata/spec]] — related registry-metadata work affecting the same
+  version-comparison pipeline this feature reuses

--- a/specs/009-pypi-requirements-txt/spec.md
+++ b/specs/009-pypi-requirements-txt/spec.md
@@ -1,0 +1,304 @@
+---
+aliases:
+  - requirements.txt Support in deps-pypi
+  - Plain Requirements Files
+tags:
+  - sdd
+  - spec
+  - enhancement
+  - parity-gap
+  - ecosystem/pypi
+  - priority/p2
+created: 2026-08-23
+status: draft
+related:
+  - "[[MOC-specs]]"
+---
+
+# Feature: Support requirements.txt (pip family) in deps-pypi
+
+> [!info] Metadata
+> **Author**: on-demand competitive-parity scan 2026-08-23 (research finding)
+> **Branch**: [NEEDS CLARIFICATION: assign issue number before branching, e.g. `feat/<issue>-requirements-txt`]
+> **Type**: enhancement / competitive-parity gap — this spec documents WHAT is missing and WHY;
+> the HOW (file detection routing, parser adaptation, requires.txt precedent patterns) is deferred to a future `/sdd plan` session.
+
+## 1. Overview
+
+### Problem Statement
+
+deps-pypi currently targets `pyproject.toml` only (PEP 621, PEP 735, Poetry). Plain `requirements*.txt`
+— still the most common Python dependency file across standalone scripts, data-science notebooks,
+Docker container specs, and legacy projects — has zero handling in the repo, despite being explicitly
+listed in `.claude/rules/continuous-improvement.md`'s cross-ecosystem manifest inventory.
+
+Verified this cycle (2026-08-23) via:
+```
+rg "requirements\.txt" crates/deps-pypi/src/ --type rust
+# => no output (zero hits)
+```
+
+Every direct competitor and both update bots cover requirements.txt: Dependi, Renovate (`pip_requirements`
+manager), Dependabot (`pip_requirements` config), and a dedicated VS Code extension (pypi-assistant)
+existing solely to serve this format. The gap is not a minor edge case — requirements.txt is the
+de-facto standard for distributing Python dependencies in many contexts outside of modern
+PEP 621 / Poetry workflows.
+
+This finding was identified in the competitive-parity research playbook
+(`.local/testing/playbooks/competitive-parity.md`, Scan Notes 2026-08-23) as the **top
+audience-per-effort finding** of the scan: the registry client (PEP 691 Simple JSON API) and version
+comparison logic (`pep440_rs`) are reused unchanged — this is **parser + file-detection work only**.
+
+### Goal
+
+deps-pypi recognizes and parses `requirements.txt`, `requirements-*.txt`, and `*.requirements.txt`
+files, extracting dependencies in the same way `pyproject.toml` is parsed, routing them through the
+existing LSP handlers (`hover`, `completion`, `inlay_hint`, `diagnostic`, `code_action`) so that
+plain requirements files receive identical version-checking feedback as modern PEP 621 manifests.
+
+### Out of Scope
+
+- Recursive include resolution (`-r` / `--requirement` directives) — parsing SHALL tolerate these
+  lines without error, but whether to resolve/follow them is an open design question for `/sdd plan`.
+- Constraints files (`constraints.txt`) — distinct file type with its own semantics; out of scope.
+- Line-based options (`--index-url`, `--extra-index-url`, `--hash`, `--global-options`, etc.) — these
+  are pip configuration directives, not dependency specifiers. The parser SHALL skip them gracefully.
+- Editable installs (`-e`) — the parser SHALL recognize and skip these lines gracefully (print a debug
+  warning if verbosity is enabled, but do not surface an error or diagnostic to the user).
+- Direct URLs and local paths (`file://`, `git+https://`, `/path/to/local`) — the parser SHALL skip
+  these gracefully, as they are not resolvable via the PyPI registry.
+- Private/alternative registries (`-i`, `--index-url`, `--extra-index-url` configuration) — those are
+  separate, unfiled candidates that require auth/config design; out of scope here. An open question
+  below flags this for later.
+- Nested include cycles (detecting circular `-r` includes) — an open question.
+- Lockfile support for requirements.txt (e.g., `requirements.lock` or vendor-specific lockfile formats
+  beyond Poetry's `poetry.lock` and uv's `uv.lock`) — out of scope; lockfile support is a separate
+  orthogonal concern per-ecosystem.
+
+## 2. User Stories
+
+### US-001: Plain requirements.txt receives the same version feedback as pyproject.toml
+
+AS A Python developer using a plain `requirements.txt` file (not a modern `pyproject.toml`)
+I WANT to see the same hover information, latest-version inlay hints, outdated diagnostics,
+version completion, and update code actions in my requirements.txt as I would get in a
+pyproject.toml
+SO THAT I can keep my dependencies up to date without duplicating tools or switching between
+editors/extensions.
+
+**Acceptance criteria:**
+```
+GIVEN an open requirements.txt containing N dependencies (e.g., "requests>=2.28.0")
+WHEN I hover over a dependency name or version specifier
+THEN the server returns hover content identical in format and structure to what would be
+     returned for the same dependency in a pyproject.toml (package name, current version,
+     latest version, status label)
+
+GIVEN an open requirements.txt with one or more outdated dependencies
+WHEN the editor requests inlay hints for that document
+THEN the server returns inlay-hint entries at the version specifier, showing the latest
+     resolvable version, identical to the behavior for pyproject.toml
+
+GIVEN an open requirements.txt with one or more unknown/yanked/outdated dependencies
+WHEN the editor requests diagnostics for that document
+THEN the server returns diagnostic entries with the same messages, severity levels, and
+     locations as for pyproject.toml dependencies in the same state
+```
+
+### US-002: Graceful handling of requirements.txt-specific syntax
+
+AS A Python developer with a diverse requirements.txt containing comments, environment
+markers, editable installs, and include directives
+I WANT the LSP server to extract resolvable dependencies without crashing or surfacing
+errors for non-resolvable lines
+SO THAT the LSP service degrades gracefully and still provides useful feedback on the
+dependencies I *can* manage.
+
+**Acceptance criteria:**
+```
+GIVEN a requirements.txt with:
+  - Inline comments (e.g., "requests>=2.28  # for HTTP support")
+  - Blank lines and comment-only lines
+  - PEP 508 environment markers (e.g., "dataclasses>=0.6 ; python_version < '3.7'")
+  - Editable installs (e.g., "-e ./local-package" or "-e git+https://...")
+  - Direct URLs (e.g., "flask @ https://...")
+  - Include directives (e.g., "-r base-requirements.txt")
+  - Line-based options (e.g., "--index-url https://...", "--hash sha256:...")
+WHEN the parser processes this file
+THEN it SHALL:
+  - Extract dependencies from resolvable lines
+  - Skip non-resolvable lines (editable, URL, option lines) without error
+  - Preserve and apply PEP 508 environment markers to dependencies
+  - Print debug-level logging for skipped lines (if verbosity enabled)
+  - Return a parse result with only the resolvable dependencies, no partial-parse errors
+```
+
+### US-003: Consistent behavior across ecosystem requirements formats
+
+AS A developer using deps-lsp with multiple ecosystems (e.g., Python, Node.js, Ruby)
+I WANT the requirements.txt feature to follow the same LSP feature-consistency rules as
+other ecosystem crates (per `.claude/rules/continuous-improvement.md#Cross-Ecosystem
+Consistency Testing`)
+SO THAT I don't encounter surprise divergences in hover/completion/diagnostic formatting
+between manifest types.
+
+**Acceptance criteria:**
+```
+GIVEN two dependency-manifest files with equivalent outdated-status dependencies:
+  - File 1: "requests>=2.28" in a requirements.txt (outdated, assuming latest is 2.31)
+  - File 2: "requests = '2.28'" in a pyproject.toml (outdated)
+WHEN LSP handlers (hover, inlay hints, diagnostics) are invoked on both
+THEN the hover title, status label (e.g., "outdated"), latest-version display, and
+     update code action SHALL be identical in format and wording, demonstrating
+     cross-ecosystem consistency per the documented rule
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | THE SYSTEM SHALL extend `PypiEcosystem::manifest_filenames()` in `crates/deps-pypi/src/ecosystem.rs` (currently returning `["pyproject.toml"]`) to include patterns matching `requirements.txt`, `requirements-*.txt` (e.g., `requirements-dev.txt`), and `*.requirements.txt` (e.g., `app.requirements.txt`) | must |
+| FR-002 | THE SYSTEM SHALL extend the PyPI parser in `crates/deps-pypi/src/parser.rs` to accept plain-text requirements.txt content (newline-separated dependency specifiers) in addition to TOML, detecting file format from either file extension or content heuristics | must |
+| FR-003 | WHEN parsing a requirements.txt THE SYSTEM SHALL extract each non-comment, non-option, non-editable, non-URL line as a potential dependency specifier and attempt to parse it as a PEP 508 requirement, reusing the existing `parse_pep508_requirement()` logic already in use for pyproject.toml | must |
+| FR-004 | THE SYSTEM SHALL preserve and apply PEP 508 environment markers (e.g., `; python_version < '3.8'`) found on each dependency line in requirements.txt, reusing the existing marker-handling logic (see `crates/deps-pypi/src/parser.rs` line ~4, `pep508_rs::MarkerTree`) consistent with pyproject.toml marker handling from issue #140 | must |
+| FR-005 | THE SYSTEM SHALL gracefully skip (without surfacing an error or diagnostic to the user) lines that are: comments (lines beginning with `#`), blank lines, editable installs (`-e ...`), direct URLs (lines containing `@`, `://`, or `file://`), line-based options (`--index-url`, `--hash`, etc.), and include directives (`-r`, `--requirement`, `-c`, `--constraint`), printing debug-level logging (if tracing is enabled) for each skipped line | must |
+| FR-006 | THE SYSTEM SHALL route parsed requirements.txt dependencies through the existing LSP handlers — `generate_hover()`, `generate_inlay_hints()`, `generate_diagnostics()`, `generate_completions()`, `generate_code_actions()` in `crates/deps-pypi/src/ecosystem.rs` — so that hover, completion, inlay hint, diagnostic, and code action behavior are identical to pyproject.toml dependencies, per the cross-ecosystem-consistency rule | must |
+| FR-007 | WHEN a `requirements.txt` file is edited (e.g., version specifier changed) THE SYSTEM SHALL re-parse the file on the next `textDocument/didChange` or handler invocation rather than serving stale parsed state | must |
+| FR-008 | THE SYSTEM SHALL handle case-insensitive dependency names (per PEP 503 normalization) in requirements.txt identically to how they are handled in pyproject.toml, ensuring that "Requests", "requests", and "REQUESTS" all resolve to the same PyPI package | should |
+| FR-009 | THE SYSTEM SHALL [NEEDS CLARIFICATION: determine design intent for `-r`/`--requirement` and `-c`/`--constraint` directives: (A) skip them silently (current proposal, simplest), (B) follow them and merge transitive dependencies into the parse result, or (C) surface a diagnostic suggesting the user resolve includes manually]. This decision is deferred to `/sdd plan` but SHALL be made before implementation. | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | Parsing a requirements.txt file SHALL NOT perform additional registry HTTP calls beyond what diagnostics/inlay hints already perform for the same dependencies in pyproject.toml — reuse existing cached version data from `deps_core::HttpCache` |
+| NFR-002 | Performance | Parse latency for a requirements.txt with N dependencies SHALL be in the same order of magnitude as parsing a pyproject.toml with the same N dependencies, since both reuse the same dependency-extraction and PEP 508 parsing logic |
+| NFR-003 | Correctness | PEP 440 version specifier parsing and PEP 508 requirement parsing SHALL be identical between requirements.txt and pyproject.toml — both MUST use the same parsing functions (currently `pep508_rs` crate) |
+| NFR-004 | Consistency | Environment-marker behavior (e.g., markers that evaluate to `false` on the current platform) SHALL be identical between requirements.txt and pyproject.toml — both MUST respect the same marker semantics |
+| NFR-005 | Consistency | Hover/diagnostic/inlay-hint formatting (title, status labels, code blocks) SHALL be identical across requirements.txt and pyproject.toml dependencies, per cross-ecosystem-consistency rule in `.claude/rules/continuous-improvement.md#Cross-Ecosystem Consistency Testing` — any divergence is a first-class bug |
+| NFR-006 | Compatibility | Adding requirements.txt support SHALL NOT alter existing pyproject.toml parsing, LSP behavior, or feature behavior — this is an additive capability |
+| NFR-007 | Robustness | The parser SHALL NOT crash, panic, or hang on malformed, circular, or deeply nested requirements.txt content (e.g., very long lines, malformed PEP 508 specifiers, deeply nested markers per `.claude/rules/continuous-improvement.md`) — errors SHALL be caught and logged, with partial parse results returned |
+| NFR-008 | User Experience | Diagnostics and messages produced by LSP handlers for requirements.txt dependencies SHALL use terminology consistent with pyproject.toml (no file-format-specific jargon), so a user sees "package is outdated" rather than "requirement is outdated" or ecosystem-specific wording |
+
+## 5. Data Model
+
+No new persistent entities. Requirements.txt parsing reuses the existing `PypiDependency` struct
+(defined in `crates/deps-pypi/src/types.rs`) and parse result types already used for pyproject.toml.
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| Requirements.txt content (plain text) | Newline-separated dependency specifiers, comments, markers, and pip directives | file URI, content string (parsed into `Vec<PypiDependency>` by the parser) |
+| Parsed requirements.txt dependencies (reused from pyproject.toml) | Extracted dependencies with their names, version specifiers, extras, environment markers, source location (line/column range in the requirements.txt) | `PypiDependency`: name, version_spec, extras, markers, section, line range |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Empty requirements.txt | Parser returns parse result with empty dependency vector; no LSP feedback needed |
+| requirements.txt with only comments and blank lines | Parser returns empty dependency vector; no LSP feedback |
+| Dependency with inline comment (e.g., `requests>=2.28  # HTTP library`) | Parser extracts "requests>=2.28" (comment stripped), processes normally |
+| Dependency with PEP 508 marker (e.g., `dataclasses>=0.6 ; python_version < '3.7'`) | Parser extracts marker, passes to existing marker-handling logic (reuse from pyproject.toml #140); marker evaluates at runtime to determine if dependency is applicable |
+| Editable install line (e.g., `-e ./local-package`) | Parser skips this line gracefully, prints debug log, does NOT surface error to user |
+| Direct URL dependency (e.g., `flask @ https://github.com/pallets/flask/archive/refs/heads/main.zip`) | Parser skips this line, prints debug log (not resolvable via PyPI registry) |
+| Include directive (e.g., `-r base-requirements.txt`) | [NEEDS CLARIFICATION: see FR-009 — design intent not yet determined; pending `/sdd plan`] |
+| Line-based options (e.g., `--index-url https://pypi.example.com/simple`, `--hash sha256:...`) | Parser skips this line, prints debug log (these are pip configuration, not dependency specifiers) |
+| Malformed PEP 508 specifier (e.g., `requests~@2.28` with invalid operator) | Parser logs a warning, skips the line (graceful degradation); returns partial parse result with other valid dependencies |
+| Very large requirements.txt (hundreds of lines, many invalid) | Parser processes all lines, accumulates valid dependencies, skips invalid lines with debug logging; returns complete parse result in reasonable time (no new registry calls beyond what would be made for equivalent pyproject.toml) |
+| Circular `-r` include (e.g., `base.txt` includes `dev.txt` which includes `base.txt`) | [NEEDS CLARIFICATION: design intent not yet determined; see FR-009] |
+| requirements.txt with mixed case package names (e.g., "Requests", "requests") | Parser normalizes names per PEP 503 (lowercase + underscore-to-hyphen normalization) and matches them to the same PyPI package |
+| Parser encounters a dependency already in pyproject.toml | No special handling — both files are parsed independently; if a user has both files in the same project, they see duplicate diagnostics/hovers for the same package (consistent with how VS Code displays the same file open in two tabs) — [NEEDS CLARIFICATION: is deduplication a future feature or user's responsibility?] |
+| requirements.txt is edited while an LSP handler is running | Parsing is triggered on `textDocument/didChange`; subsequent handler invocations use the updated parse result; no concurrent-access issues (LSP client synchronizes) |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | `manifest_filenames()` includes requirements patterns | `PypiEcosystem::manifest_filenames()` returns at least `["pyproject.toml", "requirements.txt"]` (exact glob set confirmed in `/sdd plan`) |
+| SC-002 | Hover for requirements.txt dependencies matches pyproject.toml | A package in requirements.txt and pyproject.toml with identical version specifier produces identical hover content (format, status label, latest version) — verified manually in a test manifest |
+| SC-003 | Inlay hints for requirements.txt match pyproject.toml | Inlay-hint positions, text, and appearance are identical between requirements.txt and pyproject.toml for the same package state (outdated/unknown/yanked) |
+| SC-004 | Diagnostics for requirements.txt match pyproject.toml | Diagnostic messages, severity levels, and line-range locations are identical for equivalent dependencies in both file formats |
+| SC-005 | Parser handles PEP 508 markers | An environment marker like `; python_version < '3.8'` is parsed and applied consistently with pyproject.toml marker handling (reusing existing logic from issue #140) |
+| SC-006 | Parser gracefully skips non-resolvable lines | A requirements.txt with `-e`, `--index-url`, direct URLs, comments, and editable installs is parsed without errors; parse result contains only resolvable dependencies |
+| SC-007 | No duplicate registry calls | Parsing requirements.txt introduces zero additional HTTP calls to PyPI registry beyond what diagnostics/inlay hints already perform for the same dependencies in pyproject.toml, verified via debug logs |
+| SC-008 | Cross-ecosystem consistency test passes | A live-testing session (per `.local/testing/` protocol) opens a requirements.txt and a pyproject.toml with identical dependencies and verifies hover/completion/diagnostic/inlay-hint behavior is equivalent; results logged in `.local/testing/coverage.md`'s LSP Feature Matrix |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Reuse the existing `PypiDependency` struct, PEP 508 parsing, and PEP 440 version-comparison logic;
+  do not duplicate them for requirements.txt.
+- Extend `manifest_filenames()` in `PypiEcosystem` to include the new file patterns; do not hard-code
+  file-type detection in the LSP server.
+- Route requirements.txt dependencies through the existing LSP handler functions (`generate_hover()`,
+  `generate_inlay_hints()`, etc.); ensure behavior is identical to pyproject.toml per
+  cross-ecosystem-consistency rule.
+- Follow existing patterns in `crates/deps-pypi/src/parser.rs` for error handling, marker parsing,
+  and logging.
+- Run the full check suite (`cargo +nightly fmt --check`, `cargo clippy --all-targets --all-features
+  --workspace -- -D warnings`, `cargo nextest run --workspace --all-features`) before considering
+  any implementation complete.
+
+### Ask First
+- Introducing a new error type distinct from existing `PypiError` variants (vs. reusing `PypiError::ParseError`).
+- Changing the `PypiDependency` struct to add new fields (vs. reusing existing fields).
+- Making the requirements.txt parser respect `-r`/`-c` includes (vs. skipping them silently) — this
+  is a design decision for `/sdd plan`.
+- Adding a new public API to `PypiEcosystem` beyond extending `manifest_filenames()` and updating
+  `parse_manifest()` to handle both file types.
+
+### Never
+- Modify existing pyproject.toml parsing logic as a side effect of adding requirements.txt support
+  — the two formats MUST be parsed independently.
+- Surface a diagnostic or error to the user for requirements.txt-specific syntax that cannot be
+  resolved (editable installs, direct URLs, include directives) — graceful skipping is required.
+- Diverge from the cross-ecosystem-consistency rule — hover/diagnostic/inlay-hint format MUST
+  remain identical between requirements.txt and pyproject.toml.
+- Introduce ecosystem-specific LSP behavior for requirements.txt that differs from how pyproject.toml
+  dependencies are handled.
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Exact file-pattern matching — should the system recognize `requirements.txt`,
+  `requirements-*.txt`, and `*.requirements.txt`? Or only `requirements*.txt`? The competitive-parity
+  note mentions all three; the final set of globs is a `/sdd plan` decision.]
+- [NEEDS CLARIFICATION: Design intent for `-r`/`--requirement` and `-c`/`--constraint` include
+  directives (FR-009): (A) skip them silently (simplest, proposed), (B) follow them recursively
+  and merge transitive dependencies, or (C) surface a warning diagnostic? This decision must be
+  made in `/sdd plan` before implementation. Recursive include detection (cycle prevention) is a
+  sub-question if (B) is chosen.]
+- [NEEDS CLARIFICATION: Should constraints.txt (e.g., `constraints.txt`, typically used with `-c`
+  directives) be treated as a distinct file type with different semantics, or grouped with
+  requirements.txt? Currently scoped out; deferred decision.]
+- [NEEDS CLARIFICATION: Handling of `--hash` lines — should these be parsed for integrity-check
+  purposes, or simply skipped as pip configuration? If parsed, should a mismatch between installed
+  and declared hashes surface a diagnostic?]
+- [NEEDS CLARIFICATION: If a user has both `requirements.txt` and `pyproject.toml` in the same
+  project with overlapping dependencies, should the server deduplicate diagnostics, or should the
+  user see redundant feedback for the same package? Currently proposed: independent parsing, user
+  sees both (consistent with text-editor tab duplication UX). Deferred to `/sdd plan` if
+  deduplication is desired.]
+- [NEEDS CLARIFICATION: Should the parser attempt to infer the Python version / environment markers
+  from project metadata (e.g., `python_requires` in pyproject.toml), or evaluate markers in a
+  platform-neutral way? Currently proposed: reuse existing marker-evaluation logic from pyproject.toml
+  handling (issue #140), which may also have this open question. Verify during plan.]
+- [NEEDS CLARIFICATION: No project constitution exists yet at `.local/specs/constitution.md` — this
+  spec cannot yet be checked against project-wide architectural principles. Recommend running
+  `/sdd init` before `/sdd plan` for this feature.]
+
+## 10. See Also
+
+- `crates/deps-pypi/src/ecosystem.rs` — `manifest_filenames()` method (~line 70-72), `parse_manifest()`
+  method (~line 78-92)
+- `crates/deps-pypi/src/parser.rs` — `PypiParser::parse_content()` (~line 145-212), PEP 508 marker
+  handling (~line 4-60, `marker_too_deep()`, `MAX_MARKER_LEN`, `MAX_MARKER_DEPTH`), existing
+  `parse_pep508_requirement()` logic for reuse
+- `crates/deps-pypi/src/types.rs` — `PypiDependency` struct definition (to be reused)
+- `.local/testing/issue-drafts-2026-08-23.md` — Draft 1 (original issue body)
+- `.local/testing/playbooks/competitive-parity.md` — Known Gaps table row, Scan Notes (2026-08-23)
+- `.claude/rules/continuous-improvement.md#Cross-Ecosystem Consistency Testing` — consistency rule
+  this feature MUST comply with
+- [[MOC-specs]] — all specifications
+- [PEP 440 — Version Identification and Dependency Specification](https://peps.python.org/pep-0440/)
+- [PEP 508 — Dependency specification for Python Software Packages](https://peps.python.org/pep-0508/)
+- [PEP 691 — JSON API for the Simple Repository API](https://peps.python.org/pep-0691/)
+- [pip requirements file format documentation](https://pip.pypa.io/en/stable/reference/requirements-file-format/)

--- a/specs/010-license-hover-policy/spec.md
+++ b/specs/010-license-hover-policy/spec.md
@@ -1,0 +1,273 @@
+---
+aliases:
+  - License Display and Policy Diagnostics
+  - SPDX License in Hover
+tags:
+  - sdd
+  - spec
+  - research
+  - parity-gap
+  - priority/p3
+created: 2026-08-23
+status: draft
+related:
+  - "[[MOC-specs]]"
+---
+
+# Feature: License in hover + optional license-policy diagnostics
+
+> [!info] Metadata
+> **Author**: on-demand competitive-parity scan 2026-08-23 (research finding)
+> **Branch**: [NEEDS CLARIFICATION: assign issue number before branching, e.g. `feat/<issue>-license-hover-policy`]
+> **Type**: research / competitive-parity gap — this spec documents WHAT is missing and WHY;
+> the HOW (license fetching, caching, policy engine) is deferred to a future `/sdd plan` session.
+
+## 1. Overview
+
+### Problem Statement
+
+deps-lsp surfaces no license information for dependencies. This is the single most-requested
+open feature on the tracker of the closest competitor — Dependi #68 "Missing license" has
+13 reactions, 2× their next-highest request — and is still unaddressed there, representing a
+clear differentiation window. Red Hat Dependency Analytics ships license-compatibility
+diagnostics on by default. Every major package manager and update bot (Dependabot, Renovate,
+npm CLI, pip/uv, cargo) surface license information; VS Code Version Lens, crates.nvim, and
+cargo-appraiser all expose it in-editor.
+
+Most registries already expose license in their payloads (crates.io, npm, PyPI, pub.dev,
+Packagist, NuGet). For ecosystems where the native registry lacks license in the hot-path
+metadata endpoint (e.g., cargo's sparse index does not include license; npm's abbreviated
+packument dropped it in favor of size optimization), deps.dev API v3 (free, keyless, no rate
+limit per request) provides per-version SPDX `licenses[]` for npm/Cargo/Go/Maven/PyPI/RubyGems/NuGet
+(but not Composer/Dart/Swift, which must fall back to registry-native license fields).
+
+### Goal
+
+deps-lsp displays license information (SPDX expression) in the hover content for each dependency,
+for both the currently resolved version and the latest available version. A secondary, optional
+phase allows configuration of an SPDX policy (allow-list or deny-list of license identifiers)
+that triggers diagnostics when a dependency's license does not comply — similar to `cargo deny
+licenses` but cross-ecosystem and inline in the editor.
+
+### Out of Scope
+
+- Full dependency-tree license aggregation (e.g., "all my transitive deps combined use X
+  distinct licenses") — scope is per-dependency only.
+- Legal advice or compatibility matrices (e.g., "MIT is compatible with my project's Apache
+  2.0 license") — RHDA and Snyk do this; deps-lsp only surfaces the data for user judgment.
+- SBOM export (CycloneDX, SPDX) — separate, complementary feature tracked elsewhere.
+- Precise field names, license-field order, or hover formatting (bold/italic) — these are HOW
+  decisions for `/sdd plan`.
+- Ecosystem-specific license-field names or alternate SPDX sources beyond deps.dev fallback —
+  this spec describes the generic approach; ecosystem-specific registry-field mapping is a plan
+  detail.
+
+## 2. User Stories
+
+### US-001: See the license when hovering a dependency
+
+AS A developer working with dependencies in a manifest file (e.g., `Cargo.toml`, `package.json`)
+I WANT to hover over or view the package name and see the license (SPDX expression) of both
+  the current pinned version and the latest available version
+SO THAT I understand the license implications of a dependency without leaving the editor or
+  consulting an external registry.
+
+**Acceptance criteria:**
+```
+GIVEN an open manifest file with a declared dependency
+WHEN the user hovers over the dependency name or version field
+THEN the hover content SHALL include the license (SPDX expression or human-readable identifier)
+     for both the resolved/current version and the latest available version
+AND IF the license differs between current and latest, the hover SHALL flag this change
+     (e.g., "License changed: MIT → Apache-2.0")
+```
+
+### US-002: Detect policy violations (optional, opt-in)
+
+AS A developer using an organization-wide or project-level SPDX policy (e.g., "deny GPL-3.0,
+  AGPL-3.0; only allow MIT, Apache-2.0, ISC")
+I WANT the editor to flag dependencies that violate this policy
+SO THAT I catch license-compliance issues before they reach CI or production.
+
+**Acceptance criteria:**
+```
+GIVEN a user-provided policy (via initializationOptions or workspace config) listing
+     allowed/denied SPDX identifiers
+WHEN parsing a manifest with dependencies whose licenses are known
+THEN the system SHALL produce a diagnostic (warning or error, per config) at the manifest line
+     for any dependency whose license does NOT match the allow-list or DOES match the deny-list
+AND the diagnostic message SHALL include the package name, its license, and a short explanation
+     (e.g., "serde-json: GPL-3.0 denied by policy")
+```
+
+### US-003: Consistent behavior across every supported ecosystem
+
+AS A developer using deps-lsp with any of the 11 supported ecosystems (Cargo, npm, PyPI, Go,
+  Bundler, Dart, Maven, Composer, Gradle, Swift, NuGet)
+I WANT license information to appear in the same format and location (in the hover) regardless
+  of which manifest format I'm editing
+SO THAT I don't have to learn ecosystem-specific patterns in how license is displayed.
+
+**Acceptance criteria:**
+```
+GIVEN two open manifests from different ecosystems (e.g., Cargo.toml and package.json), each
+     with dependencies whose licenses are retrievable
+WHEN the user hovers over equivalent dependency declarations in each
+THEN the license field format, position in the hover, and "license changed" signaling SHALL be
+     identical across both ecosystems, per the project's cross-ecosystem-consistency rule
+     (`.claude/rules/continuous-improvement.md#Cross-Ecosystem Consistency Testing`)
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN the server receives a hover request for a dependency THE SYSTEM SHALL retrieve or already have in cache the license information (SPDX expression or identifier) for the resolved version and the latest available version | must |
+| FR-002 | THE SYSTEM SHALL include license information in the hover content for each dependency (format: "License: <SPDX>" or similar) — the exact layout/formatting is a `/sdd plan` detail | must |
+| FR-003 | IF the license differs between the resolved version and the latest version THE SYSTEM SHALL flag this in the hover (e.g., "License changed: <old> → <new>") so the user is alerted to the change | should |
+| FR-004 | THE SYSTEM SHALL fetch license information from the package's native registry when available in the hot-path metadata endpoint (e.g., npm packument, PyPI JSON API, pub.dev API, Packagist, NuGet); [NEEDS CLARIFICATION: cargo sparse index and some others do not include license — fallback strategy to deps.dev or secondary fetch] | must |
+| FR-005 | FOR ecosystems where the hot-path registry endpoint does NOT include license (crates.io sparse index, Go module proxy), THE SYSTEM SHALL fall back to deps.dev API v3 (`GET https://api.deps.dev/v3/{package_type}/packages/{name}/versions/{version}` with `.licenses[]` field) or perform a secondary native-registry fetch (e.g., crates.io full metadata API) without blocking the initial hover latency — [NEEDS CLARIFICATION: lazy loading vs. eager fetch] | must |
+| FR-006 | FOR ecosystems without coverage in deps.dev (Composer, Dart, Swift) THE SYSTEM SHALL attempt to retrieve license from the native registry API (e.g., Packagist, pub.dev, SwiftPM index); if unavailable, the system SHALL display "License: (not found)" or similar gracefully | should |
+| FR-007 | (Optional / Phase 2) IF the user provides a license policy via initializationOptions OR a project config file THE SYSTEM SHALL compute diagnostics at manifest lines for dependencies whose licenses violate the policy (deny-list or allow-list) | should |
+| FR-008 | (Optional / Phase 2) THE SYSTEM SHALL allow policy configuration via `initializationOptions.licensePolicies` or a workspace config file (e.g., `.depsrc.json` / `.depsignore` / workspace setting); format SHALL be a list of SPDX identifiers under `allow` and `deny` keys — [NEEDS CLARIFICATION: exact config schema and file location] | should |
+| FR-009 | THE SYSTEM SHALL produce equivalent license hover behavior (capability, field format, "license changed" signaling) across all 11 supported ecosystem crates, per the cross-ecosystem-consistency rule | must |
+| FR-010 | WHEN a manifest is edited and dependencies change THE SYSTEM SHALL recompute license information on the next hover request (or per the existing document-change event pathway) rather than serving stale license data | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | Hover latency SHALL NOT increase materially due to license fetching — if registry fetch is required for license, it SHALL be cached (per-version, TTL matching or exceeding the existing version-data cache) and SHOULD NOT block the initial hover response (lazy loading is acceptable, with a "Loading license..." placeholder) |
+| NFR-002 | Performance | Hover response for a dependency with cached license information SHALL complete in the same order of magnitude as the existing hover latency (< 100ms target); [NEEDS CLARIFICATION: is this realistic if a secondary registry call is required?] |
+| NFR-003 | Reliability | If license information is unavailable (registry error, not found in API response), the system SHALL NOT crash, log a panic, or fail the hover request — it SHALL degrade gracefully to "License: (unknown)" or omit the field, consistent with how diagnostics/inlay hints degrade today |
+| NFR-004 | Consistency | License field format and hover content layout SHALL be identical across all 11 ecosystems — any ecosystem-specific divergence is a first-class bug per `.claude/rules/continuous-improvement.md#Cross-Ecosystem Consistency Testing` |
+| NFR-005 | Data Accuracy | SPDX license expressions MUST be preserved as-is from the registry (no normalization, translation, or manual curation) so that policy matching is deterministic |
+| NFR-006 | Compatibility | Adding license information to hover SHALL NOT alter existing hover content (description, repository, documentation, version, outdated status, etc.) — it SHALL be additive only |
+
+## 5. Data Model
+
+No new persistent entities. License information is metadata attached to each version (same as
+description, repository, etc.). This spec only describes adding license as a field; the storage
+and caching strategy (in-memory, shared cache, per-document) is a `/sdd plan` detail.
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| Package License (derived) | SPDX expression or identifier for a specific package version | package name, version, license (SPDX string), source registry |
+| License Policy (optional) | User-provided allow-list or deny-list of SPDX identifiers for compliance checking | allow: [SPDX identifiers], deny: [SPDX identifiers], [NEEDS CLARIFICATION: are both lists required, or one-or-the-other?] |
+| Policy Violation (derived) | Per-dependency diagnostic when its license does not match the policy | package name, version, license, policy-violation reason, manifest line |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| License field is missing from registry response | System SHALL degrade gracefully to "License: (unknown)" or omit the field; hover remains functional for other data (version, description, etc.) |
+| Registry API is unreachable (offline, timeout, rate-limit) | System SHALL NOT block hover — if license cannot be fetched, it SHALL display "License: (unavailable)" or similar and log a debug/warn message; hover completes with other available data |
+| License information exists for resolved version but not for latest version | Hover SHALL display resolved version's license and note "Latest version: (license unavailable)" for latest, consistent with graceful degradation |
+| Resolved and latest versions have identical licenses | No "license changed" flag needed; hover simply shows "License: MIT" once or twice depending on display layout |
+| Package has no latest stable version (all yanked, no published versions, unknown ecosystem) | [NEEDS CLARIFICATION: same graceful degradation as missing license — "Latest version: (not found)"] |
+| User provides an invalid SPDX expression in the policy (e.g., "MIT OR invalid-id") | System SHALL attempt to match the policy as-is (no normalization); if match fails due to invalid identifiers, [NEEDS CLARIFICATION: should this be a diagnostic on the config, or silently ignore?] |
+| Policy is empty (no allow-list and no deny-list) | No policy diagnostics SHALL be produced |
+| Very large number of dependencies (100+, 1000+) with policy checking enabled | Policy-violation diagnostics SHALL be computed in-memory without blocking other LSP operations; caching ensures license lookups are not repeated per dependency (one lookup per version globally) |
+| License changes between current and latest versions but user has not pinned to a specific version (e.g., `^1.0.0`) | The "license changed" flag SHALL apply to the latest version matching the requirement, consistent with how "outdated" is computed |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | License displayed in hover for resolved version | 100% of dependencies with available license data show it in hover |
+| SC-002 | License displayed in hover for latest available version | 100% of dependencies with available license data for latest version show it in hover |
+| SC-003 | "License changed" flag when current ≠ latest | Correctly identified in 100% of cases where license differs between resolved and latest versions |
+| SC-004 | Cross-ecosystem consistency | License field format, position in hover, and "license changed" signaling verified equivalent across all 11 ecosystem manifest types in a live-testing session, logged in `.local/testing/coverage.md`'s LSP Feature Matrix |
+| SC-005 | Graceful degradation | If license is unavailable for a dependency, hover remains functional and non-blocking (not blank, not panicked); verified in a live session with an offline registry or missing-data scenario |
+| SC-006 | Policy diagnostics accuracy (if Phase 2 implemented) | Diagnostics produced for 100% of dependencies violating an allow-list or deny-list policy; false positives = 0 |
+| SC-007 | No performance regression | Hover latency for a manifest with 50+ dependencies does not increase more than 20% vs. baseline (pre-license implementation) when license data is cached |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Follow existing patterns in `crates/deps-lsp/src/handlers/hover.rs` for hover content construction and
+  delegate to ecosystem implementations where applicable.
+- Reuse the existing `deps-core` caching infrastructure (HttpCache) for license fetches; do not
+  introduce a parallel caching mechanism.
+- Add license fields to the existing Metadata and/or Version traits in `crates/deps-core/src/registry.rs`
+  rather than creating a separate license-only struct.
+- Run the full check suite (`cargo +nightly fmt --check`, `cargo clippy --all-targets --all-features
+  --workspace -- -D warnings`, `cargo nextest run --workspace --all-features`) before considering
+  any implementation of this spec complete.
+
+### Ask First
+- Introducing a new registry API client distinct from deps.dev (e.g., a separate crate for fallback
+  license fetches) vs. extending the existing ecosystem registry clients to handle license.
+- Whether license should be a required field in the Metadata trait or optional (via an extension
+  trait or a sub-trait).
+- Any change to the hover-handler signature or VersionData struct that affects how license is
+  threaded through the existing handler pipeline.
+- Adding a new dependency to support SPDX parsing or policy matching, if deemed necessary.
+
+### Never
+- Modify the existing hover content for description, repository, documentation, or version fields
+  as a side effect of adding license — those must remain unchanged.
+- Introduce ecosystem-specific license hover behavior that diverges from the other 10 ecosystems
+  without an explicit, documented rationale.
+- Crash or panic if license information is unavailable — graceful degradation is mandatory.
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: cargo sparse index does not include license in the version metadata. Should
+  license be fetched via deps.dev fallback, or should a secondary call to crates.io's full-metadata
+  API (`GET /api/v1/crates/{name}/{version}`) be made? deps.dev is free and keyless; the crates.io
+  API is also free but less standardized. This is a key HOW decision for `/sdd plan`.]
+- [NEEDS CLARIFICATION: npm's abbreviated packument (post-#168's lightweight-endpoint migration) does
+  NOT include license. Should a secondary fetch to the full packument or deps.dev be used? Trade-off:
+  additional latency vs. completeness. This may require lazy loading with a loading-state indicator in
+  hover.]
+- [NEEDS CLARIFICATION: For ecosystems without deps.dev coverage (Composer, Dart, Swift), what is the
+  fallback strategy? Packagist, pub.dev, and SwiftPM all expose license, but field names and availability
+  vary. Should each ecosystem crate implement its own secondary-fetch logic, or should a unified fallback
+  approach be designed for `/sdd plan`?]
+- [NEEDS CLARIFICATION: Should license fetching be eager (block hover until license is available),
+  lazy (background fetch with placeholder), or hybrid (eager for hot-path, lazy for fallback)? This
+  affects perceived responsiveness and hover latency budgets.]
+- [NEEDS CLARIFICATION: Phase 2 — license-policy diagnostics — requires configuration (allow/deny lists
+  of SPDX identifiers). Should this be provided via `initializationOptions` (LSP protocol), a workspace
+  config file (e.g., `workspace.depsconfig`), environment variables, or all three? How are multiple
+  policies (global, workspace, project-level) merged?]
+- [NEEDS CLARIFICATION: Should the policy match SPDX expressions exactly, or should it support
+  operators (e.g., "MIT OR Apache-2.0" as a single policy entry, parsed via a SPDX expression parser)?
+  Or should the policy only match top-level identifiers (e.g., "deny GPL-3.0" catches "GPL-3.0" and
+  "GPL-3.0 OR MIT" but not "Apache-2.0 OR GPL-3.0 WITH Classpath-exception-2.0")? This affects policy
+  engine design.]
+- [NEEDS CLARIFICATION: No project constitution exists yet at `.local/specs/constitution.md` — this spec
+  cannot yet be checked against project-wide architectural principles. Recommend running `/sdd init`
+  before `/sdd plan` for this feature.]
+
+## 10. See Also
+
+- Dependi #68 "Missing license" (13 reactions; primary competitive demand signal):
+  https://github.com/filllabs/dependi/issues/68
+- Red Hat Dependency Analytics (ships license diagnostics on by default):
+  https://raw.githubusercontent.com/fabric8-analytics/fabric8-analytics-vscode-extension/master/README.md
+- deps.dev API v3 (free, keyless, per-version SPDX licenses[] for 6 ecosystems):
+  https://docs.deps.dev/api/v3/
+- crates.io sparse index documentation (does NOT include license):
+  https://github.com/rust-lang/crates.io
+- npm packument format (abbreviated form lacks license; full form includes it):
+  https://github.com/npm/registry/blob/main/docs/REGISTRY-API.md#get-a-package
+- PyPI PEP 691 Simple API (lacks license; full JSON API has `license` field):
+  https://peps.python.org/pep-0691/
+- crates.nvim (shows license in hover):
+  https://github.com/Saecki/crates.nvim
+- cargo-appraiser (shows license, downloads, publish dates):
+  https://github.com/simnillrig/cargo-appraiser
+- `cargo deny licenses` (inspiration for Phase 2 policy engine):
+  https://docs.rs/cargo-deny/latest/cargo_deny/
+- `.local/testing/playbooks/competitive-parity.md` — full scan notes and ranking of all findings
+  (2026-08-23)
+- `.local/testing/issue-drafts-2026-08-23.md` — draft 2, raw issue template for reference
+- [[MOC-specs]] — all specifications
+- [[002-osv-vulnerability-diagnostics/spec]] — related diagnostics work using similar per-dependency
+  metadata pipeline
+- [[004-release-freshness-signal/spec]] — related version-metadata (publish date) work that overlaps
+  this feature's data fetching
+- [[007-lightweight-registry-metadata/spec]] — registry-payload optimization that impacts what license
+  data is available hot-path

--- a/specs/011-deprecation-replacement-diagnostics/spec.md
+++ b/specs/011-deprecation-replacement-diagnostics/spec.md
@@ -1,0 +1,216 @@
+---
+aliases:
+  - Deprecation/Abandoned Package Diagnostics
+  - Deprecation with Replacement Suggestions
+tags:
+  - sdd
+  - spec
+  - research
+  - parity-gap
+  - priority/p3
+created: 2026-08-23
+status: draft
+related:
+  - "[[MOC-specs]]"
+---
+
+# Feature: Deprecation/abandoned-package diagnostics with suggested replacement (distinct from yanked)
+
+> [!info] Metadata
+> **Author**: on-demand competitive-parity scan 2026-08-23 (research finding)
+> **Branch**: [NEEDS CLARIFICATION: assign issue number before branching, e.g. `feat/<issue>-deprecation-diagnostics`]
+> **Type**: research / competitive-parity gap — this spec documents WHAT is missing and WHY;
+> the HOW (ecosystem-specific integration, severity mapping, diagnostic on-by-default policy) is deferred to a future `/sdd plan` session.
+
+## 1. Overview
+
+### Problem Statement
+
+deps-lsp handles **yanked versions** (versions withdrawn from a registry) but not **package-level deprecation/abandonment** — a registry-native signal distinct from yanked, with first-class metadata that often includes a suggested successor package name.
+
+Today:
+- **npm**: `deprecated` field is fetched in the abbreviated packument (per-version message, e.g., "Use package X instead") but currently mapped to the `yanked` trait without surfacing the message
+- **Composer/Packagist**: `abandoned` field is fetched and mapped to `yanked`, already differentiates as "*(abandoned)*" in hover (not "*(yanked)*")
+- **NuGet**: Does not currently fetch deprecation metadata (flat-container endpoint lacks it; registration endpoint carries `deprecationMessage` + `alternatePackage` but is not yet integrated)
+- **Dart/pub.dev**: Does not currently fetch `discontinued` or `replacedBy` fields
+- **PyPI**: Does not currently fetch project status (archived/quarantined) — available from deps.dev or direct PyPI endpoint inspection
+- **Go, Bundler, Maven, Gradle, Swift**: No registry-native deprecation signal observed; would require registry research before integration
+
+Verified across the 2026-08-23 on-demand competitive-parity scan:
+```
+rg -n "deprecated|abandonm" crates/deps-*/src/types.rs --type rust
+# => npm/composer matched; nuget/dart/pypi/others showed zero deprecation-specific fields beyond yanked
+```
+
+The distinction matters:
+- **Yanked**: A version was withdrawn; the package itself may be healthy. User should upgrade to a newer version of the same package.
+- **Deprecated/Abandoned**: The package itself is no longer maintained. User should migrate to a different (replacement) package.
+
+In-editor competition is weak — no scanned competitor surfaces replacement suggestions — while the data is already in (or adjacent to) payloads we fetch. Dependi's most-reacted open feature (#68, 13 reactions, 2x their next request) is license display; deprecation with replacement is the third finding (unfiled, draft 3 in `.local/testing/issue-drafts-2026-08-23.md`).
+
+### Goal
+
+deps-lsp emits a **warning diagnostic** on deps declared against a deprecated/abandoned package (with the registry's deprecation reason when available), shows deprecation reason + suggested replacement in hover (when the registry provides one), and offers a **"Replace with X" code action** (reusing the existing update-version `WorkspaceEdit` pathway) where a replacement is named. Per-version vs package-level deprecation distinction is scoped per ecosystem.
+
+### Out of Scope
+
+- Transitive dependency deprecation — only direct (manifest-declared) dependencies trigger diagnostics.
+- Automated migration of import statements or code that uses the package (rename in manifest only).
+- Yanked-version deprecation (orthogonal to this feature; already handled).
+- Custom severity configuration or suppression comments in this initial phase — whether the diagnostic is on-by-default and how a user might silence it are deferred to `/sdd plan`.
+- Version-scoped deprecation where only some versions of a package are deprecated (e.g., npm per-version `deprecated` field behavior vs package-level abandonment); per-ecosystem scoping is a HOW question.
+
+## 2. User Stories
+
+### US-001: Discover that a package is deprecated
+
+AS A developer using a deprecated/abandoned package (e.g., Lodash alternatives, old build tooling, retired frameworks)
+I WANT the editor to warn me that the package is no longer maintained
+SO THAT I can prioritize migrating to an actively-maintained replacement.
+
+**Acceptance criteria:**
+```
+GIVEN a manifest with a dependency on a deprecated/abandoned package (verified as deprecated in the registry)
+WHEN the editor loads the manifest
+THEN the server SHALL emit a warning diagnostic (e.g., "This package is deprecated") at the dependency line
+     AND the diagnostic text SHALL include the registry's deprecation message (e.g., "Use package X instead" when provided)
+```
+
+### US-002: Learn the replacement package name
+
+AS A developer reading the deprecation warning
+I WANT to see the suggested replacement package (if the registry names one) both in hover and in a code action
+SO THAT I can quickly jump to the right alternative without consulting external docs.
+
+**Acceptance criteria:**
+```
+GIVEN a deprecated/abandoned package whose registry entry names a replacement (e.g., npm's "Use X instead" string, Packagist's abandoned: "other/package")
+WHEN the user hovers over the dependency
+THEN the hover SHALL include the deprecation reason AND the suggested replacement package name in a human-readable format (e.g., "Suggested replacement: other/package")
+     AND the server SHALL advertise a code action "Replace with other/package" that, when invoked, rewrites the manifest to depend on other/package instead
+```
+
+### US-003: Handle packages with no suggested replacement
+
+AS A developer with a deprecated package that has no replacement suggestion
+I WANT to see the deprecation warning and reason
+SO THAT I understand why the package is not recommended and can research alternatives manually.
+
+**Acceptance criteria:**
+```
+GIVEN a deprecated/abandoned package whose registry entry does NOT name a replacement
+WHEN the user hovers over the dependency
+THEN the hover SHALL include the deprecation reason or a generic message (e.g., "This package is no longer maintained")
+     AND the server SHALL NOT advertise a "Replace with X" code action (because no replacement is known)
+```
+
+### US-004: Consistent behavior across supported ecosystems
+
+AS A developer using deps-lsp with any of the 11 supported ecosystems (Cargo, npm, PyPI, Go, Bundler, Dart, Maven, Composer, Gradle, Swift, NuGet)
+I WANT deprecation diagnostics to behave consistently regardless of which manifest format I'm editing
+SO THAT I don't have to learn ecosystem-specific quirks in the deprecation workflow.
+
+**Acceptance criteria:**
+```
+GIVEN two open manifests from different ecosystems (e.g., package.json and composer.json), each with a deprecated/abandoned dependency
+WHEN the editor requests diagnostics for each
+THEN the diagnostic presence, severity, title format, and code-action behavior SHALL be equivalent across both, per the project's cross-ecosystem-consistency rule
+     (`.claude/rules/continuous-improvement.md#Cross-Ecosystem Consistency Testing`)
+     AND any ecosystem-specific divergence SHALL be documented as a first-class bug
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | THE SYSTEM SHALL detect when a resolved version's package (per-ecosystem metadata) is marked deprecated/abandoned by the registry | must |
+| FR-002 | WHEN a manifest dependency is declared against a deprecated/abandoned package THE SYSTEM SHALL emit a warning diagnostic at the dependency line, titled "This package is [deprecated\|abandoned]" (ecosystem-specific phrasing per formatter) | must |
+| FR-003 | THE SYSTEM SHALL include the registry's deprecation reason/message in the diagnostic text when available (e.g., npm's `deprecated` string, NuGet's `deprecationMessage`, Packagist's `abandoned` replacement name) | must |
+| FR-004 | THE SYSTEM SHALL surface the deprecation reason and any suggested replacement in hover markdown, reusing the existing hover pathway (crates/deps-core/src/lsp_helpers.rs ~line 600-700) | must |
+| FR-005 | WHEN a registry provides a suggested replacement package name THE SYSTEM SHALL advertise a code action "Replace with {replacement}" that, when invoked, reuses the existing update `WorkspaceEdit` pathway (crates/deps-lsp/src/server.rs `mod commands` / `execute_command` handler ~line 450-460) to change the dependency identifier to the replacement package | should |
+| FR-006 | THE SYSTEM SHALL distinguish between package-level deprecation (entire package no longer maintained) and yanked-version deprecation (a specific version withdrawn) in both diagnostics and hover labels — ecosystem-specific handling per registry capabilities (e.g., npm per-version `deprecated` vs Packagist boolean `abandoned`) | must |
+| FR-007 | THE SYSTEM SHALL produce equivalent deprecation diagnostics and code actions across all 11 supported ecosystem crates, per the cross-ecosystem-consistency rule — any ecosystem-specific divergence requires documented rationale | must |
+| FR-008 | WHEN a manifest is edited or registry data is refreshed THE SYSTEM SHALL recompute deprecation state on the next diagnostic/hover request rather than serving stale cached deprecation status | must |
+| FR-009 | THE SYSTEM SHALL NOT emit a deprecation diagnostic for a dependency when the registry provides no deprecation metadata (i.e., only emit when deprecation is confirmed, not on missing data) | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | Deprecation detection SHALL NOT trigger additional registry fetches beyond what diagnostics/hover/inlay hints already perform for the same document — it SHALL reuse already-cached per-version/per-package metadata |
+| NFR-002 | Performance | Deprecation computation (checking the flag and formatting the message) SHALL be dominated by in-memory state traversal, not I/O; target latency in the same order of magnitude as the existing `textDocument/hover` handler |
+| NFR-003 | Consistency | Deprecation diagnostic title, code-action label format, and hover presentation SHALL be identical across all 11 ecosystems — any ecosystem-specific divergence is a first-class bug per `.claude/rules/continuous-improvement.md#Cross-Ecosystem Consistency Testing` |
+| NFR-004 | Compatibility | Adding deprecation diagnostics SHALL NOT alter existing `hover`, `completion`, `inlay_hint`, `code_action` (for non-replacement updates), `diagnostic` (for non-deprecation categories), or `execute_command` behavior — this is an additive feature |
+| NFR-005 | Ecosystem coverage | Deprecation detection is a best-effort feature per ecosystem registry capabilities: ecosystems with no registry-native deprecation signal (e.g., current Go, Bundler, Maven) remain silent until registry research identifies a signal source — they are not failures |
+
+## 5. Data Model
+
+Deprecation is a property of a resolved package (or per-version, per ecosystem). No new persistent entities beyond the existing `Version` trait.
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| Deprecation status (derived) | Per-package or per-version flag indicating deprecated/abandoned state, with optional reason and replacement name | package name, ecosystem, is_deprecated: bool, deprecation_reason: Option<String>, suggested_replacement: Option<String> |
+| Deprecation diagnostic | Diagnostic entry emitted when a manifest declares a dependency on a deprecated/abandoned package | diagnostic title (e.g., "This package is deprecated"), message (reason + replacement if provided), range (dependency line), severity (warning) |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Package is deprecated but registry provides no reason | Emit diagnostic with generic message (e.g., "This package is deprecated") and no hover replacement suggestion |
+| Package is deprecated and registry provides a reason but no replacement | Emit diagnostic + hover with reason, no code action (because replacement is unknown) |
+| Package is deprecated and registry provides both reason and replacement | Emit diagnostic + hover with reason and replacement, advertise "Replace with X" code action |
+| Registry returns stale/cached data that misses a deprecation flag | System operates on the data it has; upon next registry refresh (cache expiry), deprecation state is recomputed — no immediate resolution required |
+| Per-version deprecation (npm `deprecated` field is present for version 1.0.0 but not 1.0.1) | [NEEDS CLARIFICATION: Should the deprecation diagnostic fire if the user's requirement matches a deprecated version, or only if ALL matching versions are deprecated, or per-package only?] |
+| A replacement package is itself deprecated | No special handling in this spec; the code action rewrites to the registry-suggested name; if that name is also deprecated, the next diagnostic refresh will flag it. User's recursive responsibility to follow chains. |
+| Manifest has unsaved edits when a "Replace with X" code action is invoked | [NEEDS CLARIFICATION: Does the code action operate on the last-synced document state via `WorkspaceEdit`, consistent with how the existing `deps-lsp.updateVersion` command already handles this?] |
+| Very large manifest with many deprecated dependencies | System SHALL emit one warning diagnostic per deprecated dependency, not a single aggregate diagnostic — consistent with how existing diagnostics (outdated, unknown, yanked) are per-dependency |
+| Registry is unavailable (e.g., offline mode) | System degrades gracefully: existing cached deprecation state (if any) is used; new packages cannot be checked for deprecation — consistent with how diagnostics/hover already degrade under the same condition |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Deprecation detection works for all ecosystems with registry-native deprecation signals | npm (deprecated), Composer (abandoned) confirmed functional; NuGet, Dart, PyPI integrated with verification against live registries |
+| SC-002 | Deprecation diagnostic presence matches registry state | 100% agreement between whether a diagnostic is emitted and whether the registry marks the package deprecated/abandoned, verified via spot checks in `.local/testing/coverage.md` LSP Feature Matrix |
+| SC-003 | Replacement code action is offered when and only when a replacement is available | 100% of cases where the registry provides a replacement name have a working "Replace with X" code action; cases without a replacement name show no such action |
+| SC-004 | Cross-ecosystem consistency | Deprecation diagnostic title, severity, and hover format verified equivalent across all ecosystems supporting the feature in a live-testing session, logged in `.local/testing/coverage.md` |
+| SC-005 | No duplicate registry fetches | 0 additional HTTP calls attributable to deprecation detection beyond what diagnostics already perform, verified via debug log inspection per the project's live-testing protocol |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Follow existing patterns in ecosystem crate formatters (`crates/deps-*/src/formatter.rs`) for trait method overrides (e.g., Composer already overrides `yanked_message()` and `yanked_label()`).
+- Reuse the existing `hover` and `code_action` pathways in deps-core and deps-lsp; do not duplicate logic.
+- Run the full check suite (`cargo +nightly fmt --check`, `cargo clippy --all-targets --all-features --workspace -- -D warnings`, `cargo nextest run --workspace --all-features`) before considering any implementation of this spec complete.
+
+### Ask First
+- Introducing a new diagnostic category distinct from yanked/unknown/outdated vs. leveraging an existing category with custom formatting.
+- Per-ecosystem scope decisions (e.g., whether npm treats per-version `deprecated` or package-level deprecation, or both).
+- Any change to the `Version` trait that might affect yanked-version handling or other ecosystems.
+
+### Never
+- Emit deprecation diagnostics based on assumption; only emit when the registry explicitly marks a package deprecated/abandoned.
+- Modify existing yanked/unknown diagnostic logic as a side effect of adding deprecation — they must remain fully functional and independent.
+- Introduce ecosystem-specific deprecation behavior (e.g., only checking npm, skipping others) without an explicit, documented rationale in the `/sdd plan` and code comments.
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Should "Replace with X" code action be offered unconditionally when a replacement exists, or should it require user confirmation due to risk of migrating to a wrong package (e.g., typosquatting)? Current design offers the action without gating; revisit if security concern is raised.]
+- [NEEDS CLARIFICATION: Per-version vs package-level deprecation scope per ecosystem: npm's `deprecated` field is per-version, but other ecosystems (Packagist, pub.dev) may treat deprecation as package-wide. Should the spec enforce one model across all ecosystems, or allow ecosystem-specific variation with clear documentation?]
+- [NEEDS CLARIFICATION: Should the deprecation diagnostic be on-by-default or gated by a config option (e.g., like yanked/outdated diagnostics)? Deferred to `/sdd plan`.]
+- [NEEDS CLARIFICATION: Atomicity/rollback guarantee when the "Replace with X" code action is invoked — does the `WorkspaceEdit` reuse the same batching logic as the single-version update command, or does it require special handling?]
+- [NEEDS CLARIFICATION: No project constitution exists yet at `.local/specs/constitution.md` — this spec cannot yet be checked against project-wide architectural principles. Recommend running `/sdd init` before `/sdd plan` for this feature.]
+- [NEEDS CLARIFICATION: Which registries actually provide a replacement package name in their deprecation metadata, and in what field/format? Live registry API verification needed for: NuGet (`alternatePackage` in registration endpoint), Dart pub.dev (`replacedBy`), PyPI project status (deps.dev `isDeprecated` vs direct endpoint), Go, Bundler, Maven, Gradle, Swift — to ground the "replacement available" condition in FR-005/US-002.]
+
+## 10. See Also
+
+- `crates/deps-core/src/lsp_helpers.rs` (~line 448-456) — existing `yanked_message()` / `yanked_label()` trait methods that deprecation will extend or parallel
+- `crates/deps-core/src/lsp_helpers.rs` (~line 600-700) — hover markdown generation pathway that will surface deprecation reason + replacement
+- `crates/deps-lsp/src/server.rs` (~line 450-460) — `execute_command` handler / `mod commands` that code actions reuse
+- `crates/deps-npm/src/registry.rs` (~line 229) — npm `deprecated` field already parsed; comment notes it's per-version with optional message string
+- `crates/deps-composer/src/formatter.rs` (~line 24-30) — Composer formatter already differentiates abandonment with custom `yanked_message()` / `yanked_label()`
+- `crates/deps-composer/src/registry.rs` (~line 167-179) — Packagist `abandoned` field handling: can be bool or string (replacement name)
+- `.local/testing/issue-drafts-2026-08-23.md` — draft 3 with full issue body for filing
+- `.local/testing/playbooks/competitive-parity.md` → Scan Notes (2026-08-23) — original research finding and ecosystem registry survey
+- [[MOC-specs]] — all specifications
+- [[002-osv-vulnerability-diagnostics/spec]] — related diagnostics work on the same per-dependency diagnostic pipeline

--- a/specs/012-unsatisfiable-requirement-diagnostic/spec.md
+++ b/specs/012-unsatisfiable-requirement-diagnostic/spec.md
@@ -1,0 +1,278 @@
+---
+aliases:
+  - Unsatisfiable Requirement Diagnostic
+  - No Matching Version Diagnostic
+tags:
+  - sdd
+  - spec
+  - enhancement
+  - parity-gap
+  - diagnostics
+  - priority/p3
+created: 2026-08-23
+status: draft
+related:
+  - "[[MOC-specs]]"
+---
+
+# Feature: Diagnostic for version requirements matching zero published versions
+
+> [!info] Metadata
+> **Author**: on-demand competitive-parity scan 2026-08-23 (research finding)
+> **Branch**: [NEEDS CLARIFICATION: assign issue number before branching, e.g. `feat/<issue>-unsatisfiable-requirement-diagnostic`]
+> **Type**: enhancement / competitive-parity gap — this spec documents WHAT is missing and WHY;
+> the HOW (diagnostic severity, code action target, prerelease interaction) is deferred to a future `/sdd plan` session.
+
+## 1. Overview
+
+### Problem Statement
+
+deps-lsp computes and renders three types of version-status diagnostics for dependencies:
+1. **Unknown package** (WARNING) — package name does not exist in registry
+2. **Yanked version** (WARNING) — the matching version was yanked
+3. **Newer version available** (HINT, `Outdated` status) — requirement is satisfied by current version, but not by latest
+
+There is no fourth type: **unsatisfiable requirement**. When a declared requirement matches zero
+published versions (e.g., `serde = "2"` while latest is 1.x, or a constraint like `>=3.0 <3.1`
+that no release satisfies), the dependency is currently **silent** — it appears neither outdated
+nor current. The user discovers the problem only at build/install time, when their package manager
+rejects the requirement.
+
+Verified by:
+- Live reproduction: `serde = "2"` in a `Cargo.toml` shows no diagnostic until build-time failure.
+- Competitive evidence: crates.nvim (Neovim Rust tooling) renders an explicit "No match" indicator;
+  Dependi (VS Code dependency extension, closest competitor) has this filed as a bug (#221:
+  "higher versions accepted in Cargo, no error").
+- Registry data availability: deps-lsp already fetches the full version list per package
+  (`.local/testing/playbooks/competitive-parity.md`, Scan Notes 2026-08-23); this diagnostic
+  requires pure comparison logic, not new data sources.
+
+### Goal
+
+deps-lsp detects when a declared requirement matches zero published versions in the fetched
+version list and renders a warning diagnostic ("no published version satisfies requirement;
+latest is X") at the requirement span. A code action suggests updating the requirement to a
+satisfiable value (reusing the existing version-update WorkspaceEdit pathway).
+
+### Out of Scope
+
+- Exact wording, icon, or UI placement of the diagnostic message — these are HOW details for
+  `/sdd plan`.
+- Interaction with prerelease-only matches (requirement satisfiable only by pre-release versions)
+  — whether this is a distinct diagnostic, a flag on the primary one, or a separate state is a
+  HOW decision; marked as open question below.
+- Requirements the ecosystem's own resolver would reject anyway (e.g., syntax errors, invalid
+  operators) — those are typically caught by the ecosystem's parser, not deps-lsp's version
+  comparison.
+- Graceful degradation when offline or version-list unavailable (must not false-positive on
+  network failure) — this is covered by existing diagnostics' graceful-degradation behavior
+  (no diagnostic if version list is empty/loading) and inherited here without redesign.
+- Cross-file / workspace-wide aggregation of unsatisfiable requirements — this is a per-dependency,
+  per-document diagnostic scoped to the same level as "Newer version available."
+
+## 2. User Stories
+
+### US-001: Surface impossible requirements early
+
+AS A developer with a manifest containing a requirement that no published version can satisfy
+(e.g., `serde = "2"` when the latest stable is 1.x)
+I WANT an in-editor warning diagnostic at that requirement line
+SO THAT I catch the error during editing rather than at build/install time.
+
+**Acceptance criteria:**
+```
+GIVEN a manifest with a dependency whose declared requirement matches zero published versions
+WHEN the editor requests textDocument/diagnostic for that document
+THEN the server SHALL return a warning diagnostic at the requirement span communicating that
+     no version satisfies it, and optionally showing the latest version (e.g., "no published
+     version satisfies requirement; latest is 1.5.0")
+```
+
+### US-002: Distinguish from "up to date"
+
+AS A developer reviewing a manifest
+I WANT to immediately tell the difference between:
+  - a dependency where the current version is up to date (no diagnostic)
+  - a dependency where the current version is outdated but a newer one exists ("Newer version available" HINT)
+  - a dependency where **no version ever satisfies** the requirement (warning diagnostic)
+SO THAT I understand the urgency and nature of each issue.
+
+**Acceptance criteria:**
+```
+GIVEN a manifest with three dependencies:
+     - dep-a@1.0 (requirement "^1" matches latest 1.5.0, up to date)
+     - dep-b@1.0 (requirement "^1" but latest is 2.0.0, outdated)
+     - dep-c@2 (requirement "2" but latest is 1.5.0, unsatisfiable)
+WHEN the editor requests textDocument/diagnostic
+THEN the server SHALL return:
+     - no diagnostic for dep-a
+     - HINT diagnostic "Newer version available: 2.0.0" for dep-b
+     - WARNING diagnostic communicating unsatisfiable requirement for dep-c
+```
+
+### US-003: Consistent behavior across all 11 supported ecosystems
+
+AS A developer using deps-lsp with any of the 11 supported ecosystems (Cargo, npm, PyPI, Go,
+Bundler, Dart, Maven, Composer, Gradle, Swift, NuGet)
+I WANT the unsatisfiable-requirement diagnostic to appear consistently when a requirement
+matches zero versions, regardless of ecosystem
+SO THAT I don't have to learn ecosystem-specific diagnostic quirks.
+
+**Acceptance criteria:**
+```
+GIVEN manifests from different ecosystems (e.g., Cargo.toml, package.json, pyproject.toml)
+     each containing a requirement that matches zero published versions
+WHEN textDocument/diagnostic is requested for each
+THEN the diagnostic SHALL be present for all, with equivalent severity and message format,
+     per the project's cross-ecosystem-consistency rule
+     (`.claude/rules/continuous-improvement.md#Cross-Ecosystem Consistency Testing`)
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN a dependency's parsed requirement is submitted to the ecosystem-specific version-comparison logic AND no published version in the fetched registry version list satisfies it THE SYSTEM SHALL generate a warning diagnostic at the requirement span (not the package name span, consistent with "Newer version available" placement) | must |
+| FR-002 | THE SYSTEM SHALL reuse the existing version-list data already fetched and cached for diagnostics/inlay hints (no new registry calls) by computing "zero matching versions" within the `generate_diagnostics_from_cache` / `generate_diagnostics` pathway in `deps-core/src/lsp_helpers.rs` | must |
+| FR-003 | THE SYSTEM SHALL include in the diagnostic message the latest stable version (or a note that no stable version exists, if all versions are pre-release or yanked) to guide the user toward a satisfiable alternative | must |
+| FR-004 | THE SYSTEM SHALL NOT emit this diagnostic when the version list is empty, still loading, or unavailable (offline) — the existing graceful-degradation behavior for cached versions applies unchanged | must |
+| FR-005 | THE SYSTEM SHALL NOT emit this diagnostic for special requirement forms that are not subject to version-list matching: wildcard requirements (`*`, `latest`, etc. per ecosystem), workspace dependencies, path dependencies, git/URL dependencies, or unresolved variables (Gradle `$var`, Maven `${property}`) — these are handled by `requirement_is_unresolved()` logic or ecosystem-specific guards and must remain unchanged | must |
+| FR-006 | THE SYSTEM SHALL provide a code action (invoked from the diagnostic) that suggests updating the requirement to a satisfiable value, reusing the existing `deps-lsp.updateVersion` command pathway or a new variant of it to specify the target version (one of: latest stable, highest available non-prerelease, or configurable per ecosystem) | should |
+| FR-007 | THE SYSTEM SHALL produce equivalent unsatisfiable-requirement detection across all 11 supported ecosystem crates (`deps-cargo`, `deps-npm`, `deps-pypi`, `deps-go`, `deps-bundler`, `deps-dart`, `deps-maven`, `deps-composer`, `deps-gradle`, `deps-swift`, `deps-nuget`), per the cross-ecosystem-consistency rule | must |
+| FR-008 | WHEN a manifest is edited (requirement text changes) the next textDocument/diagnostic request SHALL reflect the new unsatisfiable state — no stale caching of "this requirement is unsatisfiable" across requirement changes | must |
+| FR-009 | [NEEDS CLARIFICATION: prerelease handling] WHEN a requirement matches zero stable versions but does match one or more pre-release versions, THE SYSTEM SHALL either: (A) emit an unsatisfiable diagnostic anyway (pre-releases don't count as satisfying), or (B) emit a distinct diagnostic ("matches only pre-release versions; latest stable is X"), or (C) suppress the diagnostic and rely on a separate prerelease-awareness feature. The choice determines whether prerelease-only matches are treated as unsatisfiable or a separate state. | depends-on-design |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | Computing the unsatisfiable-requirement check SHALL NOT introduce additional registry (network) fetches beyond what diagnostics already perform — it SHALL operate on already-cached per-dependency version lists |
+| NFR-002 | Performance | Checking "does any version in the list match the requirement" SHALL be O(N) in the number of versions per dependency, dominated by the existing version-comparison logic; diagnostic rendering SHALL NOT add measurable latency to `textDocument/diagnostic` responses |
+| NFR-003 | Consistency | Unsatisfiable-requirement detection SHALL be identical across all 11 ecosystems — any ecosystem-specific divergence (e.g., one ecosystem emits the diagnostic, another silently ignores the same requirement) is a first-class bug per `.claude/rules/continuous-improvement.md#Cross-Ecosystem Consistency Testing` |
+| NFR-004 | Compatibility | Introducing unsatisfiable-requirement diagnostics SHALL NOT alter existing "Unknown package," "Yanked version," or "Newer version available" diagnostics' behavior — this is an additive diagnostic type |
+| NFR-005 | Reliability | If the unsatisfiable-requirement check encounters an error during comparison (e.g., a version-parsing panic in the ecosystem's comparison logic), the system SHALL NOT crash the server or emit a malformed diagnostic — error handling SHALL be consistent with existing diagnostic-generation error modes |
+
+## 5. Data Model
+
+No new persistent entities. This feature adds a new case to the existing `RequirementStatus` enum
+and/or version-matching logic in `deps-core`.
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| Unsatisfiable requirement (derived) | A dependency whose declared requirement matches zero versions in the fetched registry list | dependency name, declared requirement string, latest version (for diagnostic message), ecosystem-specific version-comparison result (no matches) |
+
+The detection logic is computed on-the-fly during `generate_diagnostics_from_cache` /
+`generate_diagnostics` by checking: for a given `(requirement_string, available_versions_list)`
+pair, does the ecosystem's version-comparison predicate (already used for "Outdated" detection)
+report that any version in the list satisfies the requirement? If not, emit diagnostic.
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Requirement matches zero versions | Emit unsatisfiable-requirement warning diagnostic (primary case) |
+| Requirement matches only yanked versions | [NEEDS CLARIFICATION: emit unsatisfiable, or treat yanked versions as non-existent for the purposes of this check?] — behavior depends on whether "no stable version matches" and "no version at all matches" are distinguished |
+| Requirement matches only pre-release versions | [NEEDS CLARIFICATION: see FR-009; depends on prerelease-interaction design decision] |
+| Manifest has empty version list (offline, network unavailable) | No diagnostic rendered (consistent with existing graceful degradation for "Unknown package" and "Newer version available") |
+| Manifest has version list still loading | No diagnostic rendered (existing `LoadingState::Loading` skip applies) |
+| Requirement is a wildcard (`*`, `latest`, etc.) or workspace/path/git/URL dependency | No diagnostic rendered (these are excluded by `requirement_is_unresolved()` or ecosystem-specific guards) |
+| Requirement text contains environment markers or other conditional syntax (e.g., PEP 508 markers in PyPI) | Ecosystem's existing requirement-parsing logic applies; if the conditional is unresolvable, treated as `Unresolved`; if resolvable, unsatisfiable check proceeds (OR: ecosystem may short-circuit certain conditionals — behavior inherited from existing parsing, not redesigned here) |
+| Very old requirement that used to match but no longer does (e.g., requirement `^1.0` when 1.x versions were published, now deleted) | Treated as unsatisfiable (no version exists that satisfies it today) — this is the expected behavior |
+| Typo in requirement (e.g., `serde = "2.0.0.0"`, syntactically malformed) | Ecosystem's parser catches syntax errors; if the requirement parses to a valid constraint that matches zero versions, diagnostic is emitted; if parsing fails, handled by existing error paths (no version-match diagnostic rendered, possibly a parse error instead) |
+| Registry response includes new versions since last fetch, now satisfying the requirement | On next cache refresh and diagnostic re-run, diagnostic disappears (requirement is no longer unsatisfiable); no sticky "was unsatisfiable" state |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Unsatisfiable-requirement diagnostic emitted for all test cases where requirement matches zero versions | 100% of manually-tested unsatisfiable cases produce the diagnostic |
+| SC-002 | No false positives for satisfiable requirements | 0 diagnostics for requirements matching at least one version (stable, pre-release, or otherwise available) |
+| SC-003 | Cross-ecosystem consistency | Unsatisfiable-requirement diagnostic verified present and equivalent across all 11 ecosystem manifest types in a live-testing session, logged in `.local/testing/coverage.md`'s LSP Feature Matrix |
+| SC-004 | No additional registry calls introduced | 0 new outbound HTTP requests attributable to unsatisfiable-requirement detection, verified via debug log inspection per the project's live-testing protocol |
+| SC-005 | Diagnostic does not render when version list unavailable | 0 false-positive unsatisfiable diagnostics when server is offline, cache is empty, or versions are still loading |
+| SC-006 | Code action (if implemented) successfully updates requirement | Code action to "Update to latest version" or equivalent SHALL produce a valid, satisfiable requirement string via WorkspaceEdit, tested against at least one unsatisfiable case per ecosystem |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Reuse existing version-matching logic in `deps-core`; do not duplicate comparison code.
+- Emit the diagnostic in `generate_diagnostics_from_cache` / `generate_diagnostics` alongside
+  existing diagnostics (Unknown package, Yanked, Newer version available).
+- Respect the existing graceful-degradation behavior: no diagnostic if version list is empty,
+  loading, or unavailable.
+- Run the full check suite (`cargo +nightly fmt --check`, `cargo clippy --all-targets
+  --all-features --workspace -- -D warnings`, `cargo nextest run --workspace --all-features`)
+  before considering any implementation of this spec complete.
+- Test the diagnostic across all 11 ecosystems via the project's live-testing protocol
+  (`.local/testing/playbooks/`) before marking the feature done.
+
+### Ask First
+- Whether to emit a distinct diagnostic for "matches only pre-release versions" or fold it into
+  the unsatisfiable category (depends on prerelease design decision in `/sdd plan`).
+- Whether to emit a distinct diagnostic for "matches only yanked versions" — if yanked versions
+  are treated as "non-existent" for matching purposes.
+- Modifying the `RequirementStatus` enum or the `EcosystemFormatter` trait interface to surface
+  a new state beyond `Unresolved` / `UpToDate` / `Outdated` (if that redesign is chosen over
+  treating unsatisfiable as a fourth variant).
+- Adding a new code action or command distinct from the existing `deps-lsp.updateVersion` to
+  handle the "update to satisfiable" suggestion.
+
+### Never
+- Emit this diagnostic for requirements that are unresolved (Gradle `$var`, Maven `${property}`)
+  — those already have separate handling and must remain unchanged.
+- Emit this diagnostic for workspace, path, git, or URL dependencies — those are not version-list
+  matched and must remain unchanged.
+- Silence the existing "Unknown package," "Yanked version," or "Newer version available"
+  diagnostics as a side effect of adding this one — all four types are independent.
+- Introduce ecosystem-specific unsatisfiable-requirement logic that diverges from other ecosystems
+  without an explicit, documented rationale approved in `/sdd plan`.
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Prerelease-only matches (FR-009) — when a requirement matches zero
+  stable versions but one or more pre-release versions, should this emit an unsatisfiable
+  diagnostic (pre-releases don't count), a distinct "matches only pre-release" diagnostic, or
+  no diagnostic at all? This design decision belongs in `/sdd plan` and affects SC-001 criteria.]
+
+- [NEEDS CLARIFICATION: Yanked-only matches — if a requirement matches only yanked versions
+  (no stable, no pre-release, only yanked), is this treated as unsatisfiable (yanked are dead)
+  or a distinct "only yanked versions available" diagnostic? Affects message wording and severity.]
+
+- [NEEDS CLARIFICATION: Diagnostic severity — WARNING or ERROR? "Newer version available" is
+  HINT; unknown/yanked packages are WARNING. Unsatisfiable requirement is a build-time hard
+  failure, so semantically closer to ERROR, but may be rendered as WARNING for consistency with
+  other version-mismatch diagnostics. This is a `/sdd plan` detail.]
+
+- [NEEDS CLARIFICATION: Code action target version — should "Update to satisfiable" suggest
+  (A) the latest stable version, (B) the highest pre-release if no stable exists, (C) the
+  highest available (stable or pre-release), or (D) be ecosystem-specific? How should it
+  interact with prerelease policies? This is a `/sdd plan` detail.]
+
+- [NEEDS CLARIFICATION: Should unsatisfiable-requirement detection be gated behind a config
+  flag (e.g., `disable_unsatisfiable_diagnostics: true`) or always enabled? Existing diagnostics
+  are always enabled; this decision belongs in `/sdd plan` / constitution if one is created.]
+
+- [NEEDS CLARIFICATION: No project constitution exists yet at `.local/specs/constitution.md`
+  — this spec cannot yet be checked against project-wide architectural principles. Recommend
+  running `/sdd init` before `/sdd plan` for this feature to establish default severity,
+  message templates, and code-action conventions.]
+
+## 10. See Also
+
+- `crates/deps-core/src/lsp_helpers.rs` — `generate_diagnostics_from_cache` (~line 752),
+  `RequirementStatus` enum (~line 250), `EcosystemFormatter::requirement_status()` (~line 434),
+  `EcosystemFormatter::requirement_is_unresolved()` (~line 397), existing diagnostic emission
+  (~lines 777, 800, 1122, 1148, 1162 for Unknown/Yanked/Newer patterns)
+- `crates/deps-lsp/src/handlers/diagnostics.rs` — diagnostic handler entry point, delegates to
+  ecosystem via `generate_diagnostics()`
+- `crates/deps-core/src/registry.rs` — `Version` trait (~line 135), version-comparison logic
+  used by formatters
+- `.local/testing/playbooks/competitive-parity.md` — original finding, row "unsatisfiable-
+  requirement diagnostic", verified live by crates.nvim "No match" state and Dependi bug #221
+- `.local/testing/issue-drafts-2026-08-23.md` — draft 4, full issue body and sources
+- [LSP 3.17 Diagnostic specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic)
+- [[MOC-specs]] — all specifications
+- [[008-codelens-update-all-outdated/spec]] — related LSP feature; both reuse version-comparison
+  logic and WorkspaceEdit pathways
+- [[002-osv-vulnerability-diagnostics/spec]] — related diagnostics work using the same
+  per-dependency version data

--- a/specs/013-deno-jsr-ecosystem/spec.md
+++ b/specs/013-deno-jsr-ecosystem/spec.md
@@ -1,0 +1,226 @@
+---
+aliases:
+  - Deno/JSR Ecosystem Support
+  - New Ecosystem: Deno
+tags:
+  - sdd
+  - spec
+  - research
+  - ecosystem/deno
+  - new-ecosystem
+  - priority/p3
+created: 2026-08-23
+status: draft
+related:
+  - "[[MOC-specs]]"
+---
+
+# Feature: New ecosystem — Deno/JSR (deno.json / deno.jsonc)
+
+> [!info] Metadata
+> **Author**: on-demand competitive-parity scan 2026-08-23 (research finding)
+> **Branch**: [NEEDS CLARIFICATION: assign issue number before branching, e.g. `feat/<issue>-deno-jsr`]
+> **Type**: research / new ecosystem — this spec documents WHAT is missing and WHY; the HOW (exact client reuse strategy, JSONC comment handling, JSR API versioning) is deferred to a future `/sdd plan` session.
+
+## 1. Overview
+
+### Problem Statement
+
+deps-lsp currently supports 11 package ecosystems (Cargo, npm, PyPI, Go, Bundler, Dart, Maven, Gradle, Swift, Composer, NuGet). Deno is a JavaScript/TypeScript runtime with growing adoption in the developer tools and LSP-editor communities — particularly among Zed users. Deno manifests (`deno.json` / `deno.jsonc`) declare dependencies as `jsr:` (JSR registry) and `npm:` (npm registry) specifiers in an `imports` map, with full version lists and yanked-version metadata available via a keyless JSR API.
+
+Three reference projects have shipped Deno support in 2026 or recently: Dependi (shipped v0.7.24 by user request #294), Dependabot (ecosystem added 2026), and Renovate (dedicated `deno` manager). Version Lens also lists Deno. This represents the strongest cross-project consensus among new-ecosystem candidates in the 2026-08-23 competitive-parity scan.
+
+Cheapest true new ecosystem to add: manifest is JSON (like npm's `package.json`, parsing is straightforward); `jsr:` specifiers use the JSR API (verified live at `https://jsr.io/@{scope}/{pkg}/meta.json`); `npm:` specifiers reuse the existing `deps-npm` registry client and `node-semver` comparison logic — both are already-written and battle-tested. No new version-comparison crate needed.
+
+### Goal
+
+deps-lsp recognizes `deno.json` and `deno.jsonc` manifest files, parses the `imports` map, routes JSR-specifier packages to a new JSR registry client, routes npm-specifier packages to the existing npm client, and renders `hover`, `latest-version inlay hints`, `outdated+yanked diagnostics`, `version completion`, and `update code actions` with the same fidelity and consistency as other supported ecosystems.
+
+### Out of Scope
+
+- The `scopes` field in Deno manifests (`"scopes": { "@myorg/": "https://..." }`) — an alternative imports mechanism with lower prevalence. [NEEDS CLARIFICATION: confirm, or lift into FR.]
+- Import maps referenced via `importMap` field (e.g., a separate `deno.importMap.json` file) — distinct from direct `imports` in the manifest itself.
+- https:// URL imports (legacy `deno.land/x` ecosystem — now migrating to JSR; out of scope as a separate, manual versioning burden).
+- `package.json` interoperability in Deno projects (Deno v1.40+ reads `package.json` for npm dependencies) — already handled by `deps-npm` when a `package.json` file is opened; Deno + package.json coexistence in the same project is transparent at the LSP handler level.
+- `deno.lock` resolved-version support — lockfile parsing is not required for the initial MVP (same as npm's `package-lock.json` — hover/completion/diagnostics work on the manifest alone); lockfile support is a possible future increment if demand arises.
+
+## 2. User Stories
+
+### US-001: See and update JSR package versions in deno.json
+
+AS A Deno developer with a manifest file declaring JSR dependencies (e.g., `"jsr:@std/fs@1.2"`)
+I WANT to hover over a JSR package name, see the latest version and whether my declared version is outdated, and have a code action to update to the latest
+SO THAT I can keep JSR dependencies current without manually checking the JSR registry.
+
+**Acceptance criteria:**
+```
+GIVEN an open deno.json with a JSR specifier (e.g., "jsr:@std/fs@1.2")
+WHEN the editor requests hover for that specifier
+THEN the server SHALL return metadata including the package name, description (if available),
+     latest version, and outdated/up-to-date status
+AND a code action SHALL be available to update to the latest version
+```
+
+### US-002: See and update npm package versions in deno.json
+
+AS A Deno developer with npm dependencies declared via `npm:` specifiers (e.g., `"npm:react@18"`)
+I WANT the same hover/completion/diagnostic experience for npm packages as I would see in a
+`package.json` file, applied to the `npm:` specifier in deno.json
+SO THAT switching between npm and JSR dependencies is transparent and consistent.
+
+**Acceptance criteria:**
+```
+GIVEN an open deno.json with an npm specifier (e.g., "npm:react@18")
+WHEN the editor requests hover for that specifier
+THEN the server SHALL return the same metadata and code actions as would be rendered for the
+     same package in a package.json file, using the existing deps-npm registry client
+```
+
+### US-003: No noise for valid, up-to-date versions
+
+AS A Deno developer with a manifest file where all declared dependencies match their latest
+available versions
+I WANT no diagnostics or "outdated" inlay hints to appear for those dependencies
+SO THAT the manifest is clean and I can focus on actual version work.
+
+**Acceptance criteria:**
+```
+GIVEN an open deno.json where every dependency's declared version matches (or is a valid range
+     accepting) the latest published version
+WHEN the editor requests diagnostics/inlay hints
+THEN the server SHALL NOT render outdated warnings or badges for those dependencies
+```
+
+### US-004: Consistent behavior across JSR, npm, and other ecosystems
+
+AS A Deno developer working in a polyglot monorepo with Cargo.toml, package.json, and deno.json
+files
+I WANT the hover format, diagnostic wording, code-action labels, and version-comparison logic to
+be identical across all three files
+SO THAT I can use deps-lsp consistently across the whole project without context-switching.
+
+**Acceptance criteria:**
+```
+GIVEN three open manifests (Cargo.toml, package.json, deno.json) each with one outdated
+     dependency of the same degree of outdatedness (e.g., all one major version behind latest)
+WHEN the editor requests diagnostics for each
+THEN the diagnostic message text, severity, and suggested version SHALL be equivalent across
+     all three, per the cross-ecosystem-consistency rule
+     (`.claude/rules/continuous-improvement.md#Cross-Ecosystem Consistency Testing`)
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | THE SYSTEM SHALL advertise recognition of `deno.json` and `deno.jsonc` manifest files, detected by exact filename match in `crates/deps-core/src/ecosystem_registry.rs`'s `filename_map` (alongside `Cargo.toml`, `package.json`, etc.) | must |
+| FR-002 | THE SYSTEM SHALL add `Deno` to the `EcosystemId` enum in `crates/deps-core/src/ecosystem.rs` (exhaustive match enforcer for all code that branches on ecosystem identity) | must |
+| FR-003 | THE SYSTEM SHALL implement `Ecosystem` trait in a new crate `crates/deps-deno/src/ecosystem.rs` providing `manifest_filenames()` returning `["deno.json", "deno.jsonc"]`, `parse_manifest()` that decodes JSON/JSONC and extracts the `imports` map, and `registry()` returning a `Box<dyn Registry>` | must |
+| FR-004 | WHEN parsing `deno.json`/`deno.jsonc` THE SYSTEM SHALL handle JSONC comment syntax (line comments `//`, block comments `/* */`) without crashing — [NEEDS CLARIFICATION: reuse existing JSONC library or strip comments before serde_json::parse?] | must |
+| FR-005 | FOR each import in the `imports` map THE SYSTEM SHALL classify it as either `jsr:` (routed to JSR registry) or `npm:` (routed to existing npm registry) and extract the scope/package name and version requirement — [NEEDS CLARIFICATION: exact parsing of `jsr:@scope/pkg@req` and `npm:pkg@req` format, including prerelease/tag suffixes] | must |
+| FR-006 | THE SYSTEM SHALL implement a JSR registry client in `crates/deps-deno/src/registry.rs` that fetches package metadata from the JSR API (`https://jsr.io/@{scope}/{pkg}/meta.json`), parses the response to extract version list and yanked flags, and implements the `Registry` trait (get_versions, get_latest_matching, search, package_url) | must |
+| FR-007 | FOR `npm:` specifiers in deno.json THE SYSTEM SHALL route to the existing `deps-npm` registry client — [NEEDS CLARIFICATION: instantiate a separate NpmRegistry within the Deno ecosystem implementation, or reference it from `deps-core` / a shared location?] | must |
+| FR-008 | THE SYSTEM SHALL compute version-comparison status (outdated/up-to-date/unknown/yanked) for JSR specifiers using existing `deps-core` version-comparison traits and logic (not a per-ecosystem duplicate) | must |
+| FR-009 | THE SYSTEM SHALL compute version-comparison status for `npm:` specifiers using the existing `node-semver` comparison logic (reuse, no duplication) | must |
+| FR-010 | THE SYSTEM SHALL render `hover`, `inlay_hint`, `diagnostic`, `completion`, and `code_action` for Deno manifests using the existing LSP handlers (generic across ecosystems), with no Deno-specific handler code — handlers dispatch via `EcosystemRegistry::get_for_uri()` which now returns the Deno ecosystem for `deno.json`/`deno.jsonc` URIs | must |
+| FR-011 | THE SYSTEM SHALL support version completion (via LSP `completion` request) for Deno specifiers, offering version suggestions from the JSR or npm registry as appropriate | should |
+| FR-012 | THE SYSTEM SHALL support code actions (via LSP `code_action` request) to update an outdated Deno specifier to its latest version, reusing the existing `deps-lsp.updateVersion` execute_command pathway | must |
+| FR-013 | THE SYSTEM SHALL produce equivalent hoverers across all 12 ecosystems (the existing 11 + Deno), with no ecosystem-specific divergence in format, wording, or metadata displayed — any divergence is a first-class bug | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | JSR API fetches SHALL use the existing HTTP cache (`crates/deps-core/src/http_cache.rs`) with appropriate TTL tuning (no additional network calls beyond what other ecosystems incur) |
+| NFR-002 | Performance | Parsing JSONC in deno.json/deno.jsonc SHALL NOT add measurable latency vs. parsing package.json; target the same sub-50ms cold-start window |
+| NFR-003 | Compatibility | Adding Deno support SHALL NOT alter existing Cargo/npm/PyPI/Go/Bundler/Dart/Maven/Gradle/Swift/Composer/NuGet behavior — ecosystem detection is additive, no breaking changes to other ecosystems |
+| NFR-004 | Consistency | Hover format, inlay hint badge style, diagnostic severity, and code-action labels SHALL be identical across JSR, npm (in deno.json), and all other ecosystems — no Deno-specific formatting exceptions |
+| NFR-005 | Maintainability | The JSR registry client SHALL be co-located in `crates/deps-deno/src/registry.rs`, not in a shared `crates/deps-core` location — ecosystem-specific clients are already per-ecosystem (npm, Cargo, etc.), not shared |
+| NFR-006 | Maintainability | Code SHALL follow existing patterns from `crates/deps-npm/` for JSON parsing, version handling, and registry API calls — consistency across ecosystem crates makes future maintenance easier |
+
+## 5. Data Model
+
+No new persistent entities. Deno dependencies are parsed into the same `Dependency` trait interface used by all ecosystems.
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| Deno manifest | `deno.json` or `deno.jsonc` file | File URI, parsed `imports` map |
+| Deno import entry | An entry in the `imports` map (e.g., `"@std/fs": "jsr:@std/fs@1.2.0"`) | import alias (key), specifier (value: `jsr:` or `npm:` form), package name (extracted), version requirement (extracted) |
+| JSR version list | Response from JSR API `https://jsr.io/@{scope}/{pkg}/meta.json` | Latest version string, full version array, yanked flags per version |
+| JSR/npm dependency (derived) | Unified representation of a parsed Deno import as the `Dependency` trait interface | Name, requirement string, status (outdated/up-to-date/unknown/yanked) |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| deno.json with malformed JSON | File is not recognized as a Deno manifest (fails to parse); graceful degradation (no hover/diagnostics) — same behavior as malformed package.json |
+| deno.jsonc with unclosed block comment | File is not recognized; graceful degradation |
+| deno.json with empty `imports` map | File is recognized and opened; zero dependencies parsed; no diagnostics/hints (consistent with an empty package.json) |
+| deno.json with unsupported specifier format (e.g., `http://` or `file://` URL) | Import is skipped/ignored during parsing; no error message to user (same pattern as how unknown/unparseable entries are handled in other ecosystems) |
+| JSR registry API unreachable or returns 404 for a package | Package status is marked as `Unknown` (same as when npm registry is unreachable); diagnostic shows "Unknown package"; no hover metadata |
+| JSR API returns malformed metadata | Registry error is logged; package treated as `Unknown` (graceful degradation) |
+| `npm:` specifier in deno.json, npm registry unreachable | Reuses existing npm registry error handling (package marked `Unknown`) |
+| deno.json declares `npm:react@^18` (a range), npm registry returns yanked versions in the range | Version comparison uses existing `node-semver` logic; yanked flag is respected (consistent with npm's own behavior in package.json) |
+| deno.json has both `jsr:` and `npm:` specifiers in the same `imports` map | Both are parsed and displayed correctly; JSR uses JSR registry, npm uses npm registry; no crosstalk |
+| deno.json with duplicate import keys (e.g., two `"@std/fs"` entries) | JSON parser fails or last entry wins (JSON spec dictates last-wins); behavior is deterministic and consistent with package.json handling |
+| `@scope/pkg` package name in JSR (scope required) vs. unscoped npm | JSR API requires scope in the URL path; parsing correctly extracts `@scope/pkg` and routes to `jsr.io/@scope/pkg/meta.json`; no collisions |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | `Deno` variant present in `EcosystemId` enum (`crates/deps-core/src/ecosystem.rs`) | Compile error if missing (exhaustive match) |
+| SC-002 | `deno.json` and `deno.jsonc` filenames registered in ecosystem detection (`crates/deps-core/src/ecosystem_registry.rs`) | Both filenames resolve to Deno ecosystem via `get_for_filename()` |
+| SC-003 | JSR package versions fetched and compared correctly | Live test: open deno.json with JSR specifier, hover shows latest version and outdated/up-to-date status matching JSR API response; diagnostic count and code actions agree with other ecosystems |
+| SC-004 | npm specifiers in deno.json use existing npm registry client | Live test: open deno.json with `npm:react@18`, hover/diagnostics/completions match behavior in package.json for the same package |
+| SC-005 | No regressions in existing 11 ecosystems | Full regression suite: `cargo nextest run --workspace --all-features` passes; no changes to Cargo/npm/PyPI/Go/Bundler/Dart/Maven/Gradle/Swift/Composer/NuGet behavior |
+| SC-006 | Cross-ecosystem consistency verified | Live test session (documented in `.local/testing/coverage.md`): open identical dependency-update scenarios in Cargo.toml, package.json, and deno.json; verify hover format, diagnostic wording, inlay hints, and code actions are identical across all three |
+| SC-007 | Feature flag wired correctly | `deno` feature in root `Cargo.toml`; `deps-deno` crate builds when enabled; `deps-lsp` server sees Deno ecosystem when compiled with `cargo build --all-features` |
+| SC-008 | Coverage and playbook added | Row added to `.local/testing/coverage.md` for Deno ecosystem; new playbook file `.local/testing/playbooks/deno.md` with verified test manifests and known issues |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Reuse existing `deps-core` version-comparison traits and logic (no duplication).
+- Reuse existing npm registry client for `npm:` specifiers (no reimplementation).
+- Use the same LSP handlers (hover, completion, diagnostics, code actions, inlay hints) that are already generic across ecosystems — no Deno-specific handler code should be written.
+- Follow the existing pattern from `crates/deps-npm/` for JSON parsing, error handling, and registry API calls.
+- Run the full check suite (`cargo +nightly fmt --check`, `cargo clippy --all-targets --all-features --workspace -- -D warnings`, `cargo nextest run --workspace --all-features`) before considering any implementation complete.
+
+### Ask First
+- If the `scopes` field should be supported (currently marked out of scope) — clarify scope before implementation.
+- If the `importMap` field (import maps from a separate file) should be supported — needs design discussion.
+- If JSONC parsing should use a dedicated library vs. stripping comments with regex before `serde_json::parse` — implementation trade-off worth discussing.
+- How to structure the npm registry client usage within `deps-deno`: instantiate a new `NpmRegistry` within the Deno ecosystem, or reference it from a shared location in `deps-core`? (Registry trait is already per-ecosystem, so instantiation in `deps-deno` is the pattern, but confirm.)
+- Whether `deno.lock` resolved-version support is desired for the initial MVP, or deferred as a future increment.
+
+### Never
+- Introduce Deno-specific LSP handlers — all handlers (hover, completion, etc.) remain generic and dispatch via `EcosystemRegistry`.
+- Diverge from other ecosystems' hover format, diagnostic wording, or inlay hint style — cross-ecosystem consistency is non-negotiable.
+- Create a parallel, separate version-comparison implementation for JSR — reuse `deps-core` traits.
+- Modify the existing 11 ecosystems' behavior as a side effect of adding Deno.
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Should `scopes` field in deno.json be supported? (Currently out of scope per Overview, but confirm if it is needed for initial MVP or Phase 2.)]
+- [NEEDS CLARIFICATION: Exact JSONC parsing strategy — reuse a library like `jsonc-parser` crate, strip comments with regex, or use a different approach? What does deps-npm do for package.json, and would the same pattern work for JSONC?]
+- [NEEDS CLARIFICATION: How to instantiate the npm registry client within the Deno ecosystem implementation? Should `NpmRegistry` be instantiated inside `deps-deno::DenoEcosystem::new()`, or referenced from `deps-core`? (Existing pattern: each ecosystem crate has its own registry, e.g., `deps-npm::NpmRegistry`.)]
+- [NEEDS CLARIFICATION: Version requirement format for `npm:` specifiers in Deno (e.g., is `npm:react@^18.0` vs. `npm:react@18.0` the format, or does Deno use a different specifier syntax?) — verify against live deno.json examples.]
+- [NEEDS CLARIFICATION: Should locked versions from `deno.lock` be parsed and used for resolved-version inlay hints (similar to lockfile support in other ecosystems)? Or is manifest-only comparison sufficient for MVP?]
+- [NEEDS CLARIFICATION: Does the JSR API include a search endpoint for package-name completion, or should completion use an exact-match-only approach (like some ecosystems do)?]
+- [NEEDS CLARIFICATION: No project constitution exists yet at `.local/specs/constitution.md` — this spec cannot yet be checked against project-wide architectural principles. Recommend running `/sdd init` before `/sdd plan` for this feature.]
+
+## 10. See Also
+
+- `.local/testing/issue-drafts-2026-08-23.md` (Draft 5: Deno/JSR) — original research finding with live API verification
+- `.local/testing/playbooks/competitive-parity.md` (Known Gaps table, Deno/JSR row, 2026-08-23 scan notes) — competitive evidence and JSR API verification
+- `docs/ECOSYSTEM_GUIDE.md` — architecture of ecosystem crate structure; shows how to add a new ecosystem
+- `crates/deps-core/src/ecosystem.rs` — `Ecosystem` and `EcosystemId` trait definitions
+- `crates/deps-core/src/ecosystem_registry.rs` — manifest file detection via `get_for_filename()` / `get_for_uri()`
+- `crates/deps-npm/src/` — reference implementation for JSON-based ecosystem (parser, registry, types, error handling)
+- `crates/deps-lsp/src/lib.rs` — ecosystem registration (`ecosystem!` and `register!` macros, `register_ecosystems()`)
+- `crates/deps-lsp/Cargo.toml` (root) — feature flags for per-ecosystem enablement
+- [JSR API documentation](https://jsr.io/docs/api) — meta.json endpoint and response schema
+- [GitHub Dependabot Deno support documentation](https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories)
+- [Renovate Deno manager documentation](https://docs.renovatebot.com/modules/manager/)
+- [[MOC-specs]] — all specifications

--- a/specs/014-github-actions-ecosystem/spec.md
+++ b/specs/014-github-actions-ecosystem/spec.md
@@ -1,0 +1,284 @@
+---
+aliases:
+  - GitHub Actions Ecosystem
+  - GHA Version Hints
+tags:
+  - sdd
+  - spec
+  - research
+  - ecosystem/github-actions
+  - new-ecosystem
+  - priority/p4
+created: 2026-08-23
+status: draft
+related:
+  - "[[MOC-specs]]"
+---
+
+# Feature: New ecosystem — GitHub Actions workflow `uses:` pins
+
+> [!info] Metadata
+> **Author**: on-demand competitive-parity scan 2026-08-23 (research finding)
+> **Branch**: [NEEDS CLARIFICATION: assign issue number before branching, e.g. `feat/<issue>-github-actions`]
+> **Type**: research / new ecosystem
+
+## 1. Overview
+
+### Problem Statement
+
+GitHub Actions workflows (YAML files in `.github/workflows/`) use the `uses:` syntax to reference
+external actions and reusable workflows. These references take the form `owner/repo@ref` where `ref`
+can be a branch name, a moving major tag (e.g., `v3`), a full semver tag (e.g., `v3.5.1`), or a
+specific commit SHA.
+
+deps-lsp currently provides no support for `.github/workflows/*.yml` files, leaving users without
+in-editor visibility into whether their action pins are outdated or resolvable. This is a
+particularly acute gap: GitHub Actions are the most-used CI/CD platform on GitHub (~every GitHub
+repository has workflows), making this the largest-audience new-ecosystem candidate. The closest
+competitor (Dependi) has an open, unserved feature request for this capability (#239, user
+demand), while Dependabot and Renovate both support it natively.
+
+The 2025 supply-chain security wave around action pinning (spurred by high-profile compromises in
+widely-used actions like tj-actions) has made "this SHA equals which tag? Is a newer version
+available?" a relevant security/maintenance question for production workflows.
+
+### Goal
+
+deps-lsp detects `.github/workflows/*.yml` (and `.yml`/`.yaml` variants) as manifest files,
+parses `uses: owner/repo@ref` actions (and reusable workflow calls `owner/repo/.github/workflows/x.yml@ref`,
+skipping `./local` and `docker://` forms gracefully), fetches version information from GitHub REST API tags/releases
+with rate-limit-aware caching (conditional requests with ETag/If-None-Match; optional GitHub Personal Access Token for
+unauthenticated budget overflow), and surfaces hover (ref → resolved tag + latest available), outdated diagnostics,
+inlay hints, and update code actions — consistent with all other 11 supported ecosystems.
+
+### Out of Scope
+
+- `pre-commit` hook `rev:` pins (`.pre-commit-config.yaml` — same git-tags datasource, but a
+  separate manifest format; filed as a follow-up for after this ecosystem is shipped).
+- Composite action calls within action subdirectories (e.g., `owner/repo/path/to/action@ref`) beyond
+  the basic parsing and graceful skip documented in requirements.
+- GitHub App rate-limit headers (X-RateLimit-*) beyond the existing ETag-based conditional-request
+  quota preservation.
+- Rollback/undo semantics for batch updates to multiple action pins in one `WorkspaceEdit`.
+- Workspace-wide aggregation or "update all actions in all workflows" — scoped to per-document
+  (per-workflow) scope, consistent with other manifests.
+
+## 2. User Stories
+
+### US-001: See outdated action pins in-editor
+
+AS A DevOps engineer maintaining GitHub Actions workflows with explicit commit SHAs pinned for
+supply-chain security
+I WANT to see at a glance which action pins are outdated (i.e., which SHAs correspond to older tags
+than the latest available) and what newer versions are available
+SO THAT I can decide whether to accept security/feature updates without leaving the editor to check
+GitHub release pages.
+
+**Acceptance criteria:**
+```
+GIVEN a workflow file with one or more actions pinned to specific commit SHAs or
+      semantic-version tags
+WHEN the editor requests hover over an action reference (e.g., `uses: actions/setup-node@v3.5.1`)
+THEN the server SHALL show:
+     - The resolved tag (if the ref is a SHA, what tag does it map to?)
+     - The latest available tag
+     - Whether the current pin is outdated
+     - A code action to update the pin to the latest version
+```
+
+### US-002: Hover on a moving major tag shows the resolved commit
+
+AS A user with a workflow pinning to a moving major tag (e.g., `actions/setup-node@v3`)
+I WANT to hover over that pin and see what specific version that major tag currently resolves to
+(e.g., "v3.5.1", commit SHA xyz)
+SO THAT I understand the exact behavior my workflow will get.
+
+**Acceptance criteria:**
+```
+GIVEN a workflow file with an action pinned to a moving tag (e.g., `uses: owner/repo@v3`)
+WHEN the editor requests hover for that reference
+THEN the server SHALL resolve that tag to the latest matching release and display the concrete
+     semver or commit SHA it resolves to
+```
+
+### US-003: Update action pins with SHA-to-tag conventions
+
+AS A user updating an action pin from a SHA to a newer commit
+I WANT the update code action to preserve the Dependabot/Renovate convention of trailing comments
+(e.g., `uses: actions/setup-node@abc123def456 # v4.2.0`) documenting which tag that SHA maps to
+SO THAT future readers (including automation) can quickly see which version the SHA corresponds to.
+
+**Acceptance criteria:**
+```
+GIVEN a workflow file with an action pinned to a SHA (with or without a trailing tag comment)
+WHEN the user invokes an "update action pin" code action
+THEN the system SHALL produce a new SHA pinned to the latest tag and include a trailing
+     comment (e.g., `# v4.2.0`) indicating the tag, following Dependabot/Renovate convention
+```
+
+### US-004: Consistent diagnostics and hints across all workflows
+
+AS A developer with multiple workflows in `.github/workflows/`
+I WANT the outdated diagnostics, hover, inlay hints, and update actions to work identically
+across all workflows I open
+SO THAT I don't have to learn workflow-specific quirks.
+
+**Acceptance criteria:**
+```
+GIVEN two or more workflow files with equivalent action-pin scenarios
+WHEN the server processes both files
+THEN the diagnostics, hover, inlay hints, and code action behavior SHALL be identical
+     across both, per the project's cross-ecosystem-consistency rule
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | THE SYSTEM SHALL detect `.github/workflows/*.yml` and `.github/workflows/*.yaml` files by path pattern (not filename match) and register them as manifest documents — routing through the existing LSP document-lifecycle handlers (didOpen, didChange, didClose) | must |
+| FR-002 | THE SYSTEM SHALL parse YAML workflow files, extract all `uses:` entries in `steps[]` and (open question: reusable workflow calls) sections, and identify action/workflow references in the form `owner/repo@ref` or `owner/repo/.github/workflows/name.yml@ref` | must |
+| FR-003 | THE SYSTEM SHALL skip and gracefully handle (without error or false diagnostic) `uses: ./local` (relative path actions) and `uses: docker://image:tag` (container actions) — these are not version-pinnable and should not surface diagnostics | must |
+| FR-004 | THE SYSTEM SHALL fetch version information from GitHub REST API tags endpoint (`GET /repos/{owner}/{repo}/tags`) using the existing `HttpCache` with conditional-request validation (ETag/If-None-Match headers) to minimize API quota consumption — unauthenticated requests have a 60 req/hr budget; conditional requests (304 Not Modified) do not consume quota | must |
+| FR-005 | THE SYSTEM SHALL advertise optional configuration for a GitHub Personal Access Token (PAT) to increase the unauthenticated rate limit from 60 req/hr to 5000 req/hr — via environment variable `GITHUB_TOKEN` (matching the convention already established in `crates/deps-swift/src/registry.rs`, lines 48-56) | must |
+| FR-006 | WHEN an action reference uses a semantic-version tag (e.g., `v3.5.1`) THE SYSTEM SHALL surface hover content showing the tag, resolved commit SHA, latest tag, and outdated status — consistent with how other ecosystems display version information | must |
+| FR-007 | WHEN an action reference uses a moving major tag (e.g., `v3`) THE SYSTEM SHALL resolve the tag to the latest matching release and display the concrete version (e.g., "v3.5.1") and commit SHA in hover content | must |
+| FR-008 | WHEN an action reference uses a commit SHA (with or without a trailing `# vX.Y.Z` comment) THE SYSTEM SHALL resolve the SHA to the tag it maps to (if it exists) and surface that tag in hover alongside the latest available tag | must |
+| FR-009 | THE SYSTEM SHALL produce an outdated diagnostic (warning or info level, consistent with how diagnostics treat "outdated" in other ecosystems) on any action pin where the current reference is behind the latest resolvable tag | must |
+| FR-010 | THE SYSTEM SHALL produce inlay hints showing the latest version for each action, consistent with the format and configuration (per-ecosystem `EcosystemConfig`) already used in other ecosystems | must |
+| FR-011 | THE SYSTEM SHALL expose a code action (via `textDocument/codeAction`) on any action pin, offering to update it to the latest tag — the update SHALL include a trailing comment documenting the tag (e.g., `uses: actions/setup-node@abc123def456 # v4.2.0`), following Dependabot/Renovate convention [NEEDS CLARIFICATION: trailing comment format — exact conventions used by Dependabot/Renovate] | must |
+| FR-012 | THE SYSTEM SHALL route GitHub API requests through the existing `deps-lsp.executeCommand` handler (or extend it) rather than introducing a parallel execution pathway; the "update action pin" command SHALL apply the version change as a `WorkspaceEdit` consistent with how other ecosystems perform updates | should |
+| FR-013 | THE SYSTEM SHALL produce equivalent behavior (hover, diagnostics, inlay hints, code actions) across all workflows and all action references, not introducing ecosystem-specific divergence — any GitHub-ecosystem-specific behavior must be documented and justified | must |
+| FR-014 | WHEN the GitHub API returns a 403 Forbidden (rate limit exceeded) without a valid `GITHUB_TOKEN` set THE SYSTEM SHALL display a user-facing error message recommending the user set `GITHUB_TOKEN` to increase the quota, consistent with how `crates/deps-swift/src/registry.rs` lines 82-86 handles the same situation | must |
+| FR-015 | WHEN parsing a workflow file where an action reference is unparseable or the owner/repo is malformed THE SYSTEM SHALL log a warning and skip that reference gracefully (no diagnostic, no crash) — the workflow itself remains parseable | should |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | Fetching action version lists from GitHub API SHALL use conditional requests (ETag/If-None-Match) to avoid quota consumption on cache hits; response time for `textDocument/hover` or `textDocument/codeAction` on a cached action reference SHALL be dominated by in-memory YAML parsing and cached lookup, not network I/O |
+| NFR-002 | Rate limiting | Unauthenticated GitHub API budget (60 req/hr) is the primary constraint; the system SHALL use long TTLs and aggressive conditional-request revalidation (304s) to fit within this budget for typical workflows; optional PAT support SHALL transparently increase the limit to 5000 req/hr when `GITHUB_TOKEN` is set |
+| NFR-003 | Reliability | When GitHub API is unreachable (network error, timeout) or rate-limited (403 with no token), the system SHALL degrade gracefully: cached action data (if available) is served; if no cache exists, diagnostics/hovers show loading state or minimal information, not false positives or errors |
+| NFR-004 | Consistency | Action-pin behavior (hover format, diagnostics language, inlay-hint presentation, code-action wording) SHALL be identical across all 12 supported ecosystems (the existing 11 + GitHub Actions), per the cross-ecosystem-consistency rule in `.claude/rules/continuous-improvement.md` — any divergence is a first-class bug |
+| NFR-005 | YAML parsing | YAML workflow files are parsed using the existing `yaml-rust2` crate (already used in `deps-dart` for `pubspec.yaml`, and hardened in recent PRs #174/#176); no new YAML dependency SHALL be introduced |
+| NFR-006 | Path detection | `.github/workflows/*.yml` and `.*.yaml` detection SHALL be added to the manifest-detection routing without breaking existing filename-based detection; [NEEDS CLARIFICATION: whether path-pattern-based detection requires a new trait method on `Ecosystem` or can be hardcoded in the server's manifest router] |
+| NFR-007 | Caching | Conditional-GET support already exists in `HttpCache` (RFC 7232, ETag/If-None-Match, verified in `crates/deps-core/src/cache.rs` lines 109-144); no new caching infrastructure is required |
+
+## 5. Data Model
+
+No new persistent entities. Action references are parsed as dependencies (with `name = "owner/repo"`,
+`version_requirement = "ref"`) and reuse the existing `Dependency` trait and `cached_versions`/`resolved_versions`
+maps from `DocumentState`.
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| Action reference (derived) | Per-action entry in a workflow, identified by `uses:` key | owner, repo, ref (tag/SHA/branch), resolved_sha (if applicable), resolved_tag (if applicable), latest_tag |
+| GitHub tag list (cached) | Response from GitHub REST API `/repos/{owner}/{repo}/tags`, cached per (owner/repo) | tag names, commit SHAs, creation timestamps |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Workflow file with zero action references | No diagnostics returned (empty list) |
+| Action reference using `./local` (relative path action) | Parsed but skipped gracefully — no diagnostic, no version check, no hover |
+| Action reference using `docker://image:tag` | Parsed but skipped — container images are not version-pinnable in the same way |
+| Action reference with a malformed `owner/repo` (e.g., missing `/`, extra segments) | Logged as a warning, skipped gracefully; workflow parsing continues |
+| Action reference where the repository does not exist (404 from GitHub API) | Diagnostic: "Repository not found: owner/repo"; no version data shown |
+| Workflow file is edited while version data is being fetched | Subsequent `textDocument/hover` request on the new content SHALL trigger a fresh parse and fetch; old loading state is discarded |
+| GitHub API returns 403 Forbidden (rate limit exhausted) and no `GITHUB_TOKEN` is set | User-facing error message: "GitHub API rate limit (60 req/hr unauthenticated) exhausted. Set GITHUB_TOKEN to increase limit to 5000 req/hr: export GITHUB_TOKEN=$(gh auth token)" |
+| Action reference to a moving major tag (e.g., `v3`) at a time when the tag exists but has no associated GitHub release | Tag is resolved to its current commit SHA and displayed in hover; if no release exists, latest resolved tag (not pre-release) is shown |
+| Workflow file is not valid YAML | Parse error is logged; no diagnostics produced; handlers gracefully return empty results (consistent with how other ecosystems handle malformed manifests) |
+| Very large workflow (hundreds of action references) | Parsing and hover latency SHALL remain acceptable (<1s per request); no new registry calls are made beyond one per unique (owner/repo) pair, cached thereafter |
+| Action reference with a tag that has been deleted but still exists in cached ETag data | Conditional request returns 304 Not Modified, cached data served (tag still exists in cache) — will age out when TTL expires [NEEDS CLARIFICATION: should deleted tags trigger a forced refresh, or accept stale cached data?] |
+| Action in a composite action (e.g., `uses: ./my-composite-action`) with a nested `uses:` inside its `action.yml` file | Out of scope — composite actions are a more complex multi-file parsing problem. See Also / Follow-up work |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Path-pattern detection for `.github/workflows/*.yml` | Detected and routed to the GitHub Actions ecosystem for all supported `.yml` and `.yaml` extensions |
+| SC-002 | Hover shows current + latest tag for action pins | 100% of action references with resolvable tags show hover content listing current tag/SHA and latest available tag |
+| SC-003 | Outdated diagnostics match version comparison | 100% agreement between outdated diagnostics count and the actual count of action pins behind their latest tag |
+| SC-004 | GitHub API quota preservation | Conditional-request (ETag/If-None-Match) hit rate ≥ 80% on repeated hovers of unchanged workflows (measured via log inspection and rate-limit header observation) |
+| SC-005 | Code action produces valid YAML + trailing comment | Code actions that update action pins produce syntactically valid YAML and include trailing `# vX.Y.Z` comments per Dependabot/Renovate convention, verified via round-trip parse |
+| SC-006 | Cross-ecosystem consistency | GitHub Actions behavior (hover format, diagnostic language, inlay-hint templates) verified identical to same scenarios in other ecosystems, documented in `.local/testing/coverage.md` LSP Feature Matrix |
+| SC-007 | PAT support | Optional `GITHUB_TOKEN` environment variable correctly increases GitHub API quota from 60 to 5000 req/hr, verified via mock rate-limit headers |
+| SC-008 | Graceful degradation | Workflows with invalid action references or unreachable repositories do not prevent other actions in the same workflow from being processed; malformed actions log warnings and are skipped |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Follow existing patterns in `crates/deps-core/` for ecosystem implementation (trait-based `Ecosystem`,
+  `Registry`, `ParseResult`, `Dependency`; reuse `HttpCache` for API calls).
+- Use `yaml-rust2` (already a deps-dart dependency, hardened in #174/#176) for YAML parsing.
+- Reuse the existing `deps-swift` GitHub API token handling pattern (`GITHUB_TOKEN` environment variable,
+  60 vs 5000 req/hr messaging).
+- Run the full check suite (`cargo +nightly fmt --check`, `cargo clippy --all-targets --all-features
+  --workspace -- -D warnings`, `cargo nextest run --workspace --all-features`) before considering any
+  implementation complete.
+
+### Ask First
+- Introducing a new path-pattern-based manifest detection method (vs. extending the existing
+  filename/extension routing in `EcosystemRegistry`); the `get_for_uri()` implementation currently
+  extracts only the final path segment (filename) and may need architectural change to support patterns.
+- Changing the `Ecosystem` trait to add a new detection method (e.g., `manifest_path_patterns()`) vs.
+  hardcoding the `.github/workflows/*.yml` pattern in the server's manifest router.
+- Adding configuration UI for the GitHub PAT beyond environment-variable support (e.g., `initializationOptions`,
+  config file, or workspace settings).
+
+### Never
+- Introduce ecosystem-specific divergence in hover format, diagnostic wording, or code-action behavior
+  without a documented, justified reason — all 12 ecosystems must be consistent per the
+  cross-ecosystem-consistency rule.
+- Recursively parse composite-action definitions or reusable-workflow calls beyond the single-level
+  `owner/repo/.github/workflows/name.yml@ref` syntax.
+- Attempt to resolve version constraints *within* action inputs (e.g., action parameters that
+  themselves contain version-like values) — only the `uses:` pin itself is versioned.
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Should reusable workflow calls (`uses: owner/repo/.github/workflows/x.yml@ref`)
+  be parsed and version-checked, or are they out of scope for the first iteration? Current parity
+  research shows Dependabot/Renovate both support them, but the spec as written assumes single-level
+  action references only.]
+- [NEEDS CLARIFICATION: When a composite action declares its own `uses:` in its `action.yml`, should
+  the system recursively parse and check those nested references, or treat composite actions as
+  atomic/opaque? Multi-file parsing is likely out of scope for phase 1.]
+- [NEEDS CLARIFICATION: Exact trailing-comment format convention — is `# v3.5.1` the de facto standard,
+  or do Dependabot/Renovate use a different format (e.g., `# v3.5.1` vs `# vX.Y.Z` vs `# tag: v3.5.1`)?
+  Should the format be configurable, or hardcoded?]
+- [NEEDS CLARIFICATION: When a tag is deleted from the repository, should cached data for that tag
+  age out at TTL expiry, or should the system detect deletion via a forced refresh (e.g., if GitHub
+  returns a new tag list without the old tag)?]
+- [NEEDS CLARIFICATION: How should the system handle actions in private repositories? GitHub API 404s
+  for repos the token doesn't have access to, but the user might have the repo cloned locally. Should
+  the system attempt to fall back to local git data, or accept "private repo, no version info available"?]
+- [NEEDS CLARIFICATION: Should path-pattern detection be added as a new trait method on `Ecosystem`
+  (e.g., `manifest_path_patterns() -> &[&str]`), or hardcoded in the server's manifest router as a
+  special case for GitHub Actions?]
+- [NEEDS CLARIFICATION: No project constitution exists at `.local/specs/constitution.md` — cannot yet
+  validate this spec against project-wide architectural principles. Recommend running `/sdd init` before
+  `/sdd plan` for this feature.]
+- [NEEDS CLARIFICATION: Should "pin to latest" code action also offer a "pin to latest with major filter"
+  (e.g., if current is v3.x, pin to latest v3.y, not v4)? Dependi's #231 suggests this is a user expectation.]
+
+## 10. See Also
+
+- `crates/deps-swift/src/registry.rs` (lines 12-95) — closest existing precedent for GitHub REST API
+  integration, including GITHUB_TOKEN env var handling and rate-limit messaging
+- `crates/deps-core/src/cache.rs` (lines 109-144) — HttpCache implementation with RFC 7232 conditional
+  requests (ETag/If-None-Match) already in place; no new caching work needed
+- `crates/deps-dart/src/parser.rs` — YAML parsing with yaml-rust2; established pattern for YAML
+  manifest files
+- `.claude/rules/continuous-improvement.md#Cross-Ecosystem Consistency Testing` — consistency rule
+  requiring identical behavior across all ecosystems; violations are first-class bugs
+- [GitHub Actions workflow syntax documentation](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions)
+- [GitHub REST API: List repository tags](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-tags)
+- [Dependabot supported ecosystems](https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories)
+- [Renovate managers](https://docs.renovatebot.com/modules/manager/) (includes `github-actions`)
+- [NX10 GitHub Actions Version Checker](https://marketplace.visualstudio.com/items?itemName=nx10.gha-version-checker) — existing VS Code extension in this domain
+- Dependi feature request: [#239 — GitHub Actions support](https://github.com/filllabs/dependi/issues/239) (open, unserved)
+- [[MOC-specs]] — all specifications
+- [[007-lightweight-registry-metadata/spec]] — related registry-optimization work
+- [[002-osv-vulnerability-diagnostics/spec]] — related diagnostics work
+- Pre-commit ecosystem (`.pre-commit-config.yaml` with `rev:` pins) — same git-tags datasource
+  as GitHub Actions, filed as follow-up work in the playbook

--- a/specs/015-lsp-3-18-diagnostic-markup-tooltip-gap/spec.md
+++ b/specs/015-lsp-3-18-diagnostic-markup-tooltip-gap/spec.md
@@ -1,0 +1,230 @@
+---
+aliases:
+  - LSP 3.18 Diagnostic Markup Gap
+  - Command Tooltip Gap
+tags:
+  - sdd
+  - spec
+  - research
+  - lsp-protocol
+  - dependency-gap
+created: 2026-08-24
+status: draft
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+---
+
+# Feature: LSP 3.18 Diagnostic Markup / Command Tooltip Support (Blocked on `ls-types`)
+
+> [!info] Metadata
+> **Author**: Continuous Improvement cycle (research finding)
+> **Branch**: N/A — research finding, not implementation-ready
+> **Priority**: P4
+> **Status**: Blocked on upstream dependency
+
+> [!warning] Not implementation-ready
+> This spec documents a **research finding** produced during a continuous-improvement
+> cycle. It captures WHAT capability is currently unavailable and WHY it matters, so
+> the requirement is not lost. Per project policy, no `/sdd plan` should be created
+> for this spec until the upstream blocker (see [[#9. Open Questions]]) is resolved.
+> The continuous-improvement workflow is read-only with respect to code — no
+> implementation was attempted or should be attempted from this finding alone.
+
+## 1. Overview
+
+### Problem Statement
+
+[Language Server Protocol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/)
+version 3.18 (draft) extends two capabilities that `deps-lsp` already implements —
+diagnostics and code-action commands — with richer content types:
+
+1. **Diagnostic markup content**: `Diagnostic.message` can now be either a plain
+   `string` or a `MarkupContent` object (plain text or Markdown), enabling bold text,
+   inline code spans, and hyperlinks directly inside a diagnostic message rendered in
+   an editor's Problems panel, gutter hover, or inline diagnostic overlay.
+2. **Command tooltips**: the `Command` interface gains an optional `tooltip: string`
+   field, letting a code action or CodeLens command display explanatory text on hover,
+   before the user invokes it.
+
+`deps-lsp` surfaces dependency version intelligence (outdated, yanked, unsatisfiable
+requirement, prerelease-only-match, license-policy, deprecation, etc.) almost entirely
+through diagnostics and quick-fix commands (e.g. `deps-lsp.updateVersion`). Currently
+these are plain, unformatted strings — the project cannot use bold/monospace/links to
+distinguish version numbers, registry names, or CVE identifiers from surrounding text,
+nor can it explain a quick-fix's effect before the user applies it. This is a pure
+content-richness gap on existing capabilities, not a missing LSP method.
+
+The gap is **not** a `deps-lsp` implementation choice — it is enforced by the
+underlying LSP type-definition crate the project depends on transitively.
+`deps-lsp` depends on `tower-lsp-server = "0.23"`, which depends on `ls-types v0.0.6`
+for its Rust LSP type definitions. Live inspection of `ls-types-0.0.6` confirms the
+3.18 types are absent (see [[#Reproduction / Evidence]] below).
+
+### Goal
+
+When `tower-lsp-server`/`ls-types` (or a successor crate) exposes LSP 3.18's
+`Diagnostic` markup content and `Command.tooltip` types, `deps-lsp` SHALL be able to
+opt into richer diagnostic and quick-fix presentation for all diagnostic categories
+and the existing `deps-lsp.updateVersion` command, without introducing any new LSP
+methods or breaking editors that only understand the 3.17 plain-string forms.
+
+### Out of Scope
+
+- `SnippetTextEdit` / `StringValue` (interactive snippet edits with tab stops) —
+  lower relevance, since `deps-lsp`'s quick-fixes perform literal version-string
+  replacement, not multi-cursor/tab-stop editing. Not part of this finding's scope.
+- LSP 3.18 changes unrelated to `deps-lsp`'s feature surface: regex engine capability
+  negotiation, document filter unions, D/Pascal language IDs, workspace edit metadata.
+- Any client-side (editor extension) rendering work — this spec covers only the
+  server-side capability to emit richer content once the dependency unblocks it.
+- Actual code changes to diagnostics or commands — this spec is a readiness/tracking
+  document, not an implementation plan. No `/sdd plan` follows from this spec until
+  unblocked.
+
+## 2. User Stories
+
+### US-001: Distinguish version/registry identifiers in diagnostic text
+
+AS A developer viewing a `deps-lsp` diagnostic in the Problems panel
+I WANT the outdated/yanked/unsatisfiable-requirement message to render version
+numbers, package names, and registry names in monospace, and any relevant advisory
+or documentation reference as a clickable link
+SO THAT I can distinguish structured data from prose at a glance and jump to more
+detail without leaving the editor
+
+**Acceptance criteria:**
+```
+GIVEN the client advertises support for MarkupContent in Diagnostic.message
+  (per LSP 3.18 capability negotiation)
+WHEN deps-lsp emits an outdated-dependency diagnostic
+THEN the diagnostic message SHALL render the current and available version numbers
+  in inline code spans, and SHALL degrade gracefully to an equivalent plain-text
+  message for clients that do not advertise this capability
+```
+
+### US-002: Preview a quick-fix's effect before applying it
+
+AS A developer hovering over the `deps-lsp.updateVersion` code action
+I WANT a tooltip explaining which version the manifest entry will be updated to and
+any caveat (e.g. "this crosses a major version boundary")
+SO THAT I can decide whether to invoke the quick-fix without first opening a diff or
+running it speculatively
+
+**Acceptance criteria:**
+```
+GIVEN the client advertises support for Command.tooltip (per LSP 3.18)
+WHEN deps-lsp returns a deps-lsp.updateVersion code action
+THEN the Command SHALL include a tooltip field summarizing the version change and any
+  semver-boundary caveat, and SHALL omit the field (falling back to title-only
+  presentation) for clients that do not advertise this capability
+```
+
+## 3. Functional Requirements
+
+These requirements apply **once the upstream dependency blocker is resolved**
+(see [[#9. Open Questions]]). They are not actionable today and MUST NOT be
+scheduled into a `/sdd plan`/`/sdd tasks` cycle while the blocker remains open.
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN the underlying LSP type crate exposes `Diagnostic.message` as a `MarkupContent`-capable union type THE SYSTEM SHALL be able to emit Markdown-formatted diagnostic messages for all existing diagnostic categories (outdated, yanked, unsatisfiable-requirement, prerelease-only-match, license-policy, deprecation) | should |
+| FR-002 | WHEN a client's `textDocument.publishDiagnostics.markupSupport` (or equivalent 3.18 capability) is absent or `false` THE SYSTEM SHALL fall back to the existing plain-string diagnostic message format, unchanged from current behavior | must |
+| FR-003 | WHEN the underlying LSP type crate exposes `Command.tooltip` THE SYSTEM SHALL populate a tooltip on the `deps-lsp.updateVersion` command summarizing the version transition | should |
+| FR-004 | WHEN a client does not advertise `Command.tooltip` support THE SYSTEM SHALL omit the field, matching current behavior exactly (no functional regression for existing clients) | must |
+| FR-005 | WHEN Markdown diagnostic content is emitted THE SYSTEM SHALL sanitize/escape any interpolated package names or version strings that could otherwise be interpreted as Markdown control characters, to prevent malformed rendering | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Compatibility | Adoption of 3.18 markup/tooltip types MUST NOT break editors/clients pinned to LSP 3.17 capability negotiation — plain-string fallback is mandatory, not optional |
+| NFR-002 | Dependency hygiene | The upgrade path MUST go through the project's existing dependency-monitoring cadence (`cargo outdated --workspace`, `cargo deny check advisories`) — no ad-hoc pinning to an unreleased/pre-release `ls-types`/`tower-lsp-server` version |
+| NFR-003 | Performance | Markdown formatting of diagnostic messages MUST NOT introduce measurable latency regression in diagnostic publish time (current baseline: diagnostics computed synchronously per manifest parse) |
+| NFR-004 | Maintainability | Diagnostic message construction SHOULD be centralized in `deps-core` (per the project's cross-ecosystem consistency principle) so that markup formatting, once available, is applied uniformly across all ecosystem crates rather than ecosystem-by-ecosystem |
+
+## 5. Data Model
+
+No new persistent data model — this finding concerns the **output typing** of
+existing in-memory diagnostic and command structures produced by `deps-core` and
+consumed by `deps-lsp`.
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| Diagnostic message | Existing per-diagnostic explanatory text (outdated/yanked/unsatisfiable/etc.) | Currently `String`; would become `String \| MarkupContent` once `ls-types` exposes the 3.18 union type |
+| Command tooltip | New optional field on the existing `deps-lsp.updateVersion` command | `Option<String>`, populated only once `ls-types::Command` exposes a `tooltip` field |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Client omits 3.18 markup capability in `initialize` | `deps-lsp` continues emitting current plain-string diagnostic messages (no behavior change) |
+| Client advertises markup support but only for `kind: plaintext`, not `markdown` | `deps-lsp` SHOULD emit plain-text `MarkupContent` rather than Markdown, to respect the negotiated `MarkupKind` |
+| Package name or version string contains Markdown-significant characters (`*`, `_`, `` ` ``, `[`) | Interpolated values MUST be escaped before embedding in a Markdown message, per FR-005 |
+| `ls-types`/`tower-lsp-server` ships 3.18 types but with a different shape than currently drafted in the spec (draft spec is not final) | Re-evaluate this spec against the crate's actual released types before opening `/sdd plan` — draft LSP spec fields are not guaranteed stable |
+
+## 7. Success Criteria
+
+This finding has no measurable runtime success criteria yet, since it is not
+implementable. Readiness criteria for exiting the blocked state:
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | `ls-types` (or successor crate) release exposing `Diagnostic.message` as a markup-capable type | Released and adopted in `Cargo.toml` |
+| SC-002 | `ls-types` (or successor crate) release exposing `Command.tooltip` | Released and adopted in `Cargo.toml` |
+| SC-003 | Re-verification via live `cargo tree -p deps-lsp \| grep ls-types` | Confirms version ≥ the release satisfying SC-001/SC-002 |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Re-check `ls-types`/`tower-lsp-server` version during each continuous-improvement
+  dependency-monitoring pass (`cargo outdated --workspace`)
+- Keep this spec's status as `draft — blocked` until the upstream types ship
+
+### Ask First
+- Pinning to a pre-release/beta version of `tower-lsp-server` or `ls-types` to get
+  early access to 3.18 types
+- Opening a `/sdd plan` for this feature once unblocked (confirm scope hasn't drifted
+  from the 3.18 draft spec first, since it may still change before finalization)
+
+### Never
+- Implement diagnostic markup or command tooltips against the 3.18 **draft** spec
+  fields without first confirming the released `ls-types` API surface matches
+- Modify diagnostic message formatting in ways that break plain-string clients, even
+  experimentally, outside a dedicated feature branch with capability negotiation
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: upstream crate release timeline unknown] — no published
+  timeline exists for when `tower-lsp-server`/`ls-types` will adopt LSP 3.18 types;
+  this must be re-checked each continuous-improvement dependency-monitoring cycle
+  rather than assumed
+- [NEEDS CLARIFICATION: LSP 3.18 is still in draft status as of this writing] —
+  field names/shapes for `Diagnostic.message` union and `Command.tooltip` may change
+  before the spec is finalized; re-validate against the released spec text at
+  implementation time, not against this snapshot
+- [NEEDS CLARIFICATION: which editors' clients would actually surface Markdown
+  diagnostic content] — capability adoption also depends on client-side rendering
+  support (e.g. VS Code, Zed, Neovim LSP clients); worth a parity check once the
+  server-side type is available
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[MOC-specs]] — all specifications
+- [LSP 3.18 specification (draft)](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/) — source of the `Diagnostic` markup content, `Command.tooltip`, and `SnippetTextEdit` changes referenced in this finding
+- [`ls-types` crate on crates.io](https://crates.io/crates/lsp-types) — the transitive dependency currently blocking adoption (verify current version before re-evaluating this spec)
+- `.claude/rules/continuous-improvement.md` — Research & Innovation and Dependency Monitoring sections governing how this finding was produced and how it should be re-checked
+
+> [!note] Reproduction / Evidence
+> Live-verified 2026-08-24, continuous-improvement cycle:
+> - `cargo tree -p deps-lsp | grep ls-types` confirms `ls-types v0.0.6` is pulled in
+>   transitively via `tower-lsp-server = "0.23"`
+> - `ls-types-0.0.6/src/lib.rs` line 319: `Diagnostic::message` is typed `pub message:
+>   String` — no `MarkupContent`/union variant
+> - `ls-types-0.0.6/src/lib.rs` lines 439-448: `Command` struct has only `title:
+>   String`, `command: String`, `arguments: Option<Vec<Value>>` — no `tooltip` field
+> - `grep -rln "SnippetTextEdit"` across `ls-types-0.0.6/src/*.rs` returned no matches
+> - `cargo outdated --workspace` and `cargo deny check advisories` both clean this
+>   cycle (2026-08-24, 4th consecutive clean cycle) — no newer major version of
+>   `tower-lsp-server` is available yet that bundles 3.18 types

--- a/specs/016-bundler-platform-duplicate-versions/spec.md
+++ b/specs/016-bundler-platform-duplicate-versions/spec.md
@@ -1,0 +1,253 @@
+---
+aliases:
+  - Bundler platform duplicate versions
+tags:
+  - sdd
+  - spec
+  - bug
+  - deps-bundler
+  - rubygems
+created: 2026-08-24
+status: draft
+related:
+  - "[[MOC-specs]]"
+---
+
+# Feature: Deduplicate RubyGems platform-variant versions in Bundler hover
+
+> [!info] Metadata
+> **Author**: Andrei G. (k05h31@gmail.com)
+> **Branch**: fix/bundler-platform-duplicate-versions (no tracked issue number yet)
+> **Priority**: P1
+> **Discovered during**: live verification of PR #301 (fix: stop trusting RubyGems' always-empty `yanked` signal, closes #298) — not caused by that PR, pre-existing gap
+
+## 1. Overview
+
+### Problem Statement
+
+RubyGems' `versions.json` API
+(`https://rubygems.org/api/v1/versions/<gem>.json`) returns **one entry per
+(version, platform) pair**, not one entry per distinct version number. Any
+gem that ships platform-specific prebuilt binaries — a very common pattern
+for native-extension gems (`nokogiri`, `ffi`, `sassc`, `grpc`,
+`google-protobuf`, and others) — has multiple API entries that share the same
+`number` field but differ in `platform` (e.g. `ruby`, `x86-mingw32`,
+`x64-mingw32`, `x86-mswin32`, `java`, `x86_64-linux`, `arm64-darwin`, ...).
+
+`parse_versions_response` in `crates/deps-bundler/src/registry.rs` (around
+line 98) deserializes every raw entry into a `BundlerVersion` with no
+deduplication by `number`, then sorts the full list by version descending.
+The hover "Recent versions" section
+(`crates/deps-core/src/lsp_helpers.rs`, capped by the
+`HOVER_RECENT_VERSIONS` constant defined around line 21, rendering logic
+further in the file) takes the top N entries from this undeduplicated list.
+
+Because the list is not deduplicated, the top N slots are filled with N
+copies of the same version number (one per platform variant) instead of the
+N most recent *distinct* versions. This makes the "Recent versions" hover
+section provide zero useful information for the most common
+native-extension gems in the Ruby ecosystem — a large share of real-world
+Gemfiles.
+
+Latest-version selection (`get_latest_matching`) and yanked-status logic are
+NOT affected — both already operate correctly (confirmed during #301's live
+verification, e.g. pinning to known-yanked `rest-client` 1.6.2 produces the
+correct signal). This spec is scoped exclusively to the version *list*
+construction feeding the "Recent versions" hover display.
+
+### Goal
+
+The Bundler hover "Recent versions" section shows N distinct version
+numbers, deduplicated across platform variants, for every gem — including
+native-extension gems that publish multiple platform-specific builds per
+release.
+
+### Out of Scope
+
+- Changes to latest-version resolution (`get_latest_matching`) — already
+  correct, not affected by this bug.
+- Changes to yanked-status detection/display — already correct (see #301),
+  out of scope.
+- Displaying per-platform availability information anywhere in the hover
+  (e.g. "available for: ruby, java, x86-mingw32") — a possible enhancement,
+  but not required to fix this bug. See Open Questions.
+- Changes to other ecosystems' registry clients — this is a RubyGems/Bundler
+  specific data-shape issue; no other supported registry (npm, PyPI, Cargo,
+  Go, Maven, etc.) returns one entry per platform for the versions-list
+  endpoint used by deps-lsp.
+- Changes to completion or diagnostics features — only the hover "Recent
+  versions" rendering path is affected by this bug in observable behavior
+  (the underlying `BundlerVersion` list is shared internally, but this spec
+  targets the fix at the source: list construction).
+
+## 2. User Stories
+
+### US-001: Distinct recent versions in hover for native-extension gems
+
+AS A Ruby developer using a Gemfile with native-extension gems (e.g.
+`nokogiri`, `ffi`, `sassc`)
+I WANT the hover "Recent versions" section to show distinct, genuinely
+different version numbers
+SO THAT I can see the real recent release history of the gem and decide
+whether to upgrade, instead of seeing the same version number repeated
+7-8 times with no useful information.
+
+**Acceptance criteria:**
+```
+GIVEN a Gemfile with `gem 'nokogiri'` (any version, unpinned)
+WHEN the user hovers over the package name
+THEN the "Recent versions" section shows up to HOVER_RECENT_VERSIONS (8)
+     entries, each with a distinct version `number`
+AND no version `number` appears more than once in the list
+```
+
+### US-002: Correct age/date shown per distinct version
+
+AS A Ruby developer inspecting a gem's release history via hover
+I WANT the displayed "N months/days ago" age for each listed version to
+correspond to a real publish event for that version
+SO THAT the freshness signal is meaningful (not accidentally picking a
+platform-specific `created_at` that happens to differ from the canonical
+release date for that version number).
+
+**Acceptance criteria:**
+```
+GIVEN a version number with multiple platform entries with different
+      `created_at` timestamps (they are typically published within
+      seconds/minutes of each other, but may differ)
+WHEN deduplicating entries that share the same `number`
+THEN the retained entry's `published_at` is a deterministic, documented
+     choice (e.g. earliest `created_at` among the group, or the entry
+     matching the preferred platform — see FR-002)
+```
+
+## 3. Functional Requirements
+
+Use EARS notation. Prefix with FR-NNN.
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN `parse_versions_response` builds the `Vec<BundlerVersion>` from the RubyGems `versions.json` payload, THE SYSTEM SHALL deduplicate entries so that each distinct version `number` appears at most once in the returned list | must |
+| FR-002 | WHEN multiple raw entries share the same version `number` with different `platform` values, THE SYSTEM SHALL select exactly one entry to represent that version number, using a documented, deterministic preference order (see [NEEDS CLARIFICATION] below) | must |
+| FR-003 | WHEN multiple raw entries share the same version `number` and differ in `yanked` status, THE SYSTEM SHALL treat the version as yanked only if the retained (or all, per implementation choice) entries indicate yanked — MUST NOT silently pick a non-yanked platform entry to mask a yanked release, or vice versa | must |
+| FR-004 | THE SYSTEM SHALL preserve existing sort order (version descending, via `compare_versions`) after deduplication | must |
+| FR-005 | WHEN `get_latest_matching` filters the deduplicated list for the highest version satisfying a requirement, THE SYSTEM SHALL continue to return the correct result — deduplication MUST NOT change which version number is selected as latest-matching, only remove redundant platform copies | must |
+| FR-006 | THE SYSTEM SHALL apply deduplication once, in `parse_versions_response` (or equivalent single choke point), so all consumers of `RubyGemsRegistry::get_versions` (hover "Recent versions", latest-matching, any future consumer) receive an already-deduplicated list — no per-call-site deduplication logic | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | Deduplication SHALL add no more than O(n log n) overhead to `parse_versions_response` (n = raw entry count, typically well under a few hundred for platform-heavy gems); no additional network round-trip |
+| NFR-002 | Correctness | Deduplication logic SHALL be covered by unit tests using a `mockito`-mocked RubyGems response fixture containing multiple platform entries per version number (per `.claude/rules/testing.md` mock conventions) |
+| NFR-003 | Backward compatibility | Gems with no platform variants (single entry per version — the common case for pure-Ruby gems) SHALL produce byte-identical hover output before and after the fix |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `VersionEntry` (raw, private to `registry.rs`) | One raw entry from RubyGems' `versions.json`, one per (version, platform) pair | `number`, `prerelease`, `yanked`, `created_at`, `platform` |
+| `BundlerVersion` (public, `types.rs`) | Deduplicated, display-ready version record consumed by hover/completion/latest-matching | `number`, `prerelease`, `yanked`, `published_at`, `platform` |
+
+No schema changes required — `BundlerVersion` already carries a `platform`
+field; the fix changes *how many* `BundlerVersion` records are produced per
+distinct `number`, not the struct shape.
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Gem with no platform-specific builds (single entry per version, e.g. most pure-Ruby gems) | No behavior change — list already has one entry per version |
+| Gem where the `ruby` (pure-Ruby) platform entry is missing for a given version (rare, but possible if a release is platform-only, e.g. `java`-only build) | Deduplication SHALL still retain exactly one entry for that version number, falling back to any available platform per FR-002's preference order |
+| All platform entries for a version share identical `created_at` | Any entry may be retained; resulting `published_at` is unambiguous |
+| Platform entries for the same version have differing `created_at` (staggered publish) | Deterministic choice per FR-002 (e.g. earliest, or preferred-platform's timestamp) — documented in code comment so behavior is not accidental |
+| Version has zero platform entries after malformed/partial API response | Not applicable — version numbers only exist because at least one entry produced them; no empty-group case |
+| Gem with `HOVER_RECENT_VERSIONS` (8) or fewer *distinct* versions but many raw entries (e.g. 3 distinct versions × 6 platforms = 18 raw entries) | Hover shows all 3 distinct versions, not padded/truncated incorrectly |
+| Gem with more than `HOVER_RECENT_VERSIONS` distinct versions | Existing truncation-to-N behavior applies to the deduplicated list, unchanged |
+
+## 7. Success Criteria
+
+Measurable metrics that prove the fix works:
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Hover "Recent versions" for `nokogiri` (live rubygems.org data) shows distinct version numbers | 100% of listed entries have unique `number` |
+| SC-002 | Hover "Recent versions" for `rest-client` (live rubygems.org data) no longer repeats `2.1.0` / `2.1.0.rc1` per platform | Each version number appears exactly once |
+| SC-003 | Existing `deps-bundler` unit tests plus new deduplication test(s) | All pass (`cargo nextest run -p deps-bundler`) |
+| SC-004 | `get_latest_matching` result for platform-heavy gems unchanged before/after fix | Same version number selected in a live/regression comparison |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Add/extend unit tests in `crates/deps-bundler/src/registry.rs` (or its
+  `#[cfg(test)]` module) covering multi-platform dedup, per
+  `.claude/rules/testing.md`
+- Run `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets
+  --all-features -- -D warnings`, and
+  `cargo nextest run -p deps-bundler --all-features` before considering the
+  fix complete
+- Follow existing code patterns in `registry.rs` (e.g. keep `VersionEntry`
+  private, keep dedup logic inside `parse_versions_response` or a small
+  private helper in the same module)
+- Live-verify against real `rubygems.org` API for at least `nokogiri` and
+  `rest-client` per this project's Registry Integration Gate
+  (`.claude/rules/continuous-improvement.md`)
+
+### Ask First
+- Adding a new dependency (e.g. a crate for grouping/dedup helpers) — should
+  not be necessary given `std` `HashMap`/`itertools` (if already a workspace
+  dep) suffice
+- Changing the public `BundlerVersion` struct shape (adding fields such as
+  "available platforms") — out of scope per section 1, ask before expanding
+
+### Never
+- Change latest-version selection semantics (FR-005) without an explicit
+  regression test proving the selected version is unchanged
+- Silently drop yanked-status information during deduplication (FR-003)
+- Modify other ecosystem crates (`deps-npm`, `deps-cargo`, etc.) as part of
+  this fix — this is RubyGems-specific
+
+## 9. Open Questions
+
+> [!question] Deduplication preference order
+> [NEEDS CLARIFICATION: When multiple platform entries share a version
+> number, which one should be retained? Candidate orders: (a) prefer
+> `platform == "ruby"` if present, else first-seen; (b) prefer the entry
+> with the earliest `created_at`; (c) prefer the entry with the latest
+> `created_at`; (d) always take the first entry as returned by the API
+> (API order is not documented/guaranteed). Left as an implementation
+> decision for whoever picks up the fix — recommend (a) with fallback to
+> first-seen, since `ruby` is the canonical/source-of-truth platform for
+> most gems and matches how `default_platform()` already treats missing
+> platform data.]
+
+> [!question] Yanked-status conflict resolution
+> [NEEDS CLARIFICATION: Given the `yanked` field is currently always `false`
+> in practice (per the code comment on `VersionEntry::yanked`, RubyGems
+> omits yanked versions from this endpoint entirely — see #298/#301), is
+> FR-003's conflict-handling requirement realistically reachable today, or
+> is it purely defensive for a future API change / different registry
+> behavior? If unreachable today, implementer may simplify to "pick any
+> entry, yanked is defensively OR'd across the group" without extensive
+> test coverage for the conflict case.]
+
+> [!question] Surfacing platform availability
+> [NEEDS CLARIFICATION: Should the hover eventually indicate that a version
+> has multiple platform builds (e.g. a small "(6 platforms)" suffix or
+> tooltip), or is silent deduplication sufficient? Explicitly deferred to a
+> future enhancement per section 1 Out of Scope — confirm no user-facing
+> demand exists before considering it.]
+
+## 10. See Also
+
+- [[MOC-specs]] — all specifications
+- PR #301 — fix: stop trusting RubyGems' always-empty yanked signal
+  (closes #298) — the fix that was being live-verified when this bug was
+  discovered; confirmed unaffected by this issue
+- `crates/deps-bundler/src/registry.rs` — `parse_versions_response`
+  (~line 98), fix location
+- `crates/deps-bundler/src/types.rs` — `BundlerVersion` struct (~line 39)
+- `crates/deps-core/src/lsp_helpers.rs` — `HOVER_RECENT_VERSIONS` constant
+  (~line 21), hover rendering
+- `.local/testing/journal/` — live-testing cycle that discovered this
+  finding (2026-08-24)

--- a/specs/017-hover-latest-marker-prerelease-mismatch/spec.md
+++ b/specs/017-hover-latest-marker-prerelease-mismatch/spec.md
@@ -1,0 +1,231 @@
+---
+aliases:
+  - Hover Latest Marker Prerelease Mismatch
+tags:
+  - sdd
+  - spec
+  - bug
+  - lsp-hover
+created: 2026-08-24
+status: draft
+related:
+  - "[[constitution]]"
+---
+
+# Feature: Hover "Recent versions" `(latest)` marker can disagree with the header's `Latest` field
+
+> [!info] Metadata
+> **Author**: continuous-improvement live-testing cycle
+> **Branch**: fix/hover-latest-marker-prerelease-mismatch (no issue filed yet)
+
+## 1. Overview
+
+### Problem Statement
+
+`generate_hover` in `crates/deps-core/src/lsp_helpers.rs` builds two independent
+representations of "the latest version" from two different data sources within
+the same hover popup:
+
+1. The `**Latest**:` header line (around line 1260-1276) is computed from
+   `versions.cached.<pkg>.latest`, which is the properly-selected latest
+   *stable* version — pre-releases are excluded by default SemVer matching
+   rules. This is the same selection logic already exercised correctly by the
+   `#305` unsatisfiable-requirement prerelease-hint work.
+2. The **"Recent versions"** list (around line 1284-1300) iterates
+   `available_versions` — the raw, registry-returned version list sorted
+   purely by version-number descending (see e.g. `deps-bundler`'s
+   `parse_versions_response`, which sorts with
+   `versions.sort_by(|a, b| compare_versions(&b.number, &a.number))`, a pattern
+   representative of most ecosystem crates) — and unconditionally marks index
+   `0` (`if i == 0`) with `*(latest)*`, without checking whether that raw
+   top-of-list entry is itself a pre-release.
+
+Because a raw numeric-descending sort does not distinguish "highest version
+number, possibly pre-release" from "highest stable release", whenever a
+package's most-recently-numbered version is a pre-release, the "Recent
+versions" list's `*(latest)*` tag ends up attached to that pre-release —
+directly contradicting the header's own `**Latest**:` value shown two lines
+above it in the same hover popup.
+
+This was discovered via live testing against real `nuget.org` data
+(`Newtonsoft.Json`, deps-lsp debug binary at commit `2f99f63c`, 2026-08-24)
+while regression-spot-checking `#300`'s HttpCache redirect-policy change —
+unrelated to that PR. Reproduction:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>
+```
+
+Hover over `Newtonsoft.Json` produces:
+
+```
+# Newtonsoft.Json
+Requirement: 13.0.3
+Latest: 13.0.4
+Recent versions:
+- 13.0.5-beta1 (latest) — 7 months ago
+- 13.0.4 — 11 months ago
+- 13.0.4-beta1
+- 13.0.3 — 3 years ago
+...
+```
+
+The header says `Latest: 13.0.4` (correctly excludes the pre-release), but the
+very next section's top entry marks `13.0.5-beta1` — a pre-release — as
+`(latest)`, directly contradicting the header two lines above.
+
+> [!note] Blast radius
+> This is cosmetic/informational only. It does not affect diagnostics, code
+> actions, or actual latest-version resolution logic (`versions.cached.latest`),
+> which are computed correctly and separately from the display bug described
+> here.
+
+### Goal
+
+The `*(latest)*` marker in the "Recent versions" list agrees with the header's
+`**Latest**:` value in every hover popup — i.e. it marks whichever list entry's
+version string matches the header's stable-latest version, never a
+pre-release entry that the header itself excluded.
+
+### Out of Scope
+
+- Changing how `versions.cached.<pkg>.latest` itself is computed (that
+  selection logic is already correct per `#305`).
+- Changing the sort order of `available_versions` / the raw registry-fetch
+  list (ecosystem crates' `parse_versions_response` sorting stays as-is).
+- Adding a distinct "pre-release" badge/label to individual entries in the
+  "Recent versions" list beyond what is needed to fix the marker mismatch
+  (existing yanked-label and age-suffix rendering stay unchanged).
+- Any change to `deps-core`'s existing pre-release exclusion / SemVer matching
+  rules used for `**Latest**:` computation.
+
+## 2. User Stories
+
+### US-001: Consistent hover popup
+AS A developer viewing a dependency's hover tooltip
+I WANT the "latest" marker in the recent-versions list to match the version
+the header calls "Latest"
+SO THAT I am not misled into thinking a pre-release is the recommended
+upgrade target when the header says otherwise.
+
+**Acceptance criteria:**
+```
+GIVEN a package whose raw registry version list's first (highest-numbered)
+      entry is a pre-release, and whose header `**Latest**:` value is a
+      different, stable version present further down the truncated list
+WHEN the hover popup is rendered
+THEN the `*(latest)*` marker is attached to the list entry whose version
+     string equals the header's `**Latest**:` value, not to the pre-release
+     entry at index 0
+```
+
+### US-002: No marker duplication or omission surprise
+AS A developer viewing a dependency's hover tooltip
+I WANT at most one entry in "Recent versions" tagged `(latest)`
+SO THAT the popup is unambiguous.
+
+**Acceptance criteria:**
+```
+GIVEN the header's `**Latest**:` value
+WHEN the "Recent versions" list is rendered
+THEN exactly zero or one entries carry the `*(latest)*` marker (never more
+     than one), and if the header has no `**Latest**:` value at all (e.g.
+     dependency not resolvable), no entry in the list is marked `(latest)`
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN rendering the "Recent versions" list AND a `**Latest**:` header value was computed (i.e. `latest_ver` is `Some`) THE SYSTEM SHALL mark with `*(latest)*` the list entry whose `version.version_string()` equals `latest_ver`, instead of unconditionally marking index `0` | must |
+| FR-002 | WHEN the header's `latest_ver` is `None` (dependency not resolvable / no cached latest) THE SYSTEM SHALL NOT mark any entry in the "Recent versions" list with `*(latest)*` | must |
+| FR-003 | WHEN the header's `latest_ver` string does not match any entry within the truncated top-`HOVER_RECENT_VERSIONS` slice actually rendered THE SYSTEM SHALL omit the `*(latest)*` marker entirely for that hover response rather than falling back to marking index 0 | must |
+| FR-004 | WHEN the header's `latest_ver` matches a list entry THE SYSTEM SHALL preserve all other per-entry rendering for that same index unchanged (age suffix, yanked label suppression, code-span formatting) — only the marker-selection condition changes, not the rendering of the matched line itself | must |
+| FR-005 | WHEN the header's `latest_ver` matches an entry at an index other than 0 (i.e. a pre-release sorts above it in the raw list) THE SYSTEM SHALL still render that non-zero-index entry using the same non-`(latest)` branch logic currently used for entries below index 0 (yanked check, age suffix), except it now additionally carries the `*(latest)*` marker instead of that entry's original unmarked/yanked rendering | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | The marker lookup must not change the overall hover-generation complexity class; a linear scan over the already-truncated top-`HOVER_RECENT_VERSIONS` slice (small, fixed-size N) to find the matching entry is acceptable — no additional network or registry calls |
+| NFR-002 | Compatibility | The fix must apply uniformly across all ecosystem crates that feed `available_versions` into `generate_hover` (deps-cargo, deps-npm, deps-pypi, deps-go, deps-bundler, deps-dart, deps-maven, deps-composer, deps-gradle, deps-swift, deps-nuget) without per-ecosystem special-casing, since the bug is in shared `deps-core` code, not ecosystem-specific code |
+| NFR-003 | Testability | The fix must be verifiable with a unit test fixture where the raw `available_versions` list's index-0 entry is a pre-release distinct from the separately-supplied `versions.cached.latest` stable value |
+
+## 5. Data Model
+
+No new entities. This is a display-logic fix over two existing data sources
+already present in `generate_hover`'s scope:
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `latest_ver` (existing, local `Option<&str>`) | The header's stable-latest version string, derived from `versions.cached.<pkg>.latest` | version string |
+| `available_versions` (existing) | Raw registry-returned version list, sorted numerically descending, may include pre-releases at the top | ordered list of version entries; each has `version_string()`, `is_yanked()`, publish-time metadata |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Raw list index 0 is a pre-release; header's stable latest is present further down within the rendered top-N slice | `(latest)` marker moves to that entry (per FR-001); entry at index 0 renders as a normal (non-latest) pre-release line |
+| Raw list index 0 is a pre-release; header's stable latest exists in the registry but falls outside the truncated top-`HOVER_RECENT_VERSIONS` slice actually shown | No entry in the rendered list is marked `(latest)` (per FR-003) — `[NEEDS CLARIFICATION: should the implementation instead widen the search to the full untruncated `available_versions` list before giving up, only truncating for display? Left as an implementation decision; either resolves the header/list contradiction, but full-list search is more expensive and only matters when the stable latest is unusually far down the raw list]` |
+| Header has no `**Latest**:` value at all (`latest_ver` is `None`, e.g. dependency unresolved) | No entry marked `(latest)` (per FR-002); this already matches today's absence of contradiction since the header line itself is also omitted in this case |
+| Raw list index 0 IS the stable latest (the common, non-buggy case) | Behavior is unchanged from today — index-0 entry still gets `(latest)`, now via string-match rather than positional assumption |
+| Multiple entries in the raw list happen to share the same version string as `latest_ver` (should not occur in practice, but registries can return duplicates) | Mark only the first (highest-priority / lowest-index) matching entry — `[NEEDS CLARIFICATION: confirm no ecosystem crate can legitimately return duplicate version strings in `available_versions`; if bundler platform-variant duplicates from spec 016 are still unresolved when this ships, first-match is the safe default]` |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Hover popups where header `**Latest**:` and list `*(latest)*` marker disagree on version string | 0 (verified by new unit test fixture per NFR-003 and live re-test against the `Newtonsoft.Json` NuGet reproduction case) |
+| SC-002 | Existing hover tests (`test_generate_hover_recent_versions_shows_age_when_known` and siblings, `crates/deps-core/src/lsp_helpers.rs` ~line 3738+) | All continue to pass unmodified (common case: index 0 already is the stable latest) |
+| SC-003 | Cross-ecosystem consistency check (deps-cargo, deps-npm, deps-pypi, deps-nuget, deps-bundler at minimum) with a pre-release-at-top fixture | Marker matches header in all tested ecosystems |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Add a unit test in `crates/deps-core/src/lsp_helpers.rs` that constructs a
+  fixture where the raw version list's index-0 entry is a pre-release
+  distinct from the mocked `versions.cached.latest` value, and asserts the
+  `(latest)` marker lands on the correct entry
+- Run `cargo nextest run -p deps-core` after the change
+- Follow existing code style and helper patterns already used in
+  `generate_hover` (e.g. `markdown_code_span`, `writeln!` usage)
+
+### Ask First
+- Widening the match to search beyond the truncated `HOVER_RECENT_VERSIONS`
+  slice into the full `available_versions` list (resolves the truncation edge
+  case in section 6, but changes lookup cost characteristics — confirm with
+  maintainer before implementing)
+- Any change to `HOVER_RECENT_VERSIONS` truncation count itself
+
+### Never
+- Change the pre-release exclusion / SemVer matching logic that computes
+  `versions.cached.<pkg>.latest` (out of scope, already correct)
+- Change ecosystem crates' raw version-list sort order
+  (`parse_versions_response` and equivalents)
+- Modify diagnostics or code-action logic — this is a hover-rendering-only fix
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: When the header's stable latest is not found within the
+  truncated top-N "Recent versions" slice, should the fix (a) omit the
+  `(latest)` marker entirely, or (b) search the full untruncated
+  `available_versions` list before truncating for display? Left as an
+  implementation decision per the finding; (a) is simpler and matches FR-003,
+  (b) fully eliminates the contradiction at a small extra cost.]
+- [NEEDS CLARIFICATION: Should a `(pre-release)` or similar marker be added to
+  entries above the matched `(latest)` line to make it visually obvious *why*
+  a higher-numbered version isn't tagged latest? Not required by this fix but
+  would improve UX; left out of scope per section "Out of Scope" unless the
+  maintainer wants it bundled.]
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[MOC-specs]] — all specifications
+- [[016-bundler-platform-duplicate-versions/spec|Deduplicate RubyGems platform-variant versions in Bundler hover]] — related recent hover-rendering fix in the same cycle
+- PR #305 — prerelease-hint enrichment for unsatisfiable-requirement diagnostics (source of the correct `versions.cached.latest` selection logic referenced here)

--- a/specs/018-clippy-dashmap-await-guard/plan.md
+++ b/specs/018-clippy-dashmap-await-guard/plan.md
@@ -1,0 +1,215 @@
+---
+aliases:
+  - Clippy DashMap Await-Hold Guard Plan
+tags:
+  - sdd
+  - plan
+  - enhancement
+  - tooling
+  - ci
+created: 2026-08-24
+status: draft
+related:
+  - "[[spec]]"
+  - "[[constitution]]"
+---
+
+# Technical Plan: Add `clippy.toml` `await-holding-invalid-types` config for DashMap `Ref` guards
+
+> [!info] References
+> **Spec**: [[spec]]
+
+## 1. Architecture
+
+### Approach
+
+This is a single-file, zero-code-change addition: a `clippy.toml` at the
+workspace root that extends the already-active
+`clippy::await_holding_invalid_type` lint (enabled today via
+`[workspace.lints.clippy] all = "warn"` in the root `Cargo.toml`) with
+project-specific type paths. No new lint category is introduced, no
+existing lint is silenced, and no application code changes.
+
+There is no meaningful alternative architecture to weigh here — this is the
+one canonical mechanism clippy provides for registering custom
+"must not be held across await" types (`await-holding-invalid-types` is
+`await_holding_invalid_type`'s dedicated config key; there is no equivalent
+via `#[allow]`/`#[warn]` attributes or a `build.rs` check that would be
+simpler or more idiomatic).
+
+### Component Diagram
+
+```mermaid
+graph TD
+    A[clippy.toml at workspace root] --> B[clippy::await_holding_invalid_type lint]
+    B --> C["cargo clippy --workspace --all-targets --all-features -- -D warnings"]
+    C --> D{New violation found?}
+    D -->|No| E[PR proceeds, CI green]
+    D -->|Yes, existing code| F[File follow-up bug issue, P1/P2 per severity]
+    D -->|Yes, existing code, blocking| G[Fix in this PR or split into dedicated fix PR - maintainer decision]
+```
+
+### Key Design Decisions
+
+| Decision | Choice | Rationale | Alternatives Considered |
+|----------|--------|-----------|------------------------|
+| Config mechanism | `clippy.toml` `await-holding-invalid-types` key | Purpose-built clippy feature for exactly this hazard class; zero runtime cost, enforced at every `cargo clippy` invocation including CI's existing gate | Custom `xtask`/CI grep for `Ref`/`.await` co-occurrence (rejected: fragile text-matching, false positives/negatives, duplicates work clippy already does correctly via its type-and-control-flow analysis) |
+| Which types to register | `dashmap::mapref::one::{Ref, RefMut, MappedRef, MappedRefMut}` + `dashmap::mapref::multiple::{RefMulti, RefMutMulti}` | First two (`Ref`, `RefMut`) have confirmed live usage (`ServerState::get_document`); registering all six preempts the same class for future code paths (multi-key iteration, mapped refs) without needing another spec cycle later | Registering only `Ref`/`RefMut` (rejected: cheap to add the other four now, and the Goal explicitly calls for preempting future occurrences, not just patching the currently-known one) |
+| File location | Workspace root `clippy.toml` (not `.clippy.toml`, not per-crate) | Clippy resolves config from the workspace root by convention; a single file covers all member crates uniformly, matching how `[workspace.lints.clippy]` is already centralized in the root `Cargo.toml` | Per-crate `clippy.toml` files (rejected: hazard applies workspace-wide — `deps-lsp`, `deps-core`, `deps-maven`, `deps-npm`, `deps-swift` all hold `DashMap`/`Arc<DashMap<...>>` state per the finding's grep evidence — a single root config is simpler and avoids drift between crates) |
+| Handling of pre-existing violations if the config surfaces any | Do not fix in this PR; file a separate tracked issue (FR-006) | Keeps this PR's blast radius to "add detection," matching the finding's explicit framing that a positive result here is valuable signal, not a blocker; avoids scope creep into remediation work that would need its own review | Blocking this PR on fixing any newly found violation (rejected as default — left as a maintainer judgment call per spec Open Questions, not baked into the plan as mandatory) |
+
+## 2. Project Structure
+
+```
+deps-lsp/
+├── Cargo.toml                    (unchanged — [workspace.lints.clippy] already has `all = "warn"`)
+├── clippy.toml                   (new — workspace-root lint config, this feature's only file)
+├── CHANGELOG.md                  (modified — one-line entry under [Unreleased])
+└── crates/
+    └── ...                        (unchanged — no source files touched)
+```
+
+## 3. Data Model
+
+Not applicable — no runtime types, no schema, no database. The only
+artifact is the TOML config file itself:
+
+```toml
+# clippy.toml
+#
+# Registers DashMap guard types with clippy::await_holding_invalid_type
+# (active workspace-wide via `[workspace.lints.clippy] all = "warn"` in
+# Cargo.toml). Holding one of these guards across an `.await` point pins
+# a lock on the DashMap shard for the duration of the awaited future,
+# which can starve or deadlock a concurrent access to the same shard.
+#
+# This bug class was found and fixed three times in this project's
+# history — issue #317 (inlay_hints.rs, diagnostics.rs), PR #318 (partial
+# fix, left a then-inert hazard flagged with TODO(#317-followup) comments
+# in deps-core/src/ecosystem.rs), and issue #319 / PR #325 (the live
+# version of the same hazard in hover.rs, code_actions.rs, and
+# completion.rs, the latter holding a guard across a 2s timeout).
+#
+# Do not remove entries here without confirming (a) no code in the
+# workspace constructs that guard type at all, or (b) the type's guard is
+# never held across an .await point anywhere it's constructed.
+await-holding-invalid-types = [
+    "dashmap::mapref::one::Ref",
+    "dashmap::mapref::one::RefMut",
+    "dashmap::mapref::one::MappedRef",
+    "dashmap::mapref::one::MappedRefMut",
+    "dashmap::mapref::multiple::RefMulti",
+    "dashmap::mapref::multiple::RefMutMulti",
+]
+```
+
+Note: `await-holding-invalid-types` accepts either bare type-path strings or
+`{ path = "...", reason = "..." }` tables per clippy's documented config
+schema. If the pinned clippy version supports the `reason` form, prefer it
+for each entry so the "why" surfaces directly in the lint diagnostic (not
+just in this file's header comment) — confirm support during
+implementation (see Verification step below) and use whichever form the
+installed clippy accepts.
+
+## 4. API Design
+
+Not applicable — no public API surface changes.
+
+## 5. Integration Points
+
+| System | Direction | Protocol | Notes |
+|--------|-----------|----------|-------|
+| `cargo clippy` (local + CI `check` job) | inbound config consumption | TOML file read at lint time | No network calls, no other tool integration; picked up automatically by any `cargo clippy` invocation from the workspace root, including the existing CI `check` job — no CI workflow YAML change needed |
+
+## 6. Security
+
+Not applicable — this is a static-analysis config file, not runtime code.
+No secrets, no user input, no auth surface.
+
+## 7. Testing Strategy
+
+| Level | Framework | What to Test | Coverage Target |
+|-------|-----------|-------------|-----------------|
+| Static analysis (the feature itself) | `cargo clippy --workspace --all-targets --all-features -- -D warnings` | Confirms the config parses correctly and produces zero *new* `await_holding_invalid_type` violations against the current, post-#325 codebase | Full workspace, all features, all targets — matches the project's standard pre-commit clippy invocation exactly, no new command needed |
+| Regression (existing) | `cargo nextest run --workspace --all-features --no-fail-fast` | Confirms the config addition doesn't affect runtime behavior (expected: no change at all, since this is lint-only) | Full workspace — sanity check, not testing new logic |
+| Doc build | `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace` | Confirms no incidental breakage (expected: no change) | Full workspace |
+
+No new unit or integration tests are written as part of this feature — there
+is no new code path to unit-test. The "test" for this feature *is* the full
+clippy run against the real codebase, executed once during implementation
+and once more in CI on the PR itself.
+
+## 8. Performance Considerations
+
+Negligible. `clippy.toml` type-path lookups are a constant-cost table check
+already performed by the `await_holding_invalid_type` lint pass, which runs
+regardless (it already checks the built-in default type list). Per NFR-002,
+verify informally by comparing local `cargo clippy --workspace
+--all-targets --all-features` wall-clock time before/after — no formal
+benchmark needed for a config-only change.
+
+## 9. Rollout Plan
+
+Single-PR rollout, no feature flag, no phased deployment — this is a
+CI/tooling config change with no runtime behavior to roll out gradually.
+
+Implementation sequence (all in one PR, following the spec's Agent
+Boundaries "Always" list):
+
+1. Add `clippy.toml` at the workspace root with the six type-path entries
+   (Data Model section above), verifying against the installed clippy
+   version whether the `reason`-table form is supported.
+2. Run `cargo clippy --workspace --all-targets --all-features -- -D
+   warnings` and inspect the result.
+3. **Decision point (per spec FR-006 / Open Questions)**:
+   - **If clean** (expected outcome, given #325 already fixed every
+     confirmed live occurrence): proceed directly to step 4.
+   - **If new violations surface**: do NOT fix them as part of this PR.
+     Document each violation's file/line/handler, classify severity per
+     the project's Anomaly Detection process (P0-P4; a DashMap-guard-
+     across-await hazard is realistically P1 if it wraps real I/O, P2 if
+     the awaited future never currently yields — mirroring the #317 vs.
+     #319 distinction), and file a separate GitHub issue via `gh issue
+     create` with the `bug` label plus the priority label, linking back to
+     this spec and to #317/#319/#325 for context. This config PR then
+     proceeds to merge with the new issue referenced in the PR description
+     — the config addition itself is still correct and valuable even
+     though it surfaced a pre-existing gap; blocking config-hardening work
+     on unrelated remediation work would delay the CI gate for no benefit.
+   - Note: if the maintainer's actual preference (per the spec's open
+     question) is to block on fixing rather than ship-and-file, escalate
+     before merging — this plan defaults to ship-and-file but flags the
+     alternative explicitly.
+4. Run `cargo +nightly fmt --all -- --check`, `cargo nextest run
+   --workspace --all-features --no-fail-fast`, and the rustdoc gate to
+   confirm no incidental breakage.
+5. Add a one-line `CHANGELOG.md` entry under `[Unreleased]`.
+6. Open the PR; link the PR number into the changelog entry once known.
+
+## 10. Constitution Compliance
+
+No `constitution.md` exists yet in this project
+(`.local/specs/constitution.md` — confirmed missing). This plan instead
+complies with the project's checked-in rule files as the de facto
+constitution:
+
+| Principle (from `.claude/rules/`) | Status | Notes |
+|-----------|--------|-------|
+| Full pre-commit check suite before PR (`branching.md`) | Compliant | Step 4 runs fmt, clippy (the feature itself), nextest, rustdoc gate |
+| CHANGELOG entry under `[Unreleased]`, one line + PR link (`branching.md`, global CLAUDE.md) | Compliant | Step 5-6 |
+| Continuous-improvement session is read-only, no code fixes during CI cycles (`continuous-improvement.md`) | Compliant by design | This plan explicitly defers any newly-surfaced violation to a separate follow-up issue/PR rather than fixing inline, matching the "no direct code edits in continuous improvement sessions" rule — even though this particular PR (adding the config) is itself a small code change, not a CI-cycle-only artifact |
+| YAML tooling: use `fast-yaml`/`fy` (global CLAUDE.md) | Not applicable | `clippy.toml` is TOML, not YAML — no `fy` validation needed |
+| Rust code conventions: no `#[allow]` for workspace-suppressed lints (`rust-code.md`) | Compliant | This feature adds detection, explicitly forbids new `#[allow(clippy::await_holding_invalid_type)]` suppressions per spec Agent Boundaries |
+
+## 11. Risks and Mitigations
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| Pinned CI clippy version doesn't support `await-holding-invalid-types` key | Config silently no-ops (clippy typically ignores unknown config keys with a warning, doesn't hard-fail) — feature provides no protection | Low (key has been stable in clippy for multiple releases) | Verify locally with `cargo clippy --version` and check for a "unknown clippy.toml key" warning in step 2's output before merging (NFR-003) |
+| Adding the config surfaces a real, previously-undetected violation | Requires follow-up triage work outside this PR's scope; delays full remediation | Low-medium (three prior fixes already covered every known `Ref`-returning API path per the grep evidence) | Explicit decision point in Rollout step 3 — ship the config regardless, file the issue, don't let it block the CI-hardening win |
+| Future `dashmap` major version renames/removes `MappedRef`/`RefMulti` etc. | Config references a type path that no longer exists; likely silently ignored rather than erroring | Low, deferred | Out of scope per spec — covered by existing Dependency Monitoring process when `dashmap` is next upgraded |
+
+## See Also
+
+- [[spec]] — feature specification
+- [[MOC-specs]] — all specifications

--- a/specs/018-clippy-dashmap-await-guard/spec.md
+++ b/specs/018-clippy-dashmap-await-guard/spec.md
@@ -1,0 +1,274 @@
+---
+aliases:
+  - Clippy DashMap Await-Hold Guard
+tags:
+  - sdd
+  - spec
+  - enhancement
+  - tooling
+  - ci
+created: 2026-08-24
+status: draft
+related:
+  - "[[constitution]]"
+---
+
+# Feature: Add `clippy.toml` `await-holding-invalid-types` config for DashMap `Ref` guards
+
+> [!info] Metadata
+> **Author**: continuous-improvement research cycle
+> **Branch**: fix/clippy-dashmap-await-guard (no issue filed yet)
+
+## 1. Overview
+
+### Problem Statement
+
+Holding a `dashmap::mapref::one::Ref` / `RefMut` (or their `Mapped*` /
+`RefMulti` counterparts) across an `.await` suspension point is a liveness
+hazard: the guard pins a lock on the DashMap shard for the lifetime of the
+awaited future, so any concurrent access to the same shard (e.g. another LSP
+request calling `documents.get_mut` for the same `Uri`) blocks — or, in the
+worst case observed so far, blocks for up to the full duration of a
+network-bound fetch or a multi-second timeout.
+
+This exact bug class has already been found and fixed **three separate
+times** in this project's history, across five different LSP handlers:
+
+- Issue #317 (found during #227's security audit): `inlay_hints.rs` and
+  `diagnostics.rs` held a `Ref` across `full_config.read().await` and a
+  `generate_*(...).await` call.
+- PR #318: fixed `inlay_hints.rs` by reordering (snapshot config before
+  document lookup). Left a second, then-inert `Ref`-hold across
+  `generate_*(...).await` itself, marked with `TODO` comments in
+  `crates/deps-core/src/ecosystem.rs` (around `generate_inlay_hints`,
+  line 406) noting the hazard is currently benign only because
+  `deps-core`'s default trait methods never actually yield today
+  (`Box::pin(async move { sync_fn() })`) — an implementation detail that
+  could silently change if a future override adds real I/O.
+- PR #325 (closing issue #319, the follow-up): found the *live* version of
+  the identical hazard in `hover.rs` (`Ref` held across a network-bound
+  `registry.get_versions_with(...)` fetch), `code_actions.rs` (same, via
+  `generate_code_actions`), and worst of all `completion.rs` (`Ref` held
+  across `tokio::time::timeout(COMPLETION_SEARCH_TIMEOUT, ...)`, up to 2
+  seconds of a blocking guard pinned on a tokio worker thread — a
+  concurrent `documents.get_mut` on the same shard would block outright).
+  Fixed via `DocumentState.parse_result: Box<dyn ParseResult>` →
+  `Arc<dyn ParseResult>` so handlers can clone-and-drop the `Ref` before the
+  await, plus regression tests asserting the guard is not reintroduced.
+
+Despite three occurrences, the codebase has **no compile-time or lint-time
+enforcement** preventing a fourth. The only remaining guardrails are:
+
+1. `TODO(#317-followup)`-style code comments on two `deps-core` default
+   trait methods (`generate_inlay_hints`, and similarly-worded comments near
+   `generate_diagnostics`/`generate_code_lenses`) noting the hazard is latent
+   rather than fixed.
+2. Handler-specific regression tests (`crates/deps-lsp/src/handlers/completion.rs`
+   line ~1064, `hover.rs`, `code_actions.rs`) that only cover the exact
+   handlers already fixed.
+
+A new handler, or a future override of one of the two `deps-core` default
+trait methods that adds real I/O (turning the currently-inert hazard live),
+could silently reintroduce the exact same class of bug — with nothing
+catching it short of another manual security/code audit.
+
+Clippy already ships the exact mechanism needed:
+`clippy::await_holding_invalid_type` (part of the same lint family as
+`await_holding_lock`, already active project-wide via
+`[workspace.lints.clippy] all = "warn"` in the root `Cargo.toml`) reads a
+`clippy.toml` (or `.clippy.toml`) config key `await-holding-invalid-types`
+that accepts arbitrary type paths — not just `std`/`parking_lot`
+`Mutex`/`RwLock` — to flag when held across an `.await` point.
+
+Verified facts:
+- `find /Users/rabax/Dev/deps-lsp -maxdepth 1 -iname "clippy.toml"` returns
+  no output — this project has **no `clippy.toml` at all** today.
+- `ServerState::get_document`
+  (`crates/deps-lsp/src/document/state.rs:518-521`) returns
+  `Option<dashmap::mapref::one::Ref<'_, Uri, DocumentState>>`.
+- The pinned workspace `dashmap` version is `6.2` (`Cargo.toml:16`); the
+  `dashmap::mapref::one` module exports `Ref`, `RefMut`, `MappedRef`,
+  `MappedRefMut`. This project does not currently construct `MappedRef` /
+  `MappedRefMut` values, but registering them preempts the same hazard for
+  future code that does.
+- `dashmap::mapref::multiple` additionally exports `RefMulti` / `RefMutMulti`
+  for multi-key iteration guards, which carry the identical liveness
+  hazard if ever held across an `.await`.
+- `grep -rn "dashmap::mapref::one::Ref"` in the current tree shows exactly
+  one live `Ref`-returning API (`ServerState::get_document`); the rest of
+  the codebase already routes through the clone-and-drop
+  (`Arc<dyn ParseResult>`) pattern established by PR #325.
+
+### Goal
+
+`cargo clippy --workspace --all-targets --all-features -- -D warnings` fails
+automatically, on every PR, if any future code holds a
+`dashmap::mapref::one::{Ref, RefMut, MappedRef, MappedRefMut}` or
+`dashmap::mapref::multiple::{RefMulti, RefMutMulti}` guard across an
+`.await` suspension point — turning this recurring bug class from "requires
+a human security/code audit to catch" into "CI catches it automatically."
+
+### Out of Scope
+
+- Refactoring any existing handler code. The three prior fixes (#318, #325)
+  already resolved every currently-live occurrence; this feature adds
+  *detection*, not remediation.
+- Removing or rewording the existing `TODO(#317-followup)`-style comments in
+  `crates/deps-core/src/ecosystem.rs` — those stay as human-readable context;
+  the new lint config is a second, independent guardrail, not a replacement.
+- Adding new regression tests for already-fixed handlers (covered by #325).
+- Configuring `await_holding_invalid_type` for lock types outside the
+  DashMap family (`std::sync::Mutex`, `parking_lot`, etc. are already
+  covered by clippy's built-in defaults without any config).
+- Any change to `dashmap` itself or to `ServerState`'s public API
+  (`get_document`'s `Ref`-returning signature is unchanged by this feature).
+
+## 2. User Stories
+
+### US-001: Automatic detection of a reintroduced DashMap-guard-across-await hazard
+AS A contributor (human or coding agent) adding a new LSP handler or
+overriding a `deps-core` default trait method
+I WANT the CI clippy gate to fail immediately if my code holds a DashMap
+`Ref`/`RefMut` guard across an `.await` point
+SO THAT I catch the liveness hazard at compile-check time, in my own PR,
+instead of it silently shipping and later requiring a dedicated security
+audit or bug report to discover (as happened three times already: #317,
+the #318 follow-up, #319/#325).
+
+**Acceptance criteria:**
+```
+GIVEN a new or modified function anywhere in the workspace that binds a
+      dashmap::mapref::one::Ref (or RefMut/MappedRef/MappedRefMut/
+      RefMulti/RefMutMulti) to a local variable and then awaits a future
+      while that variable is still in scope
+WHEN `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+     is run
+THEN the build fails with a clippy::await_holding_invalid_type diagnostic
+     pointing at the offending await point
+```
+
+### US-002: No new false positives on the existing, already-fixed codebase
+AS A maintainer running CI on the current `main` branch after this change
+I WANT the added `clippy.toml` config to produce zero new clippy warnings
+SO THAT the config addition itself does not block unrelated PRs or require
+immediate remediation work.
+
+**Acceptance criteria:**
+```
+GIVEN the current state of the workspace (post #325, all three prior
+      occurrences already fixed)
+WHEN `clippy.toml` with the `await-holding-invalid-types` entries is added
+     and `cargo clippy --workspace --all-targets --all-features -- -D
+     warnings` is run
+THEN the command exits successfully with no new await_holding_invalid_type
+     warnings
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | THE SYSTEM SHALL provide a `clippy.toml` file at the workspace root containing an `await-holding-invalid-types` array | must |
+| FR-002 | THE `await-holding-invalid-types` array SHALL register `dashmap::mapref::one::Ref` and `dashmap::mapref::one::RefMut` (the two types with confirmed live usage in the codebase today) | must |
+| FR-003 | THE `await-holding-invalid-types` array SHALL also register `dashmap::mapref::one::MappedRef` and `dashmap::mapref::one::MappedRefMut` (not currently used, registered preemptively per the Goal) | must |
+| FR-004 | THE `await-holding-invalid-types` array SHALL also register `dashmap::mapref::multiple::RefMulti` and `dashmap::mapref::multiple::RefMutMulti` (multi-key iteration guards carrying the identical hazard) | must |
+| FR-005 | WHEN `cargo clippy --workspace --all-targets --all-features -- -D warnings` is run after the config is added THE SYSTEM SHALL report zero new `clippy::await_holding_invalid_type` violations against the current (post-#325) codebase | must |
+| FR-006 | IF the clippy run in FR-005 surfaces one or more `await_holding_invalid_type` violations against existing code THE SYSTEM SHALL treat this as a distinct finding (a real, previously-undetected occurrence of the bug class) rather than silently suppressing or working around it — see Decision Point in the accompanying plan | must |
+| FR-007 | Each entry in the `await-holding-invalid-types` array SHALL use each type's fully qualified path as required by clippy's config schema (`clippy::await_holding_invalid_type` documentation), verified against `dashmap 6.2` docs.rs module layout | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Maintainability | The `clippy.toml` config change must be self-documenting: each registered type path is accompanied by a short comment (or the file has a header comment) explaining why DashMap guards are singled out, referencing #317/#319/#325 so future contributors understand the intent without needing to reread this spec |
+| NFR-002 | CI cost | Adding the config must not measurably change `cargo clippy` run time — `clippy.toml` type-path config lookups are a constant-cost addition to an already-running lint, no new lint passes are introduced |
+| NFR-003 | Compatibility | The config must be valid for the clippy toolchain version currently pinned/used in CI (verify `await-holding-invalid-types` key is supported by the installed clippy version before merging; this key has been stable in clippy for multiple releases but must be confirmed, not assumed) |
+| NFR-004 | Scope precision | The config must NOT globally disable or downgrade `await_holding_invalid_type` (already active via `clippy::all`) — it only *extends* the set of types the existing, already-warn-level lint checks for |
+
+## 5. Data Model
+
+No new runtime data entities — this is a static-analysis configuration
+change. The only "entity" is the lint configuration itself:
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `clippy.toml` | Workspace-root static-analysis config file consumed by `cargo clippy` | `await-holding-invalid-types: Vec<String>` (fully-qualified type paths) |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| A type path string in the config is misspelled or doesn't match dashmap's actual module layout | Clippy silently ignores unmatched type paths rather than erroring (per clippy's documented behavior for this lint) — mitigated by verifying each path against dashmap 6.2's docs.rs module tree before merging (FR-007), not by runtime validation |
+| Running `cargo clippy` against the current, already-fixed codebase surfaces a *new* violation not covered by #317/#318/#319/#325 | Per FR-006: do not fix it as part of this config PR. Document the finding and file a separate P1/P2 bug issue per the project's Anomaly Detection process, referencing the new violation's file/line; this config PR proceeds once the violation is either accepted as a documented follow-up or trivially not a real hazard (e.g. a false positive worth a targeted `#[allow]` with justification) |
+| A future `dashmap` major-version bump changes the `mapref` module layout (e.g. renames `MappedRef`) | Out of scope for this spec — covered by the project's existing Dependency Monitoring process (`cargo outdated`, changelog review) when `dashmap` is next upgraded; the config's type paths will need a matching update at that time, called out here as residual risk only |
+| A handler correctly clones a value out of a `Ref` and explicitly drops the guard before an `.await` (the pattern already used post-#325 via `Arc<dyn ParseResult>`) | No lint trigger — the guard is no longer in scope at the await point, which is exactly the pattern this config is meant to keep enforced |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | `clippy.toml` exists at workspace root with all six required type paths (FR-002/003/004) | 1 file, 6 entries, present after merge |
+| SC-002 | `cargo clippy --workspace --all-targets --all-features -- -D warnings` exit code after config is added | 0 (clean), OR a documented follow-up issue filed per FR-006/Edge Cases if new violations surface |
+| SC-003 | Time added to `cargo clippy --workspace --all-targets --all-features` wall-clock run | No measurable increase (informal check: compare a local run before/after) |
+| SC-004 | Recurrence of the DashMap-guard-across-await bug class after this change ships | 0 further manual-audit-discovered occurrences (leading indicator to monitor across future continuous-improvement cycles; not verifiable at merge time) |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Add `clippy.toml` at the workspace root with the six type paths from
+  FR-002/003/004, each with a short explanatory comment referencing
+  #317/#319/#325
+- Run `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+  after adding the file and report the result (clean, or list of new
+  violations) — do not silently proceed past a non-clean result
+- Run the project's full pre-commit check suite (`cargo +nightly fmt
+  --all -- --check`, the clippy command above, `cargo nextest run
+  --workspace --all-features --no-fail-fast`) before proposing the PR
+- Update `CHANGELOG.md` under `[Unreleased]` with a one-line entry
+
+### Ask First
+- Filing a new bug issue if FR-006/the Edge Cases table's second row is
+  triggered (a genuinely new violation surfaces) — confirm severity
+  classification (P0-P4) and whether it should block this PR or ship as a
+  parallel follow-up before creating the issue
+- Adding an `#[allow(clippy::await_holding_invalid_type)]` suppression
+  anywhere, even with justification — this defeats the purpose of the
+  feature and must be a deliberate, reviewed decision, not a default
+  workaround for a newly-surfaced violation
+
+### Never
+- Modify `ServerState::get_document`'s signature or any other DashMap
+  access pattern as part of this change (that's remediation, explicitly
+  out of scope — see Out of Scope)
+- Remove or weaken the existing `TODO(#317-followup)`-style comments in
+  `crates/deps-core/src/ecosystem.rs`
+- Suppress a newly-surfaced violation (per Edge Cases) without first
+  raising it as a separate tracked issue
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: confirm the exact clippy toolchain version pinned in
+  CI (`.github/workflows/*.yml`) supports the `await-holding-invalid-types`
+  clippy.toml key — expected to be stable across recent clippy releases but
+  not yet independently verified against this project's pinned version as
+  part of this spec.]
+- [NEEDS CLARIFICATION: if FR-006 triggers (a new violation surfaces when the
+  config is added), should the config-addition PR still merge with the
+  violation documented as a follow-up issue, or should it block on fixing
+  the violation first? Spec defaults to "ship the config, file the follow-up
+  separately" per the Edge Cases table, but this is a judgment call for
+  whoever runs the plan's verification step.]
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[MOC-specs]] — all specifications
+- Issue #317, PR #318, Issue #319, PR #325 — the three prior occurrences of
+  this exact bug class this feature is meant to prevent from recurring a
+  fourth time
+- `crates/deps-lsp/src/document/state.rs` (`ServerState::get_document`,
+  lines 518-521) — the one confirmed live `Ref`-returning API in the
+  current codebase
+- `crates/deps-core/src/ecosystem.rs` (around line 406, `generate_inlay_hints`)
+  — the `TODO(#317-followup)`-style comment this config's Goal statement
+  references as the currently-latent hazard

--- a/specs/019-npm-all-deprecated-unknown-package/spec.md
+++ b/specs/019-npm-all-deprecated-unknown-package/spec.md
@@ -1,0 +1,219 @@
+---
+aliases:
+  - npm all-deprecated Unknown package
+tags:
+  - sdd
+  - spec
+  - bug
+  - deps-npm
+  - deps-deno
+  - npm
+created: 2026-08-24
+status: draft
+related:
+  - "[[MOC-specs]]"
+---
+
+# Feature: npm/JSR packages whose every published version is deprecated must not be reported "Unknown package"
+
+> [!info] Metadata
+> **Author**: Andrei G. (k05h31@gmail.com)
+> **Branch**: (none yet)
+> **Priority**: P1
+> **Discovered during**: ci-007 live testing of #309/#324 (Deno/JSR ecosystem, npm-registry sharing) via a `deno.json` `npm:left-pad@1.0.0` import
+
+## 1. Overview
+
+### Problem Statement
+
+`left-pad` is a real, installable, currently-published npm package (versions
+`0.0.0`..`1.3.0` all present in the registry) whose *every* published version
+carries an npm-level `deprecated` message
+(`"use String.prototype.padStart()"`). This is a common, legitimate
+real-world pattern — many long-lived, still-functional npm packages
+(`left-pad`, `request`, `har-validator`, several `node-uuid`-family packages)
+carry a package-wide deprecation notice on all their versions while remaining
+perfectly installable and widely depended-upon.
+
+Live-tested against real `registry.npmjs.org` data (2026-08-24): opening a
+`deno.json` with `"left-pad": "npm:left-pad@1.0.0"` produces:
+- `textDocument/publishDiagnostics`: `Unknown package 'npm:left-pad'`
+  (severity Warning) — as if the package does not exist.
+- Hover: renders "Recent versions" correctly (each entry tagged
+  `*(deprecated)*`), but the `**Latest**:` line is missing entirely — normally
+  always present for a resolvable package.
+
+Root cause, traced live via `RUST_LOG=debug`:
+1. `crates/deps-npm/src/registry.rs`'s `Registry::select_latest_matching`
+   (~line 614) and `NpmRegistry::get_latest_matching` (~line 338) both filter
+   out any version where `v.is_yanked()` is true — and npm's `deprecated`
+   flag is mapped to `is_yanked()` (`crates/deps-npm/src/registry.rs:418`,
+   `deprecated: meta.deprecated.is_some()`).
+2. `crates/deps-lsp/src/document/lifecycle.rs` (~line 704) resolves each
+   dependency's cache entry using a **wildcard** requirement (`"*"`) for the
+   "does this package exist / what is its most-recent version" check, calling
+   `select_latest_matching(&versions, "*")` and, on `None`, falling back to
+   `get_latest_matching(name, "*")`.
+3. When every returned version is deprecated, both the wildcard
+   `select_latest_matching` and the `get_latest_matching` fallback return
+   `None` — even under a wildcard requirement that should match anything —
+   because both apply the `!v.is_yanked()` filter unconditionally, with no
+   "wildcard bypasses the yanked filter" exception.
+4. `None` here is logged as `"no version found"`
+   (`crates/deps-lsp/src/document/lifecycle.rs:783`) and no cache entry is
+   ever inserted for the package.
+5. `crates/deps-core/src/lsp_helpers/diagnostics.rs` (~line 449) then finds no
+   `package_versions` entry in cache and — since the name-syntax is valid and
+   the source is version-resolvable and no lockfile entry masks it — emits
+   `Unknown package '<name>'` (line 476). This is indistinguishable from a
+   genuinely nonexistent package.
+
+This conflates two different questions that the wildcard fast-path was meant
+to answer for two different purposes:
+- "What's the newest version I should offer to install/recommend?" — legitimately excludes deprecated versions.
+- "Does this package exist at all?" — must NOT exclude deprecated versions; a deprecated package still exists.
+
+Both currently share the same `!v.is_yanked()`-filtered wildcard call, so the
+existence check inherits the recommendation-only filter.
+
+Same root cause path applies through `deps-deno`'s shared `NpmRegistry`
+instance (#324), so this affects both `package.json` (deps-npm) and
+`deno.json` `npm:` specifiers (deps-deno) identically.
+
+### Goal
+
+A dependency on a real, currently-published npm package must never be
+reported as `Unknown package`, and its hover `**Latest**:` line must always
+be populated, regardless of whether every published version happens to carry
+a package-wide deprecation notice. Deprecated-version filtering must remain
+in effect for actual "recommend an upgrade target" decisions (diagnostics'
+"Newer version available", quick-fix code actions, completion) — this spec
+narrows the fix to the existence/latest-for-display resolution only.
+
+### Out of Scope
+
+- Changing whether `deprecated` versions are offered as upgrade targets in
+  "Newer version available" diagnostics, completion, or quick-fix code
+  actions — deprecated versions should continue to be excluded there.
+- Adding a distinct "this package is deprecated" diagnostic/hover callout —
+  a possible follow-on enhancement, not required to fix the false "Unknown
+  package" report. See Open Questions.
+- Ecosystems other than npm/Deno's `npm:` routing — no other supported
+  registry's `select_latest_matching`/`get_latest_matching` wildcard path was
+  found to have this specific gap during this cycle's spot checks (see
+  sibling findings for Maven's *different* wildcard gap, spec 021).
+
+## 2. User Stories
+
+### US-001: All-deprecated package resolves as a known, existing package
+
+AS A developer with `left-pad` (or any all-deprecated-but-published package)
+in `package.json` or `deno.json`
+I WANT hover and diagnostics to recognize the package exists
+SO THAT I am not misled into thinking I have a typo'd/nonexistent dependency
+when the package is actually installed and working fine.
+
+**Acceptance criteria:**
+```
+GIVEN a package.json/deno.json dependency on a real npm package where every
+      published version has a `deprecated` field set
+WHEN textDocument/publishDiagnostics is computed
+THEN no "Unknown package" diagnostic is emitted for that dependency
+AND hover's "**Latest**:" line is populated with the actual newest published
+    version (deprecated or not)
+```
+
+### US-002: Deprecated versions still excluded from upgrade recommendations
+
+AS A developer relying on "Newer version available" / quick-fix suggestions
+I WANT the LSP to still avoid steering me toward installing extra deprecated
+versions where a non-deprecated alternative exists
+SO THAT the fix for US-001 does not regress existing deprecated-version
+avoidance behavior for packages that DO have non-deprecated versions.
+
+**Acceptance criteria:**
+```
+GIVEN a package with a mix of deprecated and non-deprecated versions
+WHEN "Newer version available" / quick-fix candidates are computed
+THEN only non-deprecated versions are offered, unchanged from current
+     behavior (regression-checked)
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN resolving whether a package exists / its most-recent version for cache-population purposes under a wildcard (`"*"`) requirement, THE SYSTEM SHALL NOT exclude deprecated/yanked versions from that resolution | must |
+| FR-002 | WHEN resolving the recommended upgrade target for diagnostics ("Newer version available"), completion, or quick-fix code actions, THE SYSTEM SHALL continue to exclude deprecated/yanked versions when at least one non-deprecated version exists | must |
+| FR-003 | WHEN every published version of a package is deprecated/yanked, THE SYSTEM SHALL still surface the newest deprecated version as `PackageVersions.latest` / hover `**Latest**` rather than reporting no version at all | must |
+| FR-004 | THE SYSTEM SHALL apply the fix uniformly to both `deps-npm`'s direct `Registry` implementation and `deps-deno`'s shared `NpmRegistry` usage (no separate deno-specific patch) | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Correctness | New unit test(s) in `deps-npm` covering `select_latest_matching`/`get_latest_matching` under `"*"` against an all-deprecated abbreviated-packument fixture, asserting a `Some`/non-`None` result |
+| NFR-002 | Backward compatibility | Existing tests asserting deprecated versions are excluded from *matched* (non-wildcard) requirement resolution must continue to pass unchanged |
+| NFR-003 | Consistency | Fix SHALL NOT introduce a divergence between hover's `**Latest**` and diagnostics' "Unknown package"/"Newer version available" logic — both read from the same corrected cache entry |
+
+## 5. Data Model
+
+No new types. Affects `crates/deps-npm/src/registry.rs`: `Registry::select_latest_matching`
+(~line 614-623) and `NpmRegistry::get_latest_matching` (~line 338-350), and
+their interaction with `crates/deps-lsp/src/document/lifecycle.rs`'s
+wildcard-based cache-population loop (~line 704-800) and
+`crates/deps-core/src/lsp_helpers/diagnostics.rs`'s `Unknown package` branch
+(~line 449-490).
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Package has a mix of deprecated and non-deprecated versions | Existing/unchanged: `**Latest**` and upgrade recommendations pick the newest non-deprecated version |
+| Package has zero published versions at all (genuinely nonexistent) | Unchanged: `Unknown package` still correctly emitted — this fix must not weaken genuine not-found detection |
+| Package's requirement is an exact pin matching a specific deprecated version | Unchanged: exact-pin matching already works today (confirmed live — `left-pad@1.0.0` hover lists it), only the wildcard existence/latest-for-display path is affected |
+| `deps-deno`'s shared `NpmRegistry` for an `npm:` specifier in `deno.json` | Same fix applies automatically since deno.json shares the `NpmRegistry` instance (#324) — no deno-specific code path to patch separately |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Live hover for `npm:left-pad@1.0.0` (deno.json) against real `registry.npmjs.org` | `**Latest**: `1.3.0`` line present |
+| SC-002 | Live diagnostics for the same manifest | No `Unknown package 'npm:left-pad'` diagnostic |
+| SC-003 | Live diagnostics for `react@^18.2.0` (non-deprecated, real data) unchanged | Still reports `Newer version available: <stable latest>`, no deprecated version offered |
+| SC-004 | `cargo nextest run -p deps-npm -p deps-deno` | All pass, including new fixture-based test(s) |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Add unit test(s) in `crates/deps-npm/src/registry.rs` with an
+  all-deprecated abbreviated-packument fixture (see existing
+  `test_parse_abbreviated_packument_all_deprecated` for the fixture shape —
+  that test only covers parsing, not `select_latest_matching`/
+  `get_latest_matching` resolution, which is the actual gap)
+- Run `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo nextest run -p deps-npm -p deps-deno --all-features`
+- Live-verify against real `registry.npmjs.org` (`left-pad`) per the Registry Integration Gate
+
+### Ask First
+- Whether to add a distinct "package is fully deprecated" hover/diagnostic callout (Open Questions) — separate enhancement, confirm scope before implementing
+
+### Never
+- Remove deprecated-version filtering from the upgrade-recommendation paths (FR-002) — only the existence/latest-for-display wildcard path changes
+- Weaken genuine not-found detection for packages with zero versions
+
+## 9. Open Questions
+
+> [!question] Fix shape
+> [NEEDS CLARIFICATION: Should the wildcard fast-path (`select_latest_matching`/`get_latest_matching` under `"*"`) simply drop the `!v.is_yanked()` filter entirely (since `versions` is already newest-first, index 0 under `"*"` is trivially correct without any filter), or should it fall back to "newest deprecated version" only when no non-deprecated version exists (two-tier: prefer non-deprecated, else take newest regardless)? The two-tier approach is closer to current behavior for the mixed case and safer against silently changing which version diagnostics recommends; recommend two-tier.]
+
+> [!question] Deprecation-aware UX
+> [NEEDS CLARIFICATION: Once existence is fixed, should hover/diagnostics add an explicit "this package is deprecated" note distinct from "Unknown package"? Deferred — not required to close this bug, but likely valuable follow-on given how common package-wide deprecation is in the npm ecosystem.]
+
+## 10. See Also
+
+- [[MOC-specs]] — all specifications
+- [[021-maven-wildcard-latest-ignores-prerelease/spec|Maven wildcard "latest" ignores prerelease qualifier]] — same class of bug (wildcard fast-path disagreeing with the real recommendation-path filter), different ecosystem and different filter (prerelease vs deprecated)
+- `crates/deps-npm/src/registry.rs` — `select_latest_matching` (~line 614), `get_latest_matching` (~line 338)
+- `crates/deps-lsp/src/document/lifecycle.rs` — wildcard cache-population loop (~line 704)
+- `crates/deps-core/src/lsp_helpers/diagnostics.rs` — `Unknown package` branch (~line 449)
+- `.local/testing/journal/ci-007.md` — live-testing cycle that discovered this finding (2026-08-24)

--- a/specs/020-freshness-cooldown-diagnostics-blind/spec.md
+++ b/specs/020-freshness-cooldown-diagnostics-blind/spec.md
@@ -1,0 +1,213 @@
+---
+aliases:
+  - Freshness cooldown blind in diagnostics
+tags:
+  - sdd
+  - spec
+  - bug
+  - deps-lsp
+  - deps-core
+  - freshness
+created: 2026-08-24
+status: draft
+related:
+  - "[[MOC-specs]]"
+---
+
+# Feature: Release-cooldown callout never reaches diagnostics for registries that gate freshness behind `get_versions_with`
+
+> [!info] Metadata
+> **Author**: Andrei G. (k05h31@gmail.com)
+> **Branch**: (none yet)
+> **Priority**: P1
+> **Discovered during**: ci-007 live testing of #316 (release-freshness diagnostics, cooldown callout, live config reload)
+
+## 1. Overview
+
+### Problem Statement
+
+#316 shipped a diagnostic-message differentiation
+(`crates/deps-core/src/lsp_helpers/diagnostics.rs` ~line 584-606): when an
+"outdated" dependency's replacement was published within the configured
+`freshness.cooldown_secs` window (default 3 days, mirroring Dependabot),
+the diagnostic message gets extra context —
+`"Newer version available: X (published Y — still within the release
+cooldown window)"` — instead of the plain message. The equivalent hover
+callout (`crates/deps-core/src/lsp_helpers/hover.rs` ~line 179) — "⏳
+**Recently published** — this release is still within the cooldown window."
+— was live-verified working correctly.
+
+Live-tested against real `registry.npmjs.org` data (2026-08-24): a
+`package.json` pinning `@aws-sdk/client-s3` to an outdated version, with the
+real latest (`3.1116.0`, published 2 days prior — inside the default 3-day
+cooldown) produces:
+- Hover: correctly shows the full cooldown callout.
+- `textDocument/publishDiagnostics` at the exact same moment, same document:
+  plain `"Newer version available: 3.1116.0"` — **no cooldown context at
+  all**, despite being well inside the cooldown window.
+
+Root cause, traced live via `RUST_LOG=debug` (only one HTTP request was
+logged — the abbreviated packument fetch — confirming no separate
+freshness-carrying fetch happened for this diagnostics run):
+
+1. `Registry` trait (`crates/deps-core/src/registry.rs` ~line 84-114) defines
+   two methods: `get_versions` (no freshness) and `get_versions_with`
+   (freshness-aware, defaults to forwarding to `get_versions` and ignoring
+   freshness — i.e. opt-in per registry). Five registries currently override
+   `get_versions_with` to provide real `Version::published_at` data via an
+   *extra* request: `deps-npm`, `deps-deno` (shared npm client + JSR),
+   `deps-maven`, `deps-nuget`, `deps-swift`.
+2. The trait doc comment is explicit about the footgun: *"Callers that render
+   publish ages MUST call this method rather than `get_versions`: the default
+   implementation ... simply forwards to `get_versions` and ignores
+   `freshness`, so a caller that keeps calling `get_versions` silently gets
+   no freshness signal even from a registry that implements this override."*
+3. `crates/deps-lsp/src/handlers/hover.rs` correctly calls the
+   freshness-aware path (comment there references `Registry::get_versions_with`
+   explicitly).
+4. `crates/deps-lsp/src/document/lifecycle.rs` (~line 721), which populates
+   the shared diagnostics cache (`PackageVersions`, including
+   `published_at`) for **all** dependencies in a document in one bulk pass,
+   calls the **plain** `registry.get_versions(&name)` — never
+   `get_versions_with`. This is the single code path diagnostics reads from
+   (`crates/deps-core/src/lsp_helpers/diagnostics.rs` ~line 589,
+   `package_versions.published_at`).
+5. Consequently, for every one of the five registries that implement
+   `get_versions_with`, `published_at` is always `None` in the diagnostics
+   cache, so the `is_within_cooldown(...)` branch (diagnostics.rs line 595)
+   can never be reached — the cooldown-differentiated diagnostic message is
+   effectively dead code in production for those five ecosystems, even
+   though its own unit tests (which construct `PackageVersions` directly,
+   bypassing the real fetch path) pass.
+
+This is not npm-specific: any of the five `get_versions_with`-implementing
+registries (npm, Deno's npm:/jsr: routing, Maven, NuGet, Swift) has the
+diagnostics half of #316 silently inert, while the hover half works.
+
+### Goal
+
+The diagnostics "Newer version available" cooldown-context message fires
+consistently for every registry that can supply `published_at`, matching
+hover's existing correct behavior — using the same underlying data, computed
+once per document open/change rather than diverging by handler.
+
+### Out of Scope
+
+- Changing the cooldown threshold, its config surface, or the live-reload
+  mechanism — all independently verified working this cycle (see journal).
+- Changing severity of the "outdated" diagnostic — #316 already establishes
+  message-only differentiation, severity is out of scope per its own design
+  (diagnostics.rs comment ~line 585-588).
+- The 10 registries with no `get_versions_with` override (e.g. Cargo, PyPI,
+  Go, Bundler, Composer, Gradle) are unaffected by this specific bug — they
+  either have no freshness source at all, or their `get_versions` already
+  carries publish dates in the same response with no extra opt-in call.
+
+## 2. User Stories
+
+### US-001: Cooldown-aware diagnostic message
+
+AS A developer with an outdated dependency whose replacement is a very
+recent release
+I WANT the inline diagnostic (not just hover-on-demand) to warn me it may
+still be within the cooldown/soak window
+SO THAT I don't act on a squiggle-driven quick-fix to jump to a
+just-published version without the same context hover already gives me.
+
+**Acceptance criteria:**
+```
+GIVEN an outdated npm/Maven/NuGet/Swift/Deno dependency whose latest version
+      was published within freshness.cooldown_secs of "now"
+WHEN textDocument/publishDiagnostics is computed
+THEN the "Newer version available" diagnostic message includes the
+     "— still within the release cooldown window" context, matching what
+     hover already shows for the same dependency at the same instant
+```
+
+### US-002: No behavior change for registries without extra freshness cost
+
+AS A maintainer of the 10 registries that don't override `get_versions_with`
+I WANT this fix to not add an unconditional extra network round trip to
+their diagnostics path
+SO THAT diagnostics latency for Cargo/PyPI/Go/etc. is unaffected.
+
+**Acceptance criteria:**
+```
+GIVEN a registry with no get_versions_with override (uses the trait default)
+WHEN diagnostics are computed
+THEN behavior and request count are unchanged from before this fix
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN `crates/deps-lsp/src/document/lifecycle.rs` populates the diagnostics cache and `freshness.enabled` is true, THE SYSTEM SHALL call `Registry::get_versions_with` (not the plain `get_versions`) so `published_at` is populated for registries that support it | must |
+| FR-002 | WHEN `freshness.enabled` is false, THE SYSTEM SHALL continue calling the plain `get_versions` (or pass a disabled `FreshnessSettings`), avoiding the extra request for registries that only pay the freshness cost on demand | must |
+| FR-003 | THE SYSTEM SHALL NOT change the request count or behavior for the 10 registries using the trait-default `get_versions_with` (which simply forwards to `get_versions`) | must |
+| FR-004 | THE SYSTEM SHALL keep hover and diagnostics reading `published_at` from the same underlying fetch per document lifecycle, avoiding a second divergent freshness fetch already performed once for the bulk pass | should |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Correctness | New integration-level test (mockito-mocked npm registry with a `time` fixture) asserting `generate_diagnostics_from_cache` produces the cooldown-context message when fed a cache populated via the real `lifecycle.rs` bulk-fetch path, not a hand-built `PackageVersions` | 
+| NFR-002 | Performance | For the 5 affected registries, the extra freshness request already happens today for hover on-demand — this fix moves it earlier (bulk pass) but SHALL NOT double it (i.e. hover must not re-fetch once the bulk pass already has fresh `published_at` for the same TTL window, respecting each registry's existing `publish_times` cache) |
+| NFR-003 | Consistency | Hover and diagnostics MUST agree on cooldown status for the same dependency at the same instant — add a live regression scenario per registry in `regressions.md` |
+
+## 5. Data Model
+
+No new types. Affects `crates/deps-lsp/src/document/lifecycle.rs`'s bulk
+fetch loop (~line 700-800, specifically line 721's `registry.get_versions(&name)`
+call) and its interaction with `crates/deps-core/src/registry.rs`'s
+`Registry::get_versions_with` trait method (~line 107) and the five
+overriding implementations (`deps-npm`, `deps-deno`, `deps-maven`,
+`deps-nuget`, `deps-swift`).
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| `freshness.enabled = false` | No behavior/request-count change — cooldown differentiation already suppressed per existing tests |
+| Registry with no `get_versions_with` override (10 of 15) | No behavior/request-count change |
+| Registry's extra freshness fetch fails/times out | Degrades to `published_at = None` per each registry's existing "never fails the caller" contract (e.g. `deps-npm`'s `fetch_publish_times` doc comment) — diagnostics falls back to the plain message, not an error |
+| Live config reload shrinks `cooldown_secs` mid-session (already verified working for hover) | Diagnostics refresh (`workspace/diagnostic/refresh`, already implemented in `server.rs`) must reflect the new threshold on next pull/push, consistent with hover |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Live diagnostics for `@aws-sdk/client-s3` outdated pin (real npm data, latest published 2 days ago, default 3-day cooldown) | Message includes "still within the release cooldown window" |
+| SC-002 | Live hover for the same dependency, same instant | Unchanged (already correct) — used as the cross-check oracle |
+| SC-003 | `cargo nextest run --workspace --all-features` | All pass, including new fixture-driven diagnostics test |
+| SC-004 | Live regression check for a Cargo (no-`get_versions_with`) dependency's diagnostics before/after | Byte-identical output |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Add the missing `get_versions_with` call in `lifecycle.rs`'s bulk fetch loop, gated on `freshness.enabled` per FR-002
+- Add unit/integration test(s) exercising the real bulk-fetch-to-diagnostics path (not just diagnostics.rs's existing hand-built-cache unit tests, which already pass and mask this gap)
+- Run `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo nextest run --workspace --all-features`
+- Live-verify against real `registry.npmjs.org` (`@aws-sdk/client-s3` or similarly fast-moving package) per the Registry Integration Gate — re-run the exact scenario from `.local/testing/regressions.md`
+
+### Ask First
+- Whether to also route Maven/NuGet/Swift/Deno through the same fix in one PR or split per-ecosystem — recommend one PR since the fix is entirely in the shared `deps-lsp`/`deps-core` layer, not per-registry
+
+### Never
+- Add an unconditional extra network round trip for registries without a `get_versions_with` override (FR-003)
+- Change diagnostic severity as part of this fix — message-only per #316's existing design
+
+## 9. Open Questions
+
+> [!question] Caching interaction
+> [NEEDS CLARIFICATION: `deps-npm`'s `publish_times` cache is keyed by package name with its own TTL and "top-8" invalidation predicate (`crates/deps-npm/src/registry.rs` ~line 217-256). Calling `get_versions_with` from the bulk diagnostics pass (all dependencies, not just the top-8 "recent versions" window) may retain a different `current_top8` set than hover's call did moments earlier for the same package, potentially causing one extra invalidation/refetch cycle. Confirm whether this is negligible (bounded, TTL'd, already handled by `publish_times_stale`) or needs adjustment as part of this fix.]
+
+## 10. See Also
+
+- [[MOC-specs]] — all specifications
+- [[019-npm-all-deprecated-unknown-package/spec|npm/JSR packages whose every published version is deprecated must not be reported "Unknown package"]] — same live-testing session, different root cause, same `deps-npm`/`lifecycle.rs` neighborhood
+- `crates/deps-core/src/registry.rs` — `Registry::get_versions_with` (~line 107)
+- `crates/deps-lsp/src/document/lifecycle.rs` — bulk fetch loop (~line 700-800)
+- `crates/deps-core/src/lsp_helpers/diagnostics.rs` — cooldown-context branch (~line 584-606)
+- `crates/deps-core/src/lsp_helpers/hover.rs` — working cooldown callout (~line 179), used as the correctness oracle
+- `.local/testing/journal/ci-007.md` — live-testing cycle that discovered this finding (2026-08-24)

--- a/specs/021-maven-wildcard-latest-ignores-prerelease/spec.md
+++ b/specs/021-maven-wildcard-latest-ignores-prerelease/spec.md
@@ -1,0 +1,210 @@
+---
+aliases:
+  - Maven wildcard latest ignores prerelease
+tags:
+  - sdd
+  - spec
+  - bug
+  - deps-maven
+  - deps-gradle
+  - prerelease
+created: 2026-08-24
+status: draft
+related:
+  - "[[MOC-specs]]"
+---
+
+# Feature: Maven/Gradle "Newer version available" diagnostic and quick-fix must not recommend a prerelease when a stable release is newer
+
+> [!info] Metadata
+> **Author**: Andrei G. (k05h31@gmail.com)
+> **Branch**: (none yet)
+> **Priority**: P1
+> **Discovered during**: ci-007 live spot-check of #326/#330 (prerelease detection and version-comparison correctness) — Maven was not in scope of those two PRs, but this cycle's cross-ecosystem consistency check surfaced a live, independent prerelease-handling gap in the same problem space
+
+## 1. Overview
+
+### Problem Statement
+
+Live-tested against real Maven Central data (2026-08-24): `org.hibernate:hibernate-core`
+pinned to `6.0.0.Final`, where Maven Central's `maven-metadata.xml`
+currently has `<latest>8.0.0.Beta1</latest>` / `<release>8.0.0.Beta1</release>`
+(the most recently *deployed* artifact is a Beta), while the newest *stable*
+release is `7.4.6.Final`.
+
+- Hover correctly shows `**Latest**: 7.4.6.Final` — `NpmRegistry`... (n/a,
+  Maven) `get_latest_matching_typed`'s prerelease-skipping scan
+  (`crates/deps-maven/src/registry.rs` ~line 174, `.position(|v|
+  !crate::version::is_prerelease(&v.version))`) is used here and works
+  correctly.
+- `textDocument/publishDiagnostics` for the same dependency, same instant,
+  reports `"Newer version available: 8.0.0.Beta1"` — a **prerelease**, and
+  the driving diagnostic for the quick-fix code action.
+- The quick-fix code action's top suggestion is `8.0.0.Beta1 (latest)`, with
+  `8.0.0.Alpha1` as the *second* alternative — i.e. the two prerelease
+  qualifiers are offered ahead of the actual newest stable release
+  (`7.4.6.Final`, offered third).
+
+Root cause: `crates/deps-maven/src/registry.rs`'s
+`Registry::select_latest_matching` (~line 828-844), used by
+`crates/deps-lsp/src/document/lifecycle.rs`'s wildcard (`"*"`) bulk
+cache-population pass (the same code path diagnostics reads from), has a
+fast path for the wildcard case:
+
+```rust
+if req_str.is_empty() || req_str == "*" {
+    return if versions.is_empty() { None } else { Some(0) };
+}
+```
+
+This trusts that index 0 — which `get_versions`'s
+`move_release_to_front` placed there from `maven-metadata.xml`'s `<release>`
+tag — is "the" authoritative latest, with a code comment asserting this
+keeps it "in agreement with `get_latest_matching_typed`'s `<release>`-preferring
+pick". That assertion is **false** whenever the most recently deployed
+artifact happens to be a prerelease: Maven Central's `<release>`/`<latest>`
+tags carry no prerelease semantics at all (unlike npm's maintainer-curated
+`dist-tags.latest`) — they simply track the most recently *deployed*
+version, prerelease or not. `get_latest_matching_typed` (hover's path)
+explicitly re-scans past prereleases with `is_prerelease`; the wildcard fast
+path does not, and disagrees with it whenever the front-of-list entry is a
+prerelease.
+
+`is_prerelease` itself (`crates/deps-maven/src/version.rs`) correctly
+classifies both `8.0.0.Beta1` and `8.0.0.Alpha1` as prereleases (dot- and
+dash-separated qualifiers both handled per its `split_version` docs) — the
+gap is entirely in `select_latest_matching`'s wildcard shortcut skipping that
+classification.
+
+Per the code's own comment, `crates/deps-gradle`'s registry is the same
+`MavenCentralRegistry` type (#233), so Gradle inherits this bug identically
+— not independently re-verified live this cycle due to budget, flagged for
+next cycle.
+
+### Goal
+
+Maven/Gradle's "Newer version available" diagnostic and its quick-fix code
+action must agree with hover: never recommend a prerelease version as "the"
+latest when a newer-or-equal stable release exists, using the same
+`is_prerelease`-aware selection hover already uses correctly.
+
+### Out of Scope
+
+- Changing `is_prerelease`'s classification rules themselves — verified
+  correct for the qualifiers exercised this cycle (`Beta1`, `Alpha1`).
+- The `#326`/`#330` prerelease-detection fixes' actual ecosystems (pypi,
+  cargo, dart, swift, npm, deno, bundler, composer) — Maven/Gradle were never
+  in scope of those PRs; this is a pre-existing, independently-discovered gap
+  in a neighboring code path.
+- Non-wildcard (exact requirement / range) matching — unaffected; only the
+  `"*"` fast path skips the prerelease filter.
+- Offering prereleases as an *explicit, opt-in* alternative in the quick-fix
+  list — reasonable UX, but the *default*/top-ranked suggestion and the
+  diagnostic's headline version must be the stable pick per FR-002; ordering
+  of prerelease alternatives further down the list is a secondary concern
+  (see Open Questions).
+
+## 2. User Stories
+
+### US-001: Diagnostic recommends the stable latest, not a prerelease
+
+AS A Java/Kotlin developer with an outdated Maven/Gradle dependency
+I WANT the "Newer version available" diagnostic to name the newest *stable*
+release
+SO THAT I'm not nudged toward installing an Alpha/Beta/RC/Milestone/SNAPSHOT
+build I never asked for, inconsistent with what hover already tells me.
+
+**Acceptance criteria:**
+```
+GIVEN a Maven/Gradle dependency where the registry's most recently deployed
+      artifact is a prerelease (Alpha/Beta/RC/M/SNAPSHOT) but a newer-than-
+      the-pinned-version stable release also exists
+WHEN textDocument/publishDiagnostics computes "Newer version available"
+THEN the named version is the newest STABLE release, matching hover's
+     **Latest** field for the same dependency
+```
+
+### US-002: Quick-fix default suggestion is the stable latest
+
+AS A developer invoking the quick-fix code action on an outdated Maven/Gradle dependency
+I WANT the top/"(latest)"-labeled suggestion to be the stable release
+SO THAT accepting the default quick-fix never silently pins me to a prerelease.
+
+**Acceptance criteria:**
+```
+GIVEN the same scenario as US-001
+WHEN the quick-fix code action is requested
+THEN the entry labeled "(latest)" is the newest stable release
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN `Registry::select_latest_matching` is called with a wildcard (`"*"`) requirement, THE SYSTEM SHALL return the newest version for which `is_prerelease` is false, if one exists in the list | must |
+| FR-002 | WHEN every version in the list is a prerelease (no stable release exists at all), THE SYSTEM SHALL fall back to the newest version regardless of prerelease status, matching `get_latest_matching_typed`'s existing fallback behavior | must |
+| FR-003 | THE SYSTEM SHALL keep this resolution free of extra I/O (no second registry round trip) — the fix operates on the already-fetched, already-front-loaded `versions` slice, same as today | must |
+| FR-004 | THE SYSTEM SHALL produce results identical to `get_latest_matching_typed`'s existing prerelease-skipping scan for the same input list, so hover and diagnostics/quick-fix never disagree again | must |
+| FR-005 | THE SYSTEM SHALL apply the same fix to Gradle, since `deps-gradle` shares the identical `MavenCentralRegistry` implementation (#233) | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Correctness | New unit test in `crates/deps-maven/src/registry.rs` for `select_latest_matching` under `"*"` with a fixture where index 0 (front-loaded `<release>`) is a prerelease and a stable release exists later in the list |
+| NFR-002 | Consistency | Add a test asserting `select_latest_matching("*")` and `get_latest_matching_typed`'s scan agree on the same fixture |
+| NFR-003 | Backward compatibility | Existing behavior (front-of-list stable release picked directly, no scan needed) unchanged when index 0 is already stable — the common case, verified via existing tests |
+
+## 5. Data Model
+
+No new types. Affects `crates/deps-maven/src/registry.rs`'s
+`Registry::select_latest_matching` (~line 828-844) only; reuses the existing
+`crate::version::is_prerelease` predicate already relied on by
+`get_latest_matching_typed` (~line 174, ~line 210).
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Front-of-list version is already stable (common case) | Unchanged — `Some(0)` still returned directly, no scan overhead |
+| All versions are prereleases (brand-new artifact with no stable release yet) | Falls back to newest prerelease (FR-002), matching current `get_latest_matching_typed` fallback |
+| Empty version list | Unchanged: `None` |
+| Gradle (`build.gradle`/`build.gradle.kts`, `libs.versions.toml`) dependency on the same artifact | Same fix applies automatically via the shared `MavenCentralRegistry` type — no Gradle-specific code path |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Live diagnostics for `org.hibernate:hibernate-core` pinned to `6.0.0.Final` (real Maven Central data) | "Newer version available" names the newest stable release (`7.4.6.Final` at time of writing), not `8.0.0.Beta1` |
+| SC-002 | Live quick-fix code action for the same dependency | Entry labeled "(latest)" is the newest stable release |
+| SC-003 | Live hover for the same dependency, same instant | Unchanged (already correct) — used as the cross-check oracle |
+| SC-004 | `cargo nextest run -p deps-maven -p deps-gradle` | All pass, including new fixture-based tests |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Fix `select_latest_matching`'s wildcard branch to scan for the newest non-prerelease entry, falling back to index 0 only if none exists
+- Add unit tests per NFR-001/NFR-002
+- Run `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo nextest run -p deps-maven -p deps-gradle --all-features`
+- Live-verify against real Maven Central using a package whose `<release>` currently points at a prerelease (re-check `hibernate-core`'s current metadata, since the concrete versions will have moved on by fix time — pick whatever real artifact currently exhibits the pattern)
+
+### Ask First
+- Whether to also reorder the quick-fix alternatives list so prereleases sort after all stable releases (currently `8.0.0.Alpha1` ranks second, ahead of `7.4.6.Final`) — US-002/FR-001 only requires the *default* "(latest)" pick to be stable; full list reordering is a related but separable UX call (see Open Questions)
+
+### Never
+- Change `is_prerelease`'s qualifier-classification rules as part of this fix — already correct, out of scope
+- Add a second registry round trip to resolve this — must stay a pure in-memory scan (FR-003)
+
+## 9. Open Questions
+
+> [!question] Alternatives list ordering
+> [NEEDS CLARIFICATION: Should the quick-fix code action's full alternatives list (beyond the top "(latest)" pick) also demote prereleases below all stable releases, or is raw-version-descending order (current behavior) acceptable for the non-default alternatives? Live-observed order today: `8.0.0.Beta1 (latest)`, `8.0.0.Alpha1`, `7.4.6.Final`, `7.4.5.Final`, `7.4.4.Final`. Recommend demoting for consistency with FR-004's "never disagree with hover" principle, but confirm scope/cost before implementing — this may require the same fix applied to the alternatives-list builder, not just `select_latest_matching`.]
+
+## 10. See Also
+
+- [[MOC-specs]] — all specifications
+- [[019-npm-all-deprecated-unknown-package/spec|npm/JSR packages whose every published version is deprecated must not be reported "Unknown package"]] — same class of bug: a wildcard fast-path disagreeing with the real recommendation-path filter, different ecosystem and different filter (deprecated vs prerelease)
+- `crates/deps-maven/src/registry.rs` — `select_latest_matching` (~line 828), `get_latest_matching_typed` (~line 174)
+- `crates/deps-maven/src/version.rs` — `is_prerelease` (~line 13)
+- `crates/deps-gradle` — shares `MavenCentralRegistry` (#233), same fix applies
+- `.local/testing/journal/ci-007.md` — live-testing cycle that discovered this finding (2026-08-24)

--- a/specs/022-pypi-package-completion-broken/spec.md
+++ b/specs/022-pypi-package-completion-broken/spec.md
@@ -1,0 +1,271 @@
+---
+aliases:
+  - PyPI Package Completion Broken
+  - pyproject.toml Completion Zero Results
+tags:
+  - sdd
+  - spec
+  - bug
+  - completion
+  - deps-pypi
+  - pyproject-toml
+created: 2026-08-24
+status: draft
+related:
+  - "[[MOC-specs]]"
+---
+
+# Feature: PyPI Package-Name Completion Never Returns Results for Any Valid pyproject.toml Shape
+
+> [!info] Metadata
+> **Author**: Andrei G. (k05h31@gmail.com)
+> **Branch**: (none yet)
+> **Priority**: P1
+> **Type**: bug
+> **Discovered during**: ci-011 live-testing cycle, `.local/testing/lsp_test.py` completion mode against the debug binary at commit `20b6ff66` (v0.10.1, HEAD of `main`)
+
+## 1. Overview
+
+### Problem Statement
+
+PyPI (`deps-pypi`) package-name completion (`textDocument/completion` while typing
+a new dependency name in `pyproject.toml`) is completely non-functional for every
+real-world `pyproject.toml` layout. This is a compound bug with two independent,
+additive root causes in `crates/deps-lsp/src/handlers/completion.rs`.
+
+**Root cause 1 — [[#FR-001|is_in_dependencies_section]] never recognizes PEP 621's actual `dependencies` array syntax.**
+
+`is_in_toml_dependencies` (`crates/deps-lsp/src/handlers/completion.rs:381`, used for
+both `EcosystemId::Cargo` and `EcosystemId::Pypi` via the match arm at line 333) walks
+backward from the cursor line looking for a TOML section-header line that exactly
+equals one of a fixed set of strings, including `"[project.dependencies]"`. But PEP
+621 defines `project.dependencies` as an **array-of-strings key** under the
+`[project]` table (`dependencies = [...]`), not as its own TOML subtable — writing
+`[project.dependencies]` as a literal header is not how any real `pyproject.toml`
+(including this very project's own `.local/testing/manifests/pyproject.toml` fixture,
+and every tool-generated one: Poetry, Hatch, setuptools, uv, PDM) expresses it.
+Because of this, the raw-text fallback completion path (`fallback_completion`,
+`crates/deps-lsp/src/handlers/completion.rs:157`) can never trigger for the primary
+`dependencies = [...]` array — the one virtually every `pyproject.toml` has — because
+`is_in_dependencies_section` unconditionally returns `false` there.
+
+`[project.optional-dependencies]` *is* a real, valid TOML subtable header (it's a
+table of arrays, one array per named extra group), so it IS recognized — but see root
+cause 2 for why even that path still returns 0 results.
+
+**Root cause 2 — `extract_prefix` never strips the TOML quote character for PyPI, only for JSON-quoted-key ecosystems.**
+
+`extract_prefix` (`crates/deps-lsp/src/handlers/completion.rs:225`) only trims a
+leading/trailing `"` when `uses_json_quoted_keys(ecosystem_kind)` is `true` (npm's/
+Composer's `"key": ...` JSON object-key shape). PyPI's `dependencies`/
+`optional-dependencies` entries are TOML array *elements*
+(`"requests>=2.31.0"`), a different quoting shape that `uses_json_quoted_keys` does
+not cover and `uses_xml_tag_values` does not cover either. So even in the one section
+where root cause 1 doesn't block the fallback path
+(`[project.optional-dependencies]` groups), the extracted prefix keeps its literal
+leading `"` character (e.g. typing `"pytes` yields prefix `"\"pyte"`, confirmed via
+log line `fallback_completion: prefix = "\"pyte"`), which is then passed straight to
+`search_packages`/the registry query. No real PyPI package name starts with a literal
+`"`, so the search always returns 0 results (confirmed via log line
+`search_packages: query="\"pyte", ecosystem=pypi` → `search_packages: found 0
+results`) — the historical #148-class "quote-leak" defect (see
+[[006-completion-prefix-quote-stripping/spec|Strip JSON string-delimiter quote from
+fallback completion prefix]] for the npm/Composer sibling fix), but for TOML rather
+than JSON, and specific to PyPI's array-of-strings dependency shape (Cargo's own
+dependency completion types a bare/quoted TOML *key*, `foo = "1.0"`, a different code
+shape that doesn't hit this same leak).
+
+Net effect: **every** completion attempt anywhere in a `pyproject.toml` — in the
+primary `dependencies` array (root cause 1 blocks it entirely) or in an
+`optional-dependencies` group (root cause 2 empties the query) — returns zero
+package-name suggestions.
+
+Version completion for PyPI is NOT affected (independently live-verified working
+correctly, 5 results with real PyPI data, in the same session) — this bug is specific
+to package-*name* completion.
+
+### Goal
+
+Typing a partial package name anywhere inside a `pyproject.toml`
+`dependencies = [...]` array (top-level `[project]` table) or an
+`[project.optional-dependencies]` group's array must offer real, registry-backed
+PyPI package-name completions — matching the working behavior already verified live
+this session for Cargo, npm, Dart, Swift, Maven, Gradle, Composer, NuGet, and Deno
+(all of which return real registry-backed completion items for an equivalent
+partial-name scenario).
+
+### Out of Scope
+
+- Version completion for PyPI (already working, independently verified).
+- Ecosystem-native (parsed, non-fallback) completion path
+  (`ecosystem.generate_completions`) internals for PyPI, beyond confirming it also
+  returns empty for these scenarios (already observed — the fix targets the fallback
+  path, which is the one meant to cover "still typing" states).
+- `requirements.txt` completion (separate manifest format, see
+  [[009-pypi-requirements-txt/spec|Support requirements.txt (pip family) in deps-pypi]]
+  if that ecosystem's completion needs the same shape of fix).
+- Poetry's legacy `[tool.poetry.dependencies]` table shape (`requests = "^2.31.0"`,
+  key-value not array-of-strings) — not confirmed live this cycle; flagged as an open
+  question (Open Questions) since it may need a *third* code path rather than fitting
+  cleanly into either fix below.
+- Cargo's TOML dependency completion — already working correctly today, not touched
+  by this fix; confirmed to use a different code shape (bare/quoted key, not array
+  element) that does not share PyPI's quote-leak defect.
+
+## 2. User Stories
+
+### US-001: Package-name completion inside the primary `dependencies` array
+
+AS A Python developer editing `pyproject.toml`
+I WANT completion suggestions for real PyPI package names while typing inside the
+top-level `dependencies = [...]` array
+SO THAT I can add a new dependency without leaving the editor to look up the exact
+package name.
+
+**Acceptance criteria:**
+```
+GIVEN a pyproject.toml with
+  [project]
+  name = "myapp"
+  version = "0.1.0"
+  dependencies = [
+      "requests>=2.31.0",
+      "flas
+  ]
+WHEN textDocument/completion is requested with the cursor immediately after "flas"
+THEN the response contains real PyPI package-name completion items whose names start
+     with "flas" (e.g. "flask")
+```
+
+### US-002: Package-name completion inside an `optional-dependencies` group
+
+AS A Python developer editing `pyproject.toml`
+I WANT completion suggestions for real PyPI package names while typing inside an
+`[project.optional-dependencies]` group's array (e.g. `dev = [...]`)
+SO THAT optional/extra dependency groups get the same completion support as the
+primary dependencies array.
+
+**Acceptance criteria:**
+```
+GIVEN a pyproject.toml with
+  [project.optional-dependencies]
+  dev = [
+      "pytes
+  ]
+WHEN textDocument/completion is requested with the cursor immediately after "pytes"
+THEN the response contains real PyPI package-name completion items whose names start
+     with "pytes" (e.g. "pytest"), not zero results, and the query sent to the
+     registry does not contain a leading '"' character
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN the cursor is on a line inside a `[project]` table's `dependencies = [...]` array (PEP 621 primary dependency list), THE SYSTEM SHALL recognize this as a dependencies section in `is_in_dependencies_section`/`is_in_toml_dependencies`, distinct from a literal `[project.dependencies]` header which does not occur in valid PEP 621 files | must |
+| FR-002 | WHEN the cursor is on a line inside an `[project.optional-dependencies]` group's array, THE SYSTEM SHALL continue to recognize this as a dependencies section (already correct — regression guard only) | must |
+| FR-003 | WHEN `extract_prefix` is called for `EcosystemId::Pypi` on a TOML array-element line (e.g. `"pytes`), THE SYSTEM SHALL strip the leading (and, if present, trailing) `"` from the extracted prefix, the same way it already strips leading/trailing `"` for JSON-quoted-key ecosystems | must |
+| FR-004 | WHEN both FR-001/FR-002 and FR-003 hold, THE SYSTEM SHALL pass a quote-free prefix (e.g. `flas`, not `"flas` or `"\"fla"`) to `search_packages` for the PyPI registry | must |
+| FR-005 | THE SYSTEM SHALL NOT regress existing dependency-section detection or prefix extraction for `EcosystemId::Cargo`, which shares `is_in_toml_dependencies` with PyPI but has no array-of-strings dependency shape and must remain on its current (working) code path | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Correctness | Unit tests for `is_in_toml_dependencies`/`is_in_dependencies_section` covering a `dependencies = [...]` array directly under `[project]` (no literal `[project.dependencies]` header present anywhere in the fixture) |
+| NFR-002 | Correctness | Unit tests for `extract_prefix` with `EcosystemId::Pypi` on a still-typing TOML array-element line (`"flas`, unterminated) and a completed one (`"flask"`, cursor mid-token), asserting no leading/trailing `"` survives |
+| NFR-003 | Regression safety | Existing `is_in_toml_dependencies`/`extract_prefix` tests for `EcosystemId::Cargo` continue to pass unmodified |
+| NFR-004 | Live verification | Per project convention (`.claude/rules/continuous-improvement.md`), re-run `.local/testing/lsp_test.py` completion mode against the fixed debug binary for all three reproduction scenarios in this spec and confirm non-zero, real-registry results before closing |
+
+## 5. Data Model
+
+No new types. Affects `crates/deps-lsp/src/handlers/completion.rs` only:
+
+| Function | Change |
+|----------|--------|
+| `is_in_toml_dependencies` (~line 381) | Recognize the `dependencies = [...]` array under `[project]` (and, per Open Questions, possibly `[tool.poetry.dependencies]`) in addition to the existing literal-header matches |
+| `is_in_dependencies_section` (~line 327) | No signature change; may need PyPI split out of the shared `Cargo | Pypi` match arm if the array-detection logic diverges enough from Cargo's needs (see FR-005) |
+| `extract_prefix` (~line 225) | Extend the quote-stripping condition to also cover PyPI's TOML array-element shape, without affecting Cargo |
+| `uses_json_quoted_keys` (~line 305) | Likely NOT the right mechanism to extend, since it's documented as JSON-object-key-specific; a new PyPI-specific (or TOML-array-element-specific) predicate is more likely correct — implementation detail for `/sdd plan` |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Cursor inside `dependencies = [...]` array, entry unterminated (user mid-typing, e.g. `"flas`) | Recognized as dependencies section (FR-001), prefix extracted quote-free (FR-003), real completions returned |
+| Cursor inside `dependencies = [...]` array, entry already closed (e.g. `"flask"`, cursor between quotes) | Same as above — both the primary parsed path and the fallback path must agree this is a dependencies context |
+| Cursor inside `[project.optional-dependencies]` group's array | Recognized (FR-002, already working), prefix extracted quote-free (FR-003) — currently broken only by root cause 2 |
+| Cursor inside `[tool.poetry.dependencies]` (legacy Poetry table syntax, key-value not array) | Not confirmed live this cycle — see Open Questions; must not be silently broken by the FR-001 fix, but may remain a known gap if out of scope |
+| Cursor on a line inside `dependencies = [...]` that is NOT a string literal (e.g. blank line inside the array, or the closing `]`) | Existing prefix-rejection logic (`prefix.is_empty() || ... < 2 chars`) already filters this out — no new handling needed |
+| Cursor inside a `[build-system] requires = [...]` array (also array-of-strings, but not a "dependency" the user manages day-to-day the same way) | Out of scope per Goal (user-managed dependencies only) — confirm in `/sdd plan` whether build-system requirements should also get completion, but not required for this fix |
+| Cargo.toml with a `[dependencies]` table (Cargo's actual, correct syntax) | Unaffected — FR-005 regression guard |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Live completion request for reproduction scenario 1 (unterminated `"flas` inside top-level `dependencies` array) | Non-zero PyPI package-name completion items returned, matching prefix `flas` |
+| SC-002 | Live completion request for reproduction scenario 2 (closed `"flas"` entry, same array) | Non-zero PyPI package-name completion items returned |
+| SC-003 | Live completion request for reproduction scenario 3 (`"pytes` inside `[project.optional-dependencies]` `dev` group) | Non-zero PyPI package-name completion items returned; debug log shows `search_packages: query="pytes"` with no leading `"` |
+| SC-004 | `cargo nextest run -p deps-lsp` | All pass, including new fixture-based tests from NFR-001/NFR-002 |
+| SC-005 | Cargo.toml completion regression check (`.local/testing/manifests/Cargo.toml` or equivalent fixture) | Unchanged behavior — still returns correct completions, confirming FR-005 |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Fix `is_in_toml_dependencies`/`is_in_dependencies_section` to recognize PEP 621's
+  `dependencies = [...]` array shape for PyPI
+- Fix `extract_prefix` to strip the leading/trailing `"` for PyPI's TOML
+  array-element shape
+- Add unit tests per NFR-001/NFR-002
+- Run `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo nextest run -p deps-lsp --all-features`
+- Live-verify all three reproduction scenarios per NFR-004 before marking the fix
+  complete, using `.local/testing/lsp_test.py` completion mode against a freshly
+  built debug binary
+- Confirm Cargo completion is unaffected by re-running its existing passing tests
+  and a live spot-check (FR-005/SC-005)
+
+### Ask First
+- Whether to also handle `[tool.poetry.dependencies]` (legacy Poetry key-value
+  syntax) in the same fix or file it as a separate follow-up issue (see Open
+  Questions) — it is a materially different TOML shape (table of key-value pairs,
+  not an array) and may need its own detection branch
+- Whether `[build-system] requires = [...]` should get the same completion treatment
+  — out of scope per Goal, but the array-detection logic this fix adds may make it a
+  near-zero-cost addition worth a quick decision
+
+### Never
+- Modify Cargo's dependency-section detection or prefix extraction in a way that
+  changes its current (correct) behavior
+- Introduce a second registry round trip or otherwise change completion latency
+  characteristics — this is a pure text-detection/string-extraction fix
+- Touch PyPI's version-completion path — confirmed already working, out of scope
+
+## 9. Open Questions
+
+> [!question] Poetry legacy syntax
+> [NEEDS CLARIFICATION: Should `[tool.poetry.dependencies]` (Poetry's pre-PEP-621
+> key-value table syntax, e.g. `requests = "^2.31.0"`) get the same completion fix in
+> this same PR, or is it a separate follow-up? It wasn't part of the live-reproduced
+> evidence this cycle (only PEP 621 `[project.dependencies]`/
+> `[project.optional-dependencies]` were tested), and it's a structurally different
+> TOML shape (table, not array) that may need a distinct detection branch rather than
+> reusing FR-001's array-detection logic. Recommend scoping it in during `/sdd plan`
+> if low-cost, otherwise filing a separate P2/P3 follow-up issue.]
+
+> [!question] `[project.dependencies]` literal-header dead code
+> [NEEDS CLARIFICATION: Once FR-001 adds real `dependencies = [...]` array detection,
+> should the now-confirmed-dead `line == "[project.dependencies]"` literal-header
+> match in `is_in_toml_dependencies` be removed as cleanup, or left in place as
+> harmless defensive code in case some non-standard tool ever emits it? Recommend
+> removing it during `/sdd plan`/implementation to avoid misleading future readers
+> into thinking it's the reason PEP 621 completion works.]
+
+## 10. See Also
+
+- [[MOC-specs]] — all specifications
+- [[006-completion-prefix-quote-stripping/spec|Strip JSON string-delimiter quote from fallback completion prefix]] — the npm/Composer sibling of root cause 2, same class of defect (#148-class quote-leak) in a different quoting shape
+- [[009-pypi-requirements-txt/spec|Support requirements.txt (pip family) in deps-pypi]] — related PyPI manifest-format work, separate file format from pyproject.toml
+- `crates/deps-lsp/src/handlers/completion.rs` — `is_in_dependencies_section` (~line 327), `is_in_toml_dependencies` (~line 381), `fallback_completion` (~line 157), `extract_prefix` (~line 225), `uses_json_quoted_keys` (~line 305)
+- `.local/testing/manifests/pyproject.toml` — existing project fixture that itself demonstrates the bug (uses `dependencies = [...]`, never `[project.dependencies]`)
+- `.local/testing/journal/ci-011.md` — live-testing cycle that discovered this finding (2026-08-24)

--- a/specs/023-cargo-custom-registries/plan.md
+++ b/specs/023-cargo-custom-registries/plan.md
@@ -1,0 +1,338 @@
+---
+aliases:
+  - Cargo Custom Registries plan
+tags:
+  - sdd
+  - plan
+  - enhancement
+  - security
+  - cargo
+created: 2026-09-01
+status: shipped
+related:
+  - "[[spec]]"
+  - "[[constitution]]"
+---
+
+# Technical Plan: Cargo Custom/Private Registry & Source-Replacement Resolution
+
+> [!info] References
+> **Spec**: [[spec]]
+> **Priority**: P4 — plan produced per this project's SDD-integration
+> threshold despite P4, given the multi-round architecture work already
+> invested (two architect rounds, two adversarial critic reviews) and the
+> security-blocking nature of the credential-handling design (C2/R3)
+
+> [!important] Sequencing — binding, adopted from both architect and critic
+> Phase 1 splits into two sequential PRs against this one spec:
+>
+> - **1a = custom/private registries + routing + `$CARGO_HOME`-only auth.**
+>   Delivers the issue's core private-registry use case standalone
+>   (spec FR-001 through FR-004, FR-008-FR-012, FR-014-FR-016).
+> - **1b = `[source]` replace-with.** Forces config memoization (spec
+>   NFR-005) and `[source]` cycle detection (spec FR-005-FR-007) —
+>   deliberately kept out of 1a so 1a stays materially simpler and lands
+>   first.
+>
+> Do not merge 1a and 1b into one PR. Do not start 1b implementation until
+> 1a is merged and its full check suite is green.
+
+## 1. Architecture
+
+### Approach
+
+Resolve registry identity as far upstream as possible — at parse time, on
+the dependency's own `source()` — so the rest of the pipeline (fetch,
+cache, hover, diagnostics, completion) needs no new per-document plumbing.
+`CargoParser` gains `.cargo/config.toml` discovery (piggybacked on the
+existing `find_workspace_root` ancestor walk, `crates/deps-cargo/src/
+parser.rs:357`) and rewrites `DependencySource::CustomRegistry { url:
+"my-corp" }` into a resolved `DependencySource::AlternateRegistry { index:
+"https://..." }` when it can. Everything downstream — the new
+`CargoRegistry` router, the `EcosystemFormatter::can_resolve_source` gate,
+completion's context join — reads the source that already rides on the
+dependency.
+
+This was the central architectural bet from the first design round and it
+survived critique intact; what changed across the two critic rounds was
+**which network paths actually see that source** (C1/R1: all five
+`Registry` network methods, not just `get_versions`) and **how the auth
+boundary is enforced** (C2/R3: resolved into `Option<AuthToken>` at
+config-load time, not a runtime `Provenance` branch).
+
+### Component Diagram
+
+```mermaid
+graph TD
+    CT["Cargo.toml"] -->|parse| P[CargoParser]
+    CC[".cargo/config.toml hierarchy<br/>+ $CARGO_HOME/config.toml"] -->|discover, resolve| P
+    P -->|"AlternateRegistry index (resolved)<br/>or CustomRegistry alias (unresolved)"| DEP[Dependency]
+
+    DEP --> HOV["hover.rs:71,187"]
+    DEP --> CA["code_actions.rs:414"]
+    DEP --> LC["lifecycle.rs:665,760<br/>fetch_latest_versions_parallel"]
+    DEP --> COMP["ecosystem.rs:148<br/>generate_completions"]
+
+    HOV --> REG[CargoRegistry]
+    CA --> REG
+    LC --> REG
+    COMP --> REG
+
+    REG -->|"Registry / CustomRegistry(unresolved)"| CIO[CratesIoRegistry]
+    REG -->|"AlternateRegistry index"| ALT["alternates: DashMap RegistryIndex to Arc SparseIndexClient"]
+
+    CIO --> HC[HttpCache]
+    ALT -->|"unauthenticated (workspace-declared)"| HC
+    ALT -->|"authenticated, origin-pinned<br/>(CargoHome-declared only)"| HC2["get_cached_trusted_origin_with_headers"]
+
+    FMT[CargoFormatter] -->|"can_resolve_source(source)"| DIAG["generate_diagnostics_from_cache<br/>generate_hover<br/>build_unsatisfiable_fix_action"]
+```
+
+### Key Design Decisions
+
+| Decision | Choice | Rationale | Alternatives Considered |
+|----------|--------|-----------|--------------------------|
+| Where to resolve registry identity | Parse time, on `DependencySource` | Nothing downstream needs new per-document state; the source already rides on the dependency into every consumer | Resolve in the registry (needs per-document state injected into a shared `Arc<dyn Registry>`); resolve in deps-lsp lifecycle (leaks Cargo config knowledge into the generic layer) |
+| Routing contract shape | Two new defaulted `Registry` methods (`get_versions_from`, `get_latest_matching_from`) | Covers all five network-performing trait methods exhaustively (per R1); defaulted so every other ecosystem is bit-identical | A generalized `FetchContext` struct subsuming `get_versions_with` + issue #424's `minimum_stability` — rejected as a larger refactor of a shipped API for no v1 benefit |
+| Resolvability gate location | `EcosystemFormatter::can_resolve_source`, not `Registry` | Zero `pub` signature churn — the formatter is already a parameter of the three affected functions and already carries this class of gate | `Registry`-level hook (rejected — ripples to 6+ unrelated call sites and injects a registry handle into the deliberately registry-free `generate_diagnostics_from_cache`) |
+| Auth trust boundary | `auth: Option<AuthToken>` resolved at config-load time, populated only for `$CARGO_HOME`-declared entries | Structural gate — no downstream API surface can obtain a token for a workspace-declared registry | Runtime `Provenance` check at the token-lookup call site (rejected — identified as forgeable during the final critic re-verification) |
+| `replace-with` fallback | Only `sparse+https://` reroutes; `directory`/`local-registry`/non-sparse git-index keep resolving against crates.io | Cargo verifies per-version checksums, not full content-set equivalence, for replacements — crates.io's answers remain correct for a mirror; going dark is strictly worse than today | Going dark for all non-sparse replacements — rejected, takes a working vendored workspace dark |
+| `.cargo/config.toml` staleness | Document as a known limitation (spec FR-013, option b) | The existing watched-file dispatch (`did_change_watched_files`) routes every event through a lockfile-name lookup that drops anything else; building a parallel dispatch branch + reparse-scope computation is a second new subsystem for a P4 issue | Dedicated watcher branch (option a) — valid future upgrade, not required for 1a/1b |
+| New `DependencySource` variant vs. reusing `CustomRegistry` | New `AlternateRegistry { index }` variant | Makes "resolved" a type-level state; avoids string-sniffing (`starts_with("http")`) to distinguish alias-vs-URL, which is fragile | Overload `CustomRegistry.url` to sometimes hold a resolved URL — rejected, ambiguous failure mode |
+
+## 2. Project Structure
+
+```
+crates/deps-cargo/
+├── src/
+│   ├── config.rs           # NEW (1a): .cargo/config.toml discovery + resolution
+│   │                        #   CargoConfig, ResolvedRegistryEntry, Provenance, RegistryIndex
+│   ├── sparse.rs            # NEW (1a): SparseIndexClient extracted from registry.rs
+│   ├── registry.rs          # MODIFIED (1a): CargoRegistry router replaces
+│   │                        #   CratesIoRegistry as CargoEcosystem::registry()'s value;
+│   │                        #   CratesIoRegistry narrowed to a SparseIndexClient wrapper
+│   ├── formatter.rs          # MODIFIED (1a): can_resolve_source override; hover
+│   │                        #   link suppression for non-crates.io sources (FR-014)
+│   ├── parser.rs             # MODIFIED (1a): alias resolution into AlternateRegistry;
+│   │                        #   (1b) [source] replace-with two-stage resolution
+│   ├── ecosystem.rs           # MODIFIED (1a): generate_completions joins
+│   │                        #   CompletionContext::Version/Feature back to
+│   │                        #   parse_result.dependencies() for source-aware routing
+│   └── source_replace.rs    # NEW (1b): two-stage alias-to-source-id-to-replacement-chain
+│                             #   resolution, bounded iteration + cycle detection
+├── Cargo.toml                # MODIFIED (1a): url dev-dep -> real dep; + dashmap real dep
+└── tests/
+    ├── config_test.rs         # NEW (1a)
+    ├── alternate_registry_test.rs  # NEW (1a): mockito, incl. hover-fallback +
+    │                          #   background-fetch-mirror path assertions (spec SC-004)
+    └── source_replace_test.rs # NEW (1b)
+
+crates/deps-core/
+├── src/
+│   ├── parser.rs              # MODIFIED (1a): DependencySource::AlternateRegistry variant
+│   ├── registry.rs             # MODIFIED (1a): get_versions_from, get_latest_matching_from
+│   │                          #   defaulted trait methods
+│   ├── ecosystem.rs             # MODIFIED (1a): EcosystemFormatter::can_resolve_source
+│   │                          #   defaulted hook
+│   ├── cache.rs                # MODIFIED (1a): get_cached_trusted_origin_with_headers
+│   └── lsp_helpers/hover.rs      # MODIFIED (1a): :71, :187 migrated to source-aware calls;
+│                                #   is_version_resolvable() call site -> can_resolve_source
+
+crates/deps-lsp/
+├── src/
+│   ├── document/lifecycle.rs    # MODIFIED (1a): :665 fetch_latest_versions_parallel takes
+│   │                          #   (PackageName, DependencySource) pairs; :760 migrated;
+│   │                          #   :1079 dedup gains the M1 collision bail-out;
+│   │                          #   :4071 is_version_resolvable() -> can_resolve_source
+│   ├── document/code_actions.rs # MODIFIED (1a): :202, :414 migrated
+│   └── document/diagnostics.rs  # MODIFIED (1a): :498,508,540,584,611 migrated
+```
+
+## 3. Data Model
+
+See [[spec#5. Data Model]] for the full type table. Sketch:
+
+```rust
+// crates/deps-core/src/parser.rs
+pub enum DependencySource {
+    // ...unchanged variants...
+    CustomRegistry { url: String },       // unresolved alias (unchanged meaning)
+    AlternateRegistry { index: String },  // NEW: resolved index URL
+}
+
+// crates/deps-core/src/registry.rs
+pub trait Registry: Send + Sync {
+    // ...unchanged existing methods...
+
+    fn get_versions_from<'a>(
+        &'a self,
+        name: &'a PackageName,
+        source: &'a DependencySource,
+        freshness: FreshnessSettings,
+    ) -> BoxFuture<'a, Result<Vec<Box<dyn Version>>>> {
+        self.get_versions_with(name, freshness) // default: ignore source
+    }
+
+    fn get_latest_matching_from<'a>(
+        &'a self,
+        name: &'a PackageName,
+        source: &'a DependencySource,
+        req: &'a VersionReq,
+        context: FreshnessSettings,
+    ) -> BoxFuture<'a, Result<Option<Box<dyn Version>>>> {
+        self.get_latest_matching_with_context(name, req, context) // default
+    }
+}
+
+// crates/deps-core/src/ecosystem.rs
+pub trait EcosystemFormatter: Send + Sync {
+    // ...unchanged existing methods...
+
+    fn can_resolve_source(&self, source: &DependencySource) -> bool {
+        source.is_version_resolvable()
+    }
+}
+
+// crates/deps-cargo/src/config.rs
+pub struct RegistryIndex(url::Url); // https-only, no-userinfo, sparse+ stripped
+
+pub enum Provenance { CargoHome, Workspace } // diagnostics only, NOT an auth gate
+
+pub struct ResolvedRegistryEntry {
+    pub index: RegistryIndex,
+    pub auth: Option<AuthToken>,   // Some(..) ONLY when provenance == CargoHome
+    pub provenance: Provenance,    // logging only
+}
+
+pub struct CargoConfig {
+    pub registries: HashMap<String, ResolvedRegistryEntry>, // 1a
+    pub source: HashMap<String, SourceEntry>,                // 1b
+}
+
+// crates/deps-cargo/src/registry.rs
+pub struct CargoRegistry {
+    crates_io: CratesIoRegistry,
+    alternates: DashMap<RegistryIndex, Arc<SparseIndexClient>>, // capped
+    cache: Arc<HttpCache>,
+}
+```
+
+### Migrations
+Not applicable — no persistent database.
+
+## 4. API Design
+Not applicable — no new LSP protocol surface (no new requests/
+notifications). `ECOSYSTEM_GUIDE.md` documents the user-visible behavior
+change (private registries now resolve).
+
+## 5. Integration Points
+
+| System | Direction | Protocol | Notes |
+|--------|-----------|----------|-------|
+| Alternate sparse index | outbound | HTTPS GET | Same wire format as the existing crates.io sparse client |
+| `.cargo/config.toml` (workspace + `$CARGO_HOME`) | inbound (file read) | Local FS | New file-read surface for this LSP outside the open document set |
+| `CARGO_REGISTRIES_<NAME>_INDEX`/`_TOKEN` | inbound (env read) | Process env | Precedent: `deps-swift/src/registry.rs:170`'s `GITHUB_TOKEN` |
+
+## 6. Security
+
+- Authentication: `Option<AuthToken>` resolved at config-load time, gated
+  structurally on `$CARGO_HOME` provenance (spec FR-008/FR-009,
+  NFR-001).
+- Authorization: not applicable (no user-facing auth model beyond the
+  registry token itself).
+- Input validation: `RegistryIndex` newtype rejects non-https/userinfo URLs
+  at construction (spec FR-002/NFR-002); `[source]` cycle detection reuses
+  #432's untrusted-input hardening standard (spec FR-007).
+- Sensitive data: tokens never logged; origin-pinned transport
+  (`get_cached_trusted_origin_with_headers`) prevents cross-origin leakage
+  on redirect (spec FR-010).
+- **Mandatory**: security review sign-off before 1a merges, given C2/R3's
+  history as the design's two blocking findings across two critic rounds.
+  Flag the residual internal-network-reachability risk (spec NFR-003)
+  explicitly during that review — do not let it surface for the first
+  time there.
+
+## 7. Testing Strategy
+
+| Level | Framework | What to Test | Coverage Target |
+|-------|-----------|---------------|------------------|
+| Unit | `cargo nextest` | Config discovery/precedence, `RegistryIndex` validation, env-var collision handling, auth-gate structural property | All spec FR-* acceptance criteria |
+| Integration | `mockito` + `tempfile::TempDir` | Alt-index fetch on the happy path AND specifically on the hover-fallback (`get_latest_matching`) and background-fetch-mirror (`get_latest_matching_with_context`) paths — spec SC-004 | Every network-performing `Registry` method touched by an `AlternateRegistry` source |
+| Regression | `cargo nextest`, existing suite | Zero-custom-registry workspaces render identically | Full existing `deps-cargo` suite passes unmodified |
+| Live/manual | `RUST_LOG=debug cargo run -p deps-lsp`, per `.claude/rules/continuous-improvement.md` Registry Integration Gate | Real `.cargo/config.toml` fixture against a mocked or real sparse index; hover/diagnostic/completion end-to-end | Required before merge, both 1a and 1b |
+
+## 8. Performance Considerations
+
+- 1a: config discovery must add zero FS reads when no dependency carries
+  `registry`/`registry-index` (lazy trigger valid because 1a excludes
+  `replace-with`) — spec NFR-004.
+- 1b: lazy trigger no longer holds (replace-with affects plain deps);
+  memoization keyed on workspace root, invalidated by contributing-file
+  mtime, is required from 1b onward — spec NFR-005.
+- `CargoRegistry.alternates` map: capped at a bound in the low hundreds of
+  entries (spec NFR-007), exact number chosen at implementation time.
+
+## 9. Rollout Plan
+
+Given P4 priority, this plan is produced now because of the security-
+critical nature of the design (credential handling was the review's two
+blocking findings) and the value of capturing two architect/critic rounds
+of analysis before it goes stale — but implementation is deferred to a
+dedicated `/rust-team` session, not this planning cycle, per this
+project's SDD-integration threshold.
+
+1. This plan is reviewed; any residual open item (spec Section 9) is
+   confirmed acceptable before `/sdd tasks`.
+2. `/sdd tasks` breaks this plan into discrete tasks in a dedicated
+   implementation session.
+3. **1a merges first, standalone**, delivering the private-registry use
+   case in the issue. Security review sign-off is a hard gate before 1a
+   merges (see [[#6. Security]]).
+4. **1b merges second**, against main post-1a, adding `[source]`
+   replace-with.
+5. No feature flag — this is additive resolution for sources that
+   previously resolved to nothing; the no-regression requirement (spec
+   NFR-008) is the safety net, verified by the unmodified existing test
+   suite. If a regression is discovered post-merge, revert is a
+   single-PR rollback per phase (1a and 1b are independently revertible).
+6. Phase 3a/3b (git dependency in-use-version + tag-checking) is filed as
+   a separate follow-up issue once this spec lands — not designed here,
+   see spec's Out of Scope section.
+
+## 10. Constitution Compliance
+
+`[NEEDS CLARIFICATION: .local/specs/constitution.md does not exist yet for
+this project (confirmed via file check) — this plan cross-checks against
+the project's existing enforced rules under .claude/rules/, which function
+as the project's de facto constitution today.]`
+
+| Principle (from `.claude/rules/`) | Status | Notes |
+|---|---|---|
+| Dependency management (`dependencies.md`) | Compliant | `url`/`dashmap` added alphabetically to `[dependencies]`, versions inherited via `workspace = true`, no new pinned versions introduced |
+| MVP scope (root CLAUDE.md) | Compliant | 1a/1b split explicitly avoids over-scoping a P4 issue into one PR |
+| Doc comments on `pub` items (root CLAUDE.md) | Required at implementation | Every new `pub` type/trait method needs `///` docs with `# Examples` where non-trivial |
+| Full check suite before PR (`branching.md`) | Required at implementation | `cargo +nightly fmt --check`, clippy `-D warnings`, `cargo nextest run --workspace --all-features`, rustdoc gate |
+| Registry Integration Gate (`continuous-improvement.md`) | Addressed in [[#7. Testing Strategy]] | Live verification against a real/mocked sparse index required before merge, both phases |
+
+## 11. Risks and Mitigations
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| Routing enumeration incomplete a third time | High (repeats a leak of private crate names to crates.io) | Medium (happened twice already during design review) | Spec FR-001/SC-004 mandates a mockito test on the hover-fallback and background-fetch-mirror paths specifically, not just the happy path — a blocking acceptance criterion, not optional coverage |
+| Auth gate regresses to a runtime check during implementation | Critical (credential exfiltration) | Low if spec FR-008/FR-009 followed as structural | Code review must verify no fetch code path branches on `Provenance` to decide auth attachment — grep for `Provenance` usage outside `config.rs` at review time |
+| `[source]` cycle detection missed in 1b | Medium (parser hang on hostile workspace file) | Low | Reuse #432's exact hardening pattern; add a fuzz/property test with a generated cyclic graph |
+| `CargoRegistry.alternates` unbounded growth | Low (memory, not correctness) | Low | Spec NFR-007 cap, tested |
+| Spec FR-013(b) staleness surprises a real user | Low-Medium | Medium (documented but still a UX gap) | `ECOSYSTEM_GUIDE.md` must state it plainly; revisit with option (a) if live testing / user reports show it matters |
+
+## See Also
+
+- [[spec]] — feature specification
+- [[MOC-specs]] — all specifications
+- `crates/deps-core/src/registry.rs`, `crates/deps-core/src/parser.rs`,
+  `crates/deps-core/src/ecosystem.rs`, `crates/deps-core/src/cache.rs`
+- `crates/deps-cargo/src/registry.rs`, `crates/deps-cargo/src/parser.rs`
+- `crates/deps-lsp/src/document/lifecycle.rs`,
+  `crates/deps-lsp/src/server.rs`
+- `.claude/rules/continuous-improvement.md`, `.claude/rules/branching.md`,
+  `.claude/rules/dependencies.md`
+- Issue #431

--- a/specs/023-cargo-custom-registries/spec.md
+++ b/specs/023-cargo-custom-registries/spec.md
@@ -1,0 +1,358 @@
+---
+aliases:
+  - Cargo Custom Registries
+  - Cargo Private Registry Resolution
+tags:
+  - sdd
+  - spec
+  - enhancement
+  - security
+  - cargo
+created: 2026-09-01
+status: shipped
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+  - "[[024-net-policy-dns-rebinding/spec|DNS Rebinding Bypass of net_policy]]"
+---
+
+# Feature: Cargo Custom/Private Registry & Source-Replacement Resolution
+
+> [!info] Metadata
+> **Author**: k05h31@gmail.com
+> **Branch**: feat/431-cargo-custom-registries
+> **Status**: Shipped — PR 1a #440 (registries, issue #431), PR 1b #447 (source replace-with + NFR-003 SSRF sign-off, issue #443)
+> **Priority**: P4
+> **Type**: enhancement
+
+## 1. Overview
+
+### Problem Statement
+
+`deps-cargo` correctly *parses* `git`/`path`/`registry`/`registry-index`
+dependency sources — `DependencySource::CustomRegistry { url }` already
+captures a `registry = "my-corp"` alias, and `[source]` replace-with tables
+are read into the parse result — but version *resolution* is skipped for
+every source except the default crates.io registry. Verified against live
+code:
+
+- `DependencySource::is_version_resolvable()` (`crates/deps-core/src/
+  parser.rs:900`) only matches `Registry`, so hover, diagnostics
+  (`generate_diagnostics_from_cache`), and code actions all gate a
+  `CustomRegistry` dependency out before any fetch is attempted — even
+  when the alias is a real, reachable sparse-index registry.
+- The `deps_core::Registry` trait's five network-performing methods
+  (`get_versions`, `get_versions_with`, `get_latest_matching`,
+  `get_latest_matching_with_context`, `search` —
+  `crates/deps-core/src/registry.rs:83,106,141,162,179`) all take a bare
+  `&PackageName`. `CargoEcosystem::registry()` returns one
+  `Arc<dyn Registry>` per ecosystem (not per document), so nothing in the
+  current pipeline can carry "which registry does *this* dependency
+  belong to" from the parser into the fetch.
+- A consequence, verified live: `fetch_latest_versions_parallel`
+  (`crates/deps-lsp/src/document/lifecycle.rs:665`) and the dedup at
+  `lifecycle.rs:1079-1085` are name-keyed with no source filter, so a
+  private-registry dependency's **name** is sent to `index.crates.io`
+  today, even though the resulting (wrong) data is never shown — an
+  unintended privacy leak that this feature also closes as a side effect
+  of fixing the routing.
+
+This gap is silent: nothing tells a user why their `registry = "my-corp"`
+dependency shows no hover/diagnostic/completion data, so it reads as a bug
+rather than a documented limitation. The identical gap exists in every
+other ecosystem crate this LSP supports (npm `.npmrc`, Maven
+`settings.xml`, NuGet feeds, Composer `repositories`, Bundler `source`
+blocks) — this spec's reference pattern (parser resolves alias to a
+concrete index URL → formatter gates on it → registry router dispatches on
+it → per-registry client no-ops search) is intended to be copied by those
+follow-ups, not reinvented.
+
+This spec is the product of two architect design rounds and two adversarial
+critic reviews (`.local/handoff/2026-09-01T15-05-25-architect.md` through
+`2026-09-01T15-21-35-critic.md` in the `feat/431-cargo-custom-registries`
+worktree). The design converged on `significant` (no remaining structural
+issues) after the second critic pass; the requirements below fold in every
+blocking (C1-C3) and must-land (R1-R3) finding from that review as concrete,
+testable functional requirements, not left as open design questions.
+
+> [!warning] Assumptions
+> - Users' private/custom registries speak the sparse index protocol
+>   (`sparse+https://`) — the same JSON-lines wire format `deps-cargo`
+>   already parses for crates.io. Git-index (legacy) registries are not
+>   addressed and remain unsupported, matching today's behavior exactly
+>   (no regression, no new capability).
+> - Users store registry tokens the way Cargo itself expects
+>   (`CARGO_REGISTRIES_<NAME>_TOKEN` env var, or `$CARGO_HOME/config.toml`),
+>   not committed to the repository being opened.
+
+### Goal
+
+A Cargo dependency resolved against a `.cargo/config.toml`-declared
+registry, or against a workspace's `[source]` replace-with target, gets the
+same hover/diagnostic/completion value a crates.io dependency gets — with
+zero regression for workspaces that declare no custom registry, and with no
+credential ever attachable to a request whose destination URL was declared
+by a file inside the repository being opened.
+
+### Out of Scope
+
+> [!danger] Explicit Exclusions
+> - **Git dependency in-use-version-from-`Cargo.lock` and tag-checking**
+>   ("Phase 3a/3b" in the design handoffs) — `parse_cargo_source`
+>   (`crates/deps-cargo/src/lockfile.rs:166`) already yields
+>   `ResolvedSource::Git { url, rev }` and the lock entry already carries a
+>   version; hover shows nothing purely because of the same
+>   `is_version_resolvable` gate this spec replaces. Zero network,
+>   highest value-per-line item the design review identified — but the
+>   user decided this spec ships full Phase 1 (registries + replace-with)
+>   first, and Phase 3a/3b is filed as a **separate follow-up issue** after
+>   this spec lands, not designed here.
+> - **Private crate *name* search/completion** (`complete_package_names`)
+>   — the sparse index protocol has no search endpoint; this is
+>   protocol-inherent, not an implementation gap deferred by choice.
+> - **Git-index (non-sparse) registries** — remain unsupported, identical
+>   to today's behavior.
+> - **`credentials.toml` / the Cargo credential-provider plugin chain.**
+> - **`(registry, name)` cache-key widening** — the same-name-two-
+>   registries bail-out (FR-011 below) covers v1; file as a follow-up if
+>   npm scoped registries later need the wider key
+>   (`crates/deps-lsp/src/document/lifecycle.rs:1079` gets a
+>   `// TODO(critic):` marker per the design review's D1 item).
+> - **A dedicated `.cargo/config.toml` file watcher** — see FR-013's
+>   normative resolution below; this spec chooses documentation over a new
+>   watcher subsystem for v1.
+
+## 2. User Stories
+
+### US-001: Private registry version resolution
+
+AS A developer with a dependency on my company's private Cargo registry
+I WANT hover, diagnostics, and completion to work for it
+SO THAT I get the same LSP value I get for crates.io dependencies
+
+**Acceptance criteria:**
+```
+GIVEN a Cargo.toml with foo = { version = "1.0", registry = "my-corp" }
+  AND a .cargo/config.toml with [registries.my-corp]
+      index = "sparse+https://index.mycorp.dev"
+WHEN I hover over the foo dependency
+THEN the hover shows the latest version available on index.mycorp.dev,
+     not crates.io, and no request is sent to index.crates.io for "foo"
+```
+
+### US-002: Mirrored workspace resolution via `[source]` replace-with
+
+AS A developer whose team redirects crates.io through a corporate mirror
+I WANT plain dependencies to resolve against the mirror
+SO THAT hover/diagnostics reflect what my team's mirror actually serves
+
+**Acceptance criteria:**
+```
+GIVEN [source.crates-io] replace-with = "my-mirror"
+  AND [source.my-mirror] registry = "sparse+https://mirror.corp.example/"
+WHEN I hover over any plain dependency
+THEN the hover reflects my-mirror's index data
+```
+
+### US-003: No regression for vendored/git-index workspaces
+
+AS A developer using a vendored (`directory`) or git-index mirror
+I WANT the LSP to keep behaving exactly as it does today
+SO THAT I don't lose working functionality because of this feature
+
+**Acceptance criteria:**
+```
+GIVEN [source.crates-io] replace-with = "vendored"
+  AND [source.vendored] directory = "vendor/"
+WHEN I hover over a plain dependency
+THEN the hover is byte-identical to pre-feature behavior (crates.io fallback)
+```
+
+### US-004: Credentials never leak to a workspace-controlled destination
+
+AS A developer opening an untrusted cloned repository
+I WANT no credential ever sent to a URL that repository's own files declare
+SO THAT cloning and opening a hostile repo cannot exfiltrate my tokens
+
+**Acceptance criteria:**
+```
+GIVEN a repository whose .cargo/config.toml declares a registry pointing at
+     an attacker-controlled host, aliased "github"
+  AND my own environment happens to have CARGO_REGISTRIES_GITHUB_TOKEN set
+     (for an unrelated, legitimately $CARGO_HOME-declared "github" registry)
+WHEN the LSP resolves the repository's "github"-aliased dependency
+THEN no Authorization header is ever sent to the attacker-controlled host —
+     the token is attached only to requests whose resolved index URL
+     provenance is $CARGO_HOME/config.toml, never a workspace file
+```
+
+## 3. Functional Requirements
+
+Every requirement below traces to a specific blocking (C1-C3) or must-land
+(R1-R3, M1, M4, M6-M9) finding from the design review
+(`.local/handoff/2026-09-01T15-21-35-critic.md`), cited inline. FR-001
+through FR-004, FR-008-FR-012, FR-014-FR-016 ship in **PR 1a**; FR-005
+through FR-007 ship in **PR 1b** — see [[plan#Sequencing]] for the
+binding rationale.
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN any `Registry` trait method that performs a network request is called for a dependency whose source is a resolved `AlternateRegistry` THE SYSTEM SHALL route that specific call to the alternate registry's index — covering `get_versions`/`get_versions_with` via a new `get_versions_from` AND `get_latest_matching`/`get_latest_matching_with_context` via a new `get_latest_matching_from`; `search` stays crates.io-only, documented as unreachable for alternate sources (sparse protocol has no search endpoint) *(closes C1/R1 — the routing enumeration was incomplete twice during design review, first missing all five network methods, then missing the `get_latest_matching`/`get_latest_matching_with_context` fallback paths at `hover.rs:187` and `lifecycle.rs:760`)* | must |
+| FR-002 | WHEN a `Cargo.toml` dependency declares `registry = "<alias>"` or `registry-index = "sparse+https://..."` AND a matching `.cargo/config.toml` hierarchy entry resolves to a valid `https`, non-userinfo URL THE SYSTEM SHALL represent that dependency's source as `DependencySource::AlternateRegistry { index }`, a new variant distinct from the existing `CustomRegistry { url }` (which keeps meaning "unresolved alias") *(closes S2 — makes "resolved" a type-level state instead of string-sniffing `starts_with("http")`)* | must |
+| FR-003 | WHEN alias resolution fails (no matching config entry, invalid URL, non-https, userinfo present) THE SYSTEM SHALL leave the source as `DependencySource::CustomRegistry { url: <alias> }` unchanged and emit a `tracing::warn!` distinguishable from FR-011's collision warning | must |
+| FR-004 | WHEN `$CARGO_HOME` is not set in the process environment THE SYSTEM SHALL NOT attempt to read any path derived from `HOME`/`USERPROFILE`, and shall not add a `dirs`/`home` crate dependency to support such a fallback *(closes M2 — no such crate exists anywhere in this workspace today)* | must |
+| FR-005 | WHEN a `[source]` replace-with chain resolves (via a two-stage process: alias → source id, then source-replacement chain, bounded iteration + visited-set cycle check) to a `sparse+https://` index THE SYSTEM SHALL reroute plain (`Registry`-sourced) dependencies to that index | must (1b) |
+| FR-006 | WHEN a `[source]` replace-with chain resolves to a `directory` (vendored), `local-registry`, or non-sparse git-index source THE SYSTEM SHALL keep resolving plain dependencies against crates.io, unchanged from today *(closes C3, corrected per M6: Cargo verifies per-version checksums for replacements, it does NOT enforce full content-set equivalence — for a vendored source the version *set* is not equivalent to crates.io's, since the vendor dir holds only what `Cargo.lock` pinned; the fallback may therefore surface "Outdated" suggestions for versions absent from the vendor dir, identical to today's behavior, not a regression, and documented as such)* | must (1b) |
+| FR-007 | WHEN a `[source]` replace-with graph is cyclic or self-referential THE SYSTEM SHALL terminate resolution via bounded iteration and a visited-set check rather than looping, reusing the depth-guard standard already applied workspace-wide for untrusted JSON parsing (#432) *(closes S4)* | must (1b) |
+| FR-008 | WHEN a registry's index URL was resolved from `$CARGO_HOME/config.toml` THE SYSTEM SHALL attach its resolved bearer token (from `CARGO_REGISTRIES_<NAME>_TOKEN` or `$CARGO_HOME/config.toml` itself) to requests against that index | must |
+| FR-009 | WHEN a registry's index URL was resolved from any workspace file (the `Cargo.toml` alias target, any ancestor `.cargo/config.toml` within the workspace) THE SYSTEM SHALL resolve the token **at config-load time** into `auth: Option<AuthToken>` on that entry, populated **only** on the `$CARGO_HOME` branch, such that no downstream fetch code path has API surface through which to obtain a token for a workspace-declared entry *(closes C2 per the user's binding decision, hardened by R3: the first design draft proposed a runtime `Provenance` check at the call site, which the final critic re-verification identified as forgeable — "an enum field plus a conditional... is exactly a runtime check that can be forgotten at a call site." A `Provenance { CargoHome, Workspace }` enum may still exist for logging, but it must never gate auth attachment)* | must — security-blocking |
+| FR-010 | WHEN an authenticated request to an alternate index is made THE SYSTEM SHALL route it through a new `HttpCache::get_cached_trusted_origin_with_headers(url, trusted_origin, headers)` — an origin-pinned accessor composing the existing private `get_cached_with_headers_via` (`cache.rs:489`) with the existing `client_for_origin` (`cache.rs:371`) — so that an `Authorization` header cannot survive a cross-origin redirect hop, by construction, with no empirical test required *(closes S6, dissolves the original open question about reqwest's cross-origin header-stripping behavior)* | must |
+| FR-011 | WHEN one document declares the same package name against two different resolved registries THE SYSTEM SHALL skip version resolution for **all** occurrences of that name and log a `tracing::warn!` naming both resolved index URLs, using message text distinguishable from FR-003's unresolvable-source warning *(closes M1 — prevents a genuine resolution bug, which yields two different resolved strings for what should be one registry, from being silently indistinguishable from this legitimate collision)* | must |
+| FR-012 | WHEN `CompletionContext::Version`/`Feature`'s `package_name` is joined against `parse_result.dependencies()` (entirely inside `deps-cargo`'s `generate_completions`, `crates/deps-cargo/src/ecosystem.rs:148`, with zero `deps-core` signature change) and that name is ambiguous per FR-011's collision condition THE SYSTEM SHALL offer no version/feature completions for that name and warn, reusing FR-011's bail-out rather than picking a match arbitrarily *(closes C1's completion concern, corrected: version/feature completion IS in-scope, since `complete_versions`/`complete_features` are private inherent methods reachable via the already-`parse_result`-carrying `generate_completions`; only `complete_package_names` stays out of scope, per M7 for the ambiguity tie-break)* | must |
+| FR-013 | THE SYSTEM SHALL resolve `.cargo/config.toml` staleness handling via **option (b): no dedicated file watcher.** `ECOSYSTEM_GUIDE.md` documents that editing `.cargo/config.toml` does not take effect until the affected `Cargo.toml` is otherwise reparsed (edited, or the document reopened) *(closes R2, which established that "add a glob pattern to the existing lock-file watcher" does not work — every event in `did_change_watched_files`, `crates/deps-lsp/src/server.rs:496-522`, is routed through `extract_lockfile_name` → `EcosystemRegistry::get_for_lockfile`, which silently drops anything that does not resolve as a known lockfile name; registering `config.toml` as a fake lockfile name would instead misroute the event into the Cargo lockfile-change handler. Option (a) — a dedicated watcher branch with its own reparse-scope computation — is a second new subsystem this P4-priority spec declines to build for v1; see [[plan]] for the full rationale and the upgrade path if live usage shows this insufficient)* | must — the choice itself, not a specific mechanism, is mandatory |
+| FR-014 | WHEN the resolved dependency source is not crates.io THE SYSTEM SHALL suppress `CargoFormatter::package_url`/`crate_url`'s hover heading link *(closes M5 — with live version data now rendered beside it, a crates.io link for a private crate reads as confirmation the link is real, worse than today's inert hover)* | must |
+| FR-015 | WHEN `CARGO_REGISTRIES_<NAME>_INDEX`/`_TOKEN` derived env-var names collide across two distinct aliases (e.g. `my-corp` and `my_corp` both map to `CARGO_REGISTRIES_MY_CORP_INDEX`) THE SYSTEM SHALL ignore the env override for **both** aliases and log a warning naming both *(closes M4 — a deliberate, documented divergence from Cargo's own arbitrary-pick behavior on this collision)* | must |
+| FR-016 | THE SYSTEM SHALL add `EcosystemFormatter::can_resolve_source(&DependencySource) -> bool`, defaulted to `source.is_version_resolvable()`, overridden **only** by `CargoFormatter`, and migrate the 8 existing `is_version_resolvable()` call sites (`diagnostics.rs:498,508,540,584,611`, `hover.rs:63`, `code_actions.rs:202`) to it, **not** placing the hook on `Registry` *(closes S1 — a `Registry`-level hook would ripple into 6+ unrelated call sites including `deps-pypi/src/ecosystem.rs:1142` and the external `deps-gradle/tests/integration_tests.rs:226`, and would inject a registry handle into `generate_diagnostics_from_cache`, which is deliberately registry-free by design; `EcosystemFormatter` is already a parameter of all three affected functions and already carries this class of gate, e.g. `yanked_diagnostic_applies_to`)* | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Security | No credential is attachable to a request whose destination provenance traces to a workspace file, under any code path — verified by code inspection (grep for `Provenance` usage outside `config.rs`, confirming it never gates auth attachment) in addition to tests, per FR-009's structural (not runtime) requirement |
+| NFR-002 | Security | Every resolved index URL passes a `RegistryIndex` newtype (built on the `url` crate, promoted from dev-dependency to a real `deps-cargo` dependency) that rejects non-https schemes and userinfo-bearing URLs at construction, before any network request — this is SSRF-adjacent input, since a workspace file controls a network destination |
+| NFR-003 | Security | Residual risk, non-blocking, must be stated for security-reviewer sign-off before 1a merges (per M9): even with NFR-001/002 satisfied, an *unauthenticated* HTTPS GET to a workspace-declared index still occurs, which is reachability into the user's internal network (RFC1918 hosts, internal PKI endpoints) usable for existence probing by a hostile repository, and the response lands in the shared `HttpCache`. This is the same trust model Cargo itself has on `cargo build`, but an LSP auto-parses on file open — an earlier trust boundary. The design explicitly declined an opt-in gate for this (not needed to close the credential-exfiltration path, which `$CARGO_HOME`-only auth already closes) — routed to the security reviewer's judgment, not blocking this spec |
+| NFR-004 | Performance | PR 1a: config discovery adds zero additional FS reads when no dependency in the manifest carries `registry`/`registry-index` (the lazy-trigger optimization remains valid in 1a because 1a excludes `[source]` replace-with) |
+| NFR-005 | Performance | PR 1b: since replace-with affects *plain* dependencies (i.e., every manifest), the lazy trigger no longer holds once 1b lands; config resolution must be memoized keyed on workspace root, invalidated by the mtime of every file that contributed to the resolution, with a stated cap on ancestor-walk depth *(closes S3)*. `find_workspace_root` (`crates/deps-cargo/src/parser.rs:357`) already performs the ancestor walk needed — config-path collection piggybacks on that same pass, so the walk itself is not new, only the extra reads are |
+| NFR-006 | Maintainability | The routing surface's exhaustiveness (FR-001) is verified by a **mockito test asserting the alternate index is hit specifically on the hover-fallback path** (`hover.rs:187`'s `get_latest_matching_from` call) and the background-fetch-mirror path (`lifecycle.rs:760`), not only the happy-path `get_versions_from` call — this exact enumeration has been wrong twice already during design review and must not be verified by implementation-time grep a third time |
+| NFR-007 | Maintainability | `CargoRegistry.alternates: DashMap<RegistryIndex, Arc<SparseIndexClient>>` is capped per workspace root at a bound in the low hundreds of entries (e.g. 256 — generous for any realistic `.cargo/config.toml` registry count, exact number left to implementation) — otherwise unbounded, keyed by workspace-controlled URLs, for the process lifetime *(closes M8)* |
+| NFR-008 | Reliability | Zero behavior change for any workspace declaring no custom registry and no `[source]` replace-with — verified by the existing `deps-cargo` test suite passing unmodified |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `DependencySource::AlternateRegistry` | New `deps-core` variant — a *resolved* registry source | `index: String` (validated, `sparse+`-stripped index URL) |
+| `DependencySource::CustomRegistry` | Existing variant, meaning unchanged — an *unresolved* alias | `url: String` (in fact the bare alias, e.g. `"my-corp"`) |
+| `RegistryIndex` | New `deps-cargo` newtype — validated index URL | Built on `url::Url`; enforces https, no userinfo, strips `sparse+` prefix at construction |
+| `CargoConfig` | New `deps-cargo` type — merged resolved `.cargo/config.toml` hierarchy | `registries: HashMap<alias, ResolvedRegistryEntry>` (1a), `source: HashMap<name, SourceEntry>` (1b) |
+| `ResolvedRegistryEntry` | New `deps-cargo` type — one resolved `[registries.<name>]` entry | `index: RegistryIndex`, `auth: Option<AuthToken>` (populated only when `$CARGO_HOME`-declared, per FR-009), `provenance: Provenance` (diagnostics only, never an auth gate) |
+| `AuthToken` | New `deps-cargo` newtype wrapping a registry bearer-token credential | A single `String` field holding the raw token value; `Debug` and `Display` are hand-implemented to redact it (e.g. print `AuthToken(***)`), never the raw value, so it cannot leak via logs, panics, or error messages; constructed **only** inside the `$CARGO_HOME`-branch of config resolution (`config.rs`), per FR-009/R3 — no other code path has the means to construct one |
+| `Provenance` | New `deps-cargo` enum — `{ CargoHome, Workspace }` | Diagnostic/logging use only |
+| `SparseIndexClient` | New `deps-cargo` type — extracted from the existing crates.io client | `base_url`; owns `sparse_index_path`/`parse_index_json` (moved, not reimplemented) |
+| `CratesIoRegistry` | Existing type, narrowed | `SparseIndexClient` + crates.io search REST API + `crate_url` |
+| `CargoRegistry` | New `deps-cargo` type — the `Registry` impl behind `CargoEcosystem::registry()` | `crates_io: CratesIoRegistry`, `alternates: DashMap<RegistryIndex, Arc<SparseIndexClient>>` (capped, NFR-007), `cache: Arc<HttpCache>` |
+| `Registry::get_versions_from` / `get_latest_matching_from` | New defaulted trait methods on `deps-core::Registry` | Default to the existing non-source-aware methods; overridden only by `CargoRegistry` |
+| `EcosystemFormatter::can_resolve_source` | New defaulted trait method | Default `source.is_version_resolvable()`; overridden only by `CargoFormatter` |
+| `HttpCache::get_cached_trusted_origin_with_headers` | New public method on `deps-core::HttpCache` | Composes existing private `get_cached_with_headers_via` + `client_for_origin`; cache-key invariant: one `Authorization` value per index URL (key stays URL-only) |
+
+**Cargo dependency changes**: `crates/deps-cargo/Cargo.toml` — `url`
+(currently `[dev-dependencies]` only, confirmed at line 34) moves to
+`[dependencies]`; `dashmap = { workspace = true }` (already pinned at the
+workspace level, used by `deps-core`/`deps-npm`/`deps-maven`/`deps-lsp`/
+`deps-swift`, not currently a `deps-cargo` dependency) is added to
+`[dependencies]`. Both inserted alphabetically per
+`.claude/rules/dependencies.md`.
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Alias declared, no `.cargo/config.toml` entry | Stays `CustomRegistry { url: alias }`; `tracing::warn!`; dependency shows no version data (today's behavior), no crash |
+| `registry-index` URL is `http://` or carries userinfo | `RegistryIndex` construction fails; source stays unresolved; warn logged (FR-003) |
+| Same name declared against two registries in one manifest | Both occurrences skipped; distinct warn naming both resolved URLs (FR-011) |
+| `[source]` replace-with cycle | Bounded iteration + visited-set stops the loop; treated as unresolved for that chain, warn logged (FR-007) |
+| `$CARGO_HOME` unset | No `HOME`/`USERPROFILE` fallback attempted; `$CARGO_HOME`-tier config contributes nothing (FR-004) |
+| `CARGO_REGISTRIES_MY_CORP_INDEX` ambiguous between `my-corp`/`my_corp` | Override ignored for both; warn naming both aliases (FR-015) |
+| Alternate registry unreachable / times out | Dependency shows no version data; no panic; identical shape to crates.io-unreachable handling today |
+| `.cargo/config.toml` malformed TOML | That file's contributions fail closed; other hierarchy levels still apply; warn logged |
+| `.cargo/config.toml` edited after initial resolution | Stale until the affected `Cargo.toml` is next reparsed (FR-013, documented limitation) |
+| Vendored (`directory`) replace-with | Crates.io fallback continues (no regression); may show "Outdated" for versions absent from the vendor dir — documented with the precise M6 rationale ("checksum-verified per version, not equivalent in version set") |
+| Dependency declared twice against different registries, in a completion context | No version/feature completions offered for that name (FR-012) |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Private-registry dependency shows live hover/diagnostic/completion data | Pass on a real or mocked sparse-index fixture |
+| SC-002 | Zero regression on crates.io-only workspaces | Existing `deps-cargo` test suite passes unmodified |
+| SC-003 | No credential reaches a workspace-declared destination | Security-review sign-off + FR-009 structural test + `Provenance`-usage grep |
+| SC-004 | Routing surface exhaustively covered | Mockito test passes specifically on the hover-fallback (`hover.rs:187`) and background-fetch-mirror (`lifecycle.rs:760`) paths, not only the happy path — the blocking acceptance gate per NFR-006 |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Run `cargo +nightly fmt --check`, `cargo clippy --all-targets
+  --all-features --workspace -- -D warnings`, `cargo nextest run
+  --workspace --all-features` before considering a task complete.
+- Follow the Registry Integration Gate
+  (`.claude/rules/continuous-improvement.md`) — verify against a real or
+  mocked sparse index before filing the implementation PR.
+- Update `CHANGELOG.md`, `ECOSYSTEM_GUIDE.md`,
+  `.local/testing/coverage.md` (cargo row),
+  `.local/testing/playbooks/cargo.md`, `.local/testing/regressions.md`.
+- Extend `SparseIndexClient` rather than reimplementing sparse-index
+  parsing; extend `EcosystemFormatter` rather than adding a
+  `Registry`-level gate.
+
+### Ask First
+- Implementing FR-013's option (a) (a dedicated config-file watcher)
+  instead of the documented-limitation option (b) this spec adopts — a
+  scope increase beyond what this spec specifies.
+- Any change to the `$CARGO_HOME`-only auth trust rule (FR-008/FR-009) —
+  the security-blocking requirement; do not weaken it to unblock an
+  implementation difficulty.
+- Widening the `deps-core` `Registry`/`EcosystemFormatter` trait surface
+  beyond the two new defaulted methods and one hook specified here.
+
+### Never
+- Attach a credential to a request whose destination URL provenance traces
+  to a workspace file, under any code path.
+- Match exhaustively on `DependencySource` in new production code without
+  a `_ => ...` fallback arm — the low-risk-variant-addition property this
+  spec relies on (verified: every existing exhaustive match is
+  `#[cfg(test)]` with a `_ => panic!()` arm) depends on that convention
+  holding.
+- Add a `dirs`/`home` crate dependency to work around `$CARGO_HOME` being
+  unset.
+- Skip the mockito tests on the hover-fallback / background-fetch-mirror
+  paths specifically (FR-001/SC-004) — a happy-path-only test has already
+  produced two false "done" signals in this design's review history.
+
+## 9. Open Questions
+
+None blocking, and NFR-003's residual is now resolved. PR #447 answered it not
+with an opt-in `DepsConfig` gate but with a new `deps-core::net_policy`
+host classifier (`HostClass`/`classify_host`) gated by a `cargo.workspace_registries`
+setting (`off`/`public_only`/`all`, default `public_only`), applied to every
+workspace-declared registry/source URL and every redirect hop — see
+[[024-net-policy-dns-rebinding/spec|024-net-policy-dns-rebinding]] for the
+follow-up DNS-rebinding hardening on top of that classifier (PRs #457/#460).
+
+## 10. See Also
+
+- [[constitution]] — project principles (not yet created for this
+  project; cross-checked against `.claude/rules/*.md` instead, see
+  [[plan#10. Constitution Compliance]])
+- [[MOC-specs]] — all specifications
+- [[024-net-policy-dns-rebinding/spec|024-net-policy-dns-rebinding]] — the
+  DNS-rebinding follow-up hardening built on top of PR #447's `net_policy`
+- [[023-cargo-custom-registries/plan|plan]] — technical plan, 1a/1b PR
+  sequencing, task-level detail
+- PR #440 — shipped PR 1a (registries), closes issue #431
+- PR #447 — shipped PR 1b (source replace-with) + NFR-003 SSRF sign-off,
+  closes issue #443
+- `crates/deps-core/src/parser.rs` — `DependencySource`,
+  `is_version_resolvable`
+- `crates/deps-core/src/registry.rs` — `Registry` trait
+- `crates/deps-core/src/cache.rs` — `HttpCache`,
+  `get_cached_trusted_origin`
+- `crates/deps-cargo/src/registry.rs`, `crates/deps-cargo/src/parser.rs`,
+  `crates/deps-cargo/src/formatter.rs`, `crates/deps-cargo/src/
+  ecosystem.rs`
+- `crates/deps-lsp/src/document/lifecycle.rs`,
+  `crates/deps-lsp/src/server.rs`
+- Design review handoffs (`feat/431-cargo-custom-registries` worktree,
+  `.local/handoff/`): `2026-09-01T15-05-25-architect.md`,
+  `2026-09-01T15-09-21-critic.md`, `2026-09-01T15-18-17-architect.md`,
+  `2026-09-01T15-21-35-critic.md`
+- Issue #431

--- a/specs/024-net-policy-dns-rebinding/spec.md
+++ b/specs/024-net-policy-dns-rebinding/spec.md
@@ -1,0 +1,249 @@
+---
+aliases:
+  - DNS Rebinding Bypass of net_policy
+  - net_policy DNS Rebinding
+tags:
+  - sdd
+  - spec
+  - security
+  - research
+  - net-policy
+created: 2026-09-01
+status: shipped
+related:
+  - "[[constitution]]"
+  - "[[023-cargo-custom-registries/spec|Cargo Custom/Private Registry & Source-Replacement Resolution]]"
+---
+
+# Feature: Resolved-Address Validation for `net_policy` (Close DNS-Rebinding Bypass of the Workspace-Registry SSRF Classifier)
+
+> [!info] Metadata
+> **Author**: rust-researcher (CI cycle 018)
+> **Branch**: research/024-net-policy-dns-rebinding (superseded — shipped across two PRs, see Status)
+> **Priority**: P3 (research / security-hardening follow-up)
+> **Status**: Shipped in two stages — PR #457 (issue #449) closed the policy-independent `never_a_registry` tier (loopback/link-local/cloud-metadata/unspecified) via a connect-time `reqwest::dns::Resolve` guard (`BlockedAddrResolver`) wired into the shared client pool, plus NAT64-embedded-address unwrapping; PR #460 (issue #455) closed the remaining `PublicOnly`-policy-aware tier (RFC1918/CGNAT) at both connect time and on every redirect hop via a policy-snapshotted `Transport`/`AddrGuard`. All of FR-001 through FR-007 below are satisfied by the combination of the two PRs. `cargo.workspace_registries = off` remains an unaffected, complete mitigation (US-002).
+
+## 1. Overview
+
+### Problem Statement
+
+PR #447 (merged 2026-09-01, commit `a8779b43`) introduced [[net_policy|`deps-core::net_policy`]]
+(`crates/deps-core/src/net_policy.rs`) to close the SSRF/reachability-probing gap tracked by
+issue `#443`. `RegistryAccessPolicy`/`classify_host` blocks workspace-declared Cargo
+registry/source URLs — and every redirect hop reached while fetching them — whose *host
+string* falls into a blocked `HostClass` (loopback, link-local, cloud-metadata, RFC1918,
+CGNAT, unique-local IPv6, unspecified, or internal-name), gated by the
+`cargo.workspace_registries` setting (`off` / `public_only` / `all`, default `public_only`).
+
+The classifier's own module doc and the `HostClass` doc are explicit that classification is
+computed **from the URL string alone, with no DNS resolution**. This leaves a
+[DNS-rebinding](https://en.wikipedia.org/wiki/DNS_rebinding) gap: a hostname that is not
+itself a blocked literal but *resolves* to a blocked address is never caught. A hostile
+repository can declare a `registry-index`/`[source]` URL using a hostname the attacker
+controls DNS for. At the moment `classify_host` validates the string, public DNS resolves it
+to an innocuous public IP, so `HostClass::Global` passes the `public_only` gate. By the time
+(or shortly after) `reqwest` performs the actual HTTPS GET, the attacker has rebound the
+record's A/AAAA answer to `169.254.169.254` (cloud metadata) or an RFC1918 address — the
+connection lands on the blocked-in-intent internal target anyway, because `reqwest`'s
+connector resolves DNS itself at connect time, independent of, and later than, the
+string-based classification already performed. This is a textbook TOCTOU (time-of-check to
+time-of-use) gap: the check and the use are separated by a DNS resolution the attacker
+controls.
+
+This is not a bug in `classify_host`'s own rule completeness (issue `#443` and PR #447 already
+closed every string-based bypass found during design review, including the trailing-dot
+hostname bypass). It is a structural limitation of validating a *reference* to a network
+resource rather than the resource's actual resolved address at the point of use — and it was
+explicitly named and deferred by PR #447 itself ("D1 in the implementation plan"), but no
+GitHub issue or spec was ever filed for it. `gh issue list` searches for "DNS rebinding",
+"net_policy", "classify_host", and "resolver Resolve" (2026-09-01) returned zero results, and
+a full-text grep of `.local/specs/` and `.local/` for "DNS rebinding"/"D1" found no matching
+tracking artifact — `.local/specs/023-cargo-custom-registries/`'s own D1 reference is an
+unrelated design-review item. This spec exists to close that tracking gap and define the
+functional shape of the eventual fix, without prescribing its full implementation.
+
+### Goal
+
+A future fix will validate the **resolved IP address actually connected to**, not just the
+declared hostname string, against the same `HostClass` blocklist `classify_host` already
+enforces — for every workspace-declared registry/source fetch and every redirect hop, across
+all 11 ecosystem crates that share the `reqwest` client pool — closing the rebinding TOCTOU
+gap while preserving today's zero-behavior-change guarantee for legitimate public registries.
+
+### Out of Scope
+
+- Redesigning `HostClass` or its classification rules (string-based coverage is considered
+  complete as of PR #447; this spec is only about *when* the check happens, not *what* it
+  checks for).
+- Any change to `$CARGO_HOME`-declared registries (out of the SSRF threat model per PR #447 —
+  they are not workspace-attacker-controlled).
+- Non-Cargo ecosystems' own workspace-declared-URL features, since none currently exist — this
+  spec documents that any future one would inherit the same gap via the shared client pool,
+  but does not design for a feature that does not yet exist.
+- Full implementation of the `reqwest::dns::Resolve` (or equivalent) fix — the code comments
+  and PR #447 body already sketch this direction; this spec captures requirements and
+  acceptance criteria for that eventual implementation, not its design.
+- General-purpose DNS-rebinding protection for LSP traffic unrelated to workspace-declared
+  registry/source URLs (e.g., OSV.dev, npm registry, PyPI registry — these are
+  operator/server-declared endpoints, not attacker-controlled, and are out of the original
+  `#443` threat model).
+
+## 2. User Stories
+
+### US-001: Protect a developer opening a hostile repository from a rebinding-based SSRF
+
+AS A developer using `deps-lsp` on an untrusted or unreviewed repository
+I WANT the LSP to refuse to actually connect to an internal/cloud-metadata address even if
+the workspace-declared registry hostname passed string-based validation
+SO THAT a hostile `Cargo.toml`/`.cargo/config.toml` cannot use DNS rebinding to make my
+editor's background fetch reach my internal network or my cloud instance's metadata endpoint.
+
+**Acceptance criteria:**
+```
+GIVEN a workspace declares a registry-index URL whose hostname resolves, at validation time,
+  to a public IP address (passing HostClass::Global under `public_only`)
+WHEN the actual HTTP client connects to fetch that URL and DNS now resolves the same hostname
+  to an address in a blocked HostClass (e.g. 169.254.169.254, or an RFC1918 address)
+THEN the fetch SHALL be aborted before the connection is used, and the failure SHALL be
+  attributed to the resolved-address check (not silently treated as a generic network error)
+```
+
+### US-002: Preserve today's coarse workaround for users who need it now
+
+AS A security-conscious user who cannot wait for the resolved-address fix
+I WANT `cargo.workspace_registries = off` to remain a complete boundary against both the
+already-closed string-based bypass and this DNS-rebinding gap
+SO THAT I have a working mitigation today, independent of when the eventual fix ships.
+
+**Acceptance criteria:**
+```
+GIVEN cargo.workspace_registries is set to `off`
+WHEN a workspace declares any registry-index/[source] URL, regardless of hostname or DNS
+  behavior
+THEN the LSP SHALL NOT fetch it, exactly as today — this spec's eventual fix SHALL NOT change
+  `off`'s behavior or scope
+```
+
+### US-003: No functional regression for legitimate public/private registries
+
+AS A developer using a legitimate public registry (crates.io mirror) or an internal corporate
+registry reachable over a private network under `all`
+I WANT the resolved-address check to accept my registry's actual resolved address exactly as
+`classify_host` accepts its hostname today
+SO THAT closing the rebinding gap does not break workspaces that were working correctly before.
+
+**Acceptance criteria:**
+```
+GIVEN a registry-index hostname whose resolved address is consistently HostClass::Global
+  (public registry) or, under `all`, a class explicitly permitted by the active policy
+WHEN the resolved-address check runs at connect time
+THEN the fetch SHALL proceed exactly as it does today, with no added latency budget beyond
+  what DNS resolution and connection already cost
+```
+
+## 3. Functional Requirements
+
+Use EARS notation. Prefix with FR-NNN.
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN the HTTP client resolves DNS for a workspace-declared registry/source URL (or a redirect hop from one) THE SYSTEM SHALL classify every resolved IP address against the same `HostClass` blocklist `classify_host` uses for the string-based check | must |
+| FR-002 | WHEN a resolved address falls into a `HostClass` blocked by the active `WorkspaceRegistryAccess` policy (`public_only` or a future narrower `all` restriction) THE SYSTEM SHALL abort the connection before any request is sent and SHALL NOT reuse or cache the response | must |
+| FR-003 | WHEN a hostname resolves to multiple addresses (A/AAAA records) THE SYSTEM SHALL classify every returned address, not only the first one selected for connection, so an attacker cannot hide a blocked address behind an earlier innocuous one | must |
+| FR-004 | WHEN the resolved-address check blocks a connection THE SYSTEM SHALL surface a diagnostic/log message that distinguishes this case from a generic connection failure, naming the blocked `HostClass` (consistent with `classify_host`'s existing `Display` labels) | should |
+| FR-005 | WHEN `cargo.workspace_registries` is `off` THE SYSTEM SHALL continue to reject the URL before any DNS resolution occurs, unaffected by this feature | must |
+| FR-006 | WHEN the resolved-address check is added THE SYSTEM SHALL apply it identically across all 11 ecosystem crates sharing the `reqwest` client pool, not only `deps-cargo`, so a future workspace-declared-URL feature in another ecosystem inherits the protection automatically | should |
+| FR-007 | WHEN a redirect hop's resolved address is blocked THE SYSTEM SHALL apply the same resolved-address check as the initial request, consistent with the existing redirect-hop string-based reclassification hardening from PR #447 | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | The resolved-address check SHALL add no observable latency beyond DNS resolution + connection time already incurred by the request — no additional round-trip (e.g., no separate resolve-then-reconnect step distinguishable from normal TCP/TLS connect timing) |
+| NFR-002 | Architecture | The fix SHALL be implemented at the shared `reqwest` client-pool layer (e.g., a custom `reqwest::dns::Resolve`, or equivalent address-pinning at connect time) so it is inherited by all 11 ecosystem crates without per-crate duplication — consistent with `net_policy`'s existing placement rationale (DRY, no ecosystem-specific `#[cfg(feature = ...)]` gate) |
+| NFR-003 | Reliability | Legitimate registries whose resolved address is consistently public SHALL see zero behavior change — verified by the existing `deps-cargo` test suite (and equivalent suites in other ecosystem crates) passing unmodified |
+| NFR-004 | Security | The check SHALL be fail-closed: if address resolution cannot be classified (e.g., resolver error, unexpected address family) THE SYSTEM SHALL treat the connection as blocked rather than allowed, consistent with `net_policy`'s existing conservative bias |
+| NFR-005 | Maintainability | The resolved-address `HostClass` check SHALL reuse `classify_ip`/`unwrap_mapped_v4` from `crates/deps-core/src/net_policy.rs` rather than duplicating classification logic — the same DRY rationale that placed `net_policy` in `deps-core` applies to its reuse here |
+
+## 5. Data Model
+
+No new persistent entities. This feature extends the *evaluation point* of the existing
+`HostClass`/`WorkspaceRegistryAccess` model (see [[net_policy]]), not its data shape.
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `HostClass` (existing) | Classification of a host, reused unchanged for resolved addresses | `Loopback`, `LinkLocal`, `CloudMetadata`, `PrivateV4`, `Cgnat`, `UniqueLocalV6`, `Unspecified`, `InternalName`, `Global` |
+| `WorkspaceRegistryAccess` (existing) | Live-updatable policy switch, unchanged semantics | `Off`, `PublicOnly`, `All` |
+| Resolved-address check (new, unnamed) | The connect-time gate this spec requires; naming and exact placement (custom `Resolve` impl vs. connector-level hook) left to the implementation | evaluates every A/AAAA address returned for a workspace-declared host against `HostClass` before the connection is used |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Hostname resolves to a mix of public and blocked addresses (multi-A-record) | Blocked per FR-003 — any blocked address in the resolved set aborts the connection, even if a public address is also present |
+| DNS TTL expires and re-resolves to a blocked address *after* a first successful connection in the same session | [NEEDS CLARIFICATION: whether per-connection re-validation is required for long-lived/pooled connections, or whether validating once per new TCP connection attempt is sufficient — affects `reqwest` connection-pool reuse behavior] |
+| Resolver returns no addresses / resolution fails | Fail-closed per NFR-004 — treated as blocked, not silently skipped |
+| IPv4-mapped IPv6 resolved address (`::ffff:169.254.169.254`) | Unwrapped via the existing `unwrap_mapped_v4` helper before classification, consistent with the string-based check |
+| `cargo.workspace_registries = off` | No DNS resolution attempted at all — request rejected before resolve, unaffected by this feature (FR-005) |
+| Corporate registry under `all` whose hostname legitimately resolves to an RFC1918 address | Not blocked — `all` policy already permits `PrivateV4`/`Cgnat`/`UniqueLocalV6`/`InternalName` per `HostClass::never_a_registry`'s narrower definition; only `never_a_registry`-class resolved addresses are blocked under `all` |
+| A redirect hop's target resolves to a blocked address | Blocked per FR-007, consistent with existing redirect-hop string-based hardening |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Tracking artifact exists for this follow-up | This spec file exists and is linked from `MOC-specs.md` and `net_policy.rs`'s doc comment (non-code deliverable of this CI cycle) |
+| SC-002 | Rebinding attempt blocked | Shipped — `deps-core/src/cache.rs`'s `test_validate_resolved_addrs_*` unit tests and PR #460's `TestLookup`-driven `BlockedAddrResolver` integration tests cover both the `never_a_registry` tier (PR #457) and the `PublicOnly`-policy RFC1918/CGNAT tier (PR #460) rejecting a resolved address at connect time |
+| SC-003 | No regression | Shipped — the existing `deps-cargo`/workspace test suite passes unmodified; `mockito`-based tests (which bind IP literals, never hostnames) are unaffected since literals never reach the configured resolver |
+| SC-004 | No added latency | Shipped — the guard adds one in-process classification per already-occurring DNS resolution, no extra round-trip; not separately benchmarked beyond the existing test suite's timing tolerances |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Cite `crates/deps-core/src/net_policy.rs`, issue `#443`, and PR #447 as prior art when
+  implementing the eventual fix — do not re-derive `HostClass` classification logic.
+- Run the full CI check suite (fmt, clippy, nextest, rustdoc gate) before any implementation PR
+  for this spec, per project convention.
+
+### Ask First
+- Choosing the specific `reqwest::dns::Resolve` (or equivalent) implementation strategy —
+  multiple valid approaches exist (custom resolver, connector-level IP pinning,
+  `hickory-resolver` integration) and the choice affects the shared client-pool architecture
+  used by all 11 ecosystem crates.
+- Any change to `WorkspaceRegistryAccess`'s public enum shape or default policy value.
+
+### Never
+- Implement this fix by re-adding DNS resolution to `classify_host` itself — the string-based
+  classifier is deliberately resolution-free (see its module doc); the fix belongs at the
+  connection layer, not the classification layer.
+- Change `off`'s behavior or scope as part of this fix (US-002).
+- Silently downgrade the fail-closed default (NFR-004) to fail-open for convenience or
+  performance.
+
+## 9. Open Questions
+
+All resolved by the shipped implementation:
+
+- Connection-pool re-validation cadence: resolved — `BlockedAddrResolver` is a
+  `reqwest::dns::Resolve` implementation, invoked by `reqwest`'s connector on every new
+  connection attempt (not on reuse of an already-pooled connection), which the shipped design
+  accepts as sufficient (validating once per new TCP connection attempt).
+- Which `reqwest` DNS-resolution hook point to use: resolved — a custom `reqwest::dns::Resolve`
+  (`BlockedAddrResolver`), wired once at `build_client`/`Transport` construction, the workspace's
+  sole `Client::builder()` call site.
+- Whether the fix composes with PR #447's redirect-hop string-based reclassification: resolved —
+  a redirect hop reuses the same `Client`, so `BlockedAddrResolver` validates its resolved
+  address too, "for free," alongside the existing string-based `hop_targets_blocked_host` check;
+  PR #460 additionally threads the policy-aware `AddrGuard` tier into the redirect policy itself
+  for the RFC1918/CGNAT case.
+
+## 10. See Also
+
+- [[net_policy|`crates/deps-core/src/net_policy.rs`]] — the string-based classifier this spec extends, now also exposing `classify_addr` for resolved-address classification
+- Issue `#443` — original SSRF/reachability-probing gap that PR #447 closed
+- PR `#447` — introduced `net_policy`, named this gap "D1 in the implementation plan," deferred it as a follow-up
+- Issue `#449`, PR `#457` — closed the policy-independent `never_a_registry` tier of this gap (`BlockedAddrResolver`, NAT64 unwrapping)
+- Issue `#455`, PR `#460` — closed the remaining `PublicOnly`-policy-aware (RFC1918/CGNAT) tier, at connect time and on redirect hops (`Transport`/`AddrGuard`)
+- [[023-cargo-custom-registries/spec#4-non-functional-requirements|023-cargo-custom-registries spec, NFR-003]] — the original residual-risk sign-off this gap traces back to
+- [[constitution]] — project principles
+- [[MOC-specs]] — all specifications

--- a/specs/025-osv-fix-target-scan-gap/spec.md
+++ b/specs/025-osv-fix-target-scan-gap/spec.md
@@ -1,0 +1,226 @@
+---
+aliases:
+  - OSV Fix-Target Scan Gap
+  - Recommended Fix Never Scanned
+tags:
+  - sdd
+  - spec
+  - bug
+  - osv
+  - deps-lsp
+  - deps-core
+created: 2026-09-02
+status: draft
+related:
+  - "[[constitution]]"
+  - "[[002-osv-vulnerability-diagnostics/spec|OSV vulnerability diagnostics]]"
+---
+
+# Feature: OSV Fix-Target Scan Gap — Recommended Fix Version Is Never Independently Scanned
+
+> [!info] Metadata
+> **Author**: continuous-improvement cycle (research/architecture stream)
+> **Branch**: fix/osv-fix-target-scan-gap (no issue number assigned yet — file a GitHub issue before branching)
+> **Priority**: P2
+> **Type**: bug
+
+## 1. Overview
+
+### Problem Statement
+
+The OSV vulnerability-scan pipeline runs in two phases:
+
+- **Phase A** (full scan) determines which dependencies have known advisories at all,
+  producing `deps_core::osv::ScanOutcome::Vulnerable(DependencyVulnerabilities)` per key.
+- **Phase B** (`run_osv_phase_b_and_commit` in
+  `crates/deps-lsp/src/document/lifecycle.rs`, around line 552) takes every
+  dependency phase A flagged vulnerable and re-checks a *single candidate
+  version per dependency* against OSV: the registry's **latest** version
+  (`doc.cached_versions[key].latest`, built into `ScanTarget` around line
+  578). The result is written into `DependencyVulnerabilities::upgrade_status`
+  as either `CandidateClean` or `CandidateVulnerable { advisory_ids, .. }`.
+
+Independently, `DependencyVulnerabilities::recommended_fix()`
+(`crates/deps-core/src/osv/types.rs`, lines 255–293) computes a
+`FixRecommendation` whose `version` field (F) is the **maximum
+`fixed_versions` entry across advisories not excluded by
+`upgrade_status`'s `CandidateVulnerable.advisory_ids` subtraction** — i.e. the
+lowest version that clears every advisory this method is willing to *claim*
+as fixed. F is derived purely from advisory metadata already fetched; it is
+a different value from "latest" whenever the minimal version that clears
+the currently-known/claimed advisories is older than the registry's newest
+release.
+
+`crates/deps-core/src/lsp_helpers/code_actions.rs` (`generate_code_actions`,
+line ~66) reads this `FixRecommendation` and offers a one-click "Update to
+`{F}` (fixes `{advisory_id}`)" code action. **F itself is never submitted to
+`OsvClient::check_candidates`** — only "latest" was ever checked, in phase
+B, before `recommended_fix()` even ran. The code action therefore presents F
+as a verified-clean fix without OSV having verified F.
+
+This gap was known to the implementers: a
+`// TODO(critic): phase B checks registry-latest only; the fix target F is
+never scanned — see #216 critique D1` comment was added at
+`crates/deps-lsp/src/document/lifecycle.rs:560` in the *same commit*
+(PR #236, commit `c28c7e42`) that introduced `recommended_fix()`. That PR
+also *closed* #216 (the issue the TODO cites), so the comment now points at
+a closed issue with no live tracking artifact. A search of open issues
+(`gh issue list --search`, multiple term combinations) found no separate
+issue ever filed for this specific residual gap — this spec is the first
+formal artifact tracking it.
+
+### Goal
+
+Phase B (or an equivalent verification step) scans the actual recommended
+fix target F — not only the registry's "latest" — before
+`generate_code_actions` presents F to the user as a verified fix. Exactly
+how F gets verified (extra OSV round-trip vs. a provably-sufficient
+reduction over already-fetched advisory data) is an open design question,
+deferred to `/sdd plan`.
+
+### Out of Scope
+
+- Redesigning `recommended_fix()`'s advisory-selection/exclusion logic
+  itself — this spec addresses only the fact that its output version is
+  unverified, not how that version is chosen.
+- Changing the code action's UX/wording beyond what's needed to reflect a
+  verified-vs-unverified fix state.
+- Any change to phase A (the initial full OSV scan).
+- Historical vulnerability data / advisory `introduced` event tracking
+  (already documented as a separate accepted limitation in
+  `recommended_fix()`'s doc comment).
+
+## 2. User Stories
+
+### US-001: Trustworthy one-click fix
+
+AS A developer using deps-lsp's OSV code action
+I WANT the "Update to X (fixes ADVISORY-ID)" suggestion to reflect a version
+that has actually been checked against OSV
+SO THAT applying the suggested edit doesn't silently leave me exposed to a
+different, unrelated advisory that also affects the recommended version
+
+**Acceptance criteria:**
+```
+GIVEN a dependency with advisory A (fixed in 1.5.0, still affects latest
+  3.0.0) and advisory B (fixed in 2.0.0, does not affect latest)
+WHEN phase B / fix-target verification runs
+THEN the version actually offered by the code action (F) has itself been
+  checked against OSV — either via a direct check_candidates call or via a
+  data-derived proof that no other known advisory applies to F
+```
+
+### US-002: No regression in phase B's existing "latest" check
+
+AS A maintainer of the OSV pipeline
+I WANT the existing "is latest still vulnerable" signal (used elsewhere,
+e.g. hover, to say "latest is also affected") to keep working exactly as
+today
+SO THAT fixing the fix-target gap does not remove or weaken an already
+correct and tested code path
+
+**Acceptance criteria:**
+```
+GIVEN the current phase B behavior for the registry-latest candidate
+WHEN the fix-target verification is added
+THEN CandidateClean / CandidateVulnerable for the "latest" candidate is
+  computed exactly as before, unchanged in cardinality or trigger conditions
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN `recommended_fix()` computes a `FixRecommendation` whose `version` (F) differs from the registry's `latest` THE SYSTEM SHALL verify F against OSV (or a provably-sufficient equivalent) before `generate_code_actions` presents F to the user | must |
+| FR-002 | WHEN F equals the already-scanned `latest` candidate THE SYSTEM SHALL reuse the existing phase B result for `latest` rather than issuing a redundant OSV request for the same version | should |
+| FR-003 | WHEN the verification of F finds F is itself still vulnerable to an advisory not already excluded by `recommended_fix()`'s claim logic THE SYSTEM SHALL NOT present F as a fix for that excluded advisory, and SHALL update the code action / recommendation accordingly (e.g. recompute against a higher fix version, or suppress the claim) | must |
+| FR-004 | WHEN the verification step is unable to complete (timeout, OSV unavailable) THE SYSTEM SHALL fall back to a documented degraded behavior (see NFR-002 / Edge Cases) rather than silently presenting an unverified F as verified | must |
+| FR-005 | WHEN a dependency's declared version is edited to F via the code action THE SYSTEM SHALL continue to trigger the existing full-rescan-on-`version_changed` path (already implemented, per the mitigating factor) — this spec does not change that behavior, only tightens the pre-edit guarantee | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | Verifying F must not add an unbounded number of extra OSV round-trips per document scan cycle — at most one additional `check_candidates` batch call across all vulnerable dependencies in the document, batched the same way phase B already batches the `latest` candidates |
+| NFR-002 | Reliability | If F cannot be verified within the existing `fetch_timeout_secs` / `OSV_SCAN_TIMEOUT_CEILING_SECS` budget, the system must degrade to a safe, clearly-distinguishable state (e.g. mark the recommendation as unverified, or omit the code action) rather than presenting an unverified F as verified |
+| NFR-003 | Correctness | The fix must close the concrete repro scenario in §"Edge Cases and Error Handling" without introducing a new false-negative (a fix presented as verified when it was not actually checked or provably covered) |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `DependencyVulnerabilities` (existing, `crates/deps-core/src/osv/types.rs`) | Per-dependency vulnerability state after phase A/B | `advisories`, `total_known`, `upgrade_status` |
+| `UpgradeStatus` (existing) | Result of checking one candidate version against OSV | `NotChecked`, `CandidateClean { version }`, `CandidateVulnerable { version, advisory_ids }` — currently populated only for the "latest" candidate |
+| `FixRecommendation` (existing) | Computed recommendation surfaced to the code action | `version` (F), `advisory_ids` — currently computed without F itself ever being scanned |
+| `ScanTarget` (existing, `deps_core::osv`) | Input to `OsvClient::check_candidates` | `key`, `osv_name`, `version`, `display_version` — phase B currently builds these only from `latest` |
+| *(new, shape TBD)* Fix-target verification result | Whatever `DependencyVulnerabilities` needs to record "F was checked / F is clean / F is still vulnerable to {ids}" so `generate_code_actions` can read it | `[NEEDS CLARIFICATION: does this reuse `UpgradeStatus` with a second variant/field, or is a separate field needed alongside `upgrade_status` since F and latest are two distinct candidates that can both need a stored verification result?]` |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| F == latest (the common case) | No extra OSV call — reuse the existing phase B result for `latest` (FR-002) |
+| F < latest, F itself is clean against all known advisories | Code action presents F as verified-clean, using the new verification path |
+| F < latest, F is still vulnerable to an advisory C not covered by the phase-A advisory set considered in `recommended_fix()`'s exclusion (the repro scenario: advisory C fixed only in 2.1.0, F=2.0.0) | System must not claim F as a clean fix for advisories excluded solely because they don't affect *latest* — either bump the recommendation to the version that clears C too, or explicitly surface C in the code action / suppress it until resolved |
+| OSV request for F times out or fails | Fall back per NFR-002 — do not silently present F as verified; degrade to omitting the extra guarantee or the whole code action, per implementation-time decision |
+| F cannot be parsed / is not a valid version in the target ecosystem's version scheme | Skip verification for that dependency, log at `debug`/`warn`, do not crash the scan |
+| Advisory data for F is only partially known due to `ADVISORY_DISPLAY_CAP` truncation (already-documented limitation of `recommended_fix()`) | Verification of F should be understood as best-effort within the same accepted incompleteness — no additional guarantee beyond what phase A's advisory fetch already provides |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Fix targets (F) that differ from `latest` and get verified before being offered by the code action | 100% (no F is presented as a fix without being scanned or provably covered) |
+| SC-002 | Additional OSV round-trips introduced per document scan when F == latest | 0 (reuse existing `latest` result, per FR-002) |
+| SC-003 | Live-tester follow-up (see Reproduction in Description) confirms the repro scenario no longer surfaces an unverified fix recommendation | Reproduced scenario passes after fix |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Read `crates/deps-core/src/osv/types.rs` and
+  `crates/deps-lsp/src/document/lifecycle.rs` in full before editing —
+  `DependencyVulnerabilities`, `UpgradeStatus`, and `run_osv_phase_b_and_commit`
+  all carry dense doc-comment context (critique references M4, S1, D1) that
+  must not be silently dropped
+- Preserve the existing "latest" phase B behavior (US-002) — add
+  verification for F alongside it, not instead of it
+- Update or remove the now-orphaned `// TODO(critic): ... see #216 critique
+  D1` comment once this gap is tracked by a live issue/PR
+- Run full CI checks (`cargo +nightly fmt --check`, clippy, nextest, rustdoc
+  gate) per project convention before any PR
+
+### Ask First
+- Whether to extend `UpgradeStatus` with a new variant/field vs. adding a
+  parallel field to `DependencyVulnerabilities` for F's verification result
+  (data model open question above)
+- Whether verifying F should always cost one extra OSV batch call, or
+  whether an interval-safe reduction over already-fetched advisory data can
+  substitute for it in the common case (the core open design question this
+  spec defers to `/sdd plan`)
+
+### Never
+- Silently drop the mitigating factor (post-edit full rescan on
+  `version_changed`) — that path must keep working exactly as today
+  regardless of how this gap is closed
+- File this as fixed without a live-tester (or equivalent) empirical
+  verification against a real OSV-affected package, per the project's
+  Live Testing Principle (`.claude/rules/continuous-improvement.md`) — this
+  finding was code-reading-only and explicitly flagged for live-test
+  follow-up
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Should F be verified via an additional direct `OsvClient::check_candidates` call, or can it be proven safe using only already-fetched advisory data (e.g. by checking whether every known advisory's `fixed_versions` is `<= F`, making a network round-trip unnecessary in the common case)? This is the central design trade-off deferred to `/sdd plan`.]
+- [NEEDS CLARIFICATION: When F differs from `latest`, should the two candidates (F and `latest`) share one `ScanTarget`/`check_candidates` batch call, or does the existing phase B call site need to grow a second, separate candidate list? Affects NFR-001's batching requirement.]
+- [NEEDS CLARIFICATION: What is the desired code-action UX when F cannot be verified before display (timeout/failure per NFR-002) — omit the code action entirely for that dependency, show it with a "unverified" qualifier in the title, or defer showing it until the next scan cycle?]
+- [NEEDS CLARIFICATION: Should a GitHub issue be filed for this finding (with `bug` + `P2` labels, referencing this spec) before implementation starts, per the project's continuous-improvement workflow? No issue currently exists — this spec was requested to be produced first.]
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[MOC-specs]] — all specifications
+- [[002-osv-vulnerability-diagnostics/spec|OSV vulnerability diagnostics]] — the original feature spec this bug was found within
+- `crates/deps-lsp/src/document/lifecycle.rs` — `run_osv_phase_b_and_commit`, the orphaned TODO at line ~560
+- `crates/deps-core/src/osv/types.rs` — `DependencyVulnerabilities::recommended_fix`, `FixRecommendation`, `UpgradeStatus`
+- `crates/deps-core/src/lsp_helpers/code_actions.rs` — `generate_code_actions`, the consumer of `recommended_fix()`
+- PR #236, commit `c28c7e42` — introduced `recommended_fix()` and the now-orphaned TODO; closed issue #216

--- a/specs/026-deno-npm-yanked-diagnostic-alignment/spec.md
+++ b/specs/026-deno-npm-yanked-diagnostic-alignment/spec.md
@@ -1,0 +1,182 @@
+---
+aliases:
+  - Deno npm: Yanked Diagnostic Alignment
+  - Deno/npm Cross-Ecosystem Yanked Consistency
+tags:
+  - sdd
+  - spec
+  - bug
+  - deps-deno
+  - deps-npm
+  - cross-ecosystem-consistency
+created: 2026-09-02
+status: shipped
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+---
+
+# Feature: Align Deno `npm:` Yanked Diagnostic with npm's Suppressed Behavior
+
+> [!info] Metadata
+> **Status**: Shipped — PR #456 (issue #448)
+> **Priority**: P2 (bug, cross-ecosystem consistency)
+> **Type**: bug
+
+## 1. Overview
+
+### Problem Statement
+
+Issue #436 changed `NpmFormatter::yanked_diagnostic_applies_to` to return `false`
+unconditionally: npm's `deprecated` field is genuinely per-version but commonly applied
+package-wide, so even an exact-pin `package.json` dependency no longer surfaced the
+manifest-requirement "yanked" diagnostic — that signal is superseded by the dedicated
+package-level deprecation diagnostic (issue #205).
+
+`DenoFormatter::yanked_diagnostic_applies_to` was out of scope for #436/#439 and kept its
+pre-existing behavior: restrict the diagnostic to exact-pin requirements, applied uniformly to
+both `jsr:` and `npm:` specifiers, because the hook's signature took only a `&VersionReq` —
+with no way to tell which scheme a dependency used, since the scheme lives in the package name
+(`npm:lodash`, `jsr:@std/fs`), not in the version-requirement text.
+
+The consequence: an exact-pin `npm:` dependency in `deno.json` (e.g. `npm:lodash@4.17.20`)
+still surfaced the yanked-worded diagnostic, while the equivalent exact-pin `package.json`
+dependency (`"lodash": "4.17.20"`) no longer did — the same underlying npm registry signal
+(`deprecated`) produced inconsistent LSP behavior depending only on which manifest format
+referenced it. This divergence was self-documented in `DenoFormatter`'s own doc comment
+("Known cross-ecosystem divergence (#436 M1, not fixed here...)") as a known, deliberately
+deferred gap; issue #448 formalized tracking it.
+
+### Goal (as shipped)
+
+`EcosystemFormatter::yanked_diagnostic_applies_to` gained a `dep: &dyn Dependency` parameter
+alongside the existing `requirement: &VersionReq`, so an implementor can key its decision off
+the dependency's package name. `DenoFormatter` uses this to branch on scheme: `npm:`
+specifiers now return `false` unconditionally, mirroring `NpmFormatter`'s post-#436 behavior
+exactly; `jsr:` specifiers keep the pre-existing exact-pin-only restriction, unchanged by this
+PR.
+
+### Out of Scope
+
+- Relaxing the `jsr:` exact-pin-only restriction itself — tracked separately as issue #454,
+  documented in [[029-deno-jsr-yanked-exact-pin-restriction-drop/spec|a follow-up spec]].
+- Any change to `ComposerFormatter`, which does not override this hook at all (it opts out at
+  the registry level, `Registry::reports_yanked() == false`, independently justified by #233
+  R2).
+- Any change to npm's or JSR's per-version yank/deprecation data sources themselves.
+
+## 2. User Stories
+
+### US-001: Consistent yanked signal across manifest formats for the same npm package
+
+AS A developer with an `npm:` dependency in `deno.json`
+I WANT the manifest-requirement "yanked" diagnostic to behave exactly as it does for the same
+package referenced from a `package.json`
+SO THAT the LSP's signal for the same underlying npm registry data does not depend on which
+manifest format happens to declare the dependency
+
+**Acceptance criteria:**
+```
+GIVEN an exact-pin npm: dependency in deno.json (e.g. npm:lodash@4.17.20) whose pinned
+  version is npm-deprecated
+WHEN diagnostics are generated for that document
+THEN the manifest-requirement-level "yanked" diagnostic does NOT fire, exactly as it would
+  not fire for the equivalent package.json dependency
+```
+
+### US-002: No regression for `jsr:` specifiers
+
+AS A maintainer of the OSV/yanked diagnostic pipeline
+I WANT jsr: specifiers to keep their existing exact-pin-only behavior unchanged
+SO THAT fixing the npm: divergence does not silently change JSR's already-correct behavior
+
+**Acceptance criteria:**
+```
+GIVEN an exact-pin jsr: dependency (e.g. jsr:@std/fs@1.0.0) whose pinned version is yanked
+WHEN diagnostics are generated for that document
+THEN the manifest-requirement-level "yanked" diagnostic still fires, identical to pre-#448
+  behavior
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | `EcosystemFormatter::yanked_diagnostic_applies_to` SHALL accept `dep: &dyn Dependency` in addition to `requirement: &VersionReq`, so implementors can discriminate by package name/scheme | must |
+| FR-002 | WHEN `DenoFormatter::yanked_diagnostic_applies_to` is called for a dependency whose name carries the `npm:` scheme THE SYSTEM SHALL return `false` unconditionally, regardless of requirement shape | must |
+| FR-003 | WHEN `DenoFormatter::yanked_diagnostic_applies_to` is called for a dependency whose name carries the `jsr:` scheme (or is unscoped, treated as `jsr:`) THE SYSTEM SHALL retain the pre-existing exact-pin-only behavior, unchanged | must |
+| FR-004 | `NpmFormatter::yanked_diagnostic_applies_to` SHALL continue returning `false` unconditionally under the new signature, with zero behavioral change from its post-#436 state | must |
+| FR-005 | The sole call site (`generate_diagnostics_from_cache`) SHALL pass the same `dep` whose `version_requirement()` produced `requirement`, so the two parameters are never independently sourced | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Compatibility | The trait's default implementation (used by formatters that do not override the hook) SHALL remain `true` for any `dep`/`requirement` pair, preserving today's behavior for every ecosystem that does not need scheme-awareness |
+| NFR-002 | Maintainability | The doc comment on `EcosystemFormatter::yanked_diagnostic_applies_to` SHALL document why each overriding formatter (`Deno`, `Npm`) answers the way it does, including the now-tracked `jsr:` follow-up (#454), so the rationale is not lost the way the original #436 M1 divergence was |
+
+## 5. Data Model
+
+No new persistent entities. This is a trait-signature change:
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `EcosystemFormatter::yanked_diagnostic_applies_to` (changed) | Hook deciding whether the manifest-requirement yanked diagnostic may fire for a given dependency | New parameter `dep: &dyn Dependency` alongside existing `requirement: &VersionReq`; default `true` |
+| `DenoFormatter::yanked_diagnostic_applies_to` (changed) | Deno's override | Branches on `split_scheme(dep.name().as_str())`: `Scheme::Npm` -> `false`; `Scheme::Jsr` (or `None`, unreachable in practice) -> exact-pin check |
+| `NpmFormatter::yanked_diagnostic_applies_to` (changed signature only) | npm's override | Unconditional `false`, unchanged behavior under the new signature |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| `npm:` dependency, any requirement shape (exact pin, range, wildcard) | Diagnostic never fires (FR-002) |
+| `jsr:` exact-pin dependency, pinned version yanked | Diagnostic fires, unchanged (FR-003) |
+| `jsr:` range-requirement dependency | Diagnostic does not fire, unchanged pre-existing behavior (out of scope here, see #454) |
+| `split_scheme` returns `None` (unscoped name) | Unreachable in practice — every parser-produced `DenoDependency` name is scheme-qualified — folded into the `jsr:` exact-pin path as a harmless default |
+| `package.json` dependency (not Deno) | Unaffected — `NpmFormatter`'s behavior and call sites are unchanged beyond the signature |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Unit tests for `DenoFormatter::yanked_diagnostic_applies_to` | `test_yanked_diagnostic_applies_to_npm_scheme_always_false` verifies `false` across `["1.2.3", "^1.2.3", "~1.2.3", "*"]` for `npm:lodash`; `test_yanked_diagnostic_applies_to_jsr_exact_pin_only` verifies the unchanged `jsr:` behavior — both pass |
+| SC-002 | Unit test for `NpmFormatter::yanked_diagnostic_applies_to` | `test_yanked_diagnostic_applies_to_always_false` updated for the new signature, passes unchanged in behavior |
+| SC-003 | End-to-end regression test through the real diagnostics pipeline | `test_handle_diagnostics_npm_scheme_exact_pin_yanked_stays_suppressed` (deno_tests, `crates/deps-lsp/src/handlers/diagnostics.rs`) confirms an exact-pin `npm:lodash@4.17.20` dependency with a deprecated pinned version produces zero diagnostics |
+| SC-004 | End-to-end companion test proving the scheme split discriminates | `test_handle_diagnostics_jsr_scheme_exact_pin_yanked_still_fires` confirms an exact-pin `jsr:@std/fs@1.0.0` dependency with a yanked pinned version still produces exactly one diagnostic |
+| SC-005 | Documentation | `docs/ECOSYSTEM_GUIDE.md`'s ecosystem coverage table and restriction prose updated: npm (and Deno's `npm:` specifiers) marked as unconditionally disabled rather than "exact pins only" |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Keep `NpmFormatter`'s behavior byte-for-byte unchanged when touching the shared trait
+  signature — only its parameter list changed, not its logic.
+- Update `docs/ECOSYSTEM_GUIDE.md`'s yanked-diagnostic restriction prose and ecosystem
+  coverage table whenever a formatter's `yanked_diagnostic_applies_to` behavior changes.
+
+### Ask First
+- Relaxing the `jsr:` exact-pin restriction (routed to issue #454 /
+  [[029-deno-jsr-yanked-exact-pin-restriction-drop/spec|spec 029]] instead).
+
+### Never
+- Reintroduce a scheme-blind hook signature for `EcosystemFormatter::yanked_diagnostic_applies_to`
+  — the whole point of this change was giving implementors access to the dependency, not just
+  the requirement.
+
+## 9. Open Questions
+
+None. This spec documents already-shipped, merged work; the one adjacent open item (relaxing
+the `jsr:` restriction) is tracked by issue #454 and
+[[029-deno-jsr-yanked-exact-pin-restriction-drop/spec|spec 029]], not by this spec.
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[MOC-specs]] — all specifications
+- [[029-deno-jsr-yanked-exact-pin-restriction-drop/spec|Drop jsr: exact-pin-only restriction on yanked diagnostic]] — the tracked follow-up this PR deliberately left open
+- `crates/deps-deno/src/formatter.rs` — `DenoFormatter::yanked_diagnostic_applies_to`
+- `crates/deps-npm/src/formatter.rs` — `NpmFormatter::yanked_diagnostic_applies_to`
+- `crates/deps-core/src/lsp_helpers/mod.rs` — `EcosystemFormatter::yanked_diagnostic_applies_to` trait definition
+- `crates/deps-core/src/lsp_helpers/diagnostics.rs` — `generate_diagnostics_from_cache`, the sole call site
+- Issue #436 — established npm's unconditional-`false` behavior this PR aligns Deno's `npm:` scheme with
+- Issue #448 — this spec's tracking issue
+- PR #456, commit `d8b2b578` — the shipped fix

--- a/specs/027-nuget-unlisted-version-and-multiproject-lockfile/spec.md
+++ b/specs/027-nuget-unlisted-version-and-multiproject-lockfile/spec.md
@@ -1,0 +1,203 @@
+---
+aliases:
+  - NuGet Unlisted Version Marker
+  - NuGet Multi-Project Lock File Matching
+tags:
+  - sdd
+  - spec
+  - bug
+  - deps-nuget
+  - lockfile
+  - hover
+created: 2026-09-02
+status: shipped
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+---
+
+# Feature: NuGet Unlisted-Version Hover Marker and Multi-Project Lock File Matching
+
+> [!info] Metadata
+> **Author**: Andrei G. (k05h31@gmail.com)
+> **Status**: Shipped — PR #458 (issue #451)
+> **Priority**: P2
+> **Type**: bug
+
+## 1. Overview
+
+### Problem Statement
+
+`deps-nuget` carried two `TODO(critic)` markers documenting known, accepted-tradeoff gaps
+that were never turned into tracked issues — issue #451 formalized both, and PR #458 shipped
+both fixes:
+
+1. **Unlisted versions reported as listed (D1).** The flat-container `get_versions` response
+   (`PackageBaseAddress`) carries no `listed` flag at all, so an unlisted (delisted/pulled)
+   NuGet version was indistinguishable from a listed one everywhere — hover, completion, and
+   inlay hints. The registration hive (`RegistrationsBaseUrl/3.6.0`) does carry a `listed`
+   field, but fetching it for every dependency on every code path (including inlay hints,
+   which render for every dependency in an open document) was rejected as the wrong latency
+   tradeoff. The gap sat undocumented and unfiled.
+2. **Multi-project lock file names not matched (D3).** NuGet's per-project lock file
+   convention, `packages.<project_name>.lock.json`, cannot be expressed in
+   `lockfile_filenames()`'s exact-name list (`&["packages.lock.json"]`, no glob support), so
+   a project sharing a directory with sibling projects — each with its own per-project lock
+   file — never had its lock file located at all.
+
+### Goal (as shipped)
+
+- Hover renders a `*(unlisted)*` marker on each unlisted version in the "Recent versions"
+  list, sourced from the registration hive, without changing completion, inlay hints, or
+  diagnostics (which all share the un-enriched cached version list).
+- `NuGetLockParser::locate_lockfile` finds a manifest's own
+  `packages.<project_name>.lock.json` when the exact `packages.lock.json` name is absent,
+  matched by the *requesting manifest's own* file stem — never the first
+  `packages.*.lock.json` file a directory scan happens to find.
+
+### Out of Scope
+
+- Threading `listed`/unlisted status into `deps_core::Version::removal_status` — that shared
+  type backs `get_versions_with`, which completion (`complete_versions_generic`) and the
+  per-document cached version list (read by inlay hints and diagnostics) all consume.
+  `prepare_version_display_items` filters unconditionally on
+  `removal_status().blocks_resolution()`, so wiring unlisted status through there would make
+  an unlisted version silently vanish from completion suggestions too — the exact tradeoff
+  issue #451 rejected. The marker stays hover-only, by design.
+- A general-purpose glob/wildcard capability for `Ecosystem::manifest_patterns` beyond the
+  single-`*` prefix/suffix scheme already in use — the new
+  `lockfile_pattern_matches`/`manifest_pattern_matches` helpers in
+  `crates/deps-core/src/ecosystem_registry.rs` reuse that existing scheme rather than
+  introducing a new one.
+
+## 2. User Stories
+
+### US-001: See that a version is unlisted, on hover
+
+AS A developer hovering over a NuGet `PackageReference`
+I WANT the "Recent versions" list to mark any unlisted (delisted/pulled) version
+SO THAT I know not to newly depend on it, the same way a `*(yanked)*` marker warns me off a
+yanked version in other ecosystems
+
+**Acceptance criteria (as shipped):**
+```
+GIVEN a package whose registration hive marks version 1.0.0 as listed: false (or, for a
+  registration predating that field, published <= the unlisted sentinel epoch)
+WHEN I hover over a dependency on that package
+THEN the "Recent versions" bullet for 1.0.0 reads "- `1.0.0` *(unlisted)*", in the same
+  position/spacing formatter.yanked_label() uses for *(yanked)*, and completion/inlay-hints/
+  diagnostics for the same package are unaffected
+```
+
+### US-002: Resolve a per-project lock file in a multi-project directory
+
+AS A developer with two or more `.csproj` files sharing one directory, each with its own
+`packages.<ProjectName>.lock.json`
+I WANT the LSP to find *my* project's lock file, not a sibling's
+SO THAT in-use-version data (hover, diagnostics) reflects what my project actually has
+resolved, not an unrelated project's resolution
+
+**Acceptance criteria (as shipped):**
+```
+GIVEN App1.csproj and App2.csproj in the same directory, with packages.App1.lock.json and
+  packages.App2.lock.json both present
+WHEN the LSP locates App1.csproj's lock file
+THEN it resolves to packages.App1.lock.json, never packages.App2.lock.json, and if only
+  packages.App2.lock.json exists (App1's own lock file absent), locate_lockfile returns None
+  rather than misattaching App2's resolved versions
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN a registration-hive catalog entry carries `"listed": false`, OR carries no `listed` field and its `published` timestamp is the unlisted sentinel (`<= 1970-01-01T00:00:00Z`, the pre-`listed`-field signal) THE SYSTEM SHALL classify that version as unlisted | must |
+| FR-002 | WHEN `NuGetEcosystem::generate_hover` renders a hover for a dependency THE SYSTEM SHALL concurrently (`tokio::join!`, not sequentially) fetch the base hover render and `NuGetRegistry::unlisted_versions_for_hover`'s unlisted-version set, so the unlisted lookup does not double hover's worst-case latency | must |
+| FR-003 | WHEN the unlisted-version fetch does not complete within `HOVER_UNLISTED_TIMEOUT` (5 seconds) THE SYSTEM SHALL return the base hover unmodified rather than delaying or failing the hover response | must |
+| FR-004 | WHEN the unlisted-version fetch fails (parse error, unreachable feed, no `RegistrationsBaseUrl` resource) THE SYSTEM SHALL degrade to an empty unlisted set and return the base hover unmodified, never surfacing a distinct error to the caller | must |
+| FR-005 | WHEN at least one version in the rendered "Recent versions" list is unlisted THE SYSTEM SHALL insert a `*(unlisted)*` marker immediately after the version literal and before any existing tag (`*(latest)*`, age suffix), leaving non-bullet lines (headers, footer) unchanged | must |
+| FR-006 | THE SYSTEM SHALL NOT thread unlisted status into `deps_core::Version::removal_status`, completion, inlay hints, or diagnostics — the marker is hover-only by design (see Out of Scope) | must |
+| FR-007 | WHEN `NuGetLockParser::locate_lockfile`'s exact-name search (`packages.lock.json`, same directory then up to 5 ancestor directories) finds nothing THE SYSTEM SHALL fall back to `packages.<project_name>.lock.json`, where `<project_name>` is the requesting manifest's own file stem, searched in the same directory then the same ancestor-walk order | must |
+| FR-008 | WHEN the multi-project fallback searches for `packages.<project_name>.lock.json` THE SYSTEM SHALL match only that exact computed filename — never the first `packages.*.lock.json` file found by a directory scan — so a directory holding multiple projects' per-project lock files never attaches an unrelated project's resolved versions to a manifest | must — regression, tester-found |
+| FR-009 | THE SYSTEM SHALL register `"packages.*.lock.json"` in `NuGetEcosystem::lockfile_filenames()` alongside the existing exact `"packages.lock.json"`, solely so `EcosystemRegistry`'s file-watch glob registration picks up per-project lock file changes — actual lock file *location* is unaffected by this list and is performed independently by `NuGetLockParser::locate_lockfile`'s own directory scan | must |
+| FR-010 | WHEN `EcosystemRegistry::get_for_lockfile` matches a filename against a single-`*`-wildcard `lockfile_filenames()` entry THE SYSTEM SHALL apply the same prefix/suffix matching scheme `manifest_patterns` already uses (`lockfile_pattern_matches`/`prefix_suffix_matches`), not a new matching mechanism | should |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | The unlisted-version enrichment adds zero additional latency to hover's happy path beyond the pre-existing registration-hive walk already performed for publish-time freshness — both signals are extracted from the same `registration_enrichment_from_index` walk in one pass |
+| NFR-002 | Reliability | Hover must never fail or hang because of the unlisted-version enrichment — bounded by `HOVER_UNLISTED_TIMEOUT` and fully error-tolerant (FR-003/FR-004) |
+| NFR-003 | Reliability | The multi-project lock file fallback must never silently attach a sibling project's resolved versions — verified by dedicated regression tests (FR-008) |
+| NFR-004 | Maintainability | The lockfile-pattern and manifest-pattern wildcard matching share one `prefix_suffix_matches` helper in `crates/deps-core/src/ecosystem_registry.rs` rather than duplicating the match logic per call site |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `RegistrationEnrichment` (new, `deps-nuget::registry`) | Per-package result of one registration-hive walk | `published: HashMap<String, PublishTime>` (existing), `unlisted: HashSet<String>` (new) |
+| `CatalogEntry::listed` (new field) | Explicit unlist flag on a registration-hive entry, absent on entries predating the field | `Option<bool>` |
+| `NuGetRegistry::unlisted_versions_for_hover` (new method) | Hover-only accessor returning the unlisted subset of a package's recent versions | Degrades to an empty `HashSet` on any failure |
+| `NuGetLockParser::locate_multi_project_lockfile` (new function) | Computes and searches for `packages.<project_stem>.lock.json` | Mirrors `locate_lockfile_for_manifest`'s own directory-walk depth (`MAX_WORKSPACE_DEPTH = 5`) |
+| `EcosystemRegistry::get_for_directory_pattern` / `lockfile_pattern_matches` / `prefix_suffix_matches` (new, `deps-core::ecosystem_registry`) | Shared wildcard-matching primitives | `prefix_suffix_matches` is the single-`*` glob core reused by both the lockfile matcher here and the directory-pattern matcher used by the sibling pypi fix (see [[028-pypi-requirements-documentlinks-and-directory-layout/spec\|requirements.txt documentLinks and directory-layout support]]) |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Registration entry has no `listed` field (predates it) but `published` is the unlisted sentinel | Classified unlisted (FR-001's fallback signal) |
+| Registration hive unreachable / malformed / no `RegistrationsBaseUrl` resource at all | Empty unlisted set; base hover renders unmodified (FR-004) |
+| Unlisted-version fetch exceeds `HOVER_UNLISTED_TIMEOUT` | Base hover returned unmodified; a `tracing::warn!` is logged (FR-003) |
+| No unlisted versions among the rendered "Recent versions" | Hover markdown passes through `annotate_unlisted_versions` unchanged |
+| Two `.csproj` files in one directory, each with its own per-project lock file | Each resolves to its own lock file by exact file-stem match (FR-008) |
+| Only a sibling project's `packages.<OtherProject>.lock.json` exists, this manifest's own is absent | `locate_lockfile` returns `None` — no misattachment (FR-008) |
+| Both `packages.lock.json` (exact) and `packages.<project>.lock.json` present in the same directory | Exact name wins; multi-project fallback is never consulted |
+| Multi-project lock file located in an ancestor (workspace) directory, not the manifest's own directory | Found via the same ancestor-walk order `locate_lockfile_for_manifest` already uses, up to `MAX_WORKSPACE_DEPTH` |
+| Unrelated files in the directory (`packages.json`, `packages..lock.json` with an empty project-name segment) | Not matched — `project_name.is_empty()` is rejected, and `packages.json` doesn't fit the computed pattern |
+
+## 7. Success Criteria
+
+| ID | Metric | Target | Verification |
+|----|--------|--------|--------------|
+| SC-001 | Unlisted versions marked in hover | `*(unlisted)*` rendered for every version classified unlisted per FR-001 | `test_annotate_unlisted_versions_tags_matching_bullet`, `test_annotate_unlisted_versions_preserves_existing_tags_and_age_suffix` (deps-nuget/src/ecosystem.rs) |
+| SC-002 | No regression to completion/inlay-hints/diagnostics | Unaffected by this change — verified by the pre-existing `deps-nuget` test suite passing unmodified | Existing suite, unmodified |
+| SC-003 | Multi-project lock file resolves to the correct sibling | Each of two co-located per-project lock files resolves to its own manifest, never the other's | `test_locate_lockfile_multi_project_matches_own_project_not_first_found`, `test_locate_lockfile_multi_project_does_not_match_other_projects_lock_file` (deps-nuget/src/lockfile.rs) |
+| SC-004 | Exact lock file name still takes priority | `packages.lock.json` wins over the multi-project fallback when both exist | `test_locate_lockfile_prefers_exact_name_over_multi_project` |
+| SC-005 | File-watch glob registered for per-project lock files | `lockfile_filenames()` includes `"packages.*.lock.json"` | `test_lockfile_filenames` |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Keep the unlisted-version enrichment hover-only; never thread it into
+  `Version::removal_status` or the shared cached-version-list path (FR-006).
+- Keep `HOVER_UNLISTED_TIMEOUT`-bounded, fail-open behavior for the unlisted fetch — hover
+  must never hang or error because of this optional decoration.
+- Reuse `prefix_suffix_matches` for any future single-`*`-wildcard matching need in
+  `ecosystem_registry.rs` rather than re-implementing prefix/suffix comparison.
+
+### Ask First
+- Widening `Ecosystem::lockfile_filenames()`'s pattern syntax beyond a single `*` wildcard.
+- Enriching completion, inlay hints, or diagnostics with unlisted status — a deliberate,
+  documented scope exclusion (Out of Scope), not an oversight.
+
+### Never
+- Pick "the first `packages.*.lock.json` found in a directory scan" as a shortcut for the
+  multi-project fallback — this was the exact tester-found regression FR-008 closes.
+- Add a dedicated map/index for directory-pattern or lockfile-pattern matching where the
+  existing linear scan (pattern count per ecosystem is tiny) already suffices.
+
+## 9. Open Questions
+
+None — this spec documents already-shipped, merged work with no outstanding scope decisions.
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[MOC-specs]] — all specifications
+- [[028-pypi-requirements-documentlinks-and-directory-layout/spec|requirements.txt documentLinks and directory-layout support]] — the pypi half of the same PR #458, sharing the new `ecosystem_registry.rs` wildcard-matching primitives
+- `crates/deps-nuget/src/registry.rs` — `RegistrationEnrichment`, `unlisted_versions_for_hover`, `accumulate_catalog_entries`
+- `crates/deps-nuget/src/ecosystem.rs` — `generate_hover` override, `annotate_unlisted_versions`
+- `crates/deps-nuget/src/lockfile.rs` — `locate_multi_project_lockfile`
+- `crates/deps-core/src/ecosystem_registry.rs` — `prefix_suffix_matches`, `lockfile_pattern_matches`
+- Issue #451
+- PR #458

--- a/specs/028-pypi-requirements-documentlinks-and-directory-layout/spec.md
+++ b/specs/028-pypi-requirements-documentlinks-and-directory-layout/spec.md
@@ -1,0 +1,239 @@
+---
+aliases:
+  - PyPI requirements.txt documentLinks
+  - requirements/*.txt directory layout
+tags:
+  - sdd
+  - spec
+  - enhancement
+  - deps-pypi
+  - lsp-protocol
+  - security
+created: 2026-09-02
+status: shipped
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+  - "[[009-pypi-requirements-txt/spec|Support requirements.txt (pip family) in deps-pypi]]"
+  - "[[027-nuget-unlisted-version-and-multiproject-lockfile/spec|NuGet unlisted-version hover marker and multi-project lock file matching]]"
+---
+
+# Feature: PyPI `requirements.txt` `-r`/`-c` documentLinks and `requirements/*.txt` Directory-Layout Recognition
+
+> [!info] Metadata
+> **Author**: k05h31@gmail.com
+> **Status**: Shipped — PR #458 (issue #452)
+> **Priority**: P3
+> **Type**: enhancement / security-hardening
+
+## 1. Overview
+
+### Problem Statement
+
+Two `TODO(critic)` markers in the `requirements.txt`-family handling
+(`deps-pypi`) documented known gaps with no linked issue, per issue #452:
+
+1. **`-r`/`-c` targets not surfaced as documentLinks**
+   (`crates/deps-pypi/src/parser/requirements.rs:20`, pre-fix): a
+   `-r other-requirements.txt` / `-c constraints.txt` reference inside a
+   `requirements.txt` was parsed (to skip it as a non-dependency option
+   line) but never exposed as an LSP `documentLink`, so a user could not
+   ctrl/cmd-click the reference to jump to the referenced file.
+2. **`requirements/*.txt` layout unsupported**
+   (`crates/deps-core/src/ecosystem_registry.rs:284`,
+   `EcosystemRegistry::get_for_uri`, pre-fix): ecosystem lookup was
+   filename-basename-only, so the common convention of splitting
+   `requirements.txt` into `requirements/base.txt`,
+   `requirements/dev.txt`, etc. was never recognized — a bare basename
+   match cannot see the directory a file lives in, only the file itself.
+
+Both markers were explicit, accepted-but-unfiled TODOs; PR #458 closed
+both as issue #452, alongside a comparable pair of `deps-nuget` gaps
+(issue #451, tracked separately — see [[027-nuget-unlisted-version-and-multiproject-lockfile/spec|the sibling spec]]).
+
+### Goal (achieved)
+
+- `-r`, `-c`, `--requirement`, and `--constraint` option targets in
+  `requirements.txt` are surfaced as `textDocument/documentLink` entries,
+  resolvable to the referenced file, with the click target validated
+  against link-spoofing before being shown.
+- A `requirements/*.txt` directory layout is recognized by
+  `EcosystemRegistry::get_for_uri` as a PyPI manifest, routed through a
+  stricter parse gate than a primary basename match, so a same-named but
+  unrelated `.txt` file (e.g. a prose requirements-engineering document
+  under a folder literally named `requirements/`) is not misclassified
+  as a Python manifest and does not trigger spurious PyPI network
+  lookups.
+
+### Out of Scope
+
+- Any change to dependency parsing/version resolution for
+  `requirements.txt` itself — this PR only adds documentLinks and
+  broadens which files are *routed* to the existing parser, not how
+  dependencies inside them are parsed.
+- `pyproject.toml`'s own file references (unaffected; this spec is
+  `requirements.txt`-family only).
+- General Unicode security hardening beyond the specific bidi/format/
+  zero-width character classes enumerated in FR-003 (not a general
+  Unicode-normalization pass).
+
+## 2. User Stories
+
+### US-001: Navigate to a referenced requirements/constraints file
+
+AS A developer with a split `requirements.txt` (`-r base.txt` /
+`-c constraints.txt` references)
+I WANT to ctrl/cmd-click the referenced filename to jump straight to it
+SO THAT I don't have to manually locate the file in the project tree
+
+**Acceptance criteria:**
+```
+GIVEN a requirements.txt containing "-r other-requirements.txt"
+WHEN the client requests textDocument/documentLink
+THEN a DocumentLink is returned whose range covers exactly the target
+  text ("other-requirements.txt") and whose target URI resolves to that
+  file relative to the containing document's directory, with a tooltip
+  showing the resolved absolute path
+```
+
+### US-002: Link target cannot be spoofed via bidi/zero-width characters
+
+AS A developer opening an untrusted or unreviewed repository
+I WANT a documentLink's visible text and its actual click target to
+never diverge because of hidden Unicode formatting characters
+SO THAT a hostile `requirements.txt` cannot make a link that reads as
+one file but opens another
+
+**Acceptance criteria:**
+```
+GIVEN a -r/-c target string containing a bidi override, zero-width
+  joiner, or other control/format character from the rejected set
+WHEN document links are generated
+THEN no DocumentLink is produced for that line, and the rejection is
+  logged via the shared warn_rejected_value helper — the file is
+  otherwise unaffected (its dependencies still parse normally)
+```
+
+### US-003: `requirements/*.txt` split-file layout is recognized without misclassifying prose
+
+AS A developer using the `requirements/base.txt` / `requirements/dev.txt`
+split-file convention
+I WANT those files recognized as PyPI manifests with live hover/
+diagnostics
+SO THAT I get the same LSP value a root-level `requirements.txt` gets
+
+**Acceptance criteria:**
+```
+GIVEN a file at requirements/base.txt with real pip-style content
+WHEN the LSP routes the file via EcosystemRegistry::get_for_uri
+THEN it resolves to the PyPI ecosystem and parses/reports normally
+
+GIVEN a file at requirements/introduction.txt that is prose (e.g. a
+  requirements-engineering document, not a Python manifest) whose lines
+  happen to parse as bare unpinned package names
+WHEN the LSP routes the file via the directory-pattern fallback
+THEN the stricter (require_strong_signal) parse gate drops the false
+  positive — no dependencies are reported and no PyPI network request is
+  made
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN a `requirements.txt`-family file contains a `-r`, `-c`, `--requirement`, or `--constraint` option line (space-separated or `--long=value` form) with a non-empty target THE SYSTEM SHALL record a document-link reference spanning exactly the target text's byte range, for both option spellings | must |
+| FR-002 | WHEN `Ecosystem::generate_document_links` is called with a parse result containing such references THE SYSTEM SHALL resolve each target relative to the containing document's directory (skipping targets already containing a URL scheme, e.g. `http://`) and return one `DocumentLink` per reference with a tooltip showing the resolved absolute path | must |
+| FR-003 | WHEN a link target contains an ASCII control character, a bidi override/embedding/isolate character (U+200E-U+200F, U+202A-U+202E, U+2066-U+2069), a zero-width joiner/space/no-break character (U+200B-U+200D, U+2060, U+FEFF), or a JS/JSON5 line terminator (U+2028, U+2029) THE SYSTEM SHALL reject the target (no `DocumentLink` produced) and log via `warn_rejected_value`, closing a link-target/tooltip spoofing vector | must — security |
+| FR-004 | THE SYSTEM SHALL add `Ecosystem::manifest_directory_patterns() -> &[(&'static str, &'static str)]` (default empty), and `EcosystemRegistry::get_for_uri` SHALL consult it — matching a file directly inside a named directory whose basename ends with the declared suffix — only after both `manifest_filenames` and `manifest_patterns` (basename-only) checks miss | must |
+| FR-005 | PyPI's `manifest_directory_patterns()` SHALL declare `[("requirements", ".txt")]`, recognizing any `*.txt` file directly inside a directory literally named `requirements/` | must |
+| FR-006 | WHEN a `requirements.txt`-family file was routed to the PyPI parser via the directory-pattern fallback (i.e., its basename matched neither `manifest_filenames` nor `manifest_patterns`) THE SYSTEM SHALL parse it with `require_strong_signal: true`, dropping the ratio-based ("more lines parsed than failed") keep-arm and requiring a genuine pip-option or version/Git/URL-bearing line to keep any dependencies — preventing prose files that happen to contain bare-word lines from being misclassified as a manifest | must |
+| FR-007 | WHEN a file's basename directly matches `manifest_filenames`/`manifest_patterns` (the pre-existing primary routes) THE SYSTEM SHALL continue to parse with `require_strong_signal: false`, unchanged from pre-fix behavior (no regression for root-level `requirements.txt`/`constraints.txt`) | must |
+| FR-008 | `EcosystemRegistry::get_for_lockfile` SHALL support the same single-`*`-wildcard prefix/suffix pattern scheme in `lockfile_filenames()` entries that `manifest_patterns` already used, reusing one shared `prefix_suffix_matches` helper (DRY with the directory-pattern and lockfile matchers; the NuGet half of PR #458 is the pattern's first consumer, see [[027-nuget-unlisted-version-and-multiproject-lockfile/spec|027]]) | should |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Reliability | Zero regression for root-level `requirements.txt`/`constraints.txt`: existing basename-routed files keep the pre-fix lenient (`require_strong_signal: false`) gate, verified by the existing `deps-pypi` test suite passing unmodified |
+| NFR-002 | Security | Link-target validation (FR-003) runs before any `DocumentLink` is constructed — no partially-validated or best-effort tooltip is ever shown for a rejected target |
+| NFR-003 | Maintainability | Directory-pattern matching (`get_for_directory_pattern`) and lockfile wildcard matching (`lockfile_pattern_matches`) both reuse the single `prefix_suffix_matches` helper rather than duplicating the length/`starts_with`/`ends_with` check a third time |
+| NFR-004 | Performance | `get_for_directory_pattern` is only consulted when both faster basename checks (`manifest_filenames` exact lookup, `manifest_patterns` glob scan) already missed — no added cost for the common case of a root-level manifest |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `RequirementRef` (new, `deps-pypi::parser`) | One parsed `-r`/`-c`/`--requirement`/`--constraint` reference | `range: Range` (target text only), `target: String` (raw, unresolved) |
+| `ParseResult::document_links` (new field, `deps-pypi::parser`) | Collected `RequirementRef`s for a parsed file | `Vec<RequirementRef>`, empty unless the file was kept (`keep == true`) |
+| `Ecosystem::generate_document_links` (new trait method, `deps-core`) | Produces LSP `DocumentLink`s from a parse result; default returns `Vec::new()` | Only `PypiEcosystem` overrides it as of this PR |
+| `Ecosystem::manifest_directory_patterns` (new trait method, `deps-core`) | Declares `(directory_name, suffix)` pairs an ecosystem recognizes via directory-layout convention | Default empty; PyPI declares `[("requirements", ".txt")]` |
+| `PypiParser::parse_requirements` (changed signature) | Gained a `require_strong_signal: bool` parameter | `true` when routed via `manifest_directory_patterns` fallback, `false` for a primary basename match |
+| `handle_document_link` (new handler, `deps-lsp::handlers::document_link`) | `textDocument/documentLink` request handler, ecosystem-trait delegation, no registry/network access | Loads the document, reads cached parse result, delegates to `Ecosystem::generate_document_links` |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| `-r`/`-c` target already a URL (`https://...`) | Left unresolved — not joined onto the filesystem directory, no `DocumentLink` produced for it (only local relative/absolute paths are resolved) |
+| Bare `-r` with no target text after it | No `RequirementRef` recorded — `extract_option_target` returns `None` |
+| Option other than `-r`/`-c`/`--requirement`/`--constraint` (e.g. `--index-url`, `-e`, `--pre`) | Never produces a document link, even though it is a recognized/strong-signal option for the parse-keep gate |
+| Target contains a bidi override or zero-width character | Rejected per FR-003; `warn_rejected_value` logs it; no crash, no partial link |
+| `requirements/introduction.txt` (prose file with bare-word lines resembling PEP 508 names, e.g. "Introduction", "Scope") | Directory-pattern-routed, `require_strong_signal: true` gate drops the ratio-based keep-arm; file yields zero dependencies, no live PyPI lookup |
+| `requirements/base.txt` with a genuine pip option or version-pinned line | Strong-signal check alone keeps it — `require_strong_signal` only removes the *ratio* arm, not the strong-signal arm |
+| Windows path separator mismatch between `Uri::to_file_path` (forward slashes) and `Path::join` (native `\`) | Tooltip is derived by round-tripping through the resolved `target_uri.to_file_path()`, not the raw joined `target_path`, so tooltip and target stay consistent |
+
+## 7. Success Criteria
+
+| ID | Metric | Target (verified) |
+|----|--------|--------------------|
+| SC-001 | `-r`/`-c`/`--requirement`/`--constraint` targets produce a correctly-ranged documentLink | Covered by `test_document_links_short_form`, `test_document_links_long_form_space_separated`, `test_document_links_long_form_equals_separated`, `test_document_links_range_slices_to_target_text_only` (`crates/deps-pypi/src/parser/requirements.rs`) |
+| SC-002 | Unrelated/known options never produce a link; a bare option with no target is skipped | Covered by `test_document_links_ignores_unrelated_options`, `test_document_links_bare_option_with_no_target_is_skipped` |
+| SC-003 | End-to-end `textDocument/documentLink` handler resolves a real reference to a file URI | Covered by `test_handle_document_link_requirements_reference` (`crates/deps-lsp/src/handlers/document_link.rs`) |
+| SC-004 | `requirements/*.txt` directory layout is recognized; unrelated directories/suffixes are not | Covered by `test_get_for_uri_directory_pattern_matches_split_requirements_layout`, `test_get_for_uri_directory_pattern_requires_matching_directory_and_suffix` (`crates/deps-core/src/ecosystem_registry.rs`) |
+| SC-005 | Directory-pattern-only routing does not misclassify prose as a manifest; genuine manifests under the same layout still parse | Covered by `test_strict_gate_drops_prose_that_would_survive_ratio_gate`, `test_strict_gate_still_keeps_file_with_real_pip_option`, `test_strict_gate_still_keeps_file_with_version_specifier` (`crates/deps-pypi/src/parser/requirements.rs`) |
+| SC-006 | Zero regression for root-level `requirements.txt`/`constraints.txt` | `test_constraints_txt_parses_identically` and the full pre-existing `deps-pypi` suite pass unmodified with the new `require_strong_signal` parameter threaded as `false` |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Reuse `prefix_suffix_matches`/`manifest_pattern_matches` for any future
+  basename/directory/lockfile wildcard matching rather than re-deriving
+  the `starts_with`/`ends_with`/length check.
+- Route any new PyPI file-reference feature through
+  `Ecosystem::generate_document_links` rather than a PyPI-specific
+  handler bypassing the trait.
+- Apply FR-003's rejected-character set to any other future
+  user-controlled, click-through target this project introduces
+  (consistent security posture across handlers).
+
+### Ask First
+- Extending `manifest_directory_patterns` to a second PyPI directory
+  convention, or to another ecosystem, beyond `requirements/*.txt` —
+  confirm the false-positive risk profile first (per FR-006's rationale).
+- Resolving `-r`/`-c` targets that are themselves absolute filesystem
+  paths outside the workspace root (not exercised by the shipped tests).
+
+### Never
+- Construct a `DocumentLink` from an unvalidated target string — FR-003's
+  check must run before any URI/tooltip is built, not after.
+- Loosen the `require_strong_signal` gate for directory-pattern-routed
+  files back to the ratio-based arm — that regresses the exact
+  misclassification (#452 S6) this PR closed.
+
+## 9. Open Questions
+
+None — this spec documents already-shipped, tested work. No
+`[NEEDS CLARIFICATION]` items remain open.
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[MOC-specs]] — all specifications
+- [[009-pypi-requirements-txt/spec|Support requirements.txt (pip family) in deps-pypi]] — the original feature spec this builds on
+- [[027-nuget-unlisted-version-and-multiproject-lockfile/spec|NuGet unlisted-version hover marker and multi-project lock file matching]] — the sibling half of the same PR (#458), covering the `deps-nuget` gaps (issue #451)
+- `crates/deps-pypi/src/parser/requirements.rs` — `-r`/`-c` parsing, `extract_option_target`, `require_strong_signal` gate
+- `crates/deps-pypi/src/ecosystem.rs` — `generate_document_links`, `is_safe_document_link_target`, `matched_only_via_directory_pattern`
+- `crates/deps-lsp/src/handlers/document_link.rs` — `handle_document_link`
+- `crates/deps-core/src/ecosystem_registry.rs` — `get_for_directory_pattern`, `manifest_pattern_matches`, `lockfile_pattern_matches`, `prefix_suffix_matches`
+- Issue #452 — the tracked TODO(critic) gap this spec documents
+- PR #458, commit `e6a67e77` — shipped implementation

--- a/specs/029-deno-jsr-yanked-exact-pin-restriction-drop/spec.md
+++ b/specs/029-deno-jsr-yanked-exact-pin-restriction-drop/spec.md
@@ -1,0 +1,226 @@
+---
+aliases:
+  - JSR Yanked Exact-Pin Restriction Drop
+  - jsr: Yanked Range Signal Gap
+tags:
+  - sdd
+  - spec
+  - bug
+  - deps-deno
+  - jsr
+  - cross-ecosystem-consistency
+created: 2026-09-02
+status: shipped
+related:
+  - "[[constitution]]"
+  - "[[026-deno-npm-yanked-diagnostic-alignment/spec|Align deno npm: yanked diagnostic with npm's suppressed behavior]]"
+---
+
+# Feature: Drop the jsr: Exact-Pin-Only Restriction on the Deno Yanked Diagnostic
+
+> [!info] Metadata
+> **Author**: Andrei G. (k05h31@gmail.com)
+> **Status**: Shipped — PR #459 (issue #454)
+> **Priority**: P2 (bug — silent diagnostic gap)
+> **Type**: bug
+
+## 1. Overview
+
+### Problem Statement
+
+[[026-deno-npm-yanked-diagnostic-alignment/spec|PR #456]] (issue #448) gave
+`DenoFormatter::yanked_diagnostic_applies_to` scheme awareness — it can now
+tell `jsr:` and `npm:` specifiers apart, so `npm:` could be made to match
+`NpmFormatter`'s unconditional `false`. That PR deliberately left `jsr:`'s
+pre-existing exact-pin-only restriction untouched, since removing it was out
+of #448's scope, and filed the follow-up as issue #454.
+
+The exact-pin-only restriction predated scheme awareness entirely: before
+#448, the hook took only a `&VersionReq`, with no way to distinguish `jsr:`
+from `npm:`, so both schemes had to share one answer, and exact-pin-only was
+that shared, historically-npm-motivated answer. Once `jsr:` could be treated
+on its own terms, its restriction's original justification —
+"avoid conflating with the `#205` package-level deprecation diagnostic" —
+turned out not to hold for JSR at all:
+`JsrVersion`'s `deps_core::impl_version!` invocation
+(`crates/deps-deno/src/types.rs:93-95`) leaves `deprecation` unset, so
+`Version::deprecation()` is structurally `None` for every JSR version and
+the `#205` diagnostic never fires for `jsr:` dependencies in the first
+place — there was nothing to conflate with.
+
+The concrete, previously-silent consequence: a `jsr:@std/fs@^1.0.0`
+dependency where every version matching the range was yanked produced
+**zero** diagnostic signal, because three independent diagnostics all
+missed it:
+
+- The manifest-requirement-level yanked diagnostic (`#247`) was suppressed
+  — `^1.0.0` is not an exact pin.
+- The `#205` package-level deprecation diagnostic never fires for `jsr:`,
+  per the structural `None` above.
+- The `#263`-style "in-use version" diagnostic does not apply to Deno
+  either — Deno has no lockfile support, and
+  `bare_version_is_a_range` (`crates/deps-core/src/lsp_helpers/
+  in_use_version.rs:30`) includes `EcosystemId::Deno` among the ecosystems
+  it treats as range-only.
+
+Cargo/PyPI/Dart — which have comparable per-version yank signal quality —
+already report this case, since none of them override
+`yanked_diagnostic_applies_to` and so keep the trait's unconditional-`true`
+default. This was a cross-ecosystem inconsistency with no technical
+justification, only a carried-over historical one.
+
+### Goal (shipped)
+
+`DenoFormatter::yanked_diagnostic_applies_to` now applies unconditionally
+(`true`) for `jsr:` specifiers, for any requirement shape — matching the
+`EcosystemFormatter` trait default that Cargo/PyPI/Dart already rely on. A
+`jsr:` range requirement satisfiable only by yanked versions now surfaces
+the `#247` diagnostic instead of producing zero signal. `npm:` specifiers
+are unaffected by this change and keep the unconditional `false` `#448`
+shipped.
+
+### Out of Scope
+
+- Any change to `npm:` specifier behavior — untouched, still unconditional
+  `false` per `#448`.
+- Adding a package-level deprecation-style diagnostic for JSR — out of
+  scope; JSR genuinely has no such signal (structural `None`, see above).
+- Deno lockfile support / the `#263`-style in-use-version diagnostic for
+  Deno — a separate, larger gap, not addressed here.
+- Changing `EcosystemFormatter::yanked_diagnostic_applies_to`'s trait
+  default or signature beyond dropping the now-unused `requirement`
+  parameter's role for the `jsr:` branch (the hook itself already gained
+  `dep: &dyn Dependency` access in `#448`; this PR does not change the
+  signature further, only the `jsr:` branch's return value).
+
+## 2. User Stories
+
+### US-001: JSR range requirement satisfiable only by yanked versions surfaces a diagnostic
+
+AS A developer with a `jsr:` dependency in `deno.json` declared as a range
+I WANT to be warned when every version matching that range has been yanked
+SO THAT I don't silently keep depending on a package with no viable
+resolvable version, the same protection Cargo/PyPI/Dart already give me
+
+**Acceptance criteria (verified shipped):**
+```
+GIVEN a deno.json importing "@std/fs": "jsr:@std/fs@^1.0.0"
+  AND every version satisfying ^1.0.0 (1.0.0, 1.0.1) is yanked on JSR
+WHEN diagnostics are computed
+THEN exactly one diagnostic fires: the #247 manifest-requirement-level
+  yanked diagnostic, with a message naming the latest version
+  (test_handle_diagnostics_jsr_scheme_range_yanked_only_now_fires,
+  crates/deps-lsp/src/handlers/diagnostics.rs)
+```
+
+### US-002: No regression for npm: specifiers or jsr: exact pins
+
+AS A maintainer of the Deno ecosystem crate
+I WANT `npm:` specifier behavior (`#448`) and the pre-existing `jsr:`
+exact-pin case to keep working exactly as before
+SO THAT closing the range-requirement gap does not reintroduce the
+`npm:`/`package.json` divergence `#448` fixed, or regress the already-working
+exact-pin path
+
+**Acceptance criteria (verified shipped):**
+```
+GIVEN an npm: specifier in deno.json, any requirement shape
+WHEN yanked_diagnostic_applies_to is evaluated
+THEN it returns false unconditionally, unchanged from #448
+  (test_yanked_diagnostic_applies_to_npm_scheme_* — untouched by this PR)
+
+GIVEN a jsr: specifier with an exact-pin requirement satisfiable only by a
+  yanked version
+WHEN diagnostics are computed
+THEN the #247 diagnostic still fires, exactly as it did before this PR
+  (test_handle_diagnostics_jsr_scheme_exact_pin_yanked_still_fires)
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN `DenoFormatter::yanked_diagnostic_applies_to` is evaluated for a `jsr:`-scheme dependency THE SYSTEM SHALL return `true` unconditionally, regardless of requirement shape (exact pin, caret/tilde range, or wildcard) | must |
+| FR-002 | WHEN `DenoFormatter::yanked_diagnostic_applies_to` is evaluated for an `npm:`-scheme dependency THE SYSTEM SHALL continue to return `false` unconditionally, unchanged from `#448` | must |
+| FR-003 | THE SYSTEM SHALL NOT introduce any additional network fetch to support this change — JSR's `meta.json` (`JsrRegistry::get_versions`) already returns every version's `yanked` flag in one fetch, identical whether the manifest requirement is a range or an exact pin | must |
+| FR-004 | THE SYSTEM SHALL update the doc comments on `EcosystemFormatter::yanked_diagnostic_applies_to` (trait-level) and `DenoFormatter::yanked_diagnostic_applies_to` (impl-level) to state the corrected rationale (JSR's `yanked` has no package-level counterpart to conflate with) rather than the superseded "restriction carried over from before scheme-awareness" rationale | should |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | Zero additional OSV/registry round-trips — resolved per FR-003; the issue's pre-implementation open question ("does the underlying deps-deno registry client have per-version yank data cheaply available outside the exact-pin fetch path?") is answered yes, the data was already fetched unconditionally |
+| NFR-002 | Reliability | No regression to `npm:` specifier handling or `jsr:` exact-pin handling — verified by the existing test suite plus the new range-requirement test, all passing |
+| NFR-003 | Consistency | Deno's `jsr:` yanked-diagnostic coverage now matches Cargo/PyPI/Dart's (unconditional trait default), closing the cross-ecosystem divergence noted in `docs/ECOSYSTEM_GUIDE.md`'s yanked-diagnostic coverage table |
+
+## 5. Data Model
+
+No new entities. This change narrows one existing trait method's behavior
+for one existing scheme branch.
+
+| Entity | Description | Change |
+|--------|-------------|--------|
+| `EcosystemFormatter::yanked_diagnostic_applies_to` (existing) | Per-dependency gate deciding whether the `#247` manifest-requirement yanked diagnostic may fire | Doc comment corrected (FR-004); signature unchanged from `#448` (`dep: &dyn Dependency`, `requirement: &VersionReq`) |
+| `DenoFormatter::yanked_diagnostic_applies_to` (existing impl) | Scheme-branching implementation | `jsr:` branch changed from `node_semver::Version::parse(requirement.as_str().trim()).is_ok()` (exact-pin check) to unconditional `true`; the `requirement` parameter is now unused for this impl and renamed `_requirement` |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior (shipped) |
+|----------|-------------------|
+| `jsr:` exact pin, pinned version yanked | Diagnostic fires — unchanged from before this PR |
+| `jsr:` range (`^`, `~`, wildcard `*`), every matching version yanked | Diagnostic now fires (the fixed bug) |
+| `jsr:` range, at least one matching version not yanked | Diagnostic does not fire — `yanked_diagnostic_applies_to` returning `true` only gates *eligibility*; the actual yanked-only-match computation (unchanged by this PR) still requires every satisfying version to be yanked |
+| `npm:` specifier, any requirement shape | Diagnostic never fires — untouched, `#448` behavior preserved |
+| `jsr:` dependency with a package-level deprecation payload | Not applicable — JSR versions structurally never carry one (`impl_version!`'s `deprecation` left unset), so there is no diagnostic to conflate with, confirming the original restriction's justification never held |
+
+## 7. Success Criteria
+
+| ID | Metric | Target (verified shipped) |
+|----|--------|--------|
+| SC-001 | `jsr:` range requirement satisfiable only by yanked versions surfaces the `#247` diagnostic | Pass — `test_handle_diagnostics_jsr_scheme_range_yanked_only_now_fires` |
+| SC-002 | `jsr:` exact-pin and `npm:` behavior unchanged | Pass — `test_handle_diagnostics_jsr_scheme_exact_pin_yanked_still_fires` and existing `npm:`-scheme tests pass unmodified |
+| SC-003 | Unit-level coverage of the relaxed `jsr:` branch across requirement shapes | Pass — `test_yanked_diagnostic_applies_to_jsr_scheme_always_true` asserts `true` for `"1.2.3"`, `"^1.2.3"`, `"~1.2.3"`, `"*"` |
+| SC-004 | No additional OSV/registry round-trip introduced | Confirmed by code inspection — `JsrRegistry::get_versions` fetch shape is unchanged; only the formatter-level gate changed |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Keep `npm:` and `jsr:` branches independently testable — do not
+  reintroduce a shared code path that could silently recouple their
+  behavior (the original bug's root cause).
+- Run full CI checks (`cargo +nightly fmt --check`, clippy, nextest,
+  rustdoc gate) per project convention before any follow-up PR touching
+  this area.
+
+### Ask First
+- Adding a Deno-specific package-level deprecation-style diagnostic for
+  JSR — JSR has no such upstream signal today; inventing one would be a
+  new feature, not a bug fix, and needs its own spec.
+
+### Never
+- Reintroduce the exact-pin-only restriction for `jsr:` without a new,
+  concrete technical justification — the original one is documented here
+  as unfounded.
+- Conflate this fix with `#448`'s `npm:` scope or with Deno lockfile
+  support (`#263`-style in-use-version diagnostic) — both are explicitly
+  out of scope (see Overview).
+
+## 9. Open Questions
+
+None. The issue's one pre-implementation question — whether verifying
+yanked status for a range costs an extra fetch — is resolved by FR-003/
+NFR-001: JSR's `meta.json` already returns every version's `yanked` flag
+in the single fetch the ecosystem performs regardless of requirement
+shape, so no design trade-off remained to defer.
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[MOC-specs]] — all specifications
+- [[026-deno-npm-yanked-diagnostic-alignment/spec|Align deno npm: yanked diagnostic with npm's suppressed behavior]] — the direct predecessor (`#448`/PR #456) that made this hook scheme-aware and deferred this `jsr:` follow-up
+- `crates/deps-deno/src/formatter.rs` — `DenoFormatter::yanked_diagnostic_applies_to`, the `jsr:` branch this PR relaxed
+- `crates/deps-deno/src/types.rs` — `JsrVersion`, `RemovalStatus::from_yanked`
+- `crates/deps-core/src/lsp_helpers/mod.rs` — `EcosystemFormatter::yanked_diagnostic_applies_to` trait doc
+- `crates/deps-core/src/lsp_helpers/in_use_version.rs` — `bare_version_is_a_range`, why the `#263`-style diagnostic does not cover Deno
+- `docs/ECOSYSTEM_GUIDE.md` — yanked-diagnostic ecosystem coverage table, updated by this PR
+- Issue #454, PR #459 (commit `209c7587`)

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -1,0 +1,61 @@
+---
+aliases:
+  - Specifications Index
+  - Specs Overview
+tags:
+  - moc
+  - sdd
+created: 2026-08-19
+status: moc
+---
+
+# Specifications
+
+> [!abstract]
+> Map of Content for all project specifications. Each entry links to
+> a feature spec with its current phase and status.
+
+## Active Specs
+
+| ID | Feature | Phase | Status |
+|----|---------|-------|--------|
+| 001 | [[001-yaml-rust2-saphyr-eval/spec\|Evaluate saphyr as eventual successor to yaml-rust2]] | specify | draft — recommendation: do not migrate now |
+| 002 | [[002-osv-vulnerability-diagnostics/spec\|OSV vulnerability diagnostics]] | specify | draft |
+| 003 | [[003-maven-legacy-version-sort/spec\|Fix Maven/Gradle version sort corrupted by legacy non-semver versions]] | specify | draft — bug, P1 |
+| 002 | [[002-osv-vulnerability-diagnostics/spec\|Vulnerability-aware diagnostics via OSV.dev batch API]] | plan | draft — plan complete, 5 open `[NEEDS CLARIFICATION]` items block `/sdd tasks` |
+| 004 | [[004-release-freshness-signal/spec\|Release-freshness signal for version recommendations]] | specify | draft — research/P2, 8 open `[NEEDS CLARIFICATION]` items |
+| 006 | [[006-completion-prefix-quote-stripping/spec\|Strip JSON string-delimiter quote from fallback completion prefix]] | specify | draft — bug, P2, 2 open `[NEEDS CLARIFICATION]` items |
+| 005 | [[005-completion-search-blocking-timeout/spec\|Bound latency of package-name completion fallback search]] | specify | draft — bug, P1, 4 open `[NEEDS CLARIFICATION]` items |
+| 007 | [[007-lightweight-registry-metadata/spec\|Adopt lightweight registry metadata formats for npm and PyPI version lookups]] | specify | draft — enhancement, P2 |
+| 007 | [[007-lightweight-registry-metadata/plan\|Adopt lightweight registry metadata formats for npm and PyPI version lookups]] | plan | draft — plan complete, 2 open `[NEEDS CLARIFICATION]` items block `/sdd tasks` |
+| 008 | [[008-codelens-update-all-outdated/spec\|CodeLens support for "update all outdated dependencies" action]] | specify | draft — research/parity, P2, 7 open `[NEEDS CLARIFICATION]` items |
+| 009 | [[009-pypi-requirements-txt/spec\|Support requirements.txt (pip family) in deps-pypi]] | specify | draft — enhancement/parity, P2, 7 open `[NEEDS CLARIFICATION]` items |
+| 010 | [[010-license-hover-policy/spec\|License in hover + license-policy diagnostics]] | specify | draft — research/parity, P3, 13 open `[NEEDS CLARIFICATION]` items |
+| 011 | [[011-deprecation-replacement-diagnostics/spec\|Deprecation/abandoned diagnostics with suggested replacement]] | specify | draft — research/parity, P3, 9 open `[NEEDS CLARIFICATION]` items |
+| 012 | [[012-unsatisfiable-requirement-diagnostic/spec\|Diagnostic for requirements matching zero published versions]] | specify | draft — enhancement/parity, P3, 9 open `[NEEDS CLARIFICATION]` items |
+| 013 | [[013-deno-jsr-ecosystem/spec\|New ecosystem: Deno/JSR (deno.json / deno.jsonc)]] | specify | draft — research/new ecosystem, P3, 10 open `[NEEDS CLARIFICATION]` items |
+| 014 | [[014-github-actions-ecosystem/spec\|New ecosystem: GitHub Actions workflow uses: pins]] | specify | draft — research/new ecosystem, P4, 9 open `[NEEDS CLARIFICATION]` items |
+| 015 | [[015-lsp-3-18-diagnostic-markup-tooltip-gap/spec\|LSP 3.18 diagnostic markup / command-tooltip support blocked by ls-types 0.0.6]] | specify | draft — research/dependency-gap, P4, 3 open `[NEEDS CLARIFICATION]` items, blocked on upstream — no `/sdd plan` |
+| 016 | [[016-bundler-platform-duplicate-versions/spec\|Deduplicate RubyGems platform-variant versions in Bundler hover]] | specify | draft — bug, P1, 3 open `[NEEDS CLARIFICATION]` items |
+| 017 | [[017-hover-latest-marker-prerelease-mismatch/spec\|Hover "Recent versions" `(latest)` marker can disagree with the header's `Latest` field]] | specify | draft — bug, P2, 2 open `[NEEDS CLARIFICATION]` items |
+| 018 | [[018-clippy-dashmap-await-guard/spec\|Add clippy.toml await-holding-invalid-types config for DashMap Ref guards]] | plan | draft — tooling/enhancement, P2, 2 open `[NEEDS CLARIFICATION]` items, plan complete |
+| 019 | [[019-npm-all-deprecated-unknown-package/spec\|npm/JSR packages whose every published version is deprecated must not be reported "Unknown package"]] | specify | draft — bug, P1, 2 open `[NEEDS CLARIFICATION]` items |
+| 020 | [[020-freshness-cooldown-diagnostics-blind/spec\|Release-cooldown callout never reaches diagnostics for registries that gate freshness behind get_versions_with]] | specify | draft — bug, P1, 1 open `[NEEDS CLARIFICATION]` item |
+| 021 | [[021-maven-wildcard-latest-ignores-prerelease/spec\|Maven/Gradle "Newer version available" diagnostic and quick-fix must not recommend a prerelease when a stable release is newer]] | specify | draft — bug, P1, 1 open `[NEEDS CLARIFICATION]` item |
+| 022 | [[022-pypi-package-completion-broken/spec\|PyPI package-name completion never returns results for any valid pyproject.toml shape]] | specify | draft — bug, P1, 2 open `[NEEDS CLARIFICATION]` items |
+| 023 | [[023-cargo-custom-registries/spec\|Cargo custom/private registry & source-replacement resolution]] | specify | shipped — enhancement/security, P4 (PR 1a #440, PR 1b #447) |
+| 023 | [[023-cargo-custom-registries/plan\|Cargo custom/private registry & source-replacement resolution]] | plan | shipped — 1a/1b PR sequencing delivered as PR #440 and PR #447 |
+| 024 | [[024-net-policy-dns-rebinding/spec\|DNS-rebinding bypass of the workspace-registry SSRF host classifier (net_policy)]] | specify | shipped — security-hardening, P3, closed in two stages (PR #457 issue #449, PR #460 issue #455) |
+| 025 | [[025-osv-fix-target-scan-gap/spec\|OSV fix-target scan gap — recommended fix version is never independently scanned]] | specify | draft — bug, P2, 4 open `[NEEDS CLARIFICATION]` items |
+| 026 | [[026-deno-npm-yanked-diagnostic-alignment/spec\|Align Deno npm: yanked diagnostic with npm's suppressed behavior]] | specify | shipped — bug, P2 (PR #456, issue #448) |
+| 027 | [[027-nuget-unlisted-version-and-multiproject-lockfile/spec\|NuGet unlisted-version hover marker and multi-project lock file matching]] | specify | shipped — bug, P2 (PR #458, issue #451) |
+| 028 | [[028-pypi-requirements-documentlinks-and-directory-layout/spec\|PyPI requirements.txt -r/-c documentLinks and requirements/*.txt directory-layout recognition]] | specify | shipped — enhancement/security-hardening, P3 (PR #458, issue #452) |
+| 029 | [[029-deno-jsr-yanked-exact-pin-restriction-drop/spec\|Drop the jsr: exact-pin-only restriction on the Deno yanked diagnostic]] | specify | shipped — bug, P2 (PR #459, issue #454) |
+
+## Completed Specs
+
+(none yet)
+
+## Project Foundation
+
+- [[constitution]] — non-negotiable project principles (not yet created)


### PR DESCRIPTION
## Summary

- Migrates the spec-driven-development archive from the gitignored `.local/specs/` into a git-tracked `specs/` folder at the repo root, so the SDD history stops disappearing at the end of each session.
- Verified sequential numbering (001-025 carried over cleanly; no gaps or duplicates found, no renumbering needed).
- Added 4 specs for already-shipped work that had no prior documentation: 026 (deno npm: yanked diagnostic alignment, #456), 027 (nuget unlisted-version hover marker + multi-project lockfile matching, #458), 028 (pypi requirements.txt documentLinks + directory-layout recognition, #458), 029 (deno jsr yanked exact-pin restriction drop, #459).
- Updated specs 023 and 024 to `shipped` status with references to the PRs that closed their remaining open questions (#440, #447, #457, #460), avoiding duplicate specs for already-covered work.
- Updated `specs/MOC-specs.md` with the final 29-entry index.

## Test plan

- [x] `git status` confirms only files under `specs/` are staged/committed; no source or `.local/` changes
- [ ] Reviewer spot-checks spec numbering and cross-links in `specs/MOC-specs.md`