### PR TITLE
fix(deps-core,deps-lsp): verify OSV fix-target version before offering it as a code action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: block DNS-rebinding to loopback/link-local/cloud-metadata/unspecified addresses at connect time, shared by every ecosystem crate (resolves #449; RFC1918/CGNAT residual tracked in #455) (#457)
 - **deps-deno**: a `jsr:` range requirement satisfiable only by yanked versions now surfaces the yanked diagnostic, matching Cargo/PyPI/Dart's behavior for the equivalent case (resolves #454)
 - **deps-core, deps-cargo, deps-lsp**: `cargo.workspace_registries`' `public_only`/`off` now enforced at connect time (resolved address) and on every redirect hop, not just the declared URL string at parse time, closing a DNS-rebinding bypass to RFC1918/CGNAT-range hosts (resolves #455) (#460)
-- **deps-core, deps-lsp**: the OSV vulnerability-fix code action's recommended target version is now independently verified against OSV before being offered, instead of only ever checking the registry's "latest" version (resolves #462)
+- **deps-core, deps-lsp**: the OSV vulnerability-fix code action's recommended target version is now independently verified against OSV before being offered, instead of only ever checking the registry's "latest" version (resolves #462) (#467)
 
 ## [0.11.1] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: block DNS-rebinding to loopback/link-local/cloud-metadata/unspecified addresses at connect time, shared by every ecosystem crate (resolves #449; RFC1918/CGNAT residual tracked in #455) (#457)
 - **deps-deno**: a `jsr:` range requirement satisfiable only by yanked versions now surfaces the yanked diagnostic, matching Cargo/PyPI/Dart's behavior for the equivalent case (resolves #454)
 - **deps-core, deps-cargo, deps-lsp**: `cargo.workspace_registries`' `public_only`/`off` now enforced at connect time (resolved address) and on every redirect hop, not just the declared URL string at parse time, closing a DNS-rebinding bypass to RFC1918/CGNAT-range hosts (resolves #455) (#460)
+- **deps-core, deps-lsp**: the OSV vulnerability-fix code action's recommended target version is now independently verified against OSV before being offered, instead of only ever checking the registry's "latest" version (resolves #462)
 
 ## [0.11.1] - 2026-09-01
 

--- a/crates/deps-core/src/lsp_helpers/code_actions.rs
+++ b/crates/deps-core/src/lsp_helpers/code_actions.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use tower_lsp_server::ls_types::{CodeAction, CodeActionKind, Position, Range, Uri, WorkspaceEdit};
 
-use crate::osv::ScanOutcome;
+use crate::osv::{ScanOutcome, UpgradeStatus};
 use crate::{ConcreteVersion, Dependency, ParseResult, Registry, VersionReq};
 
 use super::{
@@ -27,13 +27,67 @@ struct VulnerabilityFixAction {
     action: CodeAction,
 }
 
-/// Builds the "fix vulnerability" quickfix for `dep`, if OSV data
-/// recommends one.
+/// Whether `dv.fix_target_status` clears `fix` (F) as an honest, presentable fix (#462
+/// FR-003).
+///
+/// `CandidateClean { version: F }` always clears it. A `CandidateVulnerable { version: F,
+/// advisory_ids, total_known }` result can *also* clear it — F may legitimately still be
+/// affected by advisories `recommended_fix()` never claimed to resolve in the first place
+/// (excluded via `upgrade_status`'s `still_applying` subtraction, or never had a known fix at
+/// all): that is #216's original honest "partial fix" contract, not a gap this verification
+/// introduces. It is suppressed the moment `advisory_ids` names either a *claimed* advisory
+/// (`fix`'s own `advisory_ids` — the fix doesn't do what its title says) or an advisory this
+/// dependency's `advisories` never recorded at all: a brand-new advisory only visible by
+/// live-checking F itself, since phase A only ever queries the dependency's *declared*
+/// version, not F (the #462 repro: an advisory affecting some version strictly between
+/// declared and F, invisible until F is checked directly). Any other state (`None`,
+/// `NotChecked`, or a `version` mismatch) means F was never actually verified, so it is
+/// rejected too.
+///
+/// `advisory_ids` is itself capped at [`crate::osv::ADVISORY_DISPLAY_CAP`] the same way
+/// [`crate::osv::DependencyVulnerabilities::advisories`] is (#462 critic M1) — a truncated
+/// list can never be read as exhaustive, since the ids it dropped could just as easily be the
+/// claimed or unknown one that should have suppressed this fix. `advisory_ids.len() <
+/// total_known` is rejected unconditionally before the known/unclaimed check even runs, so a
+/// dependency with more affecting advisories than the cap never gets a false "verified clean"
+/// reading from a partial list.
+fn fix_target_is_verified(
+    dv: &crate::osv::DependencyVulnerabilities,
+    fix: &crate::osv::FixRecommendation,
+    version_native: &str,
+) -> bool {
+    match &dv.fix_target_status {
+        Some(UpgradeStatus::CandidateClean { version }) => version == version_native,
+        Some(UpgradeStatus::CandidateVulnerable {
+            version,
+            advisory_ids,
+            total_known,
+        }) if version == version_native => {
+            if advisory_ids.len() < *total_known {
+                return false;
+            }
+            let known_ids: HashSet<&str> = dv.advisories.iter().map(|a| a.id.as_str()).collect();
+            advisory_ids
+                .iter()
+                .all(|id| known_ids.contains(id.as_str()) && !fix.advisory_ids.contains(id))
+        }
+        _ => false,
+    }
+}
+
+/// Builds the "fix vulnerability" quickfix for `dep`, if OSV data recommends
+/// one AND that recommendation's target version F has itself been verified
+/// against OSV (#462) — see [`fix_target_is_verified`].
 ///
 /// Registry-independent by construction (FR-007, mirroring the rule already
 /// enforced in [`generate_diagnostics_from_cache`]): computed entirely from
 /// `versions.vulnerabilities` and `version_req` (the caller's already-fetched
-/// `dep.version_requirement()`), never from a registry fetch. Callers must
+/// `dep.version_requirement()`), never from a registry fetch — a *registry*
+/// outage still never hides this action. It is not OSV-independent, though:
+/// F's verification is computed in `deps-lsp`'s phase B and handed in via
+/// `dv.fix_target_status`, so an OSV outage (or a code-action request that
+/// races ahead of phase B completing) leaves that unresolved and suppresses
+/// this action — the intended fail-safe degradation, not a bug. Callers must
 /// still reconcile the result against a successful registry fetch when one
 /// is available — see the yank check in [`generate_code_actions`].
 fn build_vulnerability_fix_action(
@@ -73,6 +127,14 @@ fn build_vulnerability_fix_action(
         );
         return None;
     }
+
+    // #462: F must itself have been independently verified against OSV before it is
+    // offered as a fix — see `fix_target_is_verified`'s doc for the exact contract and why
+    // a `CandidateVulnerable` result doesn't always disqualify F.
+    if !fix_target_is_verified(dv, &fix, &version_native) {
+        return None;
+    }
+
     // Computed before the N1 guard below against the *same* formatting the
     // plain "update version" action uses (`format_version_replacing`), not
     // the bare version: several ecosystems wrap or expand it (`deps-dart`'s
@@ -354,17 +416,23 @@ fn build_replacement_action(
 /// Otherwise returns up to three kinds of action, in this order:
 ///
 /// 1. At most one `QUICKFIX` "fix vulnerability" action, if `versions`
-///    carries an OSV scan result flagging this dependency and
+///    carries an OSV scan result flagging this dependency,
 ///    [`crate::osv::DependencyVulnerabilities::recommended_fix`] has a
-///    claimable target (see the private `build_vulnerability_fix_action` helper
-///    just above). This action
+///    claimable target F, and F's own `fix_target_status` (populated by
+///    `deps-lsp`'s phase B, #462) clears it as a verified fix — see the
+///    private `build_vulnerability_fix_action` helper just above. This action
 ///    is computed entirely from `versions` and the dependency's declared
 ///    requirement, deliberately *before* the `registry.get_versions` call
-///    below — a registry outage must never hide a known-vulnerable
+///    below — a *registry* outage must never hide a known-vulnerable
 ///    dependency's fix (FR-007), so this action is still returned even when
-///    the registry fetch that produces the plain list below fails. When the
-///    fetch does succeed, a fix target the registry reports as yanked is
-///    dropped rather than offered.
+///    the registry fetch that produces the plain list below fails. This does
+///    not extend to an *OSV* outage or unavailability: F's verification is an
+///    OSV-derived precondition (`fix_target_status`), not a registry one, so
+///    an OSV outage — or a code-action request racing ahead of phase B
+///    completing — degrades to omitting this action entirely rather than
+///    presenting an unverified F as verified (FR-004, fail-safe). When the
+///    registry fetch does succeed, a fix target the registry reports as
+///    yanked is dropped rather than offered.
 /// 2. At most one `QUICKFIX` "fix unsatisfiable requirement" action, computed the same
 ///    registry-independent way (see the private `build_unsatisfiable_fix_action` helper
 ///    just above) for the same FR-007 reason. If its rewritten text collides with the
@@ -686,6 +754,9 @@ mod tests {
                     }),
                 ],
                 total_known: 2,
+                fix_target_status: Some(UpgradeStatus::CandidateClean {
+                    version: "1.2.0".to_string(),
+                }),
                 upgrade_status: UpgradeStatus::NotChecked,
             }),
         );
@@ -729,6 +800,13 @@ mod tests {
         // version that clears what is actually claimed — not 3.0.0, which
         // would push the user across an unnecessary major-version boundary
         // for a fix A1 that version does not even resolve.
+        //
+        // #462 critic S1: `fix_target_status` is deliberately `CandidateVulnerable{1.2.0,
+        // [A1]}`, not `CandidateClean` — the state a real live-check of F=1.2.0 would
+        // actually produce here, since A1 (known, fixed only at 3.0.0 > 1.2.0) still
+        // applies. Because A1 was already excluded from `claimed` (it is not in
+        // `fix.advisory_ids`), this must still be presented as a fix for A2 — the honest
+        // #216 partial-fix contract `fix_target_is_verified` preserves.
         use crate::osv::{Advisory, DependencyVulnerabilities, UpgradeStatus, VulnSeverity};
         use std::collections::HashMap;
 
@@ -765,9 +843,15 @@ mod tests {
                     }),
                 ],
                 total_known: 2,
+                fix_target_status: Some(UpgradeStatus::CandidateVulnerable {
+                    version: "1.2.0".to_string(),
+                    advisory_ids: vec!["A1".to_string()],
+                    total_known: 1,
+                }),
                 upgrade_status: UpgradeStatus::CandidateVulnerable {
                     version: "3.0.0".to_string(),
                     advisory_ids: vec!["A1".to_string()],
+                    total_known: 1,
                 },
             }),
         );
@@ -789,6 +873,347 @@ mod tests {
 
         let titles = quickfix_titles(&actions);
         assert_eq!(titles, vec!["Update to 1.2.0 (fixes A2)"]);
+    }
+
+    #[tokio::test]
+    async fn test_generate_code_actions_fix_target_is_not_suppressed_by_an_open_ended_advisory() {
+        // #462 critic re-critique: the sibling S1 scenario the fix exists to preserve — a
+        // dependency with an *open-ended* advisory (A1, no known fix at all) must not lose its
+        // quickfix. `recommended_fix()` filters A1 out of `claimed` for having no
+        // `fixed_versions` (a *different* exclusion path than the still-applying-at-latest
+        // subtraction the `..._subtracted_advisory` test above exercises), so F is computed
+        // from A2 alone (1.2.0) and `fix.advisory_ids = ["A2"]`. The live check of F=1.2.0
+        // correctly reports A1 still applies (it was never fixed) — A1 is known and unclaimed,
+        // so this must still be presented as a fix for A2, the honest #216 partial-fix contract.
+        use crate::osv::{Advisory, DependencyVulnerabilities, UpgradeStatus, VulnSeverity};
+        use std::collections::HashMap;
+
+        let (dep, version_range, content) = vulnerable_dep("1.0.0");
+        let parse_result = MockParseResult {
+            deps: vec![dep],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+
+        let mut vulnerabilities = crate::osv::VulnerabilityMap::new();
+        vulnerabilities.insert(
+            "pkg".to_string(),
+            ScanOutcome::Vulnerable(DependencyVulnerabilities {
+                advisories: vec![
+                    std::sync::Arc::new(Advisory {
+                        id: "A1".to_string(),
+                        modified: "2023-01-01T00:00:00Z".to_string(),
+                        summary: None,
+                        aliases: vec![],
+                        severity: VulnSeverity::High,
+                        cvss_vector: None,
+                        fixed_versions: vec![],
+                        url: String::new(),
+                    }),
+                    std::sync::Arc::new(Advisory {
+                        id: "A2".to_string(),
+                        modified: "2023-01-01T00:00:00Z".to_string(),
+                        summary: None,
+                        aliases: vec![],
+                        severity: VulnSeverity::Medium,
+                        cvss_vector: None,
+                        fixed_versions: vec!["1.2.0".to_string()],
+                        url: String::new(),
+                    }),
+                ],
+                total_known: 2,
+                fix_target_status: Some(UpgradeStatus::CandidateVulnerable {
+                    version: "1.2.0".to_string(),
+                    advisory_ids: vec!["A1".to_string()],
+                    total_known: 1,
+                }),
+                upgrade_status: UpgradeStatus::NotChecked,
+            }),
+        );
+
+        let cached = HashMap::new();
+        let resolved = HashMap::new();
+        let versions = VersionData::new(&cached, &resolved).with_vulnerabilities(&vulnerabilities);
+
+        let actions = generate_code_actions(
+            &parse_result,
+            version_range.start,
+            parse_result.uri(),
+            versions,
+            &content,
+            &MockRegistry,
+            &MockFormatter,
+        )
+        .await;
+
+        let titles = quickfix_titles(&actions);
+        assert_eq!(titles, vec!["Update to 1.2.0 (fixes A2)"]);
+    }
+
+    #[tokio::test]
+    async fn test_generate_code_actions_omits_fix_when_fix_target_status_reports_still_vulnerable()
+    {
+        // #462 critic C1 repro shape (smallvec 0.6.0 -> F=0.6.13, still affected by
+        // RUSTSEC-2021-0003, an advisory phase A's declared-version-only query never saw):
+        // `recommended_fix()` computes a claim (A1, fixed at 1.2.0) from the only advisory
+        // this dependency's `advisories` records, but the live verification of F reports a
+        // *different* id (A2) still applies — one this dependency's `advisories` never
+        // recorded at all. Unlike an already-known-and-excluded advisory (see the
+        // `..._subtracted_advisory` test above), a brand-new unknown advisory must always
+        // suppress the fix: it is not the honest #216 partial-fix case, it is exactly the
+        // gap #462 exists to close.
+        use crate::osv::{Advisory, DependencyVulnerabilities, UpgradeStatus, VulnSeverity};
+        use std::collections::HashMap;
+
+        let (dep, version_range, content) = vulnerable_dep("1.0.0");
+        let parse_result = MockParseResult {
+            deps: vec![dep],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+
+        let mut vulnerabilities = crate::osv::VulnerabilityMap::new();
+        vulnerabilities.insert(
+            "pkg".to_string(),
+            ScanOutcome::Vulnerable(DependencyVulnerabilities {
+                advisories: vec![std::sync::Arc::new(Advisory {
+                    id: "A1".to_string(),
+                    modified: "2023-01-01T00:00:00Z".to_string(),
+                    summary: None,
+                    aliases: vec![],
+                    severity: VulnSeverity::High,
+                    cvss_vector: None,
+                    fixed_versions: vec!["1.2.0".to_string()],
+                    url: String::new(),
+                })],
+                total_known: 1,
+                fix_target_status: Some(UpgradeStatus::CandidateVulnerable {
+                    version: "1.2.0".to_string(),
+                    advisory_ids: vec!["A2".to_string()],
+                    total_known: 1,
+                }),
+                upgrade_status: UpgradeStatus::NotChecked,
+            }),
+        );
+
+        let cached = HashMap::new();
+        let resolved = HashMap::new();
+        let versions = VersionData::new(&cached, &resolved).with_vulnerabilities(&vulnerabilities);
+
+        let actions = generate_code_actions(
+            &parse_result,
+            version_range.start,
+            parse_result.uri(),
+            versions,
+            &content,
+            &MockRegistry,
+            &MockFormatter,
+        )
+        .await;
+
+        assert!(
+            quickfix_titles(&actions).is_empty(),
+            "a fix target OSV found still vulnerable must never be presented as a verified fix"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_code_actions_omits_fix_when_fix_target_status_reports_a_claimed_advisory_still_applies()
+     {
+        // #462 FR-003, the other half of the S1 fix: unlike an already-excluded known
+        // advisory, a live check reporting that a *claimed* advisory (one `fix.advisory_ids`
+        // actually names) still applies to F means the fix doesn't do what its own title
+        // says — this must suppress the action even though the id is known, distinguishing
+        // it from the `..._subtracted_advisory` test's honest-partial-fix case.
+        use crate::osv::{Advisory, DependencyVulnerabilities, UpgradeStatus, VulnSeverity};
+        use std::collections::HashMap;
+
+        let (dep, version_range, content) = vulnerable_dep("1.0.0");
+        let parse_result = MockParseResult {
+            deps: vec![dep],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+
+        let mut vulnerabilities = crate::osv::VulnerabilityMap::new();
+        vulnerabilities.insert(
+            "pkg".to_string(),
+            ScanOutcome::Vulnerable(DependencyVulnerabilities {
+                advisories: vec![std::sync::Arc::new(Advisory {
+                    id: "A1".to_string(),
+                    modified: "2023-01-01T00:00:00Z".to_string(),
+                    summary: None,
+                    aliases: vec![],
+                    severity: VulnSeverity::High,
+                    cvss_vector: None,
+                    fixed_versions: vec!["1.2.0".to_string()],
+                    url: String::new(),
+                })],
+                total_known: 1,
+                // A1 is claimed (it's the only advisory, with a known fix, and nothing
+                // excludes it), yet the live check of F=1.2.0 reports A1 itself still
+                // applies — a claim the verification actually contradicts.
+                fix_target_status: Some(UpgradeStatus::CandidateVulnerable {
+                    version: "1.2.0".to_string(),
+                    advisory_ids: vec!["A1".to_string()],
+                    total_known: 1,
+                }),
+                upgrade_status: UpgradeStatus::NotChecked,
+            }),
+        );
+
+        let cached = HashMap::new();
+        let resolved = HashMap::new();
+        let versions = VersionData::new(&cached, &resolved).with_vulnerabilities(&vulnerabilities);
+
+        let actions = generate_code_actions(
+            &parse_result,
+            version_range.start,
+            parse_result.uri(),
+            versions,
+            &content,
+            &MockRegistry,
+            &MockFormatter,
+        )
+        .await;
+
+        assert!(
+            quickfix_titles(&actions).is_empty(),
+            "a fix must never claim to resolve an advisory the live check found it doesn't"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_code_actions_omits_fix_when_fix_target_status_advisory_ids_are_truncated()
+     {
+        // #462 critic M1: `check_candidates` caps `advisory_ids` at `ADVISORY_DISPLAY_CAP` the
+        // same way `DependencyVulnerabilities::advisories` is capped, so a `CandidateVulnerable`
+        // whose `advisory_ids` is shorter than `total_known` is NOT the complete list of
+        // advisories still affecting F — one of the truncated-away ids could be the claimed or
+        // unknown one that should suppress this fix. Here the single reported id (A2) is known
+        // and unclaimed — which the pre-M1-fix gate would have accepted — but `total_known: 2`
+        // proves a second, unreported advisory exists, so this must still be rejected rather
+        // than trusting a partial list as if it were exhaustive.
+        use crate::osv::{Advisory, DependencyVulnerabilities, UpgradeStatus, VulnSeverity};
+        use std::collections::HashMap;
+
+        let (dep, version_range, content) = vulnerable_dep("1.0.0");
+        let parse_result = MockParseResult {
+            deps: vec![dep],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+
+        let mut vulnerabilities = crate::osv::VulnerabilityMap::new();
+        vulnerabilities.insert(
+            "pkg".to_string(),
+            ScanOutcome::Vulnerable(DependencyVulnerabilities {
+                advisories: vec![
+                    std::sync::Arc::new(Advisory {
+                        id: "A1".to_string(),
+                        modified: "2023-01-01T00:00:00Z".to_string(),
+                        summary: None,
+                        aliases: vec![],
+                        severity: VulnSeverity::High,
+                        cvss_vector: None,
+                        fixed_versions: vec!["1.2.0".to_string()],
+                        url: String::new(),
+                    }),
+                    std::sync::Arc::new(Advisory {
+                        id: "A2".to_string(),
+                        modified: "2023-01-01T00:00:00Z".to_string(),
+                        summary: None,
+                        aliases: vec![],
+                        severity: VulnSeverity::Medium,
+                        cvss_vector: None,
+                        fixed_versions: vec![],
+                        url: String::new(),
+                    }),
+                ],
+                total_known: 2,
+                // Only A2 is reported (known, unclaimed — A1 is the sole claimed advisory),
+                // but `total_known: 2` says the live check actually found 2 advisories still
+                // affecting F; the second one was truncated out of `advisory_ids` and could be
+                // anything, including the still-applying A1 itself.
+                fix_target_status: Some(UpgradeStatus::CandidateVulnerable {
+                    version: "1.2.0".to_string(),
+                    advisory_ids: vec!["A2".to_string()],
+                    total_known: 2,
+                }),
+                upgrade_status: UpgradeStatus::NotChecked,
+            }),
+        );
+
+        let cached = HashMap::new();
+        let resolved = HashMap::new();
+        let versions = VersionData::new(&cached, &resolved).with_vulnerabilities(&vulnerabilities);
+
+        let actions = generate_code_actions(
+            &parse_result,
+            version_range.start,
+            parse_result.uri(),
+            versions,
+            &content,
+            &MockRegistry,
+            &MockFormatter,
+        )
+        .await;
+
+        assert!(
+            quickfix_titles(&actions).is_empty(),
+            "a truncated advisory_ids list must never be trusted as exhaustive"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_code_actions_omits_fix_when_fix_target_status_is_unresolved() {
+        // #462 FR-004/NFR-002: `fix_target_status: None` covers both "verification never ran
+        // yet" and "verification timed out" — either way, an unverified F must never be
+        // offered as a fix, the fail-safe default (no "unverified" qualifier, just omission).
+        use crate::osv::{Advisory, DependencyVulnerabilities, UpgradeStatus, VulnSeverity};
+        use std::collections::HashMap;
+
+        let (dep, version_range, content) = vulnerable_dep("1.0.0");
+        let parse_result = MockParseResult {
+            deps: vec![dep],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+
+        let mut vulnerabilities = crate::osv::VulnerabilityMap::new();
+        vulnerabilities.insert(
+            "pkg".to_string(),
+            ScanOutcome::Vulnerable(DependencyVulnerabilities {
+                advisories: vec![std::sync::Arc::new(Advisory {
+                    id: "A1".to_string(),
+                    modified: "2023-01-01T00:00:00Z".to_string(),
+                    summary: None,
+                    aliases: vec![],
+                    severity: VulnSeverity::High,
+                    cvss_vector: None,
+                    fixed_versions: vec!["1.2.0".to_string()],
+                    url: String::new(),
+                })],
+                total_known: 1,
+                fix_target_status: None,
+                upgrade_status: UpgradeStatus::NotChecked,
+            }),
+        );
+
+        let cached = HashMap::new();
+        let resolved = HashMap::new();
+        let versions = VersionData::new(&cached, &resolved).with_vulnerabilities(&vulnerabilities);
+
+        let actions = generate_code_actions(
+            &parse_result,
+            version_range.start,
+            parse_result.uri(),
+            versions,
+            &content,
+            &MockRegistry,
+            &MockFormatter,
+        )
+        .await;
+
+        assert!(
+            quickfix_titles(&actions).is_empty(),
+            "an unverified fix target must never be presented as a fix, timed out or not yet checked"
+        );
     }
 
     #[tokio::test]
@@ -817,6 +1242,9 @@ mod tests {
                     url: String::new(),
                 })],
                 total_known: 1,
+                fix_target_status: Some(UpgradeStatus::CandidateClean {
+                    version: "2.0.0".to_string(),
+                }),
                 upgrade_status: UpgradeStatus::NotChecked,
             }),
         );
@@ -874,6 +1302,7 @@ mod tests {
                     url: String::new(),
                 })],
                 total_known: 1,
+                fix_target_status: None,
                 upgrade_status: UpgradeStatus::NotChecked,
             }),
         );
@@ -928,6 +1357,7 @@ mod tests {
                     url: String::new(),
                 })],
                 total_known: 1,
+                fix_target_status: None,
                 upgrade_status: UpgradeStatus::NotChecked,
             }),
         );
@@ -1099,6 +1529,7 @@ mod tests {
                     url: String::new(),
                 })],
                 total_known: 1,
+                fix_target_status: None,
                 upgrade_status: UpgradeStatus::NotChecked,
             }),
         );
@@ -1198,6 +1629,9 @@ mod tests {
                     url: String::new(),
                 })],
                 total_known: 1,
+                fix_target_status: Some(UpgradeStatus::CandidateClean {
+                    version: "2.17.1".to_string(),
+                }),
                 upgrade_status: UpgradeStatus::NotChecked,
             }),
         );
@@ -1273,6 +1707,9 @@ mod tests {
                     url: String::new(),
                 })],
                 total_known: 1,
+                fix_target_status: Some(UpgradeStatus::CandidateClean {
+                    version: "1.2.5".to_string(),
+                }),
                 upgrade_status: UpgradeStatus::NotChecked,
             }),
         );
@@ -1394,6 +1831,9 @@ mod tests {
                     url: String::new(),
                 })],
                 total_known: 1,
+                fix_target_status: Some(UpgradeStatus::CandidateClean {
+                    version: "1.0.2".to_string(),
+                }),
                 upgrade_status: UpgradeStatus::NotChecked,
             }),
         );
@@ -1451,6 +1891,9 @@ mod tests {
                     url: String::new(),
                 })],
                 total_known: 1,
+                fix_target_status: Some(UpgradeStatus::CandidateClean {
+                    version: "1.2.0".to_string(),
+                }),
                 upgrade_status: UpgradeStatus::NotChecked,
             }),
         );
@@ -1511,6 +1954,9 @@ mod tests {
                     url: String::new(),
                 })],
                 total_known: 1,
+                fix_target_status: Some(UpgradeStatus::CandidateClean {
+                    version: "1.2.0".to_string(),
+                }),
                 upgrade_status: UpgradeStatus::NotChecked,
             }),
         );
@@ -1656,6 +2102,9 @@ mod tests {
                     url: String::new(),
                 })],
                 total_known: 1,
+                fix_target_status: Some(UpgradeStatus::CandidateClean {
+                    version: "1.0.2".to_string(),
+                }),
                 upgrade_status: UpgradeStatus::NotChecked,
             }),
         );
@@ -1940,6 +2389,7 @@ mod tests {
                         url: String::new(),
                     })],
                     total_known: 1,
+                    fix_target_status: None,
                     upgrade_status: UpgradeStatus::NotChecked,
                 }),
             );
@@ -2576,6 +3026,9 @@ mod tests {
                         url: String::new(),
                     })],
                     total_known: 1,
+                    fix_target_status: Some(UpgradeStatus::CandidateClean {
+                        version: "5.5.5".to_string(),
+                    }),
                     upgrade_status: UpgradeStatus::NotChecked,
                 }),
             );
@@ -2653,6 +3106,9 @@ mod tests {
                         url: String::new(),
                     })],
                     total_known: 1,
+                    fix_target_status: Some(UpgradeStatus::CandidateClean {
+                        version: "9.9.9".to_string(),
+                    }),
                     upgrade_status: UpgradeStatus::NotChecked,
                 }),
             );
@@ -2713,6 +3169,9 @@ mod tests {
                         url: String::new(),
                     })],
                     total_known: 1,
+                    fix_target_status: Some(UpgradeStatus::CandidateClean {
+                        version: "9.9.5".to_string(),
+                    }),
                     upgrade_status: UpgradeStatus::NotChecked,
                 }),
             );

--- a/crates/deps-core/src/lsp_helpers/diagnostics.rs
+++ b/crates/deps-core/src/lsp_helpers/diagnostics.rs
@@ -2670,6 +2670,7 @@ mod tests {
             ScanOutcome::Vulnerable(DependencyVulnerabilities {
                 advisories: vec![sample_advisory("RUSTSEC-2020-0071", VulnSeverity::High)],
                 total_known: 1,
+                fix_target_status: None,
                 upgrade_status: UpgradeStatus::NotChecked,
             }),
         );
@@ -2718,6 +2719,7 @@ mod tests {
             ScanOutcome::Vulnerable(DependencyVulnerabilities {
                 advisories,
                 total_known: 40,
+                fix_target_status: None,
                 upgrade_status: UpgradeStatus::NotChecked,
             }),
         );
@@ -2798,6 +2800,7 @@ mod tests {
             ScanOutcome::Vulnerable(DependencyVulnerabilities {
                 advisories: vec![sample_advisory("RUSTSEC-2020-0071", VulnSeverity::High)],
                 total_known: 1,
+                fix_target_status: None,
                 upgrade_status: UpgradeStatus::NotChecked,
             }),
         );

--- a/crates/deps-core/src/lsp_helpers/hover.rs
+++ b/crates/deps-core/src/lsp_helpers/hover.rs
@@ -2099,9 +2099,11 @@ mod tests {
             ScanOutcome::Vulnerable(DependencyVulnerabilities {
                 advisories: vec![sample_advisory("RUSTSEC-2020-0071", VulnSeverity::Critical)],
                 total_known: 3,
+                fix_target_status: None,
                 upgrade_status: UpgradeStatus::CandidateVulnerable {
                     version: "2.0.0".into(),
                     advisory_ids: vec!["RUSTSEC-2020-0071".to_string()],
+                    total_known: 1,
                 },
             }),
         );
@@ -2177,6 +2179,7 @@ mod tests {
             ScanOutcome::Vulnerable(DependencyVulnerabilities {
                 advisories: vec![sample_advisory("RUSTSEC-2020-0071", VulnSeverity::Critical)],
                 total_known: 1,
+                fix_target_status: None,
                 upgrade_status: UpgradeStatus::NotChecked,
             }),
         );

--- a/crates/deps-core/src/osv/mod.rs
+++ b/crates/deps-core/src/osv/mod.rs
@@ -247,6 +247,7 @@ impl OsvClient {
                     ScanOutcome::Vulnerable(dv) => UpgradeStatus::CandidateVulnerable {
                         version,
                         advisory_ids: dv.advisories.iter().map(|a| a.id.clone()).collect(),
+                        total_known: dv.total_known,
                     },
                     ScanOutcome::Skipped(_) => return None,
                 };
@@ -507,6 +508,7 @@ impl OsvClient {
             ScanOutcome::Vulnerable(DependencyVulnerabilities {
                 advisories,
                 total_known: total,
+                fix_target_status: None,
                 upgrade_status: UpgradeStatus::NotChecked,
             })
         }
@@ -530,6 +532,7 @@ impl OsvClient {
         ScanOutcome::Vulnerable(DependencyVulnerabilities {
             advisories,
             total_known: vuln_ids.len(),
+            fix_target_status: None,
             upgrade_status: UpgradeStatus::NotChecked,
         })
     }
@@ -1236,8 +1239,8 @@ mod tests {
         ));
         assert!(matches!(
             statuses.get("bad-pkg"),
-            Some(UpgradeStatus::CandidateVulnerable { version, advisory_ids })
-                if version == "2.0.0" && advisory_ids == &vec!["ADV-1".to_string()]
+            Some(UpgradeStatus::CandidateVulnerable { version, advisory_ids, total_known })
+                if version == "2.0.0" && advisory_ids == &vec!["ADV-1".to_string()] && *total_known == 1
         ));
     }
 

--- a/crates/deps-core/src/osv/types.rs
+++ b/crates/deps-core/src/osv/types.rs
@@ -125,7 +125,10 @@ pub struct Advisory {
 /// Result of checking whether a recommended upgrade target is itself affected.
 ///
 /// Populated by [`crate::osv::OsvClient::check_candidates`] (phase B), which only runs for
-/// dependencies phase A already flagged as [`ScanOutcome::Vulnerable`].
+/// dependencies phase A already flagged as [`ScanOutcome::Vulnerable`]. Used for both the
+/// registry's "latest" candidate ([`DependencyVulnerabilities::upgrade_status`]) and the
+/// independently-verified fix target F ([`DependencyVulnerabilities::fix_target_status`]) —
+/// see the latter's doc for why F needs its own verification result distinct from latest's.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UpgradeStatus {
     /// Phase B has not run for this dependency (phase A found nothing, or
@@ -140,8 +143,20 @@ pub enum UpgradeStatus {
     CandidateVulnerable {
         /// The version that was checked.
         version: String,
-        /// Advisory IDs that still apply to the candidate version.
+        /// Advisory IDs that still apply to the candidate version, capped at
+        /// [`crate::osv::ADVISORY_DISPLAY_CAP`] the same way
+        /// [`DependencyVulnerabilities::advisories`] is (#462 critic M1) —
+        /// **not necessarily exhaustive**. Compare its length against
+        /// `total_known` before treating it as the complete set of advisories
+        /// still affecting this candidate; a shorter list means some are
+        /// missing, not that none exist.
         advisory_ids: Vec<String>,
+        /// The true count of advisories OSV reported as still affecting this
+        /// candidate, independent of how many `advisory_ids` actually
+        /// carries — the same `total_known`/capped-list split
+        /// [`DependencyVulnerabilities`] already makes, mirrored here so a
+        /// truncated `advisory_ids` is never silently mistaken for complete.
+        total_known: usize,
     },
 }
 
@@ -155,8 +170,27 @@ pub struct DependencyVulnerabilities {
     /// how many were actually fetched — the source of the render layer's
     /// "+N more advisories" count (`architecture.md` §7/§8 invariant 3).
     pub total_known: usize,
-    /// Result of phase B, if it has run for this dependency.
+    /// Result of phase B's "latest" check, if it has run for this dependency.
     pub upgrade_status: UpgradeStatus,
+    /// Independent verification of [`Self::recommended_fix`]'s target version F, if F
+    /// differs from the "latest" candidate `upgrade_status` already covers. `None` until
+    /// [`Self::recommended_fix`] has been computed and F's status resolved — either reused
+    /// from `upgrade_status` when F equals latest, or checked live via
+    /// [`crate::osv::OsvClient::check_candidates`] otherwise (always live-checked when F
+    /// differs from latest: a data-derived shortcut was tried and rejected — see git history
+    /// on this field and #462's critique — because it degenerates into checking F against
+    /// exactly the advisories it was computed from, proving nothing about an advisory phase
+    /// A never fetched at all, which is the actual gap #462 closes). See
+    /// `run_osv_phase_b_and_commit` in `deps-lsp` for the resolution order.
+    ///
+    /// A caller must not treat a bare `Some(UpgradeStatus::CandidateClean { .. })` check as
+    /// the only valid "verified" state: `Some(UpgradeStatus::CandidateVulnerable { .. })` can
+    /// also be a legitimate, presentable fix when every reported id is an advisory
+    /// [`Self::recommended_fix`] already declined to claim (excluded via `still_applying`, or
+    /// never had a known fix) — see `deps-core`'s `lsp_helpers::code_actions::fix_target_is_verified`
+    /// (the actual gate `generate_code_actions` uses) for the full contract, rather than
+    /// re-deriving it ad hoc.
+    pub fix_target_status: Option<UpgradeStatus>,
 }
 
 /// A single upgrade target recommended by [`DependencyVulnerabilities::recommended_fix`].
@@ -245,6 +279,7 @@ impl DependencyVulnerabilities {
     ///     advisories: vec![advisory("RUSTSEC-1", "1.2.0")],
     ///     total_known: 1,
     ///     upgrade_status: UpgradeStatus::NotChecked,
+    ///     fix_target_status: None,
     /// };
     ///
     /// let fix = dv.recommended_fix().unwrap();
@@ -777,6 +812,7 @@ mod recommended_fix_tests {
             total_known: advisories.len(),
             advisories,
             upgrade_status,
+            fix_target_status: None,
         }
     }
 
@@ -820,6 +856,7 @@ mod recommended_fix_tests {
             UpgradeStatus::CandidateVulnerable {
                 version: "1.2.0".to_string(),
                 advisory_ids: vec!["A1".to_string()],
+                total_known: 1,
             },
         );
 
@@ -835,6 +872,7 @@ mod recommended_fix_tests {
             UpgradeStatus::CandidateVulnerable {
                 version: "1.1.0".to_string(),
                 advisory_ids: vec!["A1".to_string()],
+                total_known: 1,
             },
         );
         assert!(vulns.recommended_fix().is_none());
@@ -883,6 +921,7 @@ mod recommended_fix_tests {
             UpgradeStatus::CandidateVulnerable {
                 version: "3.0.0".to_string(),
                 advisory_ids: vec!["A1".to_string()],
+                total_known: 1,
             },
         );
 

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -21,7 +21,7 @@ use deps_core::VersionReq;
 use deps_core::lsp_helpers::in_use_version;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tower_lsp_server::Client;
@@ -527,7 +527,9 @@ async fn run_osv_scan_phase_a(
 /// Phase B: for every dependency phase A flagged [`deps_core::osv::ScanOutcome::Vulnerable`],
 /// checks whether the version currently recommended (the registry's latest,
 /// now that the registry fetch has resolved — critique S1) is itself
-/// affected, then commits the result into `DocumentState.vulnerabilities`.
+/// affected (B.1), then independently verifies each dependency's recommended
+/// *fix target* F (B.2, #462 — see [`run_osv_fix_target_verification`]),
+/// before committing the result into `DocumentState.vulnerabilities`.
 ///
 /// Must be called only *after* the registry fetch has updated
 /// `doc.cached_versions`: calling it concurrently with that fetch (as the
@@ -540,7 +542,14 @@ async fn run_osv_scan_phase_a(
 /// M4): `spawn_background_task` aborts the *previous* task only after the
 /// new `DocumentState` is already installed, so an in-flight scan from stale
 /// content could otherwise commit advisories computed against content the
-/// document no longer has.
+/// document no longer has. B.1 and B.2 share one `phase_b_deadline` (#462
+/// critic S2/M1) rather than each getting a fresh `fetch_timeout_secs`
+/// budget: B.2 is a second sequential network round-trip added *before* this
+/// guard, so giving it its own full budget would both double phase B's
+/// worst-case wall-clock time (contradicting NFR-002's singular "existing...
+/// budget" framing) and widen the window in which a mid-scan edit discards
+/// this whole result, `upgrade_status` included. Sharing one deadline caps
+/// the total at the original ceiling, same as before this fix existed.
 async fn run_osv_phase_b_and_commit(
     uri: &Uri,
     state: &Arc<ServerState>,
@@ -557,16 +566,20 @@ async fn run_osv_phase_b_and_commit(
         .collect();
 
     if !vulnerable_keys.is_empty() {
-        // TODO(critic): phase B checks registry-latest only; the fix target F is
-        // never scanned — see #216 critique D1
-        let candidates: Vec<deps_core::osv::ScanTarget> = {
+        let phase_b_deadline = Instant::now()
+            + Duration::from_secs(fetch_timeout_secs.min(OSV_SCAN_TIMEOUT_CEILING_SECS));
+
+        // B.1 (US-002, unchanged by #462): checks the registry's "latest" candidate.
+        // `latest_native_by_key` is kept for B.2 below, which needs the same native
+        // "latest" string to detect a fix target F that coincides with latest (FR-002)
+        // without re-deriving it from `doc.cached_versions` a second time.
+        let latest_native_by_key: HashMap<String, String> = {
             let Some(doc) = state.get_document(uri) else {
                 return;
             };
             vulnerable_keys
                 .iter()
                 .filter_map(|key| {
-                    let osv_name = result.osv_name_by_key.get(key)?.clone();
                     let latest = doc
                         .cached_versions
                         .get(key.as_str())
@@ -576,19 +589,27 @@ async fn run_osv_phase_b_and_commit(
                         })?
                         .latest
                         .clone();
-                    Some(deps_core::osv::ScanTarget {
-                        key: key.clone(),
-                        osv_name,
-                        version: formatter.osv_version(latest.as_str()),
-                        display_version: latest.to_string(),
-                    })
+                    Some((key.clone(), latest.to_string()))
                 })
                 .collect()
         };
 
+        let candidates: Vec<deps_core::osv::ScanTarget> = vulnerable_keys
+            .iter()
+            .filter_map(|key| {
+                let osv_name = result.osv_name_by_key.get(key)?.clone();
+                let latest_native = latest_native_by_key.get(key)?.clone();
+                Some(deps_core::osv::ScanTarget {
+                    key: key.clone(),
+                    osv_name,
+                    version: formatter.osv_version(&latest_native),
+                    display_version: latest_native,
+                })
+            })
+            .collect();
+
         if !candidates.is_empty() {
-            let timeout_duration =
-                Duration::from_secs(fetch_timeout_secs.min(OSV_SCAN_TIMEOUT_CEILING_SECS));
+            let timeout_duration = phase_b_deadline.saturating_duration_since(Instant::now());
             let statuses = state
                 .osv
                 .check_candidates(ecosystem_id, &candidates, timeout_duration)
@@ -601,6 +622,18 @@ async fn run_osv_phase_b_and_commit(
                 }
             }
         }
+
+        run_osv_fix_target_verification(
+            &mut result.vulnerabilities,
+            &vulnerable_keys,
+            &result.osv_name_by_key,
+            &latest_native_by_key,
+            ecosystem_id,
+            formatter,
+            &state.osv,
+            phase_b_deadline,
+        )
+        .await;
     }
 
     if let Some(mut doc) = state.documents.get_mut(uri) {
@@ -608,6 +641,203 @@ async fn run_osv_phase_b_and_commit(
             doc.update_vulnerabilities(result.vulnerabilities);
         } else {
             tracing::debug!("dropping stale OSV scan result: document content changed mid-scan");
+        }
+    }
+}
+
+/// Synthetic [`deps_core::osv::ScanTarget::key`] suffix marking a fix-target (F) live-check
+/// candidate as distinct from the same dependency's "latest" candidate (B.1) within the
+/// shared `VulnerabilityMap` key space — see [`run_osv_fix_target_verification`].
+const FIX_TARGET_KEY_SUFFIX: &str = "\u{0}fix";
+
+/// B.2 (#462): independently verifies each vulnerable dependency's recommended fix target F
+/// (`DependencyVulnerabilities::recommended_fix`'s `version`), which B.1 above never scans —
+/// B.1 only ever checks the registry's "latest" candidate, and F is frequently a different,
+/// older version (the minimal version that clears the advisories B.1's "latest" check did
+/// not already exclude). Without this, `generate_code_actions` could offer F as a verified
+/// fix when OSV was never asked about F itself — see
+/// `deps_core::osv::DependencyVulnerabilities::fix_target_status`'s doc, which this function
+/// populates, and the orphaned-TODO history in this function's git blame (formerly tracked
+/// only by a `// TODO(critic): ... see #216 critique D1` comment; now #462).
+///
+/// Resolution order per dependency, cheapest first:
+/// 1. F equals the already-checked "latest" candidate (FR-002) — reuse `upgrade_status`,
+///    no extra call.
+/// 2. Otherwise, queue a live [`deps_core::osv::OsvClient::check_candidates`] check for F,
+///    batched into a single call across every dependency that reaches this branch (NFR-001)
+///    — never one call per dependency. There is no data-derived shortcut here: a proof
+///    checking F against the advisories `recommended_fix()` computed F *from* is a
+///    tautology at its only call site (critic C1) — phase A only ever queries the
+///    dependency's declared version, so an advisory affecting some version strictly
+///    between declared and F, but not the declared version itself, is invisible to any
+///    check built only from `self.advisories`. Only a live query of F itself can surface
+///    that advisory (the actual gap #462 exists to close).
+///
+/// A dependency whose F fails [`deps_core::lsp_helpers::is_safe_version_string`], or whose
+/// `osv_name` is unavailable, is skipped (logged at `debug`), never crashes the scan. A
+/// dependency whose live check above times out or fails simply keeps `fix_target_status:
+/// None` (case 2's `HashMap` result never carries that key) — the safe, fail-closed
+/// degradation FR-004/NFR-002 call for: `deps_core::lsp_helpers::code_actions::fix_target_is_verified`
+/// treats an unresolved status as unverified and omits the fix action, so a stalled
+/// verification never surfaces a fix action that was never actually checked.
+#[allow(clippy::too_many_arguments)]
+async fn run_osv_fix_target_verification(
+    vulnerabilities: &mut deps_core::osv::VulnerabilityMap,
+    vulnerable_keys: &[String],
+    osv_name_by_key: &HashMap<String, String>,
+    latest_native_by_key: &HashMap<String, String>,
+    ecosystem_id: EcosystemId,
+    formatter: &dyn deps_core::lsp_helpers::EcosystemFormatter,
+    osv: &deps_core::osv::OsvClient,
+    phase_b_deadline: Instant,
+) {
+    use deps_core::osv::ScanOutcome;
+
+    let (resolved, live_check_candidates) = collect_fix_target_resolutions(
+        vulnerabilities,
+        vulnerable_keys,
+        osv_name_by_key,
+        latest_native_by_key,
+        formatter,
+    );
+
+    for (key, status) in resolved {
+        if let Some(ScanOutcome::Vulnerable(dv)) = vulnerabilities.get_mut(key.as_str()) {
+            dv.fix_target_status = Some(status);
+        }
+    }
+
+    if live_check_candidates.is_empty() {
+        return;
+    }
+
+    let timeout_duration = phase_b_deadline.saturating_duration_since(Instant::now());
+    let statuses = osv
+        .check_candidates(ecosystem_id, &live_check_candidates, timeout_duration)
+        .await;
+
+    apply_live_fix_target_statuses(vulnerabilities, statuses);
+}
+
+/// Outcome of [`resolve_fix_target`] for one vulnerable dependency.
+#[derive(Debug, PartialEq, Eq)]
+enum FixTargetResolution {
+    /// No fix recommended, F failed [`deps_core::lsp_helpers::is_safe_version_string`], or no
+    /// `osv_name` is on record for this key — nothing to verify or record; `fix_target_status`
+    /// stays untouched (`None`).
+    Skip,
+    /// F's status was resolved without a network call by reusing the already-checked
+    /// "latest" candidate's result (FR-002, F == latest).
+    Resolved(deps_core::osv::UpgradeStatus),
+    /// F differs from latest and needs a live [`deps_core::osv::OsvClient::check_candidates`]
+    /// check — carries the [`deps_core::osv::ScanTarget`] to batch into the caller's single
+    /// combined call (NFR-001), keyed with [`FIX_TARGET_KEY_SUFFIX`] so its result cannot
+    /// collide with the same dependency's "latest" candidate in the same `VulnerabilityMap`
+    /// key space.
+    NeedsLiveCheck(deps_core::osv::ScanTarget),
+}
+
+/// Pure (network-free) decision logic for [`run_osv_fix_target_verification`]'s per-dependency
+/// resolution order — see that function's doc for the two cases and their rationale. Split
+/// out so each case is unit-testable without an `OsvClient`/network dependency.
+fn resolve_fix_target(
+    dv: &deps_core::osv::DependencyVulnerabilities,
+    key: &str,
+    latest_native_by_key: &HashMap<String, String>,
+    osv_name_by_key: &HashMap<String, String>,
+    formatter: &dyn deps_core::lsp_helpers::EcosystemFormatter,
+) -> FixTargetResolution {
+    use deps_core::lsp_helpers::is_safe_version_string;
+    use deps_core::osv::ScanTarget;
+
+    let Some(fix) = dv.recommended_fix() else {
+        return FixTargetResolution::Skip;
+    };
+    let version_native = formatter.osv_version_to_native(&fix.version);
+    if !is_safe_version_string(&version_native) {
+        tracing::debug!(
+            key,
+            version = %fix.version,
+            "OSV #462: fix-target version failed validation, skipping verification"
+        );
+        return FixTargetResolution::Skip;
+    }
+
+    if latest_native_by_key.get(key) == Some(&version_native) {
+        return FixTargetResolution::Resolved(dv.upgrade_status.clone());
+    }
+
+    let Some(osv_name) = osv_name_by_key.get(key).cloned() else {
+        tracing::debug!(
+            key,
+            "OSV #462: no osv_name on record for fix-target verification, skipping"
+        );
+        return FixTargetResolution::Skip;
+    };
+    FixTargetResolution::NeedsLiveCheck(ScanTarget {
+        key: format!("{key}{FIX_TARGET_KEY_SUFFIX}"),
+        osv_name,
+        version: fix.version,
+        display_version: version_native,
+    })
+}
+
+/// Pure aggregation step of [`run_osv_fix_target_verification`]: resolves every vulnerable
+/// dependency's fix target via [`resolve_fix_target`], splitting immediately-resolvable
+/// results (`resolved`) from the ones that need a live check (`live_check_candidates`) — the
+/// latter collected into one `Vec` across *every* dependency before the caller's single
+/// `check_candidates` call, so multiple dependencies needing a live check always batch into
+/// one network round-trip rather than one per dependency (NFR-001). Split out from the async
+/// orchestrator specifically so this batching/aggregation behavior is unit-testable without
+/// an `OsvClient`.
+fn collect_fix_target_resolutions(
+    vulnerabilities: &deps_core::osv::VulnerabilityMap,
+    vulnerable_keys: &[String],
+    osv_name_by_key: &HashMap<String, String>,
+    latest_native_by_key: &HashMap<String, String>,
+    formatter: &dyn deps_core::lsp_helpers::EcosystemFormatter,
+) -> (
+    Vec<(String, deps_core::osv::UpgradeStatus)>,
+    Vec<deps_core::osv::ScanTarget>,
+) {
+    use deps_core::osv::ScanOutcome;
+
+    let mut resolved = Vec::new();
+    let mut live_check_candidates = Vec::new();
+
+    for key in vulnerable_keys {
+        let Some(ScanOutcome::Vulnerable(dv)) = vulnerabilities.get(key.as_str()) else {
+            continue;
+        };
+        match resolve_fix_target(dv, key, latest_native_by_key, osv_name_by_key, formatter) {
+            FixTargetResolution::Skip => {}
+            FixTargetResolution::Resolved(status) => resolved.push((key.clone(), status)),
+            FixTargetResolution::NeedsLiveCheck(target) => live_check_candidates.push(target),
+        }
+    }
+
+    (resolved, live_check_candidates)
+}
+
+/// Applies a live [`deps_core::osv::OsvClient::check_candidates`] result keyed with
+/// [`FIX_TARGET_KEY_SUFFIX`] back onto the matching dependency's `fix_target_status`.
+///
+/// A key absent from `statuses` (timeout, OSV outage, or a chunk `check_candidates` itself
+/// dropped) simply leaves that dependency's `fix_target_status` untouched — `None` if it was
+/// never set, which is exactly the fail-closed degradation FR-004/NFR-002 call for (never a
+/// panic, never a fabricated "verified" status).
+fn apply_live_fix_target_statuses(
+    vulnerabilities: &mut deps_core::osv::VulnerabilityMap,
+    statuses: HashMap<String, deps_core::osv::UpgradeStatus>,
+) {
+    use deps_core::osv::ScanOutcome;
+
+    for (synthetic_key, status) in statuses {
+        let Some(key) = synthetic_key.strip_suffix(FIX_TARGET_KEY_SUFFIX) else {
+            continue;
+        };
+        if let Some(ScanOutcome::Vulnerable(dv)) = vulnerabilities.get_mut(key) {
+            dv.fix_target_status = Some(status);
         }
     }
 }
@@ -6562,6 +6792,279 @@ tokio = "1.0"
                 Some(&vec!["0.1.43".to_string(), "0.1.44".to_string()]),
                 "both occurrences' in-use versions must be tracked, not just the last one"
             );
+        }
+    }
+
+    /// #462: `resolve_fix_target`'s pure per-dependency decision logic (reuse / provably
+    /// clean / needs a live check / skip), and `apply_live_fix_target_statuses`'s handling of
+    /// a live-check result map that may be missing keys (timeout/outage).
+    mod fix_target_verification_tests {
+        use super::*;
+        use deps_core::lsp_helpers::EcosystemFormatter;
+        use deps_core::osv::{
+            Advisory, DependencyVulnerabilities, ScanOutcome, UpgradeStatus, VulnSeverity,
+            VulnerabilityMap,
+        };
+        use std::sync::Arc;
+
+        struct IdentityFormatter;
+        impl EcosystemFormatter for IdentityFormatter {
+            fn format_version_for_text_edit(&self, version: &ConcreteVersion) -> String {
+                version.to_string()
+            }
+            fn package_url(&self, name: &PackageName) -> String {
+                format!("https://example.com/{name}")
+            }
+        }
+
+        fn advisory(id: &str, fixed_versions: &[&str]) -> Arc<Advisory> {
+            Arc::new(Advisory {
+                id: id.to_string(),
+                modified: "2023-01-01T00:00:00Z".to_string(),
+                summary: None,
+                aliases: vec![],
+                severity: VulnSeverity::High,
+                cvss_vector: None,
+                fixed_versions: fixed_versions.iter().map(ToString::to_string).collect(),
+                url: String::new(),
+            })
+        }
+
+        fn dv(
+            advisories: Vec<Arc<Advisory>>,
+            upgrade_status: UpgradeStatus,
+        ) -> DependencyVulnerabilities {
+            DependencyVulnerabilities {
+                total_known: advisories.len(),
+                advisories,
+                upgrade_status,
+                fix_target_status: None,
+            }
+        }
+
+        #[test]
+        fn resolve_fix_target_skips_when_no_fix_is_recommended() {
+            // No advisory has a known fix, so `recommended_fix()` returns `None`.
+            let dv = dv(vec![advisory("A1", &[])], UpgradeStatus::NotChecked);
+            let resolution = resolve_fix_target(
+                &dv,
+                "pkg",
+                &HashMap::new(),
+                &HashMap::new(),
+                &IdentityFormatter,
+            );
+            assert_eq!(resolution, FixTargetResolution::Skip);
+        }
+
+        #[test]
+        fn resolve_fix_target_reuses_latest_when_f_equals_latest() {
+            // Case (c): F (1.2.0, the only advisory's fix) coincides with the already-checked
+            // "latest" candidate — reuse its result, no live check queued.
+            let latest_status = UpgradeStatus::CandidateClean {
+                version: "1.2.0".to_string(),
+            };
+            let dv = dv(vec![advisory("A1", &["1.2.0"])], latest_status.clone());
+            let mut latest_native_by_key = HashMap::new();
+            latest_native_by_key.insert("pkg".to_string(), "1.2.0".to_string());
+
+            let resolution = resolve_fix_target(
+                &dv,
+                "pkg",
+                &latest_native_by_key,
+                &HashMap::new(),
+                &IdentityFormatter,
+            );
+            assert_eq!(resolution, FixTargetResolution::Resolved(latest_status));
+        }
+
+        #[test]
+        fn resolve_fix_target_always_needs_live_check_when_f_differs_from_latest() {
+            // #462 critic C1: there is no data-derived shortcut. Even though every known
+            // advisory's fix (1.2.0) is already at or below F, that is a tautology — F is
+            // *computed from* these exact advisories, so this check would always pass at its
+            // only call site and prove nothing about an advisory phase A never fetched at
+            // all. F (1.2.0) differs from latest (3.0.0), so this must always queue a live
+            // check, batched under the fix-target key suffix.
+            let dv = dv(
+                vec![advisory("A1", &["1.2.0"])],
+                UpgradeStatus::CandidateClean {
+                    version: "3.0.0".to_string(),
+                },
+            );
+            let mut latest_native_by_key = HashMap::new();
+            latest_native_by_key.insert("pkg".to_string(), "3.0.0".to_string());
+            let mut osv_name_by_key = HashMap::new();
+            osv_name_by_key.insert("pkg".to_string(), "pkg".to_string());
+
+            let resolution = resolve_fix_target(
+                &dv,
+                "pkg",
+                &latest_native_by_key,
+                &osv_name_by_key,
+                &IdentityFormatter,
+            );
+            assert_eq!(
+                resolution,
+                FixTargetResolution::NeedsLiveCheck(deps_core::osv::ScanTarget {
+                    key: format!("pkg{FIX_TARGET_KEY_SUFFIX}"),
+                    osv_name: "pkg".to_string(),
+                    version: "1.2.0".to_string(),
+                    display_version: "1.2.0".to_string(),
+                })
+            );
+        }
+
+        #[test]
+        fn resolve_fix_target_skips_when_osv_name_is_unavailable() {
+            // A live check is needed (F != latest) but no `osv_name` is on record for this
+            // key — nothing to query, so this degrades to `Skip` rather than panicking or
+            // building a `ScanTarget` with an empty name.
+            let dv = dv(vec![advisory("A1", &["1.0.0"])], UpgradeStatus::NotChecked);
+            let resolution = resolve_fix_target(
+                &dv,
+                "pkg",
+                &HashMap::new(),
+                &HashMap::new(),
+                &IdentityFormatter,
+            );
+            assert_eq!(resolution, FixTargetResolution::Skip);
+        }
+
+        #[test]
+        fn resolve_fix_target_skips_when_f_is_not_a_safe_version_string() {
+            // A malformed `fixed_versions` entry (as if it somehow reached this dependency's
+            // `advisories` despite OSV's own wire-boundary validation) must never be queued
+            // for a live check or treated as any kind of resolvable target — `is_safe_version_string`
+            // rejects it before anything else runs.
+            let dv = dv(
+                vec![advisory("A1", &["1.2.0\", \"evil\": \"true"])],
+                UpgradeStatus::NotChecked,
+            );
+            let resolution = resolve_fix_target(
+                &dv,
+                "pkg",
+                &HashMap::new(),
+                &HashMap::new(),
+                &IdentityFormatter,
+            );
+            assert_eq!(resolution, FixTargetResolution::Skip);
+        }
+
+        #[test]
+        fn collect_fix_target_resolutions_batches_multiple_dependencies_needing_live_check_into_one_vec()
+         {
+            // #462 NFR-001: three vulnerable dependencies — "reused" (F == latest, resolved
+            // without a call), "live-a" and "live-b" (F != latest, both need a live check) —
+            // must collapse into exactly one `resolved` entry and one `live_check_candidates`
+            // Vec of length 2, proving multiple dependencies needing verification are batched
+            // into a single prospective `check_candidates` call rather than one per dependency.
+            let mut vulnerabilities = VulnerabilityMap::new();
+            vulnerabilities.insert(
+                "reused".to_string(),
+                ScanOutcome::Vulnerable(dv(
+                    vec![advisory("A1", &["1.0.0"])],
+                    UpgradeStatus::CandidateClean {
+                        version: "1.0.0".to_string(),
+                    },
+                )),
+            );
+            vulnerabilities.insert(
+                "live-a".to_string(),
+                ScanOutcome::Vulnerable(dv(
+                    vec![advisory("A2", &["1.2.0"])],
+                    UpgradeStatus::NotChecked,
+                )),
+            );
+            vulnerabilities.insert(
+                "live-b".to_string(),
+                ScanOutcome::Vulnerable(dv(
+                    vec![advisory("A3", &["2.2.0"])],
+                    UpgradeStatus::NotChecked,
+                )),
+            );
+
+            let vulnerable_keys = vec![
+                "reused".to_string(),
+                "live-a".to_string(),
+                "live-b".to_string(),
+            ];
+            let mut latest_native_by_key = HashMap::new();
+            latest_native_by_key.insert("reused".to_string(), "1.0.0".to_string());
+            latest_native_by_key.insert("live-a".to_string(), "9.0.0".to_string());
+            latest_native_by_key.insert("live-b".to_string(), "9.0.0".to_string());
+            let mut osv_name_by_key = HashMap::new();
+            osv_name_by_key.insert("reused".to_string(), "reused".to_string());
+            osv_name_by_key.insert("live-a".to_string(), "live-a".to_string());
+            osv_name_by_key.insert("live-b".to_string(), "live-b".to_string());
+
+            let (resolved, live_check_candidates) = collect_fix_target_resolutions(
+                &vulnerabilities,
+                &vulnerable_keys,
+                &osv_name_by_key,
+                &latest_native_by_key,
+                &IdentityFormatter,
+            );
+
+            assert_eq!(resolved.len(), 1, "{resolved:?}");
+            assert_eq!(resolved[0].0, "reused");
+
+            assert_eq!(live_check_candidates.len(), 2, "{live_check_candidates:?}");
+            let keys: std::collections::HashSet<&str> = live_check_candidates
+                .iter()
+                .map(|t| t.key.as_str())
+                .collect();
+            assert!(keys.contains(format!("live-a{FIX_TARGET_KEY_SUFFIX}").as_str()));
+            assert!(keys.contains(format!("live-b{FIX_TARGET_KEY_SUFFIX}").as_str()));
+        }
+
+        #[test]
+        fn apply_live_fix_target_statuses_sets_only_matching_keys_leaving_others_untouched() {
+            // Case (e): a live-check batch that timed out for one dependency simply omits
+            // its key from `statuses` — that dependency's `fix_target_status` must stay
+            // `None` afterward, with no panic, while a dependency whose result did arrive
+            // gets it applied.
+            let mut vulnerabilities = VulnerabilityMap::new();
+            vulnerabilities.insert(
+                "checked".to_string(),
+                ScanOutcome::Vulnerable(dv(
+                    vec![advisory("A1", &["1.0.0"])],
+                    UpgradeStatus::NotChecked,
+                )),
+            );
+            vulnerabilities.insert(
+                "timed-out".to_string(),
+                ScanOutcome::Vulnerable(dv(
+                    vec![advisory("A2", &["1.0.0"])],
+                    UpgradeStatus::NotChecked,
+                )),
+            );
+
+            let mut statuses = HashMap::new();
+            statuses.insert(
+                format!("checked{FIX_TARGET_KEY_SUFFIX}"),
+                UpgradeStatus::CandidateClean {
+                    version: "1.0.0".to_string(),
+                },
+            );
+            // "timed-out" deliberately has no entry in `statuses`.
+
+            apply_live_fix_target_statuses(&mut vulnerabilities, statuses);
+
+            let ScanOutcome::Vulnerable(checked) = vulnerabilities.get("checked").unwrap() else {
+                panic!("expected Vulnerable");
+            };
+            assert_eq!(
+                checked.fix_target_status,
+                Some(UpgradeStatus::CandidateClean {
+                    version: "1.0.0".to_string()
+                })
+            );
+
+            let ScanOutcome::Vulnerable(timed_out) = vulnerabilities.get("timed-out").unwrap()
+            else {
+                panic!("expected Vulnerable");
+            };
+            assert_eq!(timed_out.fix_target_status, None);
         }
     }
 

--- a/crates/deps-lsp/src/document/osv_snapshot_tests.rs
+++ b/crates/deps-lsp/src/document/osv_snapshot_tests.rs
@@ -71,6 +71,7 @@ async fn diagnostics_snapshot_for(
         ScanOutcome::Vulnerable(DependencyVulnerabilities {
             advisories: vec![sample_advisory()],
             total_known: 6,
+            fix_target_status: None,
             upgrade_status: UpgradeStatus::NotChecked,
         }),
     );

--- a/crates/deps-lsp/src/handlers/code_actions.rs
+++ b/crates/deps-lsp/src/handlers/code_actions.rs
@@ -545,6 +545,9 @@ serde = "1.0.0"
                         url: String::new(),
                     })],
                     total_known: 1,
+                    fix_target_status: Some(UpgradeStatus::CandidateClean {
+                        version: "1.0.5".to_string(),
+                    }),
                     upgrade_status: UpgradeStatus::NotChecked,
                 }),
             );
@@ -709,6 +712,9 @@ serde = "1.0.0"
                         url: String::new(),
                     })],
                     total_known: 1,
+                    fix_target_status: Some(UpgradeStatus::CandidateClean {
+                        version: "4.50.1".to_string(),
+                    }),
                     upgrade_status: UpgradeStatus::NotChecked,
                 }),
             );


### PR DESCRIPTION
## Summary

Phase B of the OSV vulnerability scan only ever checked the registry's *latest* version against OSV. `recommended_fix()` separately computed a fix target F (the max `fixed_versions` entry across claimed advisories), which can differ from latest — F itself was never scanned, so the one-click "Update to X (fixes ADVISORY-ID)" code action could present an unverified version as a verified fix.

This adds a second verification phase (B.2) that resolves F's status before the code action is generated:

- If F equals the already-checked "latest" candidate, reuse that result (no extra OSV call).
- Otherwise, always live-check F via a batched `OsvClient::check_candidates` call across all dependencies needing verification in the same document scan.
- `DependencyVulnerabilities` gains `fix_target_status: Option<UpgradeStatus>`, and `UpgradeStatus::CandidateVulnerable` now carries `total_known` so a truncated `advisory_ids` list (bounded by `ADVISORY_DISPLAY_CAP`) can never be mistaken for exhaustive.
- `generate_code_actions` only offers the fix when `fix_target_is_verified()` confirms no claimed or previously-unknown advisory still applies to F.

The existing "latest" candidate check and the post-edit full-rescan-on-`version_changed` behavior are unchanged.

An initial implementation used a data-derived shortcut (checking F only against already-fetched advisory data) that turned out to be a tautology — it always passed because F was itself computed from those same advisories, so it never caught advisories affecting F that phase A had not fetched. This was caught by adversarial review before merge (verified live against `smallvec = "0.6.0"`, where the shortcut would have offered 0.6.13 as a "verified" fix while it remained vulnerable to RUSTSEC-2021-0003) and replaced with the unconditional live-check approach described above.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (3358 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New/updated unit tests covering: F==latest reuse, F!=latest live-check, batching of multiple dependencies into one OSV call, an unfixed advisory not suppressing an otherwise-valid fix, a truncated advisory list never being treated as exhaustive, and an unparseable fix-target version being skipped without a panic
- [x] Live-tested end-to-end through a running LSP server against `smallvec = "0.6.0"` (confirms the fix action is correctly withheld) and `time = "0.1.43"` (confirms the fix action is correctly offered when F is genuinely clean); added to `.local/testing/regressions.md`

Closes #462