### PR TITLE
feat(deps-github-actions,deps-core,deps-lsp): add GitHub Actions ecosystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **deps-github-actions, deps-core, deps-lsp**: new GitHub Actions ecosystem — hover, inlay hints, diagnostics, code actions, and code lens for `uses:` steps in `.github/workflows/*.yml`/`*.yaml`, covering tag, commit-SHA (optionally `# vX.Y.Z`-annotated), and branch pins via the GitHub tags API (resolves #208)
 - **deps-nuget**: hover now flags an unlisted (delisted/pulled) NuGet version with a `*(unlisted)*` marker in "Recent versions", enriched from `RegistrationsBaseUrl/3.6.0` on the hover path only (resolves #451) (#458)
 - **deps-nuget**: a multi-project `packages.<project>.lock.json` lock file is now resolved by the manifest's own project name instead of picking an arbitrary `packages.*.lock.json` match from the directory (resolves #451) (#458)
 - **deps-pypi, deps-lsp**: `-r`/`-c` (and `--requirement`/`--constraint`) targets in a `requirements.txt`/`constraints.txt` file are now surfaced as clickable `documentLink`s, resolved relative to the containing file (resolves #452) (#458)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **deps-github-actions, deps-core, deps-lsp**: new GitHub Actions ecosystem — hover, inlay hints, diagnostics, code actions, and code lens for `uses:` steps in `.github/workflows/*.yml`/`*.yaml`, covering tag, commit-SHA (optionally `# vX.Y.Z`-annotated), and branch pins via the GitHub tags API (resolves #208)
+- **deps-github-actions, deps-core, deps-lsp**: new GitHub Actions ecosystem — hover, inlay hints, diagnostics, code actions, and code lens for `uses:` steps in `.github/workflows/*.yml`/`*.yaml`, covering tag, commit-SHA (optionally `# vX.Y.Z`-annotated), and branch pins via the GitHub tags API (resolves #208) (#471)
 - **deps-nuget**: hover now flags an unlisted (delisted/pulled) NuGet version with a `*(unlisted)*` marker in "Recent versions", enriched from `RegistrationsBaseUrl/3.6.0` on the hover path only (resolves #451) (#458)
 - **deps-nuget**: a multi-project `packages.<project>.lock.json` lock file is now resolved by the manifest's own project name instead of picking an arbitrary `packages.*.lock.json` match from the directory (resolves #451) (#458)
 - **deps-pypi, deps-lsp**: `-r`/`-c` (and `--requirement`/`--constraint`) targets in a `requirements.txt`/`constraints.txt` file are now surfaced as clickable `documentLink`s, resolved relative to the containing file (resolves #452) (#458)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,6 +546,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deps-github-actions"
+version = "0.11.1"
+dependencies = [
+ "bytes",
+ "dashmap",
+ "deps-core",
+ "mockito",
+ "reqwest",
+ "semver",
+ "serde",
+ "tokio",
+ "tokio-test",
+ "tower-lsp-server",
+ "tracing",
+ "yaml-rust2",
+]
+
+[[package]]
 name = "deps-go"
 version = "0.11.1"
 dependencies = [
@@ -594,6 +612,7 @@ dependencies = [
  "deps-core",
  "deps-dart",
  "deps-deno",
+ "deps-github-actions",
  "deps-go",
  "deps-gradle",
  "deps-maven",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ deps-composer = { version = "0.11.1", path ="crates/deps-composer" }
 deps-core = { version = "0.11.1", path ="crates/deps-core" }
 deps-dart = { version = "0.11.1", path ="crates/deps-dart" }
 deps-deno = { version = "0.11.1", path ="crates/deps-deno" }
+deps-github-actions = { version = "0.11.1", path ="crates/deps-github-actions" }
 deps-go = { version = "0.11.1", path ="crates/deps-go" }
 deps-gradle = { version = "0.11.1", path ="crates/deps-gradle" }
 deps-lsp = { version = "0.11.1", path ="crates/deps-lsp" }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![MSRV](https://img.shields.io/badge/MSRV-1.91-blue)](https://blog.rust-lang.org/)
 [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 
-A universal Language Server Protocol (LSP) server for dependency management across Cargo, npm, PyPI, Go, Bundler, Dart, Maven, Gradle, Swift, Composer, NuGet, and Deno ecosystems.
+A universal Language Server Protocol (LSP) server for dependency management across Cargo, npm, PyPI, Go, Bundler, Dart, Maven, Gradle, Swift, Composer, NuGet, Deno, and GitHub Actions ecosystems.
 
 ![deps-lsp in action](https://raw.githubusercontent.com/bug-ops/deps-zed/main/assets/img.png)
 
@@ -41,6 +41,7 @@ A universal Language Server Protocol (LSP) server for dependency management acro
 | Swift | SPM | `Package.swift` | Supported |
 | PHP | Composer | `composer.json` | Supported |
 | C# | NuGet | `.csproj`, `.fsproj`, `.vbproj`, `Directory.Packages.props`, `packages.config` | Supported |
+| YAML | GitHub Actions | `.github/workflows/*.yml`, `*.yaml` | Supported |
 
 > [!NOTE]
 > **Ecosystem details:**
@@ -54,6 +55,7 @@ A universal Language Server Protocol (LSP) server for dependency management acro
 > - **Composer** — `require`/`require-dev` sections, Packagist v2 API with metadata de-minification, Composer-specific tilde semantics (`~1.2` = `>=1.2.0 <2.0.0`)
 > - **NuGet** — `PackageReference` (attribute and child-element form), Central Package Management (`Directory.Packages.props`), legacy `packages.config`, `packages.lock.json`; NuGet V3 registry (service index, flat container, search)
 > - **Deno** — `imports` map only (`scopes`/`importMap` not yet supported); `jsr:` specifiers via the keyless JSR API, `npm:` specifiers reuse the existing npm registry client; no `deno.lock` support yet
+> - **GitHub Actions** — `uses:` steps and reusable-workflow calls across every job; tag, commit-SHA (optionally `# vX.Y.Z`-annotated), and branch pins via the GitHub tags API; no lock file, no package-name search completion
 
 ## Installation
 
@@ -115,6 +117,7 @@ cargo install deps-lsp --no-default-features --features "pypi"
 | `swift` | Swift | Package.swift | Yes |
 | `composer` | PHP | composer.json | Yes |
 | `nuget` | C# | .csproj, Directory.Packages.props, packages.config | Yes |
+| `github-actions` | YAML | .github/workflows/*.yml, *.yaml | Yes |
 
 ## Usage
 
@@ -401,6 +404,7 @@ deps-lsp/
 │   ├── deps-composer/  # composer.json parser + Packagist registry
 │   ├── deps-nuget/     # .csproj/packages.config parser + NuGet V3 registry
 │   ├── deps-deno/      # deno.json parser + JSR registry (npm: delegates to deps-npm)
+│   ├── deps-github-actions/ # workflow YAML parser + GitHub tags API registry
 │   ├── deps-lsp/       # Main LSP server
 │   └── deps-zed/       # Zed extension (WASM)
 ├── .config/            # nextest configuration

--- a/crates/deps-core/src/ecosystem.rs
+++ b/crates/deps-core/src/ecosystem.rs
@@ -67,6 +67,8 @@ pub enum EcosystemId {
     NuGet,
     /// Deno ecosystem (`deno.json`/`deno.jsonc`), mixing `jsr:` and `npm:` specifiers.
     Deno,
+    /// GitHub Actions ecosystem (`.github/workflows/*.yml`/`*.yaml`).
+    GithubActions,
 }
 
 impl EcosystemId {
@@ -87,6 +89,7 @@ impl EcosystemId {
             Self::Swift => "swift",
             Self::NuGet => "nuget",
             Self::Deno => "deno",
+            Self::GithubActions => "github-actions",
         }
     }
 
@@ -120,6 +123,7 @@ impl EcosystemId {
             Self::Composer => "Packagist",
             Self::Swift => "SwiftURL",
             Self::NuGet => "NuGet",
+            Self::GithubActions => "GitHub Actions",
         })
     }
 }
@@ -147,6 +151,7 @@ impl std::str::FromStr for EcosystemId {
             "swift" => Ok(Self::Swift),
             "nuget" => Ok(Self::NuGet),
             "deno" => Ok(Self::Deno),
+            "github-actions" => Ok(Self::GithubActions),
             _ => Err(crate::error::DepsError::UnsupportedEcosystem(s.to_string())),
         }
     }
@@ -407,10 +412,16 @@ pub trait Ecosystem: Send + Sync + private::Sealed {
         &[]
     }
 
-    /// `(directory_name, file_suffix)` pairs identifying a file solely by its
-    /// immediate parent directory and suffix (e.g. `[("requirements", ".txt")]`
-    /// for Python's `requirements/base.txt` split-file layout, where the
-    /// basename alone carries no ecosystem signal).
+    /// `(directory_path, file_suffix)` pairs identifying a file solely by its
+    /// containing directory path and suffix. `directory_path` may be a single
+    /// segment (e.g. `[("requirements", ".txt")]` for Python's
+    /// `requirements/base.txt` split-file layout) or multiple `/`-joined
+    /// segments (e.g. `[(".github/workflows", ".yml")]` for GitHub Actions
+    /// workflow files) — either way it is matched against the *tail* of the
+    /// file's directory path on segment boundaries, not just the immediate
+    /// parent, so a multi-segment pattern matches regardless of how many
+    /// ancestor directories precede it. Used when the basename alone carries
+    /// no ecosystem signal.
     ///
     /// Consulted by [`crate::EcosystemRegistry::get_for_uri`] only, after both
     /// [`manifest_patterns`](Ecosystem::manifest_patterns) and
@@ -687,6 +698,7 @@ mod tests {
             EcosystemId::Swift,
             EcosystemId::NuGet,
             EcosystemId::Deno,
+            EcosystemId::GithubActions,
         ];
 
         for id in ALL {
@@ -711,6 +723,7 @@ mod tests {
             (EcosystemId::Swift, "SwiftURL"),
             (EcosystemId::NuGet, "NuGet"),
             (EcosystemId::Deno, "npm"),
+            (EcosystemId::GithubActions, "GitHub Actions"),
         ];
 
         for (id, expected_str) in expected {

--- a/crates/deps-core/src/ecosystem_registry.rs
+++ b/crates/deps-core/src/ecosystem_registry.rs
@@ -287,27 +287,33 @@ impl EcosystemRegistry {
         self.get_for_directory_pattern(path, filename)
     }
 
-    /// Matches a file directly inside a directory whose name and file suffix
-    /// are declared by an ecosystem's
-    /// [`manifest_directory_patterns`](Ecosystem::manifest_directory_patterns)
-    /// (e.g. Python's `requirements/base.txt` layout, where the basename alone —
-    /// `base.txt` — carries no signal). This needs the full path, not just the
-    /// basename, so unlike [`manifest_patterns`](Ecosystem::manifest_patterns) it
-    /// is consulted only from [`get_for_uri`](Self::get_for_uri), never from
+    /// Matches a file whose containing directory path (tail) and file suffix are
+    /// declared by an ecosystem's
+    /// [`manifest_directory_patterns`](Ecosystem::manifest_directory_patterns) — e.g.
+    /// Python's single-segment `requirements/base.txt` layout, or GitHub Actions'
+    /// multi-segment `.github/workflows/ci.yml` layout, where the basename alone
+    /// carries no ecosystem signal. This needs the full path, not just the basename,
+    /// so unlike [`manifest_patterns`](Ecosystem::manifest_patterns) it is consulted
+    /// only from [`get_for_uri`](Self::get_for_uri), never from
     /// [`get_for_filename`](Self::get_for_filename). Mirrors
     /// [`get_for_lockfile`](Self::get_for_lockfile)'s linear scan rather than
     /// building a dedicated map — the pattern count per ecosystem is tiny.
+    ///
+    /// The scan is `DashMap`-iteration-order-dependent when two ecosystems' patterns
+    /// could both match the same path; today's registered patterns (PyPI's
+    /// `requirements`, GitHub Actions' `.github/workflows`) are disjoint, so this is
+    /// deterministic in practice, but a future third owner introducing an overlapping
+    /// pattern would need its own disambiguation, not silent first-match-wins.
     fn get_for_directory_pattern(&self, path: &str, filename: &str) -> Option<Arc<dyn Ecosystem>> {
-        let mut segments = path.rsplit('/');
-        segments.next()?; // the filename itself
-        let dir = segments.next()?;
-
         for entry in self.ecosystems.iter() {
             let ecosystem = entry.value();
-            let matches = ecosystem
-                .manifest_directory_patterns()
-                .iter()
-                .any(|(dir_name, suffix)| *dir_name == dir && filename.ends_with(suffix));
+            let matches =
+                ecosystem
+                    .manifest_directory_patterns()
+                    .iter()
+                    .any(|(dir_pattern, suffix)| {
+                        directory_pattern_matches(path, filename, dir_pattern, suffix)
+                    });
             if matches {
                 return Some(Arc::clone(ecosystem));
             }
@@ -439,6 +445,35 @@ fn prefix_suffix_matches(filename: &str, prefix: &str, suffix: &str) -> bool {
     filename.len() >= prefix.len() + suffix.len()
         && filename.starts_with(prefix)
         && filename.ends_with(suffix)
+}
+
+/// Whether `filename`'s containing directory path, relative to any ancestor, ends
+/// exactly at `dir_pattern` on a `/`-segment boundary, and `filename` itself ends
+/// with `suffix`.
+///
+/// `dir_pattern` may be a single segment (PyPI's `"requirements"`, matching any
+/// `.../requirements/base.txt`) or multiple segments joined by `/` (GitHub Actions'
+/// `".github/workflows"`, matching any `.../.github/workflows/ci.yml`) — the
+/// single-segment case is just the multi-segment rule applied to a one-element path,
+/// so both share this one matcher rather than PyPI keeping a separate
+/// immediate-parent-only check.
+///
+/// `path` is the full URI path (e.g. `/home/user/project/.github/workflows/ci.yml`);
+/// `filename` is its basename, passed separately so the caller (which already split
+/// it off) does not force a second basename computation here.
+fn directory_pattern_matches(path: &str, filename: &str, dir_pattern: &str, suffix: &str) -> bool {
+    if !filename.ends_with(suffix) {
+        return false;
+    }
+    let Some(dir_path) = path.strip_suffix(filename) else {
+        return false;
+    };
+    let dir_path = dir_path.trim_end_matches('/');
+    match dir_path.len().checked_sub(dir_pattern.len()) {
+        Some(0) => dir_path == dir_pattern,
+        Some(n) => dir_path.ends_with(dir_pattern) && dir_path.as_bytes()[n - 1] == b'/',
+        None => false,
+    }
 }
 
 /// Whether `filename` matches a raw [`Ecosystem::manifest_patterns`] entry (e.g.
@@ -687,6 +722,69 @@ mod tests {
             dir_patterns: &[("requirements", ".txt")],
         }));
         registry
+    }
+
+    /// D1 regression fixture: a multi-segment `manifest_directory_patterns` entry
+    /// (`.github/workflows`), the shape a single-segment directory pattern like
+    /// PyPI's `requirements` could never express.
+    fn gha_pattern_registry() -> EcosystemRegistry {
+        let registry = EcosystemRegistry::new();
+        registry.register(Arc::new(MockPatternEcosystem {
+            id: "github-actions",
+            patterns: &[],
+            dir_patterns: &[
+                (".github/workflows", ".yml"),
+                (".github/workflows", ".yaml"),
+            ],
+        }));
+        registry
+    }
+
+    #[test]
+    fn test_get_for_uri_multi_segment_directory_pattern_matches_yml_and_yaml() {
+        let registry = gha_pattern_registry();
+        for path in [
+            "/repo/.github/workflows/ci.yml",
+            "/repo/.github/workflows/release.yaml",
+        ] {
+            let uri = crate::test_util::test_uri(path);
+            assert_eq!(
+                registry.get_for_uri(&uri).map(|e| e.id()),
+                Some("github-actions"),
+                "{path} should match the .github/workflows/*.y[a]ml directory pattern"
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_for_uri_multi_segment_directory_pattern_matches_nested_repo() {
+        let registry = gha_pattern_registry();
+        let uri = crate::test_util::test_uri("/home/user/a/b/.github/workflows/x.yml");
+        assert_eq!(
+            registry.get_for_uri(&uri).map(|e| e.id()),
+            Some("github-actions"),
+            "a repo nested under arbitrary ancestor directories should still match"
+        );
+    }
+
+    #[test]
+    fn test_get_for_uri_multi_segment_directory_pattern_rejects_partial_paths() {
+        let registry = gha_pattern_registry();
+        for path in [
+            // Missing the `.github` segment entirely.
+            "/repo/workflows/x.yml",
+            // Missing the `workflows` segment.
+            "/repo/.github/x.yml",
+            // A directory that merely ends with the pattern as a substring, not on a
+            // segment boundary — mirrors PyPI's `myrequirements` regression guard.
+            "/repo/my.github/workflows/x.yml",
+        ] {
+            let uri = crate::test_util::test_uri(path);
+            assert!(
+                registry.get_for_uri(&uri).is_none(),
+                "{path} should not match the .github/workflows/*.y[a]ml directory pattern"
+            );
+        }
     }
 
     #[test]

--- a/crates/deps-core/src/lsp_helpers/code_actions.rs
+++ b/crates/deps-core/src/lsp_helpers/code_actions.rs
@@ -145,8 +145,11 @@ fn build_vulnerability_fix_action(
     // `^`-prefix, a range), and `deps-pypi` rewrites it in place to preserve
     // the manifest's existing pin style (`==1.0.1` -> `==1.0.2`) — the guard
     // must compare the text that would actually be written.
-    let new_text = formatter
-        .format_version_replacing(&ConcreteVersion::new(version_native.as_str()), version_req);
+    let new_text = formatter.format_version_replacing_for(
+        dep,
+        &ConcreteVersion::new(version_native.as_str()),
+        version_req,
+    );
 
     // N1: skip a no-op edit — the manifest already declares exactly the text
     // this action would write, so applying it would rewrite the text to
@@ -289,7 +292,7 @@ fn build_unsatisfiable_fix_action(
         );
         return None;
     }
-    let new_text = formatter.format_version_replacing(&latest, version_req.as_str());
+    let new_text = formatter.format_version_replacing_for(dep, &latest, version_req.as_str());
 
     // Mirrors `build_vulnerability_fix_action`'s N1 guard: compares against
     // `dep.version_literal()` rather than `version_req` when the ecosystem provides one,
@@ -673,7 +676,8 @@ pub async fn generate_code_actions<R: Registry + ?Sized>(
                 );
                 continue;
             }
-            let new_text = formatter.format_version_replacing(&item.version, version_req.as_str());
+            let new_text =
+                formatter.format_version_replacing_for(dep, &item.version, version_req.as_str());
 
             if !emitted_texts.insert(strip_whitespace(&new_text)) {
                 continue;

--- a/crates/deps-core/src/lsp_helpers/code_lenses.rs
+++ b/crates/deps-core/src/lsp_helpers/code_lenses.rs
@@ -169,7 +169,7 @@ pub fn collect_update_all_edits(
             continue;
         }
 
-        let new_text = formatter.format_version_replacing(latest, version_req.as_str());
+        let new_text = formatter.format_version_replacing_for(dep, latest, version_req.as_str());
         // No-op guard, mirroring the REFACTOR-loop dedup and vulnerability-fix N1
         // guard in `code_actions`: a formatter can decide a declared
         // requirement has no single unambiguous rewrite (e.g. `deps-gradle`'s

--- a/crates/deps-core/src/lsp_helpers/in_use_version.rs
+++ b/crates/deps-core/src/lsp_helpers/in_use_version.rs
@@ -7,6 +7,28 @@ use std::collections::HashMap;
 use crate::lsp_helpers::EcosystemFormatter;
 use crate::{ConcreteVersion, Dependency, EcosystemId, PackageName};
 
+/// How a *bare* (no explicit pin marker) version requirement should be treated when
+/// deciding whether it denotes a single concrete version.
+///
+/// Replaces a plain boolean (critique B2 of #208's plan) because neither `true` nor
+/// `false` is correct for GitHub Actions: `AlwaysRange`/`Concrete` alone cannot express
+/// "a bare `v4` is a range, but a bare `v4.2.0` is a pin" — the two forms share no
+/// syntactic marker to distinguish them by, only the number of components present.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BareRequirementPolicy {
+    /// A bare requirement is always a range under this ecosystem's own default
+    /// semantics (Cargo's implicit caret, npm/Composer's implicit caret) — never
+    /// treated as concrete without an explicit `=`/`==` pin marker.
+    AlwaysRange,
+    /// A bare requirement is concrete only when it has the shape of a full
+    /// `major.minor.patch` version ([`is_full_semver_shape`]); a partial form (a bare
+    /// major or major.minor, e.g. GitHub Actions' moving-major `v4` tag) is treated as
+    /// a range instead, since it is one.
+    ConcreteIfFullVersion,
+    /// A bare requirement is already exact (no implicit range operator).
+    Concrete,
+}
+
 /// Ecosystems whose *bare* (no explicit pin marker) version requirement is a
 /// range under that ecosystem's own default semantics — Cargo's implicit
 /// caret, npm/Composer's implicit caret. For these, [`is_concrete_version`]
@@ -18,17 +40,71 @@ use crate::{ConcreteVersion, Dependency, EcosystemId, PackageName};
 /// (`DenoFormatter::compile_requirement` compiles both through the same
 /// `node_semver::Range` npm itself uses), so it gets the same treatment here.
 ///
+/// GitHub Actions gets [`BareRequirementPolicy::ConcreteIfFullVersion`]: a bare `v4`
+/// (a moving-major tag) genuinely is a range, so it must not be queried as if it were
+/// the concrete version `4`, but a bare `v4.2.0` is a pin — see
+/// [`BareRequirementPolicy`]'s docs. A bare 40-character SHA also falls to the
+/// `None` side of this gate ([`is_full_semver_shape`] rejects it), which is the
+/// correct "honest unknown" outcome: resolving a SHA to its tag would need registry
+/// access this pure function does not have.
+///
 /// Gradle is deliberately excluded: a bare Gradle coordinate version (e.g.
 /// `"2.14.1"`) is an exact match under `GradleFormatter`'s own
 /// `version_satisfies_requirement` unless it uses the `+` dynamic-version
 /// suffix, which [`looks_like_a_single_version`] already rejects via its
 /// reject-char set — Gradle has no implicit-caret default the way
 /// Cargo/npm/Composer do.
-const fn bare_version_is_a_range(ecosystem: EcosystemId) -> bool {
-    matches!(
-        ecosystem,
-        EcosystemId::Cargo | EcosystemId::Npm | EcosystemId::Composer | EcosystemId::Deno
-    )
+const fn bare_requirement_policy(ecosystem: EcosystemId) -> BareRequirementPolicy {
+    match ecosystem {
+        EcosystemId::Cargo | EcosystemId::Npm | EcosystemId::Composer | EcosystemId::Deno => {
+            BareRequirementPolicy::AlwaysRange
+        }
+        EcosystemId::GithubActions => BareRequirementPolicy::ConcreteIfFullVersion,
+        _ => BareRequirementPolicy::Concrete,
+    }
+}
+
+/// Whether `s` has the shape of a full `major.minor.patch` version.
+///
+/// An optional leading `v`/`V`, three dot-separated all-digit components, and an
+/// optional SemVer-style prerelease/build suffix introduced by `-` or `+` (accepted,
+/// but not itself validated beyond "starts here").
+///
+/// Hand-rolled rather than pulled in via the `regex` crate: this is consulted from
+/// `bare_requirement_policy` in `deps-core`, the workspace's most-depended-on crate,
+/// which has no `regex` dependency today — equivalent to the pattern
+/// `^v?\d+\.\d+\.\d+(?:[-+].*)?$`. Shared verbatim by `deps-github-actions`'s
+/// SHA-comment-tag parsing rule so the two mechanisms can never silently diverge on
+/// what counts as a full version (e.g. `v4.2.0-beta.1` must be treated identically by
+/// both).
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::lsp_helpers::is_full_semver_shape;
+///
+/// assert!(is_full_semver_shape("v4.2.0"));
+/// assert!(is_full_semver_shape("4.2.0-beta.1"));
+/// assert!(!is_full_semver_shape("v4"));
+/// assert!(!is_full_semver_shape("v4.2"));
+/// assert!(!is_full_semver_shape("not-a-version"));
+/// ```
+#[must_use]
+pub fn is_full_semver_shape(s: &str) -> bool {
+    let s = s.strip_prefix(['v', 'V']).unwrap_or(s);
+    let core = match s.find(['-', '+']) {
+        Some(idx) => &s[..idx],
+        None => s,
+    };
+    let mut parts = core.split('.');
+    let (Some(major), Some(minor), Some(patch), None) =
+        (parts.next(), parts.next(), parts.next(), parts.next())
+    else {
+        return false;
+    };
+    [major, minor, patch]
+        .iter()
+        .all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
 }
 
 /// Returns `true` if `s` (already stripped of any pin marker) has the shape
@@ -109,8 +185,15 @@ pub fn concrete_pin_version(requirement: &str, ecosystem: EcosystemId) -> Option
 
     match pinned.or(bracket_pinned) {
         Some(body) => looks_like_a_single_version(body).then_some(body),
-        None if bare_version_is_a_range(ecosystem) => None,
-        None => looks_like_a_single_version(trimmed).then_some(trimmed),
+        None => match bare_requirement_policy(ecosystem) {
+            BareRequirementPolicy::AlwaysRange => None,
+            BareRequirementPolicy::Concrete => {
+                looks_like_a_single_version(trimmed).then_some(trimmed)
+            }
+            BareRequirementPolicy::ConcreteIfFullVersion => {
+                is_full_semver_shape(trimmed).then_some(trimmed)
+            }
+        },
     }
 }
 
@@ -360,5 +443,71 @@ mod tests {
         assert_eq!(concrete_pin_version("^1.0", EcosystemId::Cargo), None);
         assert_eq!(concrete_pin_version("1.2.3", EcosystemId::Cargo), None);
         assert_eq!(concrete_pin_version(">=1.0,<2.0", EcosystemId::Pypi), None);
+    }
+
+    // --- is_full_semver_shape ---
+
+    #[test]
+    fn is_full_semver_shape_accepts_full_versions_with_and_without_v_prefix() {
+        assert!(is_full_semver_shape("4.2.0"));
+        assert!(is_full_semver_shape("v4.2.0"));
+        assert!(is_full_semver_shape("V4.2.0"));
+    }
+
+    #[test]
+    fn is_full_semver_shape_accepts_prerelease_and_build_suffixes() {
+        assert!(is_full_semver_shape("v4.2.0-beta.1"));
+        assert!(is_full_semver_shape("4.2.0+build.5"));
+    }
+
+    #[test]
+    fn is_full_semver_shape_rejects_partial_versions() {
+        assert!(!is_full_semver_shape("v4"));
+        assert!(!is_full_semver_shape("v4.2"));
+    }
+
+    #[test]
+    fn is_full_semver_shape_rejects_non_version_and_sha_shapes() {
+        assert!(!is_full_semver_shape("main"));
+        assert!(!is_full_semver_shape(
+            "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+        ));
+        assert!(!is_full_semver_shape(""));
+        assert!(!is_full_semver_shape("4.2.0.1"));
+        assert!(!is_full_semver_shape("4..0"));
+    }
+
+    // --- concrete_pin_version: BareRequirementPolicy::ConcreteIfFullVersion (GitHub Actions) ---
+
+    #[test]
+    fn concrete_pin_version_github_actions_full_bare_tag_is_concrete() {
+        assert_eq!(
+            concrete_pin_version("v4.2.0", EcosystemId::GithubActions),
+            Some("v4.2.0")
+        );
+    }
+
+    #[test]
+    fn concrete_pin_version_github_actions_moving_major_tag_is_a_range() {
+        // `v4` genuinely is a range (a moving major tag) — must not be queried as if
+        // it were the concrete version `4` (critique B2).
+        assert_eq!(concrete_pin_version("v4", EcosystemId::GithubActions), None);
+        assert_eq!(
+            concrete_pin_version("v4.2", EcosystemId::GithubActions),
+            None
+        );
+    }
+
+    #[test]
+    fn concrete_pin_version_github_actions_bare_sha_is_not_concrete() {
+        // A bare SHA has no dots, so it fails `is_full_semver_shape` and falls to the
+        // honest "unknown" `None` rather than being queried as a fabricated version.
+        assert_eq!(
+            concrete_pin_version(
+                "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+                EcosystemId::GithubActions
+            ),
+            None
+        );
     }
 }

--- a/crates/deps-core/src/lsp_helpers/mod.rs
+++ b/crates/deps-core/src/lsp_helpers/mod.rs
@@ -26,7 +26,7 @@ pub use diagnostics::{
     compile_requirement_unless, generate_diagnostics_from_cache, requirement_is_unsatisfiable,
 };
 pub use hover::generate_hover;
-pub use in_use_version::{concrete_pin_version, in_use_version};
+pub use in_use_version::{concrete_pin_version, in_use_version, is_full_semver_shape};
 pub use inlay_hints::generate_inlay_hints;
 
 /// Maximum number of recent versions hover's "Recent versions" section renders.
@@ -687,6 +687,31 @@ pub trait EcosystemFormatter: Send + Sync {
     /// of pinning.
     fn format_version_replacing(&self, version: &ConcreteVersion, _current: &str) -> String {
         self.format_version_for_text_edit(version)
+    }
+
+    /// Like [`format_version_replacing`](Self::format_version_replacing), but also
+    /// carries the dependency identity `version`/`current` apply to.
+    ///
+    /// Default: ignores `dep`, delegating to
+    /// [`format_version_replacing`](Self::format_version_replacing). Override when the
+    /// replacement text cannot be derived from `version`/`current` alone — e.g.
+    /// `deps-github-actions`'s SHA-pinned `uses: owner/repo@<sha> # vX.Y.Z` form, where
+    /// the new SHA for a given tag is looked up per `dep.name()` (a tag's commit SHA is
+    /// per-repository, unknowable from the tag string alone) in a registry-populated
+    /// index the formatter holds a shared handle to.
+    ///
+    /// Every shared call site that builds a version-update edit (the vulnerability and
+    /// unsatisfiable-requirement quickfixes, the REFACTOR-loop "update to X" actions, and
+    /// the "Update N outdated dependencies" code lens) already has `dep` in scope and
+    /// calls this method instead of [`format_version_replacing`](Self::format_version_replacing)
+    /// directly, so an override here is picked up on every edit path at once.
+    fn format_version_replacing_for(
+        &self,
+        _dep: &dyn Dependency,
+        version: &ConcreteVersion,
+        current: &str,
+    ) -> String {
+        self.format_version_replacing(version, current)
     }
 
     /// Check if a version satisfies a requirement string.
@@ -2149,6 +2174,21 @@ mod tests {
         );
         assert_eq!(formatter.yanked_message(), "This version has been yanked");
         assert_eq!(formatter.yanked_label(), "*(yanked)*");
+    }
+
+    #[test]
+    fn test_format_version_replacing_for_default_delegates_to_format_version_replacing() {
+        let formatter = MockFormatter;
+        let dep = MockDep {
+            name: pkg("test-pkg"),
+            version_req: VersionReq::new("1.0.0"),
+            version_range: Range::default(),
+            name_range: Range::default(),
+        };
+        assert_eq!(
+            formatter.format_version_replacing_for(&dep, &ConcreteVersion::new("1.2.3"), "1.0.0"),
+            formatter.format_version_replacing(&ConcreteVersion::new("1.2.3"), "1.0.0")
+        );
     }
 
     #[test]

--- a/crates/deps-github-actions/Cargo.toml
+++ b/crates/deps-github-actions/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "deps-github-actions"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "GitHub Actions workflow dependency support for deps-lsp"
+
+[lints]
+workspace = true
+
+[dependencies]
+bytes = { workspace = true }
+dashmap = { workspace = true }
+deps-core = { workspace = true }
+reqwest = { workspace = true }
+semver = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["sync"] }
+tower-lsp-server = { workspace = true }
+tracing = { workspace = true }
+yaml-rust2 = { workspace = true }
+
+[dev-dependencies]
+deps-core = { workspace = true, features = ["test-util"] }
+mockito = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio-test = { workspace = true }

--- a/crates/deps-github-actions/README.md
+++ b/crates/deps-github-actions/README.md
@@ -1,0 +1,84 @@
+# deps-github-actions
+
+[![Crates.io](https://img.shields.io/crates/v/deps-github-actions)](https://crates.io/crates/deps-github-actions)
+[![docs.rs](https://img.shields.io/docsrs/deps-github-actions)](https://docs.rs/deps-github-actions)
+[![CI](https://github.com/bug-ops/deps-lsp/actions/workflows/ci.yml/badge.svg)](https://github.com/bug-ops/deps-lsp/actions)
+[![codecov](https://codecov.io/gh/bug-ops/deps-lsp/graph/badge.svg?token=S71PTINTGQ&flag=deps-github-actions)](https://codecov.io/gh/bug-ops/deps-lsp)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../../LICENSE)
+
+GitHub Actions workflow dependency support for deps-lsp.
+
+This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) workspace. It
+provides parsing and registry integration for `.github/workflows/*.yml`/`*.yaml` files and
+implements `deps_core::Ecosystem`.
+
+## Features
+
+- **Event-driven YAML parsing** — `yaml-rust2`'s `MarkedEventReceiver` API tracks every
+  `uses:` step individually with its own position, so two occurrences of the same action
+  pinned at different refs get distinct, independently editable ranges
+- **Full pin-style coverage** — tag (`@v4`, `@v4.2.0`), commit SHA (`@<40hex>`, optionally
+  annotated `# vX.Y.Z`), and branch (`@main`) refs, plus recognition (without version
+  resolution) of local composite actions (`./local`), Docker image refs (`docker://...`),
+  and reusable-workflow calls
+- **GitHub tags API registry** — per-repository tag/commit-SHA cross-reference, with
+  request coalescing so N workflows referencing the same action on a cold cache issue one
+  fetch, not N, and a local rate-limit gate that stops hammering GitHub once a 403 is seen
+- **SHA-pin-aware code actions** — updating a `@<sha> # vX.Y.Z` pin writes both a new SHA
+  and its matching tag comment, never silently downgrading a SHA pin to a bare tag
+
+## Installation
+
+```toml
+[dependencies]
+deps-github-actions = "0.11"
+```
+
+> [!IMPORTANT]
+> Requires Rust 1.91 or later.
+
+## Usage
+
+```rust
+use deps_github_actions::{parse_workflow_yaml, GithubActionsRegistry};
+use std::sync::Arc;
+
+let result = parse_workflow_yaml(content, &uri)?;
+let registry = GithubActionsRegistry::new(Arc::new(deps_core::HttpCache::new()));
+```
+
+## Pin contract
+
+| `uses:` form | `version_range` spans | `version_requirement()` | `version_literal()` |
+|---|---|---|---|
+| `actions/checkout@v4` | `v4` | `v4` | `None` |
+| `…@v4.2.0` / `…@4.2.0` | the tag | same | `None` |
+| `…@<40hex> # v4.2.0` | `<40hex> # v4.2.0` | `v4.2.0` (from the comment) | the raw span |
+| `…@<40hex>` (no comment) | `<40hex>` | `<40hex>` | `None` |
+| `…@main` | `main` | `main` | `None` |
+| `./local`, `docker://x:1`, a reusable-workflow call | `None` | `None` | `None` |
+
+The SHA-with-comment row is load-bearing: the comment is treated as the declared intent
+(Dependabot/Renovate always write it), so the shared "is this up to date" comparison works
+against the tag with zero SHA-to-tag network resolution.
+
+## Known limitations
+
+- Bare SHA and branch refs have no resolvable version — no outdated diagnostic, no inlay
+  hint, matching the existing Maven `${property}`/Gradle `$var` precedent for an
+  unresolvable requirement
+- Reusable-workflow calls (`owner/repo/.github/workflows/x.yml@ref`) are parsed and
+  recognized but deliberately non-resolvable: the referenced workflow's version and the
+  host repository's release tags are not reliably the same thing, and a wrong diagnostic
+  on a supply-chain feature is worse than none
+- No publish-date/freshness signal — the tags API carries no publish timestamp, and
+  fetching one via `/releases` would double the request count per repository
+- Package-name completion is unimplemented (`search()` always returns empty): GitHub has
+  no action-specific search endpoint cheaper than repository search, and querying it per
+  keystroke would burn the 60 req/hour unauthenticated budget fast
+- The unauthenticated GitHub API budget (60 req/hour) is per-IP and shared with any
+  `deps-swift` traffic in the same process; set `GITHUB_TOKEN` to raise it to 5000 req/hour
+
+## License
+
+[MIT](../../LICENSE)

--- a/crates/deps-github-actions/src/ecosystem.rs
+++ b/crates/deps-github-actions/src/ecosystem.rs
@@ -1,0 +1,328 @@
+//! GitHub Actions ecosystem implementation for deps-lsp.
+
+use std::any::Any;
+use std::sync::Arc;
+use tower_lsp_server::ls_types::{Hover, HoverContents, Position, Uri};
+
+use deps_core::{
+    Ecosystem, ParseResult as ParseResultTrait, Registry, Result,
+    completion::Completions,
+    lsp_helpers::{EcosystemFormatter, markdown_code_span},
+};
+
+use crate::formatter::GithubActionsFormatter;
+use crate::registry::GithubActionsRegistry;
+use crate::types::{GithubActionsDependency, PinStyle};
+
+/// GitHub Actions ecosystem implementation.
+///
+/// Provides LSP functionality for `.github/workflows/*.yml`/`*.yaml` files, including:
+/// - Dependency parsing with position tracking (see `parser` module docs for the pin
+///   contract)
+/// - Version information from the GitHub tags API
+/// - Inlay hints, hover, completions, diagnostics, and code actions/lenses via the
+///   shared `deps_core::lsp_helpers` machinery
+pub struct GithubActionsEcosystem {
+    registry: Arc<GithubActionsRegistry>,
+    formatter: GithubActionsFormatter,
+}
+
+impl GithubActionsEcosystem {
+    /// Creates a new GitHub Actions ecosystem with the given HTTP cache.
+    #[must_use]
+    pub fn new(cache: Arc<deps_core::HttpCache>) -> Self {
+        let registry = Arc::new(GithubActionsRegistry::new(cache));
+        let formatter = GithubActionsFormatter {
+            tag_index: registry.tag_index(),
+        };
+        Self {
+            registry,
+            formatter,
+        }
+    }
+}
+
+impl deps_core::ecosystem::private::Sealed for GithubActionsEcosystem {}
+
+impl Ecosystem for GithubActionsEcosystem {
+    fn id(&self) -> &'static str {
+        "github-actions"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "GitHub Actions"
+    }
+
+    fn manifest_filenames(&self) -> &[&'static str] {
+        &[]
+    }
+
+    /// GHA declares no fixed filename or extension — it is routed solely by directory
+    /// path (D1): a `.github/workflows/*.yml`/`*.yaml` file, regardless of how many
+    /// ancestor directories precede `.github`.
+    fn manifest_directory_patterns(&self) -> &[(&'static str, &'static str)] {
+        &[
+            (".github/workflows", ".yml"),
+            (".github/workflows", ".yaml"),
+        ]
+    }
+
+    fn lockfile_filenames(&self) -> &[&'static str] {
+        &[]
+    }
+
+    fn parse_manifest<'a>(
+        &'a self,
+        content: &'a str,
+        uri: &'a Uri,
+    ) -> deps_core::ecosystem::BoxFuture<'a, Result<Box<dyn ParseResultTrait>>> {
+        Box::pin(async move {
+            let result = crate::parser::parse_workflow_yaml(content, uri)?;
+            Ok(Box::new(result) as Box<dyn ParseResultTrait>)
+        })
+    }
+
+    fn registry(&self) -> Arc<dyn Registry> {
+        self.registry.clone() as Arc<dyn Registry>
+    }
+
+    fn formatter(&self) -> &dyn EcosystemFormatter {
+        &self.formatter
+    }
+
+    fn generate_completions<'a>(
+        &'a self,
+        parse_result: &'a dyn ParseResultTrait,
+        position: Position,
+        content: &'a str,
+        freshness: deps_core::FreshnessSettings,
+    ) -> deps_core::ecosystem::BoxFuture<'a, Completions> {
+        Box::pin(async move {
+            use deps_core::completion::{CompletionContext, detect_completion_context};
+
+            match detect_completion_context(parse_result, position, content) {
+                CompletionContext::Version {
+                    package_name,
+                    prefix,
+                } => deps_core::completion::complete_versions_generic(
+                    self.registry.as_ref(),
+                    &package_name,
+                    &prefix,
+                    &[],
+                    freshness,
+                )
+                .await
+                .into(),
+                CompletionContext::PackageName { .. }
+                | CompletionContext::Feature { .. }
+                | CompletionContext::None => Completions::default(),
+            }
+        })
+    }
+
+    /// One documented NFR-004 divergence (S3): appends a `**Resolved**` line naming the
+    /// tag a SHA pin's commit actually corresponds to, per
+    /// [`crate::registry::GithubActionsRegistry`]'s [`crate::registry::TagIndex`].
+    ///
+    /// Necessary, not merely additive: `versions.resolved` (the shared helper's
+    /// `**Current**` source) is keyed by package name and is unconditionally empty for
+    /// GHA (no lockfile provider), so it cannot express per-occurrence resolution when
+    /// the same action is pinned at two different SHAs in one workflow. The splice also
+    /// makes a stale or hand-edited `# vX.Y.Z` comment visible for free (M4): the tag
+    /// shown here comes from `TagIndex.sha_to_tag`, not from trusting the comment text.
+    ///
+    /// Scoped to [`PinStyle::Sha`] only — the SHA is the one pin form GitHub itself does
+    /// not render as a readable version, and it is the only form
+    /// [`crate::registry::TagIndex`] can resolve unambiguously by construction (it is
+    /// populated only from fully-`major.minor.patch`-parseable tags, so a moving major
+    /// tag like `v4` never has its own entry to resolve through). Guarded on
+    /// `dep.version_range().is_some()` (N3): a non-resolvable dependency (a reusable-
+    /// workflow call, `./local`, `docker://…`) still matches the shared helper's own
+    /// hover-target predicate and must not have a `**Resolved**` line spliced onto it.
+    fn generate_hover<'a>(
+        &'a self,
+        parse_result: &'a dyn ParseResultTrait,
+        position: Position,
+        versions: deps_core::VersionData<'a>,
+        freshness: deps_core::FreshnessSettings,
+    ) -> deps_core::ecosystem::BoxFuture<'a, Option<Hover>> {
+        Box::pin(async move {
+            let registry = self.registry.clone();
+            let base_hover = deps_core::lsp_generate_hover(
+                parse_result,
+                position,
+                versions,
+                registry.as_ref(),
+                self.formatter(),
+                freshness,
+                deps_core::PublishTime::now(),
+            )
+            .await;
+            let mut hover = base_hover?;
+
+            let dep = parse_result.dependencies().into_iter().find(|d| {
+                deps_core::position_in_range(position, d.name_range())
+                    || d.version_range()
+                        .is_some_and(|r| deps_core::position_in_range(position, r))
+            });
+            let Some(dep) = dep else {
+                return Some(hover);
+            };
+            if dep.version_range().is_none() {
+                return Some(hover);
+            }
+            let Some(gha_dep) = dep.as_any().downcast_ref::<GithubActionsDependency>() else {
+                return Some(hover);
+            };
+            let Some(PinStyle::Sha { comment_tag }) = &gha_dep.pin else {
+                return Some(hover);
+            };
+
+            let sha = match comment_tag {
+                // Whitespace-token split, not `split_once(" # ")`: the parser's
+                // comment-tag rule (B3) only requires the `#` to be *preceded* by
+                // whitespace, so `<sha>  # v4.2.0` (two spaces) or `<sha>\t# v4.2.0`
+                // are both valid literals that a single-space exact match would miss
+                // (critic M2).
+                Some(_) => gha_dep
+                    .version_literal
+                    .as_deref()
+                    .and_then(|lit| lit.split_whitespace().next()),
+                None => gha_dep
+                    .version_req
+                    .as_ref()
+                    .map(deps_core::VersionReq::as_str),
+            };
+            let Some(sha) = sha else {
+                return Some(hover);
+            };
+
+            let Some(resolved_tag) = self
+                .formatter
+                .tag_index
+                .get(dep.name())
+                .and_then(|index| index.sha_to_tag.get(sha).cloned())
+            else {
+                return Some(hover);
+            };
+
+            if let HoverContents::Markup(content) = &mut hover.contents {
+                content.value = splice_resolved_line(&content.value, &resolved_tag, sha);
+            }
+
+            Some(hover)
+        })
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Inserts a `**Resolved**: `tag` (`sha…`)` line immediately after the shared hover's
+/// `**Current**`/`**Requirement**` line (whichever is present), falling back to append
+/// only if neither anchor is found.
+fn splice_resolved_line(markdown: &str, resolved_tag: &str, sha: &str) -> String {
+    // `sha` is expected to be a validated, pure-ASCII full hex SHA by the time it
+    // reaches here (`TagIndex` entries are filtered in `tags_to_versions`, security
+    // S-3), so a byte slice is normally safe — `get(..7)` is a char-boundary-safe
+    // belt-and-braces guard rather than a raw index (security S-4), falling back to
+    // the whole string on anything unexpected instead of panicking.
+    let short_sha = sha.get(..7).unwrap_or(sha);
+    let line = format!(
+        "**Resolved**: {} ({})\n\n",
+        markdown_code_span(resolved_tag),
+        markdown_code_span(&format!("{short_sha}…"))
+    );
+
+    for anchor in ["**Current**: ", "**Requirement**: "] {
+        if let Some(pos) = markdown.find(anchor)
+            && let Some(rel_end) = markdown[pos..].find("\n\n")
+        {
+            let insert_at = pos + rel_end + 2;
+            let mut out = String::with_capacity(markdown.len() + line.len());
+            out.push_str(&markdown[..insert_at]);
+            out.push_str(&line);
+            out.push_str(&markdown[insert_at..]);
+            return out;
+        }
+    }
+    format!("{markdown}{line}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ecosystem_id_and_display_name() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = GithubActionsEcosystem::new(cache);
+        assert_eq!(eco.id(), "github-actions");
+        assert_eq!(eco.display_name(), "GitHub Actions");
+    }
+
+    #[test]
+    fn test_manifest_routing_is_directory_pattern_only() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = GithubActionsEcosystem::new(cache);
+        assert!(eco.manifest_filenames().is_empty());
+        assert!(eco.manifest_patterns().is_empty());
+        assert!(eco.manifest_extensions().is_empty());
+        assert_eq!(
+            eco.manifest_directory_patterns(),
+            &[
+                (".github/workflows", ".yml"),
+                (".github/workflows", ".yaml")
+            ]
+        );
+    }
+
+    #[test]
+    fn test_as_any() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = GithubActionsEcosystem::new(cache);
+        assert!(eco.as_any().is::<GithubActionsEcosystem>());
+    }
+
+    #[tokio::test]
+    async fn test_parse_manifest_valid() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = GithubActionsEcosystem::new(cache);
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let content = "steps:\n  - uses: actions/checkout@v4\n";
+        let result = eco.parse_manifest(content, &uri).await.unwrap();
+        assert_eq!(result.dependencies().len(), 1);
+    }
+
+    #[test]
+    fn test_splice_resolved_line_after_requirement() {
+        let markdown = "# actions/checkout\n\n**Requirement**: `v4.2.0`\n\n**Latest**: `v4.3.0`\n";
+        let spliced = splice_resolved_line(markdown, "v4.2.0", &"a".repeat(40));
+        let req_pos = spliced.find("**Requirement**").unwrap();
+        let resolved_pos = spliced.find("**Resolved**").unwrap();
+        let latest_pos = spliced.find("**Latest**").unwrap();
+        assert!(req_pos < resolved_pos);
+        assert!(resolved_pos < latest_pos);
+        assert!(spliced.contains("aaaaaaa…"));
+    }
+
+    #[test]
+    fn test_splice_resolved_line_after_current_when_present() {
+        let markdown = "# actions/checkout\n\n**Current**: `v4.2.0`\n\n**Requirement**: `v4`\n";
+        let spliced = splice_resolved_line(markdown, "v4.2.0", &"b".repeat(40));
+        let current_pos = spliced.find("**Current**").unwrap();
+        let resolved_pos = spliced.find("**Resolved**").unwrap();
+        let requirement_pos = spliced.find("**Requirement**").unwrap();
+        assert!(current_pos < resolved_pos);
+        assert!(resolved_pos < requirement_pos);
+    }
+
+    #[test]
+    fn test_splice_resolved_line_falls_back_to_append_when_no_anchor() {
+        let markdown = "# actions/checkout\n\nno anchors here\n";
+        let spliced = splice_resolved_line(markdown, "v4.2.0", &"c".repeat(40));
+        assert!(spliced.starts_with(markdown));
+        assert!(spliced.contains("**Resolved**"));
+    }
+}

--- a/crates/deps-github-actions/src/formatter.rs
+++ b/crates/deps-github-actions/src/formatter.rs
@@ -1,0 +1,354 @@
+//! GitHub Actions ecosystem formatter.
+
+use dashmap::DashMap;
+use deps_core::lsp_helpers::EcosystemFormatter;
+use deps_core::{
+    ConcreteVersion, Dependency, PackageName, VersionReq, lsp_helpers::warn_rejected_value,
+};
+use std::sync::Arc;
+
+use crate::parser::{is_full_sha, is_tag_shaped};
+use crate::registry::TagIndex;
+use crate::types::{GithubActionsDependency, PinStyle};
+
+/// Formatter for GitHub Actions ecosystem LSP responses.
+pub struct GithubActionsFormatter {
+    /// Shared handle to [`crate::registry::GithubActionsRegistry`]'s tag/SHA
+    /// cross-reference — read-only from here (`format_version_replacing_for`'s
+    /// `PinStyle::Sha` branch).
+    pub(crate) tag_index: Arc<DashMap<PackageName, Arc<TagIndex>>>,
+}
+
+/// Rewrites `tag` to match `current`'s leading `v`/`V` prefix style (or lack of one).
+///
+/// A repository can change its tagging convention over time (`4.0.0` -> `v5.0.0`); the
+/// formatted replacement should still read naturally against the user's existing pin
+/// style rather than silently flipping it.
+fn match_v_prefix_style(current: &str, tag: &str) -> String {
+    let current_has_v = current.starts_with(['v', 'V']);
+    let tag_has_v = tag.starts_with(['v', 'V']);
+    match (current_has_v, tag_has_v) {
+        (true, false) => format!("v{tag}"),
+        (false, true) => tag[1..].to_string(),
+        _ => tag.to_string(),
+    }
+}
+
+impl EcosystemFormatter for GithubActionsFormatter {
+    fn format_version_for_text_edit(&self, version: &ConcreteVersion) -> String {
+        version.as_str().to_string()
+    }
+
+    /// Tag → the latest tag, preserving `current`'s `v`-prefix style. SHA → looks up the
+    /// new SHA for `version`'s tag in the shared [`TagIndex`]; on a miss, returns
+    /// `dep.version_literal().unwrap_or(current)` — byte-identical to the raw declared
+    /// span, so every shared no-op guard (comparing against exactly that text)
+    /// suppresses the action instead of emitting a destructive downgrade-to-tag edit
+    /// (B1). Branch → `current` unchanged, for the same reason.
+    fn format_version_replacing_for(
+        &self,
+        dep: &dyn Dependency,
+        version: &ConcreteVersion,
+        current: &str,
+    ) -> String {
+        let Some(gha_dep) = dep.as_any().downcast_ref::<GithubActionsDependency>() else {
+            return self.format_version_for_text_edit(version);
+        };
+        match &gha_dep.pin {
+            Some(PinStyle::Tag) => match_v_prefix_style(current, version.as_str()),
+            Some(PinStyle::Sha { .. }) => self
+                .tag_index
+                .get(dep.name())
+                .and_then(|index| index.tag_to_sha.get(version.as_str()).cloned())
+                .map(|sha| format!("{sha} # {}", version.as_str()))
+                .unwrap_or_else(|| dep.version_literal().unwrap_or(current).to_string()),
+            Some(PinStyle::Branch) | None => current.to_string(),
+        }
+    }
+
+    fn package_url(&self, name: &PackageName) -> String {
+        if crate::is_valid_github_identity(name.as_str()) {
+            format!("https://github.com/{name}")
+        } else {
+            warn_rejected_value(
+                "is_valid_github_identity",
+                "github actions package display formatting",
+                name.as_str(),
+            );
+            String::new()
+        }
+    }
+
+    fn normalize_package_name(&self, name: &PackageName) -> String {
+        name.as_str().to_lowercase()
+    }
+
+    /// Rewrites a native tag string into the spelling OSV.dev's SEMVER range matching
+    /// expects: unprefixed (verified live against `GHSA-mrrh-fwg8-r2c3`, whose ranges
+    /// carry no `v` prefix regardless of the affected repository's own tagging
+    /// convention).
+    ///
+    /// `osv_version_to_native` is deliberately left at its default identity: adding a `v`
+    /// prefix unconditionally, the way `deps-go` does for module versions, would be wrong
+    /// for a GitHub Actions repository that tags without one — and
+    /// `format_version_replacing_for`'s `match_v_prefix_style` already reconciles the
+    /// prefix against the dependency's *own* declared pin style downstream, so no native
+    /// version ever reaches the manifest with the wrong style regardless of what this
+    /// method returns.
+    fn osv_version(&self, version: &str) -> String {
+        version
+            .strip_prefix(['v', 'V'])
+            .unwrap_or(version)
+            .to_string()
+    }
+
+    /// A major-only or major.minor requirement (`v4`) is up to date while `latest`'s
+    /// corresponding leading components match; a full version is compared component-for-
+    /// component. `v`/`V` is normalized off both sides first. An unparseable requirement
+    /// (a bare SHA or branch name — neither is dot-separated all-digit) returns `true`,
+    /// never a false "outdated": [`Self::requirement_is_unresolved`] is what actually
+    /// gates those out of the diagnostic/inlay-hint path; this is only the fallback for a
+    /// caller (the "Update N outdated" code lens) that does not consult that hook first.
+    fn is_requirement_up_to_date(
+        &self,
+        requirement: &VersionReq,
+        latest: &ConcreteVersion,
+    ) -> bool {
+        let req = requirement
+            .as_str()
+            .strip_prefix(['v', 'V'])
+            .unwrap_or(requirement.as_str());
+        let lat = latest
+            .as_str()
+            .strip_prefix(['v', 'V'])
+            .unwrap_or(latest.as_str());
+
+        let req_parts: Vec<&str> = req.split('.').collect();
+        let lat_parts: Vec<&str> = lat.split('.').collect();
+
+        let is_all_digits = |parts: &[&str]| {
+            !parts.is_empty()
+                && parts
+                    .iter()
+                    .all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
+        };
+        if !is_all_digits(&req_parts) || req_parts.len() > lat_parts.len() {
+            return true;
+        }
+        req_parts.iter().zip(lat_parts.iter()).all(|(r, l)| r == l)
+    }
+
+    /// A bare SHA or branch ref is recognizable from the requirement string alone: a
+    /// 40-character hex string is a SHA, and anything not shaped like a tag (an optional
+    /// `v`/`V` followed by a digit) is treated as a branch — the "honest unknown" side,
+    /// since neither can be resolved to a concrete version without a `TagIndex` lookup
+    /// this pure predicate has no access to.
+    fn requirement_is_unresolved(&self, requirement: &VersionReq) -> bool {
+        let req = requirement.as_str();
+        is_full_sha(req) || !is_tag_shaped(req)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use deps_core::parser::DependencySource;
+    use tower_lsp_server::ls_types::{Position, Range};
+
+    fn formatter() -> GithubActionsFormatter {
+        GithubActionsFormatter {
+            tag_index: Arc::new(DashMap::new()),
+        }
+    }
+
+    fn dep(pin: Option<PinStyle>, name: &str, literal: Option<&str>) -> GithubActionsDependency {
+        GithubActionsDependency {
+            name: name.into(),
+            name_range: Range::new(Position::new(0, 0), Position::new(0, 1)),
+            version_req: Some("v4".into()),
+            version_range: Some(Range::new(Position::new(0, 0), Position::new(0, 1))),
+            version_literal: literal.map(str::to_string),
+            pin,
+            source: DependencySource::Registry,
+        }
+    }
+
+    #[test]
+    fn test_package_url_valid_and_invalid() {
+        let fmt = formatter();
+        assert_eq!(
+            fmt.package_url(&PackageName::new("actions/checkout")),
+            "https://github.com/actions/checkout"
+        );
+        assert_eq!(fmt.package_url(&PackageName::new("no-slash")), "");
+        assert_eq!(fmt.package_url(&PackageName::new("owner/..")), "");
+    }
+
+    #[test]
+    fn test_normalize_package_name() {
+        let fmt = formatter();
+        assert_eq!(
+            fmt.normalize_package_name(&PackageName::new("Actions/Checkout")),
+            "actions/checkout"
+        );
+    }
+
+    #[test]
+    fn test_osv_version_strips_v_prefix() {
+        let fmt = formatter();
+        assert_eq!(fmt.osv_version("v4.2.0"), "4.2.0");
+        assert_eq!(fmt.osv_version("4.2.0"), "4.2.0");
+    }
+
+    #[test]
+    fn test_is_requirement_up_to_date_major_only() {
+        let fmt = formatter();
+        assert!(
+            fmt.is_requirement_up_to_date(&VersionReq::new("v4"), &ConcreteVersion::new("4.3.1"))
+        );
+        assert!(
+            !fmt.is_requirement_up_to_date(&VersionReq::new("v4"), &ConcreteVersion::new("5.0.0"))
+        );
+    }
+
+    #[test]
+    fn test_is_requirement_up_to_date_full_version() {
+        let fmt = formatter();
+        assert!(fmt.is_requirement_up_to_date(
+            &VersionReq::new("v4.2.0"),
+            &ConcreteVersion::new("v4.2.0")
+        ));
+        assert!(!fmt.is_requirement_up_to_date(
+            &VersionReq::new("v4.2.0"),
+            &ConcreteVersion::new("v4.3.0")
+        ));
+    }
+
+    #[test]
+    fn test_is_requirement_up_to_date_unparseable_never_false_positive() {
+        let fmt = formatter();
+        assert!(fmt.is_requirement_up_to_date(
+            &VersionReq::new("a".repeat(40)),
+            &ConcreteVersion::new("v4.3.1")
+        ));
+        assert!(
+            fmt.is_requirement_up_to_date(
+                &VersionReq::new("main"),
+                &ConcreteVersion::new("v4.3.1")
+            )
+        );
+    }
+
+    #[test]
+    fn test_requirement_is_unresolved_sha_and_branch() {
+        let fmt = formatter();
+        assert!(fmt.requirement_is_unresolved(&VersionReq::new("a".repeat(40))));
+        assert!(fmt.requirement_is_unresolved(&VersionReq::new("main")));
+    }
+
+    #[test]
+    fn test_requirement_is_unresolved_tag_is_resolved() {
+        let fmt = formatter();
+        assert!(!fmt.requirement_is_unresolved(&VersionReq::new("v4")));
+        assert!(!fmt.requirement_is_unresolved(&VersionReq::new("v4.2.0")));
+    }
+
+    #[test]
+    fn test_format_version_replacing_for_tag_preserves_v_style() {
+        let fmt = formatter();
+        let d = dep(Some(PinStyle::Tag), "actions/checkout", None);
+        assert_eq!(
+            fmt.format_version_replacing_for(&d, &ConcreteVersion::new("5.0.0"), "v4"),
+            "v5.0.0"
+        );
+        assert_eq!(
+            fmt.format_version_replacing_for(&d, &ConcreteVersion::new("v5.0.0"), "4"),
+            "5.0.0"
+        );
+    }
+
+    #[test]
+    fn test_format_version_replacing_for_sha_resolves_via_tag_index() {
+        let fmt = formatter();
+        let name = PackageName::new("actions/checkout");
+        let mut index = TagIndex::default();
+        index
+            .tag_to_sha
+            .insert("v5.0.0".to_string(), "deadbeef".repeat(5));
+        fmt.tag_index.insert(name, Arc::new(index));
+
+        let d = dep(
+            Some(PinStyle::Sha {
+                comment_tag: Some("v4.2.0".to_string()),
+            }),
+            "actions/checkout",
+            Some("oldsha # v4.2.0"),
+        );
+        let new_text =
+            fmt.format_version_replacing_for(&d, &ConcreteVersion::new("v5.0.0"), "v4.2.0");
+        assert_eq!(new_text, format!("{} # v5.0.0", "deadbeef".repeat(5)));
+    }
+
+    #[test]
+    fn test_format_version_replacing_for_sha_miss_returns_raw_literal_not_current() {
+        // B1: on a TagIndex miss, the guard must compare byte-identical to the raw
+        // literal span (`dep.version_literal()`), never to `current` (the synthesized
+        // tag requirement) — else the shared no-op guard fails to fire and the edit
+        // silently downgrades a SHA pin to a bare tag.
+        let fmt = formatter();
+        let d = dep(
+            Some(PinStyle::Sha {
+                comment_tag: Some("v4.2.0".to_string()),
+            }),
+            "actions/checkout",
+            Some("oldsha # v4.2.0"),
+        );
+        let new_text =
+            fmt.format_version_replacing_for(&d, &ConcreteVersion::new("v5.0.0"), "v4.2.0");
+        assert_eq!(new_text, "oldsha # v4.2.0");
+        assert_ne!(new_text, "v4.2.0");
+    }
+
+    #[test]
+    fn test_format_version_replacing_for_branch_returns_current_unchanged() {
+        let fmt = formatter();
+        let d = dep(Some(PinStyle::Branch), "dev/tool", None);
+        assert_eq!(
+            fmt.format_version_replacing_for(&d, &ConcreteVersion::new("v1.0.0"), "main"),
+            "main"
+        );
+    }
+
+    #[test]
+    fn test_format_version_replacing_for_non_gha_dependency_falls_back_to_identity() {
+        struct OtherDep;
+        impl Dependency for OtherDep {
+            fn name(&self) -> &PackageName {
+                static NAME: std::sync::LazyLock<PackageName> =
+                    std::sync::LazyLock::new(|| PackageName::new("other"));
+                &NAME
+            }
+            fn name_range(&self) -> Range {
+                Range::default()
+            }
+            fn version_requirement(&self) -> Option<&VersionReq> {
+                None
+            }
+            fn version_range(&self) -> Option<Range> {
+                None
+            }
+            fn source(&self) -> DependencySource {
+                DependencySource::Registry
+            }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+        }
+        let fmt = formatter();
+        let d = OtherDep;
+        assert_eq!(
+            fmt.format_version_replacing_for(&d, &ConcreteVersion::new("1.0.0"), "0.9.0"),
+            "1.0.0"
+        );
+    }
+}

--- a/crates/deps-github-actions/src/lib.rs
+++ b/crates/deps-github-actions/src/lib.rs
@@ -1,0 +1,100 @@
+//! GitHub Actions ecosystem support for deps-lsp.
+//!
+//! Provides LSP features for `.github/workflows/*.yml`/`*.yaml` files:
+//! - Version autocomplete and hover for `uses: owner/repo@ref` steps
+//! - Diagnostics and code actions for outdated tag pins and SHA-with-comment pins
+//! - GitHub tags API for version discovery, with per-repository commit SHA resolution
+//!
+//! # Pin contract
+//!
+//! | `uses:` form | `version_range` spans | `version_requirement()` | `version_literal()` |
+//! |---|---|---|---|
+//! | `actions/checkout@v4` | `v4` | `v4` | `None` |
+//! | `…@v4.2.0` / `…@4.2.0` | the tag | same | `None` |
+//! | `…@<40hex> # v4.2.0` | `<40hex> # v4.2.0` | `v4.2.0` (from the comment) | the raw span |
+//! | `…@<40hex>` (no comment) | `<40hex>` | `<40hex>` | `None` |
+//! | `…@main` | `main` | `main` | `None` |
+//! | `./local`, `docker://x:1`, a reusable-workflow call | `None` | `None` | `None` |
+//!
+//! Reusable-workflow calls (`owner/repo/.github/workflows/x.yml@ref`) are recognized and
+//! their `owner/repo` truncated for display, but treated as non-resolvable — same shape as
+//! `./local`/`docker://` — because the referenced workflow's version and the host repo's
+//! release tags are not reliably the same thing (see `parser` module docs).
+
+pub mod ecosystem;
+pub mod formatter;
+pub mod parser;
+pub mod registry;
+pub mod types;
+
+pub use ecosystem::GithubActionsEcosystem;
+pub use formatter::GithubActionsFormatter;
+pub use parser::parse_workflow_yaml;
+pub use registry::GithubActionsRegistry;
+pub use types::{
+    GithubActionsDependency, GithubActionsParseResult, GithubActionsVersion, PinStyle,
+};
+
+/// Whether `name` matches the `owner/repo` GitHub identifier shape this crate accepts:
+/// `[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+`, with neither segment being exactly `.`/`..` (see
+/// [`deps_core::is_dot_segment`]).
+///
+/// Shared by `registry::validate_owner_repo` (a credential-bearing fetch-URL gate) and
+/// `formatter::GithubActionsFormatter::package_url` (a display-URL gate) — precedent:
+/// `deps_swift::is_valid_github_identity` (`crates/deps-swift/src/lib.rs`), which this
+/// mirrors so both GitHub-API-backed crates share one URL-injection gate shape.
+///
+/// # Examples
+///
+/// ```
+/// use deps_github_actions::is_valid_github_identity;
+///
+/// assert!(is_valid_github_identity("actions/checkout"));
+/// assert!(!is_valid_github_identity("not-a-valid-identifier"));
+/// assert!(!is_valid_github_identity("owner/.."));
+/// ```
+#[must_use]
+pub fn is_valid_github_identity(name: &str) -> bool {
+    let Some((owner, repo)) = name.split_once('/') else {
+        return false;
+    };
+    if owner.is_empty() || repo.is_empty() || repo.contains('/') {
+        return false;
+    }
+    let charset_ok = |s: &str| {
+        s.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
+    };
+    charset_ok(owner)
+        && charset_ok(repo)
+        && !deps_core::is_dot_segment(owner)
+        && !deps_core::is_dot_segment(repo)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_valid_github_identity_accepts_owner_repo() {
+        assert!(is_valid_github_identity("actions/checkout"));
+        assert!(is_valid_github_identity("org.name/repo_name-v2"));
+    }
+
+    #[test]
+    fn test_is_valid_github_identity_rejects_malformed() {
+        assert!(!is_valid_github_identity("no-slash"));
+        assert!(!is_valid_github_identity(""));
+        assert!(!is_valid_github_identity("owner/repo/extra"));
+        assert!(!is_valid_github_identity("owner/ repo"));
+        assert!(!is_valid_github_identity("../../etc/passwd"));
+    }
+
+    #[test]
+    fn test_is_valid_github_identity_rejects_dot_segment() {
+        assert!(!is_valid_github_identity("owner/.."));
+        assert!(!is_valid_github_identity("owner/."));
+        assert!(!is_valid_github_identity("../repo"));
+        assert!(!is_valid_github_identity("./repo"));
+    }
+}

--- a/crates/deps-github-actions/src/parser.rs
+++ b/crates/deps-github-actions/src/parser.rs
@@ -1,0 +1,1103 @@
+//! `.github/workflows/*.yml`/`*.yaml` parser using `yaml-rust2`'s event-driven
+//! (`MarkedEventReceiver`) API.
+//!
+//! An event-driven parser, rather than a tree-and-text-search approach (`deps-dart`'s), is
+//! what makes duplicate `uses:` lines addressable with distinct ranges — the common case in
+//! real workflows (the same action pinned at the same or different refs across several
+//! jobs).
+//!
+//! # Reusable-workflow calls
+//!
+//! `owner/repo/.github/workflows/x.yml@ref` is parsed, its `owner/repo` truncated for
+//! display, and recognized — but deliberately treated as **non-resolvable**, the same shape
+//! as `./local`/`docker://`. The complexity here is semantic, not syntactic: such a call is
+//! versioned by the *host repository's* tags, which for a reusable-workflow host are
+//! routinely its unrelated package releases rather than that specific workflow's — "outdated
+//! → update to vX" would then rewrite the pin to a tag that may not even contain the
+//! workflow. A wrong diagnostic on a supply-chain feature is worse than none. Subdirectory
+//! actions (`github/codeql-action/init@v3`) are unaffected: their repo's tags genuinely are
+//! the correct versioning, so they stay fully resolvable. The discriminator is whether the
+//! path segments after `owner/repo` start with `.github/workflows/`.
+
+use crate::types::{GithubActionsDependency, GithubActionsParseResult, PinStyle};
+use deps_core::lsp_helpers::{LineOffsetTable, is_full_semver_shape, warn_rejected_value};
+use deps_core::parser::DependencySource;
+use deps_core::{DepsError, Result};
+use tower_lsp_server::ls_types::{Range, Uri};
+use yaml_rust2::parser::{Event, MarkedEventReceiver, Parser};
+use yaml_rust2::scanner::{Marker, TScalarStyle};
+
+/// Length of a full, lowercase-or-not hex commit SHA.
+const SHA_LEN: usize = 40;
+
+/// Whether `s` is a 40-character hex string — GitHub's commit SHA shape.
+pub(crate) fn is_full_sha(s: &str) -> bool {
+    s.len() == SHA_LEN && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Whether `s` has the shape of a tag ref: an optional leading `v`/`V` followed by a digit.
+/// Anything else (that isn't a [`is_full_sha`] SHA) is treated as a branch name — the
+/// "honest unknown" side per the pin contract, since a branch cannot be resolved to a
+/// concrete version without registry access.
+pub(crate) fn is_tag_shaped(s: &str) -> bool {
+    if is_full_sha(s) {
+        return false;
+    }
+    let stripped = s.strip_prefix(['v', 'V']).unwrap_or(s);
+    stripped.starts_with(|c: char| c.is_ascii_digit())
+}
+
+/// Maps a `yaml-rust2` char index (see module-level note below) to a byte offset in
+/// `content`, and a byte offset to the end of its containing line.
+///
+/// `yaml_rust2::scanner::Marker::index()` increments once per `char` consumed by the
+/// scanner (it is built over `Parser::new_from_str`'s `str::chars()` iterator) — despite
+/// its own doc comment claiming "in bytes", it is a **character** index, verified against
+/// `yaml-rust2` 0.12's `Scanner::skip_non_blank`/`skip_blank` (`self.mark.index += 1` per
+/// char, not per byte). For ASCII-only content (true for the overwhelming majority of real
+/// `uses:` lines) the two coincide, but a comment or action name containing non-ASCII text
+/// would silently desync every downstream byte-offset computation without this table.
+struct CharOffsets {
+    byte_of_char: Vec<usize>,
+}
+
+impl CharOffsets {
+    fn new(content: &str) -> Self {
+        let mut byte_of_char: Vec<usize> = content.char_indices().map(|(b, _)| b).collect();
+        byte_of_char.push(content.len());
+        Self { byte_of_char }
+    }
+
+    fn byte_offset(&self, char_index: usize) -> usize {
+        self.byte_of_char
+            .get(char_index)
+            .copied()
+            .unwrap_or(*self.byte_of_char.last().unwrap_or(&0))
+    }
+}
+
+/// Upper bound, in bytes past `search_from`, on how far [`locate_value_span`]'s
+/// fallback scan will search.
+///
+/// The fallback exists only to correct for `yaml-rust2`'s marker-vs-value quoting
+/// offset — a handful of bytes at most for any real `uses:` value (a GitHub
+/// `owner/repo[/sub]@ref` plus an optional `# vX.Y.Z` comment rarely exceeds a few
+/// hundred bytes). Leaving the scan unbounded made it an
+/// `O(line_length × value_length)` scan over the *rest of the line* regardless of how
+/// far away the real match could possibly be: a several-megabyte single-line workflow
+/// (comfortably under the crate's YAML expansion-size gate) cost whole minutes of
+/// single-core CPU per `didOpen`/`didChange` (security S-2). Capping the window bounds
+/// the fallback's cost independent of line length; a value that genuinely cannot be
+/// located within this window is treated the same as any other unlocatable value —
+/// the candidate is silently skipped (`build_dependency`'s `?`), not an error.
+const MAX_FALLBACK_SCAN_BYTES: usize = 1024;
+
+/// Finds the byte offset in `content` (searching only within the line starting at
+/// `search_from`) where the literal bytes of `value` occur.
+///
+/// The scanner-reported [`Marker`] usually points exactly at the value's start for a
+/// plain scalar, but may point at the opening quote for a quoted one — rather than
+/// reverse-engineering `yaml-rust2`'s exact escaping/quoting byte accounting, this
+/// verifies the direct-offset guess first and falls back to a bounded same-line search
+/// (see [`MAX_FALLBACK_SCAN_BYTES`]), which is exact for the unescaped ASCII text every
+/// real `uses:` value is.
+fn locate_value_span(content: &str, search_from: usize, value: &str) -> Option<(usize, usize)> {
+    if value.is_empty() {
+        return Some((search_from, search_from));
+    }
+    let bytes = content.as_bytes();
+    if search_from + value.len() <= bytes.len()
+        && &bytes[search_from..search_from + value.len()] == value.as_bytes()
+    {
+        return Some((search_from, search_from + value.len()));
+    }
+    let line_end = bytes[search_from..]
+        .iter()
+        .position(|&b| b == b'\n')
+        .map_or(bytes.len(), |p| search_from + p);
+    let scan_end = line_end.min(search_from.saturating_add(MAX_FALLBACK_SCAN_BYTES));
+    let haystack = &bytes[search_from..scan_end];
+    let needle = value.as_bytes();
+    haystack
+        .windows(needle.len())
+        .position(|w| w == needle)
+        .map(|rel| (search_from + rel, search_from + rel + needle.len()))
+}
+
+/// The first whitespace-delimited token after a whitespace-preceded `#` in
+/// `rest_of_line` (the raw source text following a ref's end, up to end of line),
+/// accepted as a comment tag only when it has the shape of a full `major.minor.patch`
+/// version ([`is_full_semver_shape`], shared with the crate's `BareRequirementPolicy`
+/// gate so the two mechanisms can't diverge — B2/B3/N1).
+///
+/// Returns `(tag_text, byte_offset_in_rest_of_line_where_the_token_ends)`. A `#` not
+/// preceded by whitespace is not a YAML comment and is skipped (only the *first*
+/// whitespace-preceded `#` is considered); a shape-rejected token (`# v4`, `# v4.2`) or
+/// no `#` at all yields `None` — the ref degrades to a bare, commentless pin.
+fn extract_comment_tag(rest_of_line: &str) -> Option<(&str, usize)> {
+    let bytes = rest_of_line.as_bytes();
+    for i in 0..bytes.len() {
+        if bytes[i] != b'#' {
+            continue;
+        }
+        if i == 0 || !bytes[i - 1].is_ascii_whitespace() {
+            continue;
+        }
+        let after_hash = &rest_of_line[i + 1..];
+        let after_ws = after_hash.trim_start();
+        let ws_len = after_hash.len() - after_ws.len();
+        let token_len = after_ws.find(char::is_whitespace).unwrap_or(after_ws.len());
+        let token = &after_ws[..token_len];
+        return if is_full_semver_shape(token) {
+            Some((token, i + 1 + ws_len + token_len))
+        } else {
+            None
+        };
+    }
+    None
+}
+
+/// Outcome of classifying a raw `uses:` scalar value's `owner/repo[...]` prefix.
+enum ParsedUses {
+    /// `./local` or `.\local` — a local composite action.
+    Path,
+    /// `docker://image:tag` — a Docker Hub / registry image reference.
+    Docker,
+    /// A bare `owner/repo` with no `@ref` at all — nothing to version.
+    NoAt { name: String },
+    /// `owner/repo@ref`, or a truncated `owner/repo/.github/workflows/x.yml@ref`.
+    Ref {
+        name: String,
+        is_reusable_workflow: bool,
+        /// Byte length of the value's full pre-`@` path (`owner/repo[/sub/path]`), NOT
+        /// `name.len()` — for a subdirectory action or reusable-workflow call, `name` is
+        /// truncated at the second `/` while the `@` sits after the untruncated path.
+        /// Using `name.len()` here would place `ref_text`'s range short by the truncated
+        /// subpath's length (critic S1 in the implementation review).
+        before_at_len: usize,
+        ref_text: String,
+    },
+    /// Does not look like a GitHub identifier at all — skipped entirely (FR-015).
+    Malformed,
+}
+
+/// Splits a raw `uses:` value into `owner/repo` (truncated at the second `/`) and its ref,
+/// classifying the source shape. Does not resolve the ref against the tags API — that is
+/// [`classify_ref`]'s job on the returned `ref_text`.
+fn classify_uses_value(value: &str) -> ParsedUses {
+    let value = value.trim();
+    if value.is_empty() {
+        return ParsedUses::Malformed;
+    }
+    if value.starts_with("./") || value.starts_with(".\\") {
+        return ParsedUses::Path;
+    }
+    if value.starts_with("docker://") {
+        return ParsedUses::Docker;
+    }
+
+    let (before_at, ref_text) = match value.split_once('@') {
+        Some((b, r)) => (b, Some(r)),
+        None => (value, None),
+    };
+
+    let mut segments = before_at.splitn(3, '/');
+    let (Some(owner), Some(repo)) = (segments.next(), segments.next()) else {
+        return ParsedUses::Malformed;
+    };
+    if owner.is_empty() || repo.is_empty() {
+        return ParsedUses::Malformed;
+    }
+    let name = format!("{owner}/{repo}");
+    if !crate::is_valid_github_identity(&name) {
+        return ParsedUses::Malformed;
+    }
+    let is_reusable_workflow = segments
+        .next()
+        .is_some_and(|rest| rest.starts_with(".github/workflows/"));
+
+    match ref_text {
+        None => ParsedUses::NoAt { name },
+        Some("") => ParsedUses::Malformed,
+        Some(r) => ParsedUses::Ref {
+            name,
+            is_reusable_workflow,
+            before_at_len: before_at.len(),
+            ref_text: r.to_string(),
+        },
+    }
+}
+
+// --- Event-driven `uses:` scalar detection ---
+
+#[derive(Clone, Copy)]
+enum FrameKind {
+    Mapping,
+    Sequence,
+}
+
+/// Which special key (if any) a `Mapping` frame's `awaiting_key: false` state is
+/// currently waiting on the value for.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PendingKey {
+    /// Not awaiting a value (`awaiting_key: true`), or the pending key is neither
+    /// `uses` nor `with`.
+    None,
+    Uses,
+    With,
+}
+
+struct Frame {
+    kind: FrameKind,
+    is_with_ancestor: bool,
+    awaiting_key: bool,
+    pending_key: PendingKey,
+}
+
+/// One `uses:` scalar found by [`WorkflowReceiver`], not yet classified or range-mapped.
+struct UsesCandidate {
+    value: String,
+    style: TScalarStyle,
+    char_index: usize,
+}
+
+/// Collects every `uses:` value-scalar event, skipping any `uses` key that has a `with:`
+/// ancestor (a step input literally named `uses`) — covers `jobs.*.steps[].uses` and
+/// `jobs.<id>.uses` (reusable-workflow calls) with one rule, matching Renovate.
+struct WorkflowReceiver {
+    stack: Vec<Frame>,
+    candidates: Vec<UsesCandidate>,
+}
+
+impl WorkflowReceiver {
+    fn new() -> Self {
+        Self {
+            stack: Vec::new(),
+            candidates: Vec::new(),
+        }
+    }
+
+    fn child_is_with_ancestor(&self) -> bool {
+        self.stack.last().is_some_and(|top| match top.kind {
+            FrameKind::Mapping => top.is_with_ancestor || top.pending_key == PendingKey::With,
+            FrameKind::Sequence => top.is_with_ancestor,
+        })
+    }
+
+    fn consume_pending_value(&mut self) {
+        if let Some(top) = self.stack.last_mut() {
+            top.awaiting_key = true;
+            top.pending_key = PendingKey::None;
+        }
+    }
+
+    fn push_container(&mut self, kind: FrameKind) {
+        let is_with_ancestor = self.child_is_with_ancestor();
+        self.consume_pending_value();
+        self.stack.push(Frame {
+            kind,
+            is_with_ancestor,
+            awaiting_key: true,
+            pending_key: PendingKey::None,
+        });
+    }
+}
+
+impl MarkedEventReceiver for WorkflowReceiver {
+    fn on_event(&mut self, event: Event, marker: Marker) {
+        match event {
+            Event::MappingStart(..) => self.push_container(FrameKind::Mapping),
+            Event::SequenceStart(..) => self.push_container(FrameKind::Sequence),
+            Event::MappingEnd | Event::SequenceEnd => {
+                self.stack.pop();
+                self.consume_pending_value();
+            }
+            Event::Scalar(value, style, _anchor, _tag) => {
+                let is_key = self
+                    .stack
+                    .last()
+                    .is_some_and(|top| matches!(top.kind, FrameKind::Mapping) && top.awaiting_key);
+                if is_key {
+                    if let Some(top) = self.stack.last_mut() {
+                        top.pending_key = if value == "uses" && !top.is_with_ancestor {
+                            PendingKey::Uses
+                        } else if value == "with" {
+                            PendingKey::With
+                        } else {
+                            PendingKey::None
+                        };
+                        top.awaiting_key = false;
+                    }
+                } else {
+                    let is_uses_value = self.stack.last().is_some_and(|top| {
+                        matches!(top.kind, FrameKind::Mapping)
+                            && top.pending_key == PendingKey::Uses
+                    });
+                    if is_uses_value {
+                        self.candidates.push(UsesCandidate {
+                            value,
+                            style,
+                            char_index: marker.index(),
+                        });
+                    }
+                    self.consume_pending_value();
+                }
+            }
+            // A `uses: *anchor` alias value must still clear the pending `uses`/`with`
+            // key slot, or the next mapping key/value pair desyncs (the following key
+            // gets consumed as if it were this `uses`'s value) — critic M5. GitHub
+            // itself does not support YAML anchors/aliases in workflow files, so this
+            // is defense-in-depth rather than a reachable real-world case.
+            Event::Alias(_) => self.consume_pending_value(),
+            Event::Nothing
+            | Event::StreamStart
+            | Event::StreamEnd
+            | Event::DocumentStart
+            | Event::DocumentEnd => {}
+        }
+    }
+}
+
+/// Builds a [`GithubActionsDependency`] for one `uses:` candidate, or `None` if its
+/// `owner/repo` prefix does not look like a GitHub identifier (logged and skipped, FR-015).
+fn build_dependency(
+    content: &str,
+    line_table: &LineOffsetTable,
+    char_offsets: &CharOffsets,
+    candidate: UsesCandidate,
+) -> Option<GithubActionsDependency> {
+    let value_start = char_offsets.byte_offset(candidate.char_index);
+    let (raw_start, raw_end) = locate_value_span(content, value_start, &candidate.value)?;
+
+    // `classify_uses_value` (and every offset computed below) works over the
+    // *trimmed* value, but the span located above is the raw, untrimmed scalar
+    // text. For a quoted `uses:` value with leading/trailing whitespace (e.g.
+    // `" actions/checkout@v4"`), anchoring the downstream `name.len()`/
+    // `before_at_len`-relative arithmetic to the untrimmed start desyncs every
+    // computed offset by the trimmed byte count: on ordinary ASCII input this
+    // silently points `version_range` at the wrong text (an accepted "update
+    // version" code action then overwrites the wrong span), and on multi-byte
+    // leading whitespace (e.g. an ideographic space, U+3000) it can split a UTF-8
+    // sequence and panic on a raw `content[..]` slice downstream (security S-1).
+    // Re-anchoring `span_start`/`span_end` to the trimmed text here — both still
+    // guaranteed char-boundary-aligned in `content`, since `str::trim_start`/
+    // `trim_end` only ever cut at `candidate.value`'s own char boundaries, and
+    // that value is byte-identical to `content[raw_start..raw_end]` by
+    // `locate_value_span`'s own contract — means every reference to them
+    // downstream is already correct, with no further per-call adjustment needed.
+    let leading_ws = candidate.value.len() - candidate.value.trim_start().len();
+    let trailing_ws = candidate.value.len() - candidate.value.trim_end().len();
+    let span_start = raw_start + leading_ws;
+    let span_end = raw_end.saturating_sub(trailing_ws);
+    let trimmed_value = candidate.value.trim().to_string();
+
+    let make_range = |start: usize, end: usize| -> Range {
+        Range::new(
+            line_table.byte_offset_to_position(content, start),
+            line_table.byte_offset_to_position(content, end),
+        )
+    };
+
+    match classify_uses_value(&candidate.value) {
+        ParsedUses::Path => Some(GithubActionsDependency {
+            name: trimmed_value.clone().into(),
+            name_range: make_range(span_start, span_end),
+            version_req: None,
+            version_range: None,
+            version_literal: None,
+            pin: None,
+            source: DependencySource::Path {
+                path: trimmed_value,
+            },
+        }),
+        ParsedUses::Docker => Some(GithubActionsDependency {
+            name: trimmed_value.clone().into(),
+            name_range: make_range(span_start, span_end),
+            version_req: None,
+            version_range: None,
+            version_literal: None,
+            pin: None,
+            source: DependencySource::Url { url: trimmed_value },
+        }),
+        ParsedUses::NoAt { name } => {
+            let name_end = span_start + name.len();
+            Some(GithubActionsDependency {
+                name: name.into(),
+                name_range: make_range(span_start, name_end),
+                version_req: None,
+                version_range: None,
+                version_literal: None,
+                pin: None,
+                source: DependencySource::Registry,
+            })
+        }
+        ParsedUses::Ref {
+            name,
+            is_reusable_workflow,
+            before_at_len,
+            ref_text,
+        } => {
+            let name_end = span_start + name.len();
+            // Not `name_end + 1`: `name` is truncated at the second `/` for a
+            // subdirectory action or reusable-workflow call, but the `@` sits after the
+            // full pre-`@` path (`before_at_len`) — using `name_end` would place every
+            // ref offset short by the truncated subpath's length (critic S1).
+            let ref_start = span_start + before_at_len + 1; // skip the '@'
+            let ref_end = ref_start + ref_text.len();
+            let name_range = make_range(span_start, name_end);
+
+            if is_reusable_workflow {
+                return Some(GithubActionsDependency {
+                    name: name.clone().into(),
+                    name_range,
+                    version_req: None,
+                    version_range: None,
+                    version_literal: None,
+                    pin: None,
+                    source: DependencySource::Url {
+                        url: format!("https://github.com/{name}"),
+                    },
+                });
+            }
+
+            if is_full_sha(&ref_text) {
+                let rest_of_line = &content[ref_end..];
+                let rest_of_line_end = rest_of_line.find('\n').unwrap_or(rest_of_line.len());
+                let rest_of_line = &rest_of_line[..rest_of_line_end];
+
+                let comment = (candidate.style == TScalarStyle::Plain)
+                    .then(|| extract_comment_tag(rest_of_line))
+                    .flatten();
+
+                return Some(match comment {
+                    Some((tag, token_end)) => GithubActionsDependency {
+                        name: name.into(),
+                        name_range,
+                        version_req: Some(tag.into()),
+                        version_range: Some(make_range(ref_start, ref_end + token_end)),
+                        version_literal: Some(content[ref_start..ref_end + token_end].to_string()),
+                        pin: Some(PinStyle::Sha {
+                            comment_tag: Some(tag.to_string()),
+                        }),
+                        source: DependencySource::Registry,
+                    },
+                    None => GithubActionsDependency {
+                        name: name.into(),
+                        name_range,
+                        version_req: Some(ref_text.into()),
+                        version_range: Some(make_range(ref_start, ref_end)),
+                        version_literal: None,
+                        pin: Some(PinStyle::Sha { comment_tag: None }),
+                        source: DependencySource::Registry,
+                    },
+                });
+            }
+
+            let pin = if is_tag_shaped(&ref_text) {
+                PinStyle::Tag
+            } else {
+                PinStyle::Branch
+            };
+            Some(GithubActionsDependency {
+                name: name.into(),
+                name_range,
+                version_req: Some(ref_text.into()),
+                version_range: Some(make_range(ref_start, ref_end)),
+                version_literal: None,
+                pin: Some(pin),
+                source: DependencySource::Registry,
+            })
+        }
+        ParsedUses::Malformed => {
+            // Logs only the value's length, not the raw attacker-controlled text
+            // (security S-5) — matches every other rejection site in the workspace,
+            // e.g. `deps_swift::registry::validate_owner_repo`.
+            warn_rejected_value(
+                "classify_uses_value",
+                "workflow uses: value",
+                &candidate.value,
+            );
+            None
+        }
+    }
+}
+
+/// Parses a `.github/workflows/*.yml`/`*.yaml` file and returns every `uses:` dependency
+/// found, with LSP position tracking.
+///
+/// Gated first (as `deps-dart`'s pubspec.yaml parser) by
+/// [`deps_core::check_yaml_nesting_depth`]/[`deps_core::check_yaml_expansion`], which return
+/// a real [`DepsError::ParseError`]. A downstream YAML syntax error, by contrast, degrades to
+/// an **empty** [`GithubActionsParseResult`] (logged at `debug`) rather than propagating —
+/// workflows are numerous per repository, and one malformed file should not disable hover/
+/// completion for every other open workflow.
+///
+/// # Errors
+///
+/// Returns [`DepsError::ParseError`] only when `content` exceeds the shared YAML
+/// nesting-depth or expansion-size gate.
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::Dependency;
+/// use deps_github_actions::parse_workflow_yaml;
+///
+/// let content = "steps:\n  - uses: actions/checkout@v4\n";
+/// let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+/// let result = parse_workflow_yaml(content, &uri).unwrap();
+///
+/// assert_eq!(result.dependencies.len(), 1);
+/// assert_eq!(result.dependencies[0].name(), "actions/checkout");
+/// ```
+pub fn parse_workflow_yaml(content: &str, uri: &Uri) -> Result<GithubActionsParseResult> {
+    if let Err(depth) =
+        deps_core::check_yaml_nesting_depth(content, deps_core::MAX_YAML_NESTING_DEPTH)
+    {
+        return Err(DepsError::ParseError {
+            file_type: "workflow.yml".into(),
+            source: Box::new(std::io::Error::other(format!(
+                "YAML nesting depth {depth} exceeds maximum of {}",
+                deps_core::MAX_YAML_NESTING_DEPTH
+            ))),
+        });
+    }
+    if let Err(bytes) = deps_core::check_yaml_expansion(content, deps_core::MAX_YAML_EXPANDED_BYTES)
+    {
+        return Err(DepsError::ParseError {
+            file_type: "workflow.yml".into(),
+            source: Box::new(std::io::Error::other(format!(
+                "YAML expansion {bytes} bytes exceeds maximum of {} bytes",
+                deps_core::MAX_YAML_EXPANDED_BYTES
+            ))),
+        });
+    }
+
+    let mut receiver = WorkflowReceiver::new();
+    let mut parser = Parser::new_from_str(content);
+    if let Err(e) = parser.load(&mut receiver, false) {
+        tracing::debug!(error = %e, "failed to parse workflow YAML, treating as empty");
+        return Ok(GithubActionsParseResult {
+            dependencies: Vec::new(),
+            uri: uri.clone(),
+        });
+    }
+
+    let line_table = LineOffsetTable::new(content);
+    let char_offsets = CharOffsets::new(content);
+    let dependencies = receiver
+        .candidates
+        .into_iter()
+        .filter_map(|candidate| build_dependency(content, &line_table, &char_offsets, candidate))
+        .collect();
+
+    Ok(GithubActionsParseResult {
+        dependencies,
+        uri: uri.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use deps_core::Dependency;
+
+    fn test_uri() -> Uri {
+        deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml")
+    }
+
+    /// Slices `content` over a single-line LSP `Range` (every fixture below is
+    /// single-line ASCII, so character offsets equal byte offsets).
+    fn slice(content: &str, range: Range) -> &str {
+        assert_eq!(
+            range.start.line, range.end.line,
+            "fixture must be single-line"
+        );
+        let line = content.lines().nth(range.start.line as usize).unwrap();
+        &line[range.start.character as usize..range.end.character as usize]
+    }
+
+    // --- R1: marker/range-derivation sanity, verified before anything else depends on it ---
+
+    #[test]
+    fn test_marker_positions_yield_correct_ranges_for_tag_pin() {
+        let content = "on: push\njobs:\n  build:\n    steps:\n      - uses: actions/checkout@v4\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        let dep = &result.dependencies[0];
+        assert_eq!(slice(content, dep.name_range), "actions/checkout");
+        assert_eq!(slice(content, dep.version_range().unwrap()), "v4");
+    }
+
+    // --- Pin contract table ---
+
+    #[test]
+    fn test_tag_pin_major_only() {
+        let content = "steps:\n  - uses: actions/checkout@v4\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name(), "actions/checkout");
+        assert_eq!(
+            dep.version_requirement().map(deps_core::VersionReq::as_str),
+            Some("v4")
+        );
+        assert_eq!(dep.version_literal(), None);
+        assert_eq!(dep.pin, Some(PinStyle::Tag));
+    }
+
+    #[test]
+    fn test_tag_pin_full_version_with_and_without_v() {
+        for (uses, expected_req) in [
+            ("actions/checkout@v4.2.0", "v4.2.0"),
+            ("actions/checkout@4.2.0", "4.2.0"),
+        ] {
+            let content = format!("steps:\n  - uses: {uses}\n");
+            let result = parse_workflow_yaml(&content, &test_uri()).unwrap();
+            let dep = &result.dependencies[0];
+            assert_eq!(
+                dep.version_requirement().map(deps_core::VersionReq::as_str),
+                Some(expected_req),
+                "{uses}"
+            );
+            assert_eq!(dep.pin, Some(PinStyle::Tag));
+        }
+    }
+
+    #[test]
+    fn test_sha_with_comment_tag() {
+        let sha = "a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5";
+        let content = format!("steps:\n  - uses: actions/checkout@{sha} # v4.2.0\n");
+        let result = parse_workflow_yaml(&content, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert_eq!(
+            dep.version_requirement().map(deps_core::VersionReq::as_str),
+            Some("v4.2.0")
+        );
+        assert_eq!(
+            dep.version_literal(),
+            Some(format!("{sha} # v4.2.0").as_str())
+        );
+        assert_eq!(
+            slice(&content, dep.version_range().unwrap()),
+            format!("{sha} # v4.2.0")
+        );
+        assert_eq!(
+            dep.pin,
+            Some(PinStyle::Sha {
+                comment_tag: Some("v4.2.0".to_string())
+            })
+        );
+    }
+
+    #[test]
+    fn test_sha_with_comment_and_trailing_annotation_keeps_range_at_tag_end() {
+        let sha = "a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5";
+        let content =
+            format!("steps:\n  - uses: actions/checkout@{sha} # v4.2.0 — pinned, do not bump\n");
+        let result = parse_workflow_yaml(&content, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert_eq!(
+            dep.version_requirement().map(deps_core::VersionReq::as_str),
+            Some("v4.2.0")
+        );
+        // The range must stop at the tag token, not run to end of line — the
+        // trailing annotation is never part of version_literal/version_range.
+        assert_eq!(
+            dep.version_literal(),
+            Some(format!("{sha} # v4.2.0").as_str())
+        );
+    }
+
+    #[test]
+    fn test_sha_without_comment_is_bare_and_unresolved() {
+        let sha = "a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5";
+        let content = format!("steps:\n  - uses: actions/checkout@{sha}\n");
+        let result = parse_workflow_yaml(&content, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert_eq!(
+            dep.version_requirement().map(deps_core::VersionReq::as_str),
+            Some(sha)
+        );
+        assert_eq!(dep.version_literal(), None);
+        assert_eq!(dep.pin, Some(PinStyle::Sha { comment_tag: None }));
+    }
+
+    #[test]
+    fn test_sha_comment_partial_tag_rejected_stays_bare() {
+        // `# v4` / `# v4.2` are deliberately rejected (B2/B3): a partial comment
+        // tag would make the pin permanently "up to date" while the SHA rots.
+        let sha = "a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5";
+        for suffix in ["v4", "v4.2"] {
+            let content = format!("steps:\n  - uses: actions/checkout@{sha} # {suffix}\n");
+            let result = parse_workflow_yaml(&content, &test_uri()).unwrap();
+            let dep = &result.dependencies[0];
+            assert_eq!(
+                dep.version_requirement().map(deps_core::VersionReq::as_str),
+                Some(sha),
+                "{suffix}"
+            );
+            assert_eq!(dep.pin, Some(PinStyle::Sha { comment_tag: None }));
+        }
+    }
+
+    #[test]
+    fn test_sha_comment_prerelease_tag_accepted() {
+        let sha = "a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5";
+        let content = format!("steps:\n  - uses: actions/checkout@{sha} # v4.2.0-beta.1\n");
+        let result = parse_workflow_yaml(&content, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert_eq!(
+            dep.version_requirement().map(deps_core::VersionReq::as_str),
+            Some("v4.2.0-beta.1")
+        );
+    }
+
+    #[test]
+    fn test_sha_comment_not_whitespace_preceded_is_not_a_comment() {
+        // `#` glued directly to the ref (no preceding whitespace) is not a YAML
+        // comment at all, so it stays part of the plain scalar's value.
+        let sha = "a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5";
+        let content = format!("steps:\n  - uses: actions/checkout@{sha}#v4.2.0\n");
+        let result = parse_workflow_yaml(&content, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        // The whole `{sha}#v4.2.0` is the ref text — not a valid 40-hex SHA (extra
+        // trailing characters), so this falls through to the branch bucket instead
+        // of ever being treated as a SHA-with-comment pin.
+        assert_eq!(
+            dep.version_requirement().map(deps_core::VersionReq::as_str),
+            Some(format!("{sha}#v4.2.0").as_str())
+        );
+        assert_eq!(dep.pin, Some(PinStyle::Branch));
+    }
+
+    #[test]
+    fn test_quoted_sha_with_real_yaml_comment_outside_quotes_degrades_to_bare_sha() {
+        // B3: the comment-tag rule applies only to plain (unquoted) scalars. Here the
+        // quoted value is a clean 40-hex SHA, and `# v4.2.0` is a genuine YAML
+        // comment sitting *outside* the quotes — but since the scalar itself is
+        // quoted, no comment scan runs at all, and the pin degrades to a bare SHA.
+        let sha = "a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5";
+        let content = format!("steps:\n  - uses: \"actions/checkout@{sha}\" # v4.2.0\n");
+        let result = parse_workflow_yaml(&content, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert_eq!(
+            dep.version_requirement().map(deps_core::VersionReq::as_str),
+            Some(sha)
+        );
+        assert_eq!(dep.pin, Some(PinStyle::Sha { comment_tag: None }));
+    }
+
+    #[test]
+    fn test_quoted_scalar_with_comment_like_text_is_not_a_valid_sha() {
+        let sha = "a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5";
+        let content = format!("steps:\n  - uses: \"actions/checkout@{sha} # v4.2.0\"\n");
+        let result = parse_workflow_yaml(&content, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        // For a quoted scalar, `#` is part of the value — no comment scan runs, so
+        // the ref text is `"{sha} # v4.2.0"` verbatim: not a valid 40-hex SHA (extra
+        // trailing characters), so this falls through to the branch bucket, the
+        // honest outcome for an unparseable ref shape.
+        assert_eq!(
+            dep.version_requirement().map(deps_core::VersionReq::as_str),
+            Some(format!("{sha} # v4.2.0").as_str())
+        );
+        assert_eq!(dep.pin, Some(PinStyle::Branch));
+    }
+
+    #[test]
+    fn test_branch_pin() {
+        let content = "steps:\n  - uses: dev/tool@main\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert_eq!(
+            dep.version_requirement().map(deps_core::VersionReq::as_str),
+            Some("main")
+        );
+        assert_eq!(dep.pin, Some(PinStyle::Branch));
+    }
+
+    #[test]
+    fn test_local_path_action() {
+        let content = "steps:\n  - uses: ./local-action\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert!(dep.version_range().is_none());
+        assert!(dep.version_requirement().is_none());
+        assert!(matches!(dep.source(), DependencySource::Path { .. }));
+    }
+
+    #[test]
+    fn test_docker_image_ref() {
+        let content = "steps:\n  - uses: docker://alpine:3.18\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert!(dep.version_range().is_none());
+        assert!(matches!(dep.source(), DependencySource::Url { .. }));
+    }
+
+    #[test]
+    fn test_bare_owner_repo_no_at() {
+        let content = "steps:\n  - uses: actions/checkout\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name(), "actions/checkout");
+        assert!(dep.version_range().is_none());
+        assert!(dep.version_requirement().is_none());
+    }
+
+    #[test]
+    fn test_subdirectory_action_truncates_and_stays_resolvable() {
+        let content = "steps:\n  - uses: github/codeql-action/init@v3\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name(), "github/codeql-action");
+        assert_eq!(
+            dep.version_requirement().map(deps_core::VersionReq::as_str),
+            Some("v3")
+        );
+        assert!(matches!(dep.source(), DependencySource::Registry));
+        // Critic S1 regression: `version_range` must span the ref (`v3`), not a
+        // substring of the truncated subpath (`in`, from `codeql-action/**in**it@v3`)
+        // — the bug the range assertion here is specifically for.
+        assert_eq!(slice(content, dep.version_range().unwrap()), "v3");
+        assert_eq!(slice(content, dep.name_range()), "github/codeql-action");
+    }
+
+    #[test]
+    fn test_subdirectory_action_sha_with_comment_range_excludes_subpath() {
+        // Critic S1: for the SHA-with-comment form, `version_range` must start right
+        // after the full `owner/repo/sub@` prefix, not after the truncated `owner/repo@`.
+        let sha = "a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5";
+        let content = format!("steps:\n  - uses: github/codeql-action/init@{sha} # v3.1.0\n");
+        let result = parse_workflow_yaml(&content, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name(), "github/codeql-action");
+        assert_eq!(
+            slice(&content, dep.version_range().unwrap()),
+            format!("{sha} # v3.1.0")
+        );
+    }
+
+    #[test]
+    fn test_reusable_workflow_call_is_recognized_but_non_resolvable() {
+        let content = "jobs:\n  call:\n    uses: octo-org/repo/.github/workflows/x.yml@v1\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name(), "octo-org/repo");
+        assert!(dep.version_range().is_none());
+        assert!(dep.version_requirement().is_none());
+        assert!(matches!(dep.source(), DependencySource::Url { .. }));
+    }
+
+    #[test]
+    fn test_malformed_uses_value_is_skipped_not_erroring() {
+        let content = "steps:\n  - uses: not-a-valid-identifier\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        assert!(result.dependencies.is_empty());
+    }
+
+    // --- Structural coverage ---
+
+    #[test]
+    fn test_duplicate_uses_lines_get_distinct_ranges() {
+        let content = "steps:\n  - uses: actions/checkout@v3\n  - uses: actions/checkout@v4\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 2);
+        assert_ne!(
+            result.dependencies[0].version_range(),
+            result.dependencies[1].version_range()
+        );
+        assert_eq!(
+            result.dependencies[0]
+                .version_requirement()
+                .map(deps_core::VersionReq::as_str),
+            Some("v3")
+        );
+        assert_eq!(
+            result.dependencies[1]
+                .version_requirement()
+                .map(deps_core::VersionReq::as_str),
+            Some("v4")
+        );
+    }
+
+    #[test]
+    fn test_quoted_scalar_uses_value_parses() {
+        let content = "steps:\n  - uses: \"actions/checkout@v4\"\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name(), "actions/checkout");
+        assert_eq!(
+            dep.version_requirement().map(deps_core::VersionReq::as_str),
+            Some("v4")
+        );
+    }
+
+    #[test]
+    fn test_with_block_uses_key_is_ignored() {
+        // A step input literally named `uses` (inside `with:`) must not be treated
+        // as an action reference.
+        let content = "steps:\n  - uses: actions/github-script@v7\n    with:\n      uses: not-a-real-dependency\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].name(), "actions/github-script");
+    }
+
+    #[test]
+    fn test_alias_value_does_not_desync_following_uses_key() {
+        // Critic M5: an `Event::Alias` (YAML anchor reference) filling a `uses:` value
+        // must still clear the pending-key slot, or the *next* key/value pair in the
+        // same mapping desyncs. A single step normally has only one `uses:` key, so the
+        // bug is invisible unless the alias-valued key is followed by another
+        // key/value pair in the same mapping — demonstrated here with a (syntactically
+        // valid, if unrealistic for a real workflow) duplicate `uses:` key: without the
+        // fix, the second, literal `uses:` value is never recognized as a dependency at
+        // all (it gets misread as a key with the alias's own value swallowing it).
+        let content =
+            "steps:\n  - uses: &a actions/checkout@v3\n  - uses: *a\n    uses: real/repo@v9\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        let names: Vec<&str> = result
+            .dependencies
+            .iter()
+            .map(|d| d.name().as_str())
+            .collect();
+        assert!(
+            names.contains(&"real/repo"),
+            "expected 'real/repo' among {names:?}"
+        );
+    }
+
+    #[test]
+    fn test_reusable_workflow_job_level_uses_with_with_block_still_recognized() {
+        let content = "jobs:\n  call:\n    uses: owner/repo/.github/workflows/x.yml@v1\n    with:\n      config: default\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].name(), "owner/repo");
+    }
+
+    #[test]
+    fn test_invalid_yaml_returns_empty_result_not_error() {
+        let content = "steps:\n  - uses: [unterminated\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        assert!(result.dependencies.is_empty());
+    }
+
+    #[test]
+    fn test_empty_content() {
+        let result = parse_workflow_yaml("", &test_uri()).unwrap();
+        assert!(result.dependencies.is_empty());
+    }
+
+    #[test]
+    fn test_quoted_value_with_multibyte_leading_whitespace_does_not_panic() {
+        // Security S-1: previously panicked ("byte index N is not a char boundary")
+        // because `build_dependency` anchored its offset math on the *untrimmed*
+        // value's start while `classify_uses_value`'s `name`/`ref_text` were derived
+        // from the *trimmed* one — a multi-byte leading whitespace character (U+3000,
+        // ideographic space, 3 bytes) inside a quoted scalar shifted every downstream
+        // offset off a char boundary. Reproduced end-to-end against the real LSP
+        // binary by the security audit; this is the minimal in-crate repro.
+        let leading = "\u{3000}".repeat(15);
+        let sha = "a".repeat(40);
+        let content = format!("steps:\n  - uses: \"{leading}a/b@{sha}\"\n");
+        let result = parse_workflow_yaml(&content, &test_uri()).unwrap();
+        // The malformed-looking owner/repo (leading ideographic spaces baked into the
+        // quoted value) is expected to be classified sensibly; the requirement here is
+        // solely that parsing completes without panicking.
+        let _ = result.dependencies;
+    }
+
+    #[test]
+    fn test_quoted_value_with_leading_space_reports_correct_ref_range() {
+        // Security S-1's benign-input half: an ordinary, single-leading-space quoted
+        // value (`" actions/checkout@v4"`, valid YAML, a common formatting choice) must
+        // still resolve `version_range` to the real ref (`v4`), not a shifted
+        // substring (`@v`) — the shift the desync bug produced would corrupt the file
+        // when an "update version" code action wrote its edit at the wrong span.
+        let content = "steps:\n  - uses: \" actions/checkout@v4\"\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name(), "actions/checkout");
+        assert_eq!(slice(content, dep.version_range().unwrap()), "v4");
+    }
+
+    #[test]
+    fn test_deeply_nested_yaml_rejected_as_parse_error() {
+        // A dash-chain sequence: each `- ` nests one level deeper, mirroring
+        // `deps_core::parser`'s own gate tests.
+        let payload = format!("{}1", "- ".repeat(deps_core::MAX_YAML_NESTING_DEPTH + 1));
+        let result = parse_workflow_yaml(&payload, &test_uri());
+        assert!(matches!(result, Err(DepsError::ParseError { .. })));
+    }
+
+    // --- classify_uses_value / ref classification unit coverage ---
+
+    #[test]
+    fn test_is_full_sha_accepts_and_rejects() {
+        assert!(is_full_sha(&"a".repeat(40)));
+        assert!(!is_full_sha(&"a".repeat(39)));
+        assert!(!is_full_sha(&"g".repeat(40))); // 'g' is not hex
+    }
+
+    #[test]
+    fn test_is_tag_shaped() {
+        assert!(is_tag_shaped("v4"));
+        assert!(is_tag_shaped("4.2.0"));
+        assert!(!is_tag_shaped("main"));
+        assert!(!is_tag_shaped(&"a".repeat(40)));
+    }
+
+    #[test]
+    fn test_extract_comment_tag_multiple_hashes_uses_first() {
+        assert_eq!(
+            extract_comment_tag(" # v1.0.0 # v2.0.0"),
+            Some(("v1.0.0", " # v1.0.0".len()))
+        );
+    }
+
+    #[test]
+    fn test_extract_comment_tag_no_hash_returns_none() {
+        assert_eq!(extract_comment_tag(" no comment here"), None);
+    }
+
+    // --- locate_value_span: bounded fallback scan (security S-2) ---
+
+    #[test]
+    fn test_locate_value_span_finds_value_within_fallback_bound() {
+        let content = "prefix xxxxx actions/checkout@v4 suffix";
+        let value = "actions/checkout@v4";
+        let (start, end) = locate_value_span(content, 0, value).unwrap();
+        assert_eq!(&content[start..end], value);
+    }
+
+    #[test]
+    fn test_locate_value_span_gives_up_beyond_fallback_bound_instead_of_hanging() {
+        // The value sits at an offset well past `MAX_FALLBACK_SCAN_BYTES` on the same
+        // line — the fallback scan must bail out (`None`) rather than continue
+        // scanning to end of line, which is what made this function
+        // `O(line_length x value_length)` on an adversarial multi-megabyte single-line
+        // file (security S-2).
+        let filler = "x".repeat(MAX_FALLBACK_SCAN_BYTES + 100);
+        let value = "actions/checkout@v4";
+        let content = format!("{filler}{value}");
+        assert_eq!(locate_value_span(&content, 0, value), None);
+    }
+
+    #[test]
+    fn test_locate_value_span_bounded_scan_stays_fast_on_a_huge_line() {
+        // Regression guard for the quadratic blowup itself: a several-megabyte
+        // single-line haystack (well under the crate's YAML expansion-size gate) must
+        // resolve in milliseconds, not minutes, once the scan is bounded.
+        let filler = "y".repeat(6 * 1024 * 1024);
+        let value = "not-present-in-filler@v4";
+        let content = format!("{filler}\n");
+        let start = std::time::Instant::now();
+        let result = locate_value_span(&content, 0, value);
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(1),
+            "locate_value_span took {:?}, expected a bounded scan to finish in well under 1s",
+            start.elapsed()
+        );
+        assert_eq!(result, None);
+    }
+}

--- a/crates/deps-github-actions/src/registry.rs
+++ b/crates/deps-github-actions/src/registry.rs
@@ -1,0 +1,998 @@
+//! GitHub Actions registry using the GitHub tags API.
+//!
+//! Fetches tags for `owner/repo` action/workflow repositories. Non-GitHub identities are
+//! rejected before any request is made (`validate_owner_repo`).
+
+use bytes::Bytes;
+use dashmap::DashMap;
+use deps_core::{
+    DepsError, HttpCache, PackageName, Result, is_dot_segment, lsp_helpers::warn_rejected_value,
+};
+use serde::Deserialize;
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::types::GithubActionsVersion;
+
+const GITHUB_API: &str = "https://api.github.com";
+
+/// Display name for the registry backing GitHub Actions version lookups, used in
+/// not-found and API-response error messages.
+pub const REGISTRY: &str = "GitHub";
+
+/// Maximum number of `tags` pages fetched per repository (100 tags/page). Mirrors
+/// `deps-swift`'s bound for the identical endpoint — S2's revision reverted an earlier,
+/// arithmetically unjustified `10`: no realistic action/workflow repository has more than
+/// a few hundred tags, so page 2+ is already rare, and diverging from the sibling crate
+/// bought nothing.
+const MAX_TAG_PAGES: u32 = 30;
+
+/// Maximum number of repositories held in [`GithubActionsRegistry::tag_index`] at once.
+const MAX_TAG_INDEX_ENTRIES: usize = 256;
+
+/// Maximum number of repositories with a coalescing lock outstanding in
+/// [`GithubActionsRegistry::in_flight`] at once.
+const MAX_IN_FLIGHT_ENTRIES: usize = 256;
+
+/// How long [`RateLimitGate`] keeps `get_versions` short-circuiting locally after a
+/// 403-without-token response, before allowing another live request.
+///
+/// GitHub's unauthenticated rate limit resets on a rolling hourly window whose exact
+/// reset instant this crate has no way to learn: [`DepsError::HttpStatus`] carries only a
+/// bare status code, not response headers, so the `x-ratelimit-reset` header GitHub
+/// returns on a 403 is not observable here without widening `deps-core`'s shared HTTP
+/// error type for one caller. A fixed, conservative cooldown is the documented trade-off
+/// (critic C1) — long enough to meaningfully stop hammering a workspace with many unique
+/// actions, short enough to recover without a restart.
+const RATE_LIMIT_COOLDOWN_SECS: u64 = 300;
+
+/// Validates that `name` is a valid `owner/repo` GitHub identifier.
+///
+/// Mirrors `deps_swift::registry::validate_owner_repo`: accepts
+/// [`crate::is_valid_github_identity`]'s charset, and additionally rejects a `.`/`..`
+/// segment (not neutralized by URL construction — #357's class of bug) before `name`
+/// reaches this registry's `{api_base}/repos/{name}/tags` fetch as a bare path segment.
+fn validate_owner_repo(name: &str) -> Result<()> {
+    if crate::is_valid_github_identity(name) {
+        return Ok(());
+    }
+    if let Some((owner, repo)) = name.split_once('/')
+        && (is_dot_segment(owner) || is_dot_segment(repo))
+    {
+        warn_rejected_value("is_dot_segment", "GitHub owner/repo request URL", name);
+    }
+    Err(DepsError::InvalidUri(format!(
+        "invalid owner/repo format: '{name}'"
+    )))
+}
+
+fn now_epoch_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
+/// Local, process-lifetime gate that short-circuits further GitHub API requests once a
+/// 403-without-token response has been seen, instead of letting every remaining unique
+/// repository in a workspace fire (and lose) its own doomed request (critic C1).
+///
+/// `HttpCache::get_cached_with_headers_via` stores nothing on a failed fetch, so without
+/// this gate, per-repository in-flight coalescing alone does not help: each waiter still
+/// finds an empty cache and issues its own request once the first one fails.
+#[derive(Debug, Default)]
+struct RateLimitGate {
+    /// Unix-epoch seconds at which the gate clears; `0` means "not tripped".
+    reset_at: AtomicU64,
+}
+
+impl RateLimitGate {
+    fn is_tripped(&self) -> bool {
+        let reset_at = self.reset_at.load(Ordering::Relaxed);
+        reset_at != 0 && now_epoch_secs() < reset_at
+    }
+
+    fn trip(&self) {
+        self.reset_at.store(
+            now_epoch_secs() + RATE_LIMIT_COOLDOWN_SECS,
+            Ordering::Relaxed,
+        );
+    }
+
+    #[cfg(test)]
+    fn trip_until_epoch_secs(&self, reset_at: u64) {
+        self.reset_at.store(reset_at, Ordering::Relaxed);
+    }
+}
+
+/// Per-repository tag/SHA cross-reference.
+///
+/// Populated on every successful tags fetch (the `/tags` response already carries
+/// `commit.sha` — zero extra requests). Read by
+/// [`crate::formatter::GithubActionsFormatter`] to resolve a SHA-pin edit's replacement
+/// text and by the hover override to resolve a tag or SHA's counterpart for display.
+///
+/// Fields are `pub` (not `pub(crate)`) so a cross-crate integration test that exercises
+/// the shared `deps_core::collect_update_all_edits`/hover machinery — which never itself
+/// drives a live registry fetch — can seed a repository's entry directly via
+/// [`GithubActionsRegistry::tag_index`].
+#[derive(Debug, Default)]
+pub struct TagIndex {
+    /// Tag text (as published) -> the commit SHA it points at.
+    pub tag_to_sha: HashMap<String, String>,
+    /// Commit SHA -> the tag text (as published) it corresponds to.
+    pub sha_to_tag: HashMap<String, String>,
+}
+
+/// Evicts entries from `map` when it is already at `max_entries`, ahead of an insert that
+/// would otherwise grow it further — the single oldest-inserted entry, approximated by
+/// removing an arbitrary entry (this map has no per-entry timestamp; unlike
+/// `deps-swift`'s TTL-based memo, a repeated fetch simply repopulates whichever entry was
+/// dropped). The O(n) scan runs only on an insert that finds the map full.
+fn evict_if_full<V>(map: &DashMap<PackageName, V>, max_entries: usize) {
+    if map.len() < max_entries {
+        return;
+    }
+    // The victim key is resolved in its own `let` binding, fully dropping the
+    // iterator (and whatever shard guard it holds) before `remove` runs — folding
+    // this into a single `if let Some(key) = map.iter()....` risks the iterator's
+    // temporary being scope-extended across the `remove` call (Rust's `if let`
+    // temporary-lifetime-extension rule), which can deadlock against DashMap's
+    // internal per-shard locking.
+    let victim = map.iter().next().map(|e| e.key().clone());
+    if let Some(key) = victim {
+        map.remove(&key);
+    }
+}
+
+/// Evicts entries from the in-flight coalescing map, but — unlike [`evict_if_full`] —
+/// **only** an entry whose `Arc<Mutex<()>>` is not currently held by another waiter
+/// (`Arc::strong_count() == 1`, meaning the map's own reference is the only one left).
+///
+/// Evicting a held lock would silently defeat coalescing under exactly the load it
+/// targets: the next caller for that repository would create a *fresh* mutex and proceed
+/// concurrently with the fetch already in flight (critic C2), degrading to pre-coalescing
+/// behavior rather than corrupting anything, but undermining the whole point of #208's S2
+/// fix.
+fn evict_in_flight_if_full(map: &DashMap<PackageName, Arc<tokio::sync::Mutex<()>>>) {
+    if map.len() < MAX_IN_FLIGHT_ENTRIES {
+        return;
+    }
+    // See `evict_if_full`'s comment: the victim is resolved in its own `let`
+    // binding so the iterator's shard guard is fully released before `remove` runs.
+    let victim = map
+        .iter()
+        .find(|e| Arc::strong_count(e.value()) == 1)
+        .map(|e| e.key().clone());
+    if let Some(key) = victim {
+        map.remove(&key);
+    }
+}
+
+/// Client for fetching GitHub Actions version information from the GitHub tags API.
+#[derive(Clone)]
+pub struct GithubActionsRegistry {
+    cache: Arc<HttpCache>,
+    auth_headers: Vec<(reqwest::header::HeaderName, String)>,
+    has_token: bool,
+    /// Base URL for the GitHub API, `GITHUB_API` in production; overridable in tests to
+    /// point at a `mockito` server.
+    api_base: String,
+    tag_index: Arc<DashMap<PackageName, Arc<TagIndex>>>,
+    in_flight: Arc<DashMap<PackageName, Arc<tokio::sync::Mutex<()>>>>,
+    rate_limit: Arc<RateLimitGate>,
+}
+
+impl GithubActionsRegistry {
+    /// Creates a new GitHub Actions registry client with the given HTTP cache.
+    ///
+    /// Reads `GITHUB_TOKEN` from the environment for authenticated requests (5000 req/h
+    /// vs 60 req/h unauthenticated) — identical to `deps_swift::registry::SwiftRegistry`,
+    /// and note the 60 req/h unauthenticated budget is per-IP and **shared** with any
+    /// `deps-swift` traffic in the same process.
+    #[must_use]
+    pub fn new(cache: Arc<HttpCache>) -> Self {
+        let token = std::env::var("GITHUB_TOKEN").ok().filter(|t| !t.is_empty());
+        let has_token = token.is_some();
+        let auth_headers = token
+            .map(|token| {
+                tracing::info!("GITHUB_TOKEN detected, using authenticated GitHub API requests");
+                vec![(reqwest::header::AUTHORIZATION, format!("Bearer {token}"))]
+            })
+            .unwrap_or_default();
+
+        Self {
+            cache,
+            auth_headers,
+            has_token,
+            api_base: GITHUB_API.to_string(),
+            tag_index: Arc::new(DashMap::new()),
+            in_flight: Arc::new(DashMap::new()),
+            rate_limit: Arc::new(RateLimitGate::default()),
+        }
+    }
+
+    /// Shares this registry's [`TagIndex`] map with a [`crate::formatter::GithubActionsFormatter`],
+    /// so a formatted SHA-pin edit can resolve the new SHA for a given tag.
+    ///
+    /// `pub`, not `pub(crate)`: an integration test that exercises the shared
+    /// `deps_core` code-action/code-lens/hover machinery against this ecosystem —
+    /// which never itself drives a live registry fetch — needs a way to seed a
+    /// repository's [`TagIndex`] entry directly, without going through a mocked HTTP
+    /// fetch that path never calls.
+    #[must_use]
+    pub fn tag_index(&self) -> Arc<DashMap<PackageName, Arc<TagIndex>>> {
+        Arc::clone(&self.tag_index)
+    }
+
+    fn headers(&self) -> Vec<(reqwest::header::HeaderName, &str)> {
+        self.auth_headers
+            .iter()
+            .map(|(k, v): &(reqwest::header::HeaderName, String)| (k.clone(), v.as_str()))
+            .collect()
+    }
+
+    fn rate_limited_error() -> DepsError {
+        DepsError::CacheError(
+            "GitHub API rate limit exceeded. Set GITHUB_TOKEN to increase the limit (5000 req/h). Run: export GITHUB_TOKEN=$(gh auth token)".into(),
+        )
+    }
+
+    fn map_tags_error(&self, name: &str, e: DepsError) -> DepsError {
+        match &e {
+            // Trip the process-wide gate only for the no-token case this cooldown
+            // exists for: a *tokened* 403 is far more likely an org-policy/SAML
+            // restriction or a genuinely inaccessible private repo, scoped to that one
+            // repository — tripping the shared gate on it would disable GHA lookups
+            // workspace-wide for every other (accessible) repository too (critic M3).
+            DepsError::HttpStatus { status: 403, .. } if self.has_token => e,
+            DepsError::HttpStatus { status: 403, .. } => {
+                self.rate_limit.trip();
+                Self::rate_limited_error()
+            }
+            DepsError::HttpStatus { status: 404, .. } => DepsError::PackageNotFound {
+                package: name.to_string(),
+                registry: REGISTRY,
+            },
+            _ => e,
+        }
+    }
+
+    fn acquire_in_flight_lock(&self, name: &PackageName) -> Arc<tokio::sync::Mutex<()>> {
+        if let Some(existing) = self.in_flight.get(name) {
+            return Arc::clone(&existing);
+        }
+        if !self.in_flight.contains_key(name) {
+            evict_in_flight_if_full(&self.in_flight);
+        }
+        Arc::clone(
+            self.in_flight
+                .entry(name.clone())
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                .value(),
+        )
+    }
+
+    fn populate_tag_index(&self, name: &PackageName, tags: &[GithubActionsVersion]) {
+        let mut index = TagIndex::default();
+        for tag in tags {
+            let tag_str = tag.version.as_str().to_string();
+            index
+                .sha_to_tag
+                .entry(tag.sha.clone())
+                .or_insert_with(|| tag_str.clone());
+            index
+                .tag_to_sha
+                .entry(tag_str)
+                .or_insert_with(|| tag.sha.clone());
+        }
+        if !self.tag_index.contains_key(name) {
+            evict_if_full(&self.tag_index, MAX_TAG_INDEX_ENTRIES);
+        }
+        self.tag_index.insert(name.clone(), Arc::new(index));
+    }
+
+    /// Fetches all semver-tagged versions for `name` (`owner/repo`).
+    ///
+    /// Returns versions sorted newest-first. Non-semver tags are skipped. Follows GitHub
+    /// tags pagination up to `MAX_TAG_PAGES` pages, coalesced per-repository so that N
+    /// concurrent callers for the same repository on a cold cache issue one request, not
+    /// N (S2) — and short-circuits locally, without touching the network, once the
+    /// rate-limit gate has been tripped by an earlier 403 (critic C1).
+    pub async fn get_versions(&self, name: &str) -> Result<Vec<GithubActionsVersion>> {
+        validate_owner_repo(name)?;
+        if self.rate_limit.is_tripped() {
+            return Err(Self::rate_limited_error());
+        }
+
+        let package_name = PackageName::new(name);
+        let lock = self.acquire_in_flight_lock(&package_name);
+        let _guard = lock.lock().await;
+
+        // Re-check: an earlier waiter may have tripped the gate, or already
+        // populated the tag index, while this task waited for the lock.
+        if self.rate_limit.is_tripped() {
+            return Err(Self::rate_limited_error());
+        }
+
+        let tags = paginate_tags(name, |page| async move {
+            let url = format!(
+                "{}/repos/{name}/tags?per_page=100&page={page}",
+                self.api_base
+            );
+            self.cache
+                .get_cached_with_headers(&url, &self.headers())
+                .await
+                .map_err(|e| self.map_tags_error(name, e))
+        })
+        .await?;
+
+        let versions = tags_to_versions(tags);
+        self.populate_tag_index(&package_name, &versions);
+        Ok(versions)
+    }
+
+    /// Finds the latest version satisfying the given semver requirement.
+    pub async fn get_latest_matching(
+        &self,
+        name: &str,
+        req_str: &str,
+    ) -> Result<Option<GithubActionsVersion>> {
+        let versions = self.get_versions(name).await?;
+        let req = match semver::VersionReq::parse(normalize_semver_input(req_str).as_str()) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!("Failed to parse version req '{}': {}", req_str, e);
+                return Ok(None);
+            }
+        };
+        Ok(versions.into_iter().find(|v| {
+            semver::Version::parse(normalize_semver_input(v.version.as_str()).as_str())
+                .is_ok_and(|ver| req.matches(&ver))
+        }))
+    }
+}
+
+/// GitHub tags API response item.
+#[derive(Debug, Deserialize)]
+struct GithubTag {
+    name: String,
+    commit: GithubTagCommit,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubTagCommit {
+    sha: String,
+}
+
+/// GitHub API error response (rate limit, not found, etc.).
+#[derive(Deserialize)]
+struct GithubErrorResponse {
+    message: String,
+}
+
+/// Returns `true` when a fetched page came back full (`per_page=100` entries), meaning a
+/// subsequent page may exist and should be fetched too.
+const fn page_has_more(page_len: usize) -> bool {
+    page_len >= 100
+}
+
+fn warn_if_pagination_truncated(name: &str, page: u32, page_len: usize) {
+    if page == MAX_TAG_PAGES && page_has_more(page_len) {
+        tracing::warn!(
+            package = name,
+            pages_fetched = MAX_TAG_PAGES,
+            "GitHub Actions tags pagination for '{name}' stopped at the {MAX_TAG_PAGES}-page \
+             cap while GitHub reported more pages available; the fetched version list may be \
+             truncated"
+        );
+    }
+}
+
+/// Drives the GitHub tags pagination loop. Mirrors `deps_swift::registry::paginate_tags`.
+async fn paginate_tags<F, Fut>(name: &str, mut fetch_page: F) -> Result<Vec<GithubTag>>
+where
+    F: FnMut(u32) -> Fut,
+    Fut: std::future::Future<Output = Result<Bytes>>,
+{
+    let mut tags = Vec::new();
+    for page in 1..=MAX_TAG_PAGES {
+        let data = fetch_page(page).await?;
+        let page_tags = parse_tags_page(&data)?;
+        let page_len = page_tags.len();
+        tags.extend(page_tags);
+        if !page_has_more(page_len) {
+            break;
+        }
+        warn_if_pagination_truncated(name, page, page_len);
+    }
+    Ok(tags)
+}
+
+/// Parses a single GitHub tags API response page into raw tag entries.
+fn parse_tags_page(data: &[u8]) -> Result<Vec<GithubTag>> {
+    match deps_core::parse_json_checked(data) {
+        Ok(tags) => Ok(tags),
+        Err(_) => {
+            if let Ok(err) = deps_core::parse_json_checked::<GithubErrorResponse>(data) {
+                Err(DepsError::CacheError(format!(
+                    "GitHub API error: {}",
+                    err.message
+                )))
+            } else {
+                Ok(vec![])
+            }
+        }
+    }
+}
+
+/// Strips a leading `v`/`V` tag prefix for semver parsing only — the returned
+/// `GithubActionsVersion::version` keeps the tag exactly as published (the pin contract's
+/// "tag as published" rule).
+fn normalize_semver_input(name: &str) -> String {
+    name.strip_prefix(['v', 'V']).unwrap_or(name).to_string()
+}
+
+/// Converts raw tags (possibly accumulated across pages) into a newest-first
+/// `GithubActionsVersion` list. Non-semver tags are skipped; dedupe by normalized
+/// semver, first (page-order) occurrence wins.
+///
+/// Also drops any tag whose `commit.sha` is not [`crate::parser::is_full_sha`]-shaped
+/// (security S-3): the SHA reaches `TagIndex` unfiltered from here, and is later
+/// spliced verbatim into a manifest text edit (`GithubActionsFormatter::
+/// format_version_replacing_for`'s `PinStyle::Sha` branch) and a hover string — the one
+/// registry-supplied value in this crate that otherwise bypasses every allowlist gate
+/// (`is_safe_version_string` covers the *version*, not the SHA). Filtering at ingestion
+/// covers both consumers from one place.
+fn tags_to_versions(tags: Vec<GithubTag>) -> Vec<GithubActionsVersion> {
+    let mut seen = std::collections::HashSet::new();
+    let mut versions_with_parsed: Vec<(GithubActionsVersion, semver::Version)> = tags
+        .into_iter()
+        .filter_map(|tag| {
+            let normalized = normalize_semver_input(&tag.name);
+            let parsed = semver::Version::parse(&normalized).ok()?;
+            if !seen.insert(normalized) {
+                return None;
+            }
+            if !crate::parser::is_full_sha(&tag.commit.sha) {
+                return None;
+            }
+            let prerelease = !parsed.pre.is_empty();
+            Some((
+                GithubActionsVersion {
+                    version: tag.name.into(),
+                    sha: tag.commit.sha,
+                    prerelease,
+                },
+                parsed,
+            ))
+        })
+        .collect();
+
+    versions_with_parsed.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    versions_with_parsed.into_iter().map(|(v, _)| v).collect()
+}
+
+impl deps_core::Registry for GithubActionsRegistry {
+    fn get_versions<'a>(
+        &'a self,
+        name: &'a deps_core::PackageName,
+    ) -> deps_core::ecosystem::BoxFuture<'a, Result<Vec<Box<dyn deps_core::Version>>>> {
+        Box::pin(async move {
+            let versions = self.get_versions(name.as_str()).await?;
+            Ok(versions
+                .into_iter()
+                .map(|v| Box::new(v) as Box<dyn deps_core::Version>)
+                .collect())
+        })
+    }
+
+    fn get_latest_matching<'a>(
+        &'a self,
+        name: &'a deps_core::PackageName,
+        req: &'a deps_core::VersionReq,
+    ) -> deps_core::ecosystem::BoxFuture<'a, Result<Option<Box<dyn deps_core::Version>>>> {
+        Box::pin(async move {
+            let version = self
+                .get_latest_matching(name.as_str(), req.as_str())
+                .await?;
+            Ok(version.map(|v| Box::new(v) as Box<dyn deps_core::Version>))
+        })
+    }
+
+    /// Always empty for the MVP (S2/registry docs): a name-completion search would burn
+    /// the 60 req/h unauthenticated budget per keystroke, since GitHub has no
+    /// action-specific search endpoint cheaper than repository search.
+    fn search<'a>(
+        &'a self,
+        _query: &'a str,
+        _limit: usize,
+    ) -> deps_core::ecosystem::BoxFuture<'a, Result<Vec<Box<dyn deps_core::Metadata>>>> {
+        Box::pin(async move { Ok(vec![]) })
+    }
+
+    fn select_latest_matching(
+        &self,
+        versions: &[Box<dyn deps_core::Version>],
+        req: &deps_core::VersionReq,
+    ) -> Option<usize> {
+        if deps_core::is_existence_wildcard(req) {
+            return deps_core::select_latest_for_existence(versions, |v| v.as_ref());
+        }
+        let parsed_req =
+            semver::VersionReq::parse(normalize_semver_input(req.as_str()).as_str()).ok()?;
+        versions.iter().position(|v| {
+            semver::Version::parse(normalize_semver_input(v.version_string().as_str()).as_str())
+                .is_ok_and(|ver| parsed_req.matches(&ver))
+        })
+    }
+
+    /// GitHub's tags API exposes no yank/deprecation signal for actions.
+    fn reports_yanked(&self) -> bool {
+        false
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use deps_core::test_util::{capture_tracing_output, capture_tracing_output_async};
+
+    #[test]
+    fn test_parse_tags_response() {
+        let sha1 = "a".repeat(40);
+        let sha2 = "b".repeat(40);
+        let sha3 = "c".repeat(40);
+        let json = format!(
+            r#"[
+            {{"name": "v4.2.0", "commit": {{"sha": "{sha1}"}}}},
+            {{"name": "v4.1.0", "commit": {{"sha": "{sha2}"}}}},
+            {{"name": "not-semver", "commit": {{"sha": "{sha3}"}}}}
+        ]"#
+        );
+        let tags: Vec<GithubTag> = parse_tags_page(json.as_bytes()).unwrap();
+        let versions = tags_to_versions(tags);
+        assert_eq!(versions.len(), 2);
+        assert_eq!(versions[0].version, "v4.2.0");
+        assert_eq!(versions[0].sha, sha1);
+        assert_eq!(versions[1].version, "v4.1.0");
+    }
+
+    #[test]
+    fn test_tags_to_versions_keeps_v_prefix_as_published() {
+        let sha = "a".repeat(40);
+        let json = format!(r#"[{{"name": "4.2.0", "commit": {{"sha": "{sha}"}}}}]"#);
+        let tags: Vec<GithubTag> = parse_tags_page(json.as_bytes()).unwrap();
+        let versions = tags_to_versions(tags);
+        assert_eq!(versions[0].version, "4.2.0");
+    }
+
+    #[test]
+    fn test_tags_to_versions_dedupes_by_normalized_semver_first_wins() {
+        let first_sha = "a".repeat(40);
+        let second_sha = "b".repeat(40);
+        let json = format!(
+            r#"[
+            {{"name": "v1.0.0", "commit": {{"sha": "{first_sha}"}}}},
+            {{"name": "1.0.0", "commit": {{"sha": "{second_sha}"}}}}
+        ]"#
+        );
+        let tags: Vec<GithubTag> = parse_tags_page(json.as_bytes()).unwrap();
+        let versions = tags_to_versions(tags);
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].sha, first_sha);
+    }
+
+    #[test]
+    fn test_tags_to_versions_sorts_mixed_v_prefix_and_bare_by_semver() {
+        // Required test-matrix row (testing handoff): sort order across a mix of
+        // `v`-prefixed and bare tags for genuinely *different* versions — distinct
+        // from the dedupe test above, which mixes prefixes for the *same* version.
+        // Descending by parsed semver regardless of prefix: 5.0.0 > 4.0.0 > 3.0.0.
+        let sha_a = "a".repeat(40);
+        let sha_b = "b".repeat(40);
+        let sha_c = "c".repeat(40);
+        let json = format!(
+            r#"[
+            {{"name": "4.0.0", "commit": {{"sha": "{sha_a}"}}}},
+            {{"name": "v5.0.0", "commit": {{"sha": "{sha_b}"}}}},
+            {{"name": "v3.0.0", "commit": {{"sha": "{sha_c}"}}}}
+        ]"#
+        );
+        let tags: Vec<GithubTag> = parse_tags_page(json.as_bytes()).unwrap();
+        let versions = tags_to_versions(tags);
+        assert_eq!(
+            versions
+                .iter()
+                .map(|v| v.version.as_str())
+                .collect::<Vec<_>>(),
+            vec!["v5.0.0", "4.0.0", "v3.0.0"]
+        );
+    }
+
+    #[test]
+    fn test_parse_tags_all_non_semver_skipped() {
+        let sha = "a".repeat(40);
+        let json = format!(r#"[{{"name": "latest", "commit": {{"sha": "{sha}"}}}}]"#);
+        let tags: Vec<GithubTag> = parse_tags_page(json.as_bytes()).unwrap();
+        assert!(tags_to_versions(tags).is_empty());
+    }
+
+    #[test]
+    fn test_tags_to_versions_rejects_tag_with_non_full_sha() {
+        // Security S-3: a tag whose `commit.sha` is not a full 40-hex SHA must never
+        // reach `TagIndex`/a version list, since it is later spliced verbatim into a
+        // manifest text edit and a hover string with no other allowlist gate.
+        let json = r#"[{"name": "v1.0.0", "commit": {"sha": "not-a-real-sha"}}]"#;
+        let tags: Vec<GithubTag> = parse_tags_page(json.as_bytes()).unwrap();
+        assert!(tags_to_versions(tags).is_empty());
+    }
+
+    #[test]
+    fn test_parse_tags_invalid_json_returns_empty() {
+        let result = parse_tags_page(b"not json").unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_parse_tags_github_rate_limit_returns_error() {
+        let json = r#"{"message":"API rate limit exceeded for 1.2.3.4."}"#;
+        let result = parse_tags_page(json.as_bytes());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("rate limit"));
+    }
+
+    #[test]
+    fn test_validate_owner_repo_valid_and_invalid() {
+        assert!(validate_owner_repo("actions/checkout").is_ok());
+        assert!(validate_owner_repo("no-slash").is_err());
+        assert!(validate_owner_repo("owner/..").is_err());
+        assert!(validate_owner_repo("../repo").is_err());
+    }
+
+    #[test]
+    fn test_page_has_more() {
+        assert!(page_has_more(100));
+        assert!(!page_has_more(99));
+    }
+
+    // --- RateLimitGate ---
+
+    #[test]
+    fn test_rate_limit_gate_starts_untripped() {
+        let gate = RateLimitGate::default();
+        assert!(!gate.is_tripped());
+    }
+
+    #[test]
+    fn test_rate_limit_gate_trips_and_stays_tripped_within_cooldown() {
+        let gate = RateLimitGate::default();
+        gate.trip();
+        assert!(gate.is_tripped());
+    }
+
+    #[test]
+    fn test_rate_limit_gate_clears_after_reset_time_passes() {
+        let gate = RateLimitGate::default();
+        gate.trip_until_epoch_secs(1); // far in the past
+        assert!(!gate.is_tripped());
+    }
+
+    fn mock_registry(base: &str, has_token: bool) -> GithubActionsRegistry {
+        let auth_headers = if has_token {
+            vec![(
+                reqwest::header::AUTHORIZATION,
+                "Bearer test-token".to_string(),
+            )]
+        } else {
+            Vec::new()
+        };
+        GithubActionsRegistry {
+            cache: Arc::new(HttpCache::new()),
+            auth_headers,
+            has_token,
+            api_base: base.to_string(),
+            tag_index: Arc::new(DashMap::new()),
+            in_flight: Arc::new(DashMap::new()),
+            rate_limit: Arc::new(RateLimitGate::default()),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_versions_populates_tag_index() {
+        let sha = "abc123".repeat(7); // 42 chars, trimmed below to exactly 40
+        let sha = &sha[..40];
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/repos/actions/checkout/tags")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body(format!(
+                r#"[{{"name": "v4.2.0", "commit": {{"sha": "{sha}"}}}}]"#
+            ))
+            .create_async()
+            .await;
+
+        let registry = mock_registry(&server.url(), false);
+        let versions = registry.get_versions("actions/checkout").await.unwrap();
+        assert_eq!(versions.len(), 1);
+
+        let name = PackageName::new("actions/checkout");
+        let index = registry.tag_index.get(&name).unwrap();
+        assert_eq!(index.tag_to_sha.get("v4.2.0"), Some(&sha.to_string()));
+        assert_eq!(index.sha_to_tag.get(sha), Some(&"v4.2.0".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_get_versions_404_maps_to_package_not_found() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/repos/owner/missing/tags")
+            .match_query(mockito::Matcher::Any)
+            .with_status(404)
+            .with_body("{}")
+            .create_async()
+            .await;
+
+        let registry = mock_registry(&server.url(), false);
+        let err = registry.get_versions("owner/missing").await.unwrap_err();
+        assert!(matches!(err, DepsError::PackageNotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_get_versions_403_no_token_gets_actionable_message() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/repos/owner/repo/tags")
+            .match_query(mockito::Matcher::Any)
+            .with_status(403)
+            .with_body("{}")
+            .create_async()
+            .await;
+
+        let registry = mock_registry(&server.url(), false);
+        let err = registry.get_versions("owner/repo").await.unwrap_err();
+        assert!(err.to_string().contains("GITHUB_TOKEN"));
+    }
+
+    #[tokio::test]
+    async fn test_get_versions_403_trips_gate_and_short_circuits_next_call() {
+        let mut server = mockito::Server::new_async().await;
+        // `.expect(1)`: the second `get_versions` call below must NOT reach the network.
+        let mock = server
+            .mock("GET", "/repos/owner/repo/tags")
+            .match_query(mockito::Matcher::Any)
+            .with_status(403)
+            .with_body("{}")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let registry = mock_registry(&server.url(), false);
+        assert!(registry.get_versions("owner/repo").await.is_err());
+        assert!(registry.rate_limit.is_tripped());
+
+        let err = registry.get_versions("owner/repo").await.unwrap_err();
+        assert!(err.to_string().contains("GITHUB_TOKEN"));
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_get_versions_403_with_token_does_not_trip_shared_gate() {
+        // Critic M3: a 403 received *despite* a valid GITHUB_TOKEN (org-policy/SAML
+        // restriction, or a genuinely inaccessible private repo) is scoped to that one
+        // repository and must not disable GHA lookups workspace-wide for every other,
+        // accessible repository.
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/repos/owner/private-repo/tags")
+            .match_query(mockito::Matcher::Any)
+            .with_status(403)
+            .with_body("{}")
+            .create_async()
+            .await;
+
+        let registry = mock_registry(&server.url(), true);
+        let err = registry
+            .get_versions("owner/private-repo")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, DepsError::HttpStatus { status: 403, .. }));
+        assert!(!registry.rate_limit.is_tripped());
+    }
+
+    #[tokio::test]
+    async fn test_get_versions_rejects_invalid_owner_repo_with_zero_requests() {
+        let registry = mock_registry("http://127.0.0.1:1", false);
+        let err = registry.get_versions("../../etc/passwd").await.unwrap_err();
+        assert!(matches!(err, DepsError::InvalidUri(_)));
+    }
+
+    #[tokio::test]
+    async fn test_get_latest_matching_finds_matching_version() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/repos/owner/repo/tags")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body(format!(
+                r#"[{{"name": "v2.0.0", "commit": {{"sha": "{}"}}}}, {{"name": "v1.0.0", "commit": {{"sha": "{}"}}}}]"#,
+                "a".repeat(40),
+                "b".repeat(40)
+            ))
+            .create_async()
+            .await;
+
+        let registry = mock_registry(&server.url(), false);
+        let latest = registry
+            .get_latest_matching("owner/repo", "^1.0.0")
+            .await
+            .unwrap();
+        assert_eq!(
+            latest.map(|v| v.version.to_string()),
+            Some("v1.0.0".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_select_latest_matching_wildcard_uses_existence_ladder() {
+        use deps_core::{Registry, VersionReq};
+
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![Box::new(GithubActionsVersion {
+            version: "v2.0.0-beta.1".into(),
+            sha: "a".repeat(40),
+            prerelease: true,
+        })];
+        let registry = mock_registry("http://127.0.0.1:1", false);
+        let req = VersionReq::new("*");
+        assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
+    }
+
+    #[test]
+    fn test_evict_in_flight_never_evicts_held_lock() {
+        // Deterministic, not probabilistic (critic M4): every entry but one is held
+        // (a live second `Arc` reference simulating an in-flight waiter), so exactly
+        // one entry has `strong_count() == 1` and is the only possible victim —
+        // regardless of `DashMap`'s iteration order. The old version left
+        // `MAX_IN_FLIGHT_ENTRIES` unheld entries alongside the one held entry, so a
+        // buggy implementation with no `strong_count` filter would still pick the held
+        // entry only ~1-in-257 times and pass anyway.
+        let map: DashMap<PackageName, Arc<tokio::sync::Mutex<()>>> = DashMap::new();
+        let unheld_key = PackageName::new("owner/unheld");
+        let mut still_held = Vec::new();
+
+        for i in 0..MAX_IN_FLIGHT_ENTRIES {
+            let key = PackageName::new(format!("owner/held{i}"));
+            let lock = Arc::new(tokio::sync::Mutex::new(()));
+            still_held.push(Arc::clone(&lock));
+            map.insert(key, lock);
+        }
+        map.insert(unheld_key.clone(), Arc::new(tokio::sync::Mutex::new(())));
+        assert!(map.len() >= MAX_IN_FLIGHT_ENTRIES);
+        // `still_held` must live at least this long: each pushed `Arc` clone is what
+        // keeps every "owner/heldN" entry's `strong_count() > 1` (in-flight) for the
+        // eviction call below.
+        assert_eq!(still_held.len(), MAX_IN_FLIGHT_ENTRIES);
+
+        evict_in_flight_if_full(&map);
+
+        assert!(
+            !map.contains_key(&unheld_key),
+            "the only unheld entry must be the one evicted"
+        );
+        for i in 0..MAX_IN_FLIGHT_ENTRIES {
+            assert!(
+                map.contains_key(&PackageName::new(format!("owner/held{i}"))),
+                "a held (in-flight) coalescing lock must never be evicted"
+            );
+        }
+        drop(still_held);
+    }
+
+    #[test]
+    fn test_evict_in_flight_evicts_an_unheld_lock_when_full() {
+        let map: DashMap<PackageName, Arc<tokio::sync::Mutex<()>>> = DashMap::new();
+        for i in 0..MAX_IN_FLIGHT_ENTRIES {
+            map.insert(
+                PackageName::new(format!("owner/repo{i}")),
+                Arc::new(tokio::sync::Mutex::new(())),
+            );
+        }
+        evict_in_flight_if_full(&map);
+        assert_eq!(map.len(), MAX_IN_FLIGHT_ENTRIES - 1);
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_get_versions_for_same_repo_both_succeed() {
+        // `HttpCache::get_cached_with_headers_via` always sends a conditional
+        // revalidation request even on a cache hit (RFC 7232 ETag semantics), so a
+        // strict "exactly one HTTP request" assertion here would be testing a
+        // guarantee this architecture does not make. What per-repository coalescing
+        // *does* guarantee — no two callers racing to fill a cold, empty cache at
+        // once — is covered directly by `test_acquire_in_flight_lock_returns_shared_arc`
+        // below; this integration test only proves coalescing never breaks a
+        // concurrent pair of calls for the same repository.
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/repos/owner/repo/tags")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body(format!(
+                r#"[{{"name": "v1.0.0", "commit": {{"sha": "{}"}}}}]"#,
+                "a".repeat(40)
+            ))
+            .create_async()
+            .await;
+
+        let registry = mock_registry(&server.url(), false);
+        let (a, b) = tokio::join!(
+            registry.get_versions("owner/repo"),
+            registry.get_versions("owner/repo")
+        );
+        assert!(a.is_ok());
+        assert!(b.is_ok());
+    }
+
+    #[test]
+    fn test_acquire_in_flight_lock_returns_shared_arc_for_same_repo() {
+        let registry = mock_registry("http://127.0.0.1:1", false);
+        let a = registry.acquire_in_flight_lock(&PackageName::new("owner/repo"));
+        let b = registry.acquire_in_flight_lock(&PackageName::new("owner/repo"));
+        assert!(Arc::ptr_eq(&a, &b));
+    }
+
+    #[test]
+    fn test_acquire_in_flight_lock_returns_distinct_arc_for_different_repos() {
+        let registry = mock_registry("http://127.0.0.1:1", false);
+        let a = registry.acquire_in_flight_lock(&PackageName::new("owner/repo-a"));
+        let b = registry.acquire_in_flight_lock(&PackageName::new("owner/repo-b"));
+        assert!(!Arc::ptr_eq(&a, &b));
+    }
+
+    #[test]
+    fn test_pagination_warns_when_truncated_at_cap() {
+        let output = capture_tracing_output(|| {
+            warn_if_pagination_truncated("owner/repo", MAX_TAG_PAGES, 100);
+        });
+        assert!(output.contains("owner/repo"), "output was: {output}");
+        assert!(output.contains("cap"), "output was: {output}");
+    }
+
+    #[tokio::test]
+    async fn test_paginate_tags_stops_after_partial_page() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        fn tags_page_json(count: usize) -> Bytes {
+            let entries: Vec<String> = (0..count)
+                .map(|i| format!(r#"{{"name":"v{i}.0.0","commit":{{"sha":"s{i}"}}}}"#))
+                .collect();
+            Bytes::from(format!("[{}]", entries.join(",")))
+        }
+
+        let calls = AtomicU32::new(0);
+        let output = capture_tracing_output_async(async {
+            let result = paginate_tags("owner/repo", |page| {
+                calls.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    match page {
+                        1 => Ok(tags_page_json(100)),
+                        2 => Ok(tags_page_json(42)),
+                        _ => panic!("page {page} must not be fetched after a partial page"),
+                    }
+                }
+            })
+            .await
+            .unwrap();
+            assert_eq!(result.len(), 142);
+        })
+        .await;
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert!(output.is_empty(), "output was: {output}");
+    }
+}

--- a/crates/deps-github-actions/src/types.rs
+++ b/crates/deps-github-actions/src/types.rs
@@ -1,0 +1,226 @@
+//! GitHub Actions dependency and version types.
+
+use deps_core::parser::DependencySource;
+use tower_lsp_server::ls_types::{Range, Uri};
+
+/// How a `uses:` step's ref is pinned, driving requirement synthesis and edit shape.
+///
+/// `None` on [`GithubActionsDependency::pin`] (rather than a fourth variant here) covers
+/// every non-resolvable form (`./local`, `docker://…`, a reusable-workflow call, or a bare
+/// `uses: owner/repo` with no `@` at all) — those have no ref to classify.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PinStyle {
+    /// A tag ref, e.g. `@v4` or `@v4.2.0`.
+    Tag,
+    /// A 40-character commit SHA ref, optionally annotated with a trailing
+    /// `# vX.Y.Z` comment naming the tag it corresponds to.
+    Sha {
+        /// The tag named by the `# vX.Y.Z` comment, if present and shaped like a full
+        /// `major.minor.patch` version (see `parser`'s comment-tag rule).
+        comment_tag: Option<String>,
+    },
+    /// A branch ref, e.g. `@main`.
+    Branch,
+}
+
+/// Parsed `uses:` dependency from a GitHub Actions workflow file, with position tracking.
+///
+/// `name` is `owner/repo` — truncated at the second `/` for a subdirectory action
+/// (`github/codeql-action/init@v3` -> `github/codeql-action`) or a reusable-workflow call
+/// (`owner/repo/.github/workflows/x.yml@ref` -> `owner/repo`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GithubActionsDependency {
+    /// `owner/repo` identity.
+    pub name: deps_core::PackageName,
+    /// LSP range of the `owner/repo` text (truncated at the second `/`).
+    pub name_range: Range,
+    /// Normalized version requirement: the tag text for a [`PinStyle::Tag`] or a
+    /// [`PinStyle::Sha`] with a `comment_tag`, the raw SHA for a commentless
+    /// [`PinStyle::Sha`], the branch name for [`PinStyle::Branch`] — `None` for a
+    /// non-resolvable source.
+    pub version_req: Option<deps_core::VersionReq>,
+    /// LSP range of the ref text — for a [`PinStyle::Sha`] with a `comment_tag`, this
+    /// extends through the comment token (`<40hex> # v4.2.0`). `None` for a
+    /// non-resolvable source or a bare `uses: owner/repo` with no `@` at all.
+    pub version_range: Option<Range>,
+    /// The raw literal text `version_range` spans, when it differs from `version_req` —
+    /// populated only for the SHA-with-comment form, where `version_req` is the
+    /// comment-derived tag but `version_range` spans the full `<sha> # <tag>` text.
+    pub version_literal: Option<String>,
+    /// How the ref is pinned; `None` for a non-resolvable source.
+    pub pin: Option<PinStyle>,
+    /// Dependency source: [`DependencySource::Registry`] for any `@ref` form (tag, SHA,
+    /// or branch — all resolvable against the GitHub tags API by `name` alone),
+    /// [`DependencySource::Path`] for `./local`, [`DependencySource::Url`] for
+    /// `docker://image:tag` and a reusable-workflow call.
+    pub source: DependencySource,
+}
+
+impl deps_core::ecosystem::Dependency for GithubActionsDependency {
+    fn name(&self) -> &deps_core::PackageName {
+        &self.name
+    }
+
+    fn name_range(&self) -> Range {
+        self.name_range
+    }
+
+    fn version_requirement(&self) -> Option<&deps_core::VersionReq> {
+        self.version_req.as_ref()
+    }
+
+    fn version_range(&self) -> Option<Range> {
+        self.version_range
+    }
+
+    fn source(&self) -> DependencySource {
+        self.source.clone()
+    }
+
+    fn version_literal(&self) -> Option<&str> {
+        self.version_literal.as_deref()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// Version information for a GitHub Actions dependency (a repository tag).
+#[derive(Debug, Clone)]
+pub struct GithubActionsVersion {
+    /// The tag as published on GitHub, `v` prefix (or lack of one) kept as-is.
+    pub version: deps_core::ConcreteVersion,
+    /// The commit SHA this tag points at, as reported by the GitHub tags API.
+    pub sha: String,
+    /// Whether the tag's semver `pre` component is non-empty, computed once from the
+    /// `semver::Version` already parsed while sorting tags.
+    pub prerelease: bool,
+}
+
+// GitHub's tags API exposes no yank/deprecation signal for actions (mirroring
+// `deps-swift`'s `SwiftVersion` — see `Registry::reports_yanked` on
+// `GithubActionsRegistry`), so `status` is unconditionally `Available`.
+deps_core::impl_version!(GithubActionsVersion {
+    version: version,
+    status: |_v: &GithubActionsVersion| deps_core::RemovalStatus::Available,
+    prerelease: |v: &GithubActionsVersion| v.prerelease,
+});
+
+/// Result of parsing a `.github/workflows/*.yml`/`*.yaml` file.
+#[derive(Debug)]
+pub struct GithubActionsParseResult {
+    /// Every `uses:` dependency found, including non-resolvable ones (their consumers
+    /// filter on `version_range()`/`source()` as usual).
+    pub dependencies: Vec<GithubActionsDependency>,
+    /// URI of the parsed workflow file.
+    pub uri: Uri,
+}
+
+impl deps_core::ParseResult for GithubActionsParseResult {
+    fn dependencies(&self) -> Vec<&dyn deps_core::Dependency> {
+        self.dependencies
+            .iter()
+            .map(|d| d as &dyn deps_core::Dependency)
+            .collect()
+    }
+
+    fn workspace_root(&self) -> Option<&std::path::Path> {
+        None
+    }
+
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use deps_core::registry::Version;
+    use deps_core::{Dependency, ParseResult};
+    use tower_lsp_server::ls_types::Position;
+
+    fn range() -> Range {
+        Range::new(Position::new(0, 0), Position::new(0, 10))
+    }
+
+    #[test]
+    fn test_github_actions_dependency_tag_pin() {
+        let dep = GithubActionsDependency {
+            name: "actions/checkout".into(),
+            name_range: range(),
+            version_req: Some("v4".into()),
+            version_range: Some(range()),
+            version_literal: None,
+            pin: Some(PinStyle::Tag),
+            source: DependencySource::Registry,
+        };
+        assert_eq!(dep.name(), "actions/checkout");
+        assert_eq!(
+            dep.version_requirement().map(deps_core::VersionReq::as_str),
+            Some("v4")
+        );
+        assert_eq!(dep.version_literal(), None);
+    }
+
+    #[test]
+    fn test_github_actions_dependency_sha_with_comment_carries_literal() {
+        let dep = GithubActionsDependency {
+            name: "actions/checkout".into(),
+            name_range: range(),
+            version_req: Some("v4.2.0".into()),
+            version_range: Some(range()),
+            version_literal: Some("b4ffde65f46336ab88eb53be808477a3936bae11 # v4.2.0".to_string()),
+            pin: Some(PinStyle::Sha {
+                comment_tag: Some("v4.2.0".to_string()),
+            }),
+            source: DependencySource::Registry,
+        };
+        assert_eq!(dep.version_literal(), dep.version_literal.as_deref());
+        assert_ne!(
+            dep.version_literal(),
+            dep.version_requirement().map(deps_core::VersionReq::as_str)
+        );
+    }
+
+    #[test]
+    fn test_github_actions_version_prerelease() {
+        let stable = GithubActionsVersion {
+            version: "v4.2.0".into(),
+            sha: "a".repeat(40),
+            prerelease: false,
+        };
+        let pre = GithubActionsVersion {
+            version: "v4.2.0-beta.1".into(),
+            sha: "b".repeat(40),
+            prerelease: true,
+        };
+        assert!(!stable.is_prerelease());
+        assert!(pre.is_prerelease());
+        assert!(!stable.removal_status().blocks_resolution());
+    }
+
+    #[test]
+    fn test_parse_result_dependencies_and_uri() {
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let result = GithubActionsParseResult {
+            dependencies: vec![GithubActionsDependency {
+                name: "actions/checkout".into(),
+                name_range: range(),
+                version_req: Some("v4".into()),
+                version_range: Some(range()),
+                version_literal: None,
+                pin: Some(PinStyle::Tag),
+                source: DependencySource::Registry,
+            }],
+            uri,
+        };
+        assert_eq!(result.dependencies().len(), 1);
+        assert!(result.uri().path().as_str().ends_with("ci.yml"));
+    }
+}

--- a/crates/deps-lsp/Cargo.toml
+++ b/crates/deps-lsp/Cargo.toml
@@ -21,7 +21,7 @@ name = "deps_lsp"
 path = "src/lib.rs"
 
 [features]
-default = ["cargo", "npm", "pypi", "go", "bundler", "dart", "maven", "gradle", "swift", "composer", "nuget", "deno"]
+default = ["cargo", "npm", "pypi", "go", "bundler", "dart", "maven", "gradle", "swift", "composer", "nuget", "deno", "github-actions"]
 cargo = ["dep:deps-cargo"]
 npm = ["dep:deps-npm"]
 pypi = ["dep:deps-pypi"]
@@ -33,6 +33,7 @@ gradle = ["dep:deps-gradle"]
 swift = ["dep:deps-swift"]
 composer = ["dep:deps-composer"]
 nuget = ["dep:deps-nuget"]
+github-actions = ["dep:deps-github-actions"]
 # Pulls in deps-npm transitively (DenoRegistry delegates npm: specifiers to it, D3) even
 # when the "npm" feature itself is disabled.
 deno = ["dep:deps-deno"]
@@ -45,6 +46,7 @@ deps-composer = { workspace = true, optional = true }
 deps-core = { workspace = true }
 deps-dart = { workspace = true, optional = true }
 deps-deno = { workspace = true, optional = true }
+deps-github-actions = { workspace = true, optional = true }
 deps-go = { workspace = true, optional = true }
 deps-gradle = { workspace = true, optional = true }
 deps-maven = { workspace = true, optional = true }

--- a/crates/deps-lsp/README.md
+++ b/crates/deps-lsp/README.md
@@ -6,13 +6,13 @@
 [![codecov](https://codecov.io/gh/bug-ops/deps-lsp/graph/badge.svg?token=S71PTINTGQ&flag=deps-lsp)](https://codecov.io/gh/bug-ops/deps-lsp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../../LICENSE)
 
-Language Server Protocol implementation for dependency management across twelve package ecosystems.
+Language Server Protocol implementation for dependency management across thirteen package ecosystems.
 
-This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) workspace. It provides the LSP server binary and the ecosystem orchestration layer that wires together ecosystem-specific crates (`deps-cargo`, `deps-npm`, `deps-pypi`, `deps-go`, `deps-bundler`, `deps-dart`, `deps-maven`, `deps-gradle`, `deps-swift`, `deps-composer`, `deps-nuget`, `deps-deno`) via the `Ecosystem` trait from `deps-core`.
+This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) workspace. It provides the LSP server binary and the ecosystem orchestration layer that wires together ecosystem-specific crates (`deps-cargo`, `deps-npm`, `deps-pypi`, `deps-go`, `deps-bundler`, `deps-dart`, `deps-maven`, `deps-gradle`, `deps-swift`, `deps-composer`, `deps-nuget`, `deps-deno`, `deps-github-actions`) via the `Ecosystem` trait from `deps-core`.
 
 ## Features
 
-- **Multi-ecosystem** — Cargo.toml, package.json, pyproject.toml, go.mod, Gemfile, pubspec.yaml, pom.xml, libs.versions.toml, Package.swift, composer.json, .csproj/.fsproj/.vbproj, deno.json/deno.jsonc
+- **Multi-ecosystem** — Cargo.toml, package.json, pyproject.toml, go.mod, Gemfile, pubspec.yaml, pom.xml, libs.versions.toml, Package.swift, composer.json, .csproj/.fsproj/.vbproj, deno.json/deno.jsonc, .github/workflows/*.yml
 - **Inlay hints** — Show latest versions inline with loading indicators
 - **Hover info** — Package descriptions with resolved version from lock file
 - **Diagnostics** — Warnings for outdated, unknown, yanked, or unsatisfiable-requirement dependencies

--- a/crates/deps-lsp/src/document/state.rs
+++ b/crates/deps-lsp/src/document/state.rs
@@ -1169,6 +1169,7 @@ mod tests {
             ("swift", EcosystemId::Swift),
             ("nuget", EcosystemId::NuGet),
             ("deno", EcosystemId::Deno),
+            ("github-actions", EcosystemId::GithubActions),
         ] {
             let parsed: EcosystemId = id
                 .parse()

--- a/crates/deps-lsp/src/handlers/code_lens.rs
+++ b/crates/deps-lsp/src/handlers/code_lens.rs
@@ -732,5 +732,144 @@ let package = Package(
                 assert_guard_skips(ecosystem.as_ref(), &uri, content, cached).await;
             }
         }
+
+        /// Seeds `ecosystem`'s shared `TagIndex` for `name` with one `tag -> sha` entry,
+        /// downcasting through `Ecosystem::registry()`/`Registry::as_any()` — this test
+        /// module never drives a live registry fetch (`collect_update_all_edits` is pure
+        /// over `parse_result`/`content`/cached `VersionData`), so the index has to be
+        /// seeded directly for the SHA-pin `format_version_replacing_for` branch to have
+        /// anything to resolve.
+        #[cfg(feature = "github-actions")]
+        fn seed_gha_tag_index(
+            ecosystem: &dyn deps_core::Ecosystem,
+            name: &str,
+            tag: &str,
+            sha: &str,
+        ) {
+            let registry = ecosystem.registry();
+            let gha_registry = registry
+                .as_any()
+                .downcast_ref::<deps_github_actions::GithubActionsRegistry>()
+                .expect("github-actions ecosystem must back onto a GithubActionsRegistry");
+            let mut index = deps_github_actions::registry::TagIndex::default();
+            index.tag_to_sha.insert(tag.to_string(), sha.to_string());
+            index.sha_to_tag.insert(sha.to_string(), tag.to_string());
+            gha_registry.tag_index().insert(
+                deps_core::PackageName::new(name),
+                std::sync::Arc::new(index),
+            );
+        }
+
+        #[cfg(feature = "github-actions")]
+        #[tokio::test]
+        async fn test_github_actions_tag_pin_is_edited() {
+            let state = ServerState::new();
+            let ecosystem = state.ecosystem_registry.get("github-actions").unwrap();
+            let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+            let content = "steps:\n  - uses: actions/checkout@v4.2.0\n";
+            let mut cached = HashMap::new();
+            cached.insert(
+                "actions/checkout".into(),
+                PackageVersions::latest_only("v4.3.0"),
+            );
+
+            assert_single_edit_produces_valid_declaration(
+                ecosystem.as_ref(),
+                &uri,
+                content,
+                cached,
+                "v4.3.0",
+            )
+            .await;
+        }
+
+        #[cfg(feature = "github-actions")]
+        #[tokio::test]
+        async fn test_github_actions_sha_with_comment_pin_is_edited_to_new_sha_and_tag() {
+            let state = ServerState::new();
+            let ecosystem = state.ecosystem_registry.get("github-actions").unwrap();
+            let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+            let old_sha = "a".repeat(40);
+            let new_sha = "b".repeat(40);
+            seed_gha_tag_index(ecosystem.as_ref(), "actions/checkout", "v4.3.0", &new_sha);
+
+            let content = format!("steps:\n  - uses: actions/checkout@{old_sha} # v4.2.0\n");
+            let mut cached = HashMap::new();
+            cached.insert(
+                "actions/checkout".into(),
+                PackageVersions::latest_only("v4.3.0"),
+            );
+
+            assert_single_edit_produces_valid_declaration(
+                ecosystem.as_ref(),
+                &uri,
+                &content,
+                cached,
+                &format!("{new_sha} # v4.3.0"),
+            )
+            .await;
+        }
+
+        #[cfg(feature = "github-actions")]
+        #[tokio::test]
+        async fn test_github_actions_subdirectory_action_sha_pin_is_edited_preserving_subpath() {
+            // Critic S1 regression gate: a subdirectory action's `version_range` must
+            // start right after the full `owner/repo/sub@` prefix, not after the
+            // truncated `owner/repo@` — otherwise this edit corrupts the `/init@`
+            // segment, producing a re-parseable-but-wrong bare `owner/repo` declaration
+            // with the pin silently deleted.
+            let state = ServerState::new();
+            let ecosystem = state.ecosystem_registry.get("github-actions").unwrap();
+            let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+            let old_sha = "a".repeat(40);
+            let new_sha = "b".repeat(40);
+            seed_gha_tag_index(
+                ecosystem.as_ref(),
+                "github/codeql-action",
+                "v3.1.0",
+                &new_sha,
+            );
+
+            let content =
+                format!("steps:\n  - uses: github/codeql-action/init@{old_sha} # v3.0.0\n");
+            let mut cached = HashMap::new();
+            cached.insert(
+                "github/codeql-action".into(),
+                PackageVersions::latest_only("v3.1.0"),
+            );
+
+            assert_single_edit_produces_valid_declaration(
+                ecosystem.as_ref(),
+                &uri,
+                &content,
+                cached,
+                &format!("codeql-action/init@{new_sha} # v3.1.0"),
+            )
+            .await;
+        }
+
+        #[cfg(feature = "github-actions")]
+        #[tokio::test]
+        async fn test_github_actions_sha_pin_tag_index_miss_is_skipped() {
+            // B1's regression gate: on a `TagIndex` miss, the formatted replacement must
+            // equal the raw declared span byte-for-byte, so the shared no-op guard
+            // suppresses the edit instead of silently downgrading the SHA pin to a bare
+            // tag.
+            let state = ServerState::new();
+            let ecosystem = state.ecosystem_registry.get("github-actions").unwrap();
+            let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+            let old_sha = "a".repeat(40);
+            // No `seed_gha_tag_index` call: the index has no entry for "v4.3.0", so the
+            // formatter's `TagIndex` lookup misses.
+
+            let content = format!("steps:\n  - uses: actions/checkout@{old_sha} # v4.2.0\n");
+            let mut cached = HashMap::new();
+            cached.insert(
+                "actions/checkout".into(),
+                PackageVersions::latest_only("v4.3.0"),
+            );
+
+            assert_guard_skips(ecosystem.as_ref(), &uri, &content, cached).await;
+        }
     }
 }

--- a/crates/deps-lsp/src/handlers/completion.rs
+++ b/crates/deps-lsp/src/handlers/completion.rs
@@ -334,7 +334,8 @@ const fn uses_xml_tag_values(ecosystem_kind: EcosystemId) -> bool {
         | EcosystemId::Swift
         | EcosystemId::NuGet
         | EcosystemId::Bundler
-        | EcosystemId::Deno => false,
+        | EcosystemId::Deno
+        | EcosystemId::GithubActions => false,
     }
 }
 
@@ -391,7 +392,8 @@ const fn uses_json_quoted_keys(ecosystem_kind: EcosystemId) -> bool {
         | EcosystemId::Swift
         | EcosystemId::NuGet
         | EcosystemId::Bundler
-        | EcosystemId::Deno => false,
+        | EcosystemId::Deno
+        | EcosystemId::GithubActions => false,
     }
 }
 
@@ -419,7 +421,8 @@ const fn uses_toml_string_array_values(ecosystem_kind: EcosystemId) -> bool {
         | EcosystemId::Swift
         | EcosystemId::NuGet
         | EcosystemId::Bundler
-        | EcosystemId::Deno => false,
+        | EcosystemId::Deno
+        | EcosystemId::GithubActions => false,
     }
 }
 
@@ -486,7 +489,22 @@ fn is_in_dependencies_section(
         // such wrapper. See the Bundler arm above for why this is `false`.
         EcosystemId::NuGet => false,
         EcosystemId::Deno => is_in_json_dependencies(content, line_number, &["imports"]),
+        // A `uses:` step key can appear at any nesting depth in a workflow file
+        // (`jobs.*.steps[].uses`, `jobs.<id>.uses`), so unlike the other YAML/TOML/
+        // JSON ecosystems above there is no enclosing section header to track —
+        // the target line itself is the only signal needed.
+        EcosystemId::GithubActions => is_github_actions_uses_line(content, line_number),
     }
+}
+
+/// Whether line `line_number` of `content` is a workflow `uses:` step key
+/// (`uses: owner/repo@ref` or, as a sequence item, `- uses: owner/repo@ref`).
+fn is_github_actions_uses_line(content: &str, line_number: usize) -> bool {
+    content
+        .lines()
+        .nth(line_number)
+        .map(str::trim_start)
+        .is_some_and(|trimmed| trimmed.starts_with("uses:") || trimmed.starts_with("- uses:"))
 }
 
 /// Checks if a line is inside a TOML dependencies section.
@@ -949,6 +967,29 @@ fn create_package_completion_item(
                 format!("\"{bare}\": \"{name}\"")
             } else {
                 format!("\"{bare}\": \"{name}@^{latest}\"")
+            }
+        }
+        // GHA's `search()` always returns `Ok(vec![])` (MVP scope — see
+        // `deps-github-actions`'s registry docs), so this arm is unreachable in
+        // practice today; it exists only to keep the match exhaustive (#118) and to
+        // behave correctly if package-name search is ever added. The `owner/repo`
+        // shape check is inlined rather than calling
+        // `deps_github_actions::is_valid_github_identity` — that dependency is
+        // feature-gated, while this match (on `EcosystemId`, not a per-feature type)
+        // is compiled unconditionally.
+        EcosystemId::GithubActions => {
+            if !name.as_str().contains('/') {
+                warn_rejected_value(
+                    "owner/repo shape",
+                    "github actions package name completion item",
+                    name.as_str(),
+                );
+                return None;
+            }
+            if latest.is_empty() {
+                name.to_string()
+            } else {
+                format!("{name}@{latest}")
             }
         }
     };

--- a/crates/deps-lsp/src/lib.rs
+++ b/crates/deps-lsp/src/lib.rs
@@ -219,6 +219,20 @@ ecosystem!(
     ]
 );
 
+ecosystem!(
+    "github-actions",
+    deps_github_actions,
+    GithubActionsEcosystem,
+    [
+        GithubActionsDependency,
+        GithubActionsFormatter,
+        GithubActionsParseResult,
+        GithubActionsRegistry,
+        GithubActionsVersion,
+        parse_workflow_yaml,
+    ]
+);
+
 /// Registers all enabled ecosystems.
 ///
 /// `cargo` is special-cased (spec #443/#441, plan-1b §1.6): unlike `register!`'s generic
@@ -281,6 +295,7 @@ pub fn register_ecosystems(
     register!("swift", SwiftEcosystem, registry, &cache);
     register!("composer", ComposerEcosystem, registry, &cache);
     register!("nuget", NuGetEcosystem, registry, &cache);
+    register!("github-actions", GithubActionsEcosystem, registry, &cache);
 }
 
 #[cfg(test)]
@@ -321,6 +336,8 @@ mod tests {
         assert!(registry.get("nuget").is_some());
         #[cfg(feature = "deno")]
         assert!(registry.get("deno").is_some());
+        #[cfg(feature = "github-actions")]
+        assert!(registry.get("github-actions").is_some());
     }
 
     /// Regression guard for issue #118: `EcosystemId`'s string literals (`deps-core`)
@@ -375,6 +392,12 @@ mod tests {
         assert!(registry.get(deps_core::EcosystemId::NuGet.id()).is_some());
         #[cfg(feature = "deno")]
         assert!(registry.get(deps_core::EcosystemId::Deno.id()).is_some());
+        #[cfg(feature = "github-actions")]
+        assert!(
+            registry
+                .get(deps_core::EcosystemId::GithubActions.id())
+                .is_some()
+        );
     }
 
     /// #348 regression: `select_latest_matching` must resolve an all-`AdvisoryDeprecated`

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -4,7 +4,7 @@ This guide explains how to add support for a new package ecosystem (e.g., Go mod
 
 ## Supported Ecosystems
 
-deps-lsp provides comprehensive LSP support for 12 package ecosystems:
+deps-lsp provides comprehensive LSP support for 13 package ecosystems:
 
 | Ecosystem | Language | Manifest File(s) | Lock File(s) | Features |
 |-----------|----------|-----------------|--------------|----------|
@@ -20,6 +20,7 @@ deps-lsp provides comprehensive LSP support for 12 package ecosystems:
 | **Swift** | Swift | `Package.swift` | `Package.resolved` | Hover, inlay hints, completion, code actions, diagnostics, code lens (range-form dependencies not covered — see below), GitHub API support |
 | **NuGet** | .NET | `.csproj`, `.fsproj`, `.vbproj`, `Directory.Packages.props`, `packages.config` | `packages.lock.json`, `packages.<project>.lock.json` (multi-project) | Hover, inlay hints, completion, code actions, diagnostics, code lens, central package management support, SemVer2 prerelease handling, hover-only unlisted-version marker |
 | **Deno** | JavaScript/TypeScript (Deno runtime) | `deno.json`, `deno.jsonc` | — (no `deno.lock` support yet) | Hover, inlay hints, completion, code actions, diagnostics, code lens — `jsr:` specifiers via the keyless JSR API, `npm:` specifiers delegate to the same registry client `npm` uses; `imports` map only, `scopes`/`importMap` not covered — see below |
+| **GitHub Actions** | YAML | `.github/workflows/*.yml`, `*.yaml` | — (no lock file) | Hover, inlay hints, code actions, diagnostics, code lens (package-name completion not covered — see below); tag/commit-SHA/branch `uses:` pins via the GitHub tags API; reusable-workflow calls recognized but not version-resolved — see below |
 
 ### Cargo Custom/Private Registries
 
@@ -383,8 +384,9 @@ This is distinct from `Unknown package` (the package itself was not found) and f
 latest release). The two are mutually exclusive on the same dependency — a requirement is
 either up to date, outdated-but-satisfiable, or unsatisfiable, never more than one at once.
 
-The check is always on (no configuration flag) across all 12 ecosystems, and is
-deliberately conservative:
+The check is always on (no configuration flag) across 12 of the 13 ecosystems — GitHub
+Actions does not opt in (a pin is not a range, so there is no "requirement satisfies zero
+versions" question to ask) — and is deliberately conservative:
 
 - **Suppressed while versions are still loading**, or if the registry fetch failed — an
   empty/unknown version list means "don't know yet", not "nothing published".
@@ -527,10 +529,11 @@ dependency, so only one yanked diagnostic is ever shown per dependency.
 | NuGet | No | `NuGetVersion::is_yanked` is a hardcoded `false` constant |
 | Swift | No | `SwiftVersion.yanked` is a field that is always `false` for GitHub tags (no such concept in the source) |
 | Deno | `jsr:` yes, any requirement shape; `npm:` no | JSR `meta.json` per-version `yanked` for `jsr:` specifiers; npm `deprecated` (unconditionally off, see restriction above) for `npm:` specifiers |
+| GitHub Actions | No | GitHub's tags API exposes no yank/deprecation signal for actions — `GithubActionsRegistry::reports_yanked` is hardcoded `false`, same architectural gap as Swift |
 
-5 of 12 ecosystems can produce this diagnostic today; npm is disabled by design rather than
+5 of 13 ecosystems can produce this diagnostic today; npm is disabled by design rather than
 lacking a real signal (see restriction above), and that also covers Deno's `npm:` specifiers;
-the remaining 6 have no real yanked signal to source it from (three are architecturally
+the remaining 7 have no real yanked signal to source it from (four are architecturally
 impossible — no such registry concept exists — and Go's is a fixable but separate gap).
 
 ### Package Deprecation Diagnostics (issue #205)

--- a/templates/README.md
+++ b/templates/README.md
@@ -20,9 +20,21 @@ This directory contains template files for creating new ecosystem support in dep
 | `{LOCK_FILE}` | Lock file name | `pom.xml.lock`, `go.sum`, `packages.lock.json` |
 
 4. Implement the TODO sections in each file
-5. Add your crate to the workspace in `Cargo.toml`
-6. Add feature flag in `deps-lsp/Cargo.toml`
+5. Add your crate to the workspace in `Cargo.toml` (alphabetically — the
+   `[workspace.dependencies]` table is enforced-sorted)
+6. Add feature flag + optional dependency in `deps-lsp/Cargo.toml`
 7. Register your ecosystem in `deps-lsp/src/lib.rs` using `ecosystem!()` and `register!()` macros
+8. Add an `EcosystemId` variant in `crates/deps-core/src/ecosystem.rs`: the enum itself, the
+   `id()`/`osv_ecosystem()`/`FromStr` match arms, and both `#[cfg(test)]` tables that assert
+   over every variant — an unhandled variant there is a compile error, not a silent runtime bug
+9. Update every other exhaustive `match` on `EcosystemId` across the workspace (the compiler
+   will point you at each one): `crates/deps-lsp/src/handlers/completion.rs`'s
+   `uses_xml_tag_values`/`uses_json_quoted_keys`/`uses_toml_string_array_values`/
+   `is_in_dependencies_section`/`create_package_completion_item`, and
+   `crates/deps-lsp/src/document/state.rs`'s ecosystem-id resolution test table
+10. Update docs: root `README.md`, `crates/deps-lsp/README.md` (ecosystem count in the intro
+    sentence), `docs/ECOSYSTEM_GUIDE.md`, `CHANGELOG.md` `[Unreleased]`, and your new crate's own
+    `README.md`
 
 ## File Structure
 


### PR DESCRIPTION
## Summary

Adds a new `deps-github-actions` ecosystem crate: hover, inlay hints, outdated diagnostics, code actions, and code lens for `uses:` steps in `.github/workflows/*.yml`/`*.yaml`, covering tag, commit-SHA (with an optional `# vX.Y.Z` tag comment, following the Dependabot/Renovate convention), and branch pins, resolved against the GitHub tags REST API with `HttpCache`'s existing ETag/If-None-Match conditional-request support.

## Architecture decisions

Two additive `deps-core` extensions were required (both zero-behavior-change for the 12 existing ecosystems):

- **Manifest routing**: `manifest_directory_patterns`'s matcher is generalized from a single path segment to a multi-segment relative directory path, matched against the tail of the file's directory path on segment boundaries, so `.github/workflows` is expressible without a parallel detection pathway or a new trait method. PyPI's existing `requirements/*.txt` routing is an unmodified single-segment special case of the same rule — the 4 pre-existing PyPI directory-pattern tests pass unchanged and serve as the regression gate.
- **`EcosystemFormatter::format_version_replacing_for(dep, version, current)`**: a defaulted hook (falls back to the existing `format_version_replacing`) added because a SHA-pin update must emit `{new_sha} # {new_tag}`, and a tag's SHA is per-repository — unknowable from the tag alone. This fixes both the code-action path and the "Update N outdated" code lens, which calls the shared edit-builder directly and would otherwise silently corrupt a SHA pin down to a bare tag.

Reusable-workflow calls (`owner/repo/.github/workflows/x.yml@ref`) are parsed and recognized but scoped out of version resolution for this PR — the host repository's tags usually don't version the specific workflow file, so "update to latest tag" could point at a tag that doesn't contain that workflow. Composite actions with nested `uses:` are out of scope entirely (multi-file parsing).

## Notable fixes along the way

This went through two rounds of architecture review and four parallel validators (tests, performance, security, adversarial implementation critique) before landing. Two are worth calling out since they'd otherwise be invisible in the diff:

- A parser offset bug where any *subdirectory* action reference (e.g. `github/codeql-action/init@v3`) computed its ref range from the truncated `owner/repo` name instead of the full pre-`@` path — silently dropping diagnostics/code actions on tag pins, and on SHA pins, corrupting the pin by deleting the `init@` subpath segment when the update-all code lens applied its edit.
- A HIGH-severity bug, reproduced live against the real `deps-lsp` binary: a quoted `uses:` value with multi-byte leading whitespace caused a byte-boundary panic that killed the entire LSP server process (not just failed on that document); the same root cause silently corrupted the edit range for the far more common single-leading-space case.

Both are fixed and covered by regression tests exercising the exact repro inputs.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (3470 passed)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Live-reproduced the fixed panic and quadratic-scan bugs against the built `deps-lsp` binary
- [x] CHANGELOG, root README, `deps-lsp` README, `docs/ECOSYSTEM_GUIDE.md`, `templates/README.md`, and the new crate's own README updated

Closes #208
