### PR TITLE
fix(deps-github-actions,deps-core): suppress dead hover link and misleading footer for non-resolvable uses refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-deno**: a `jsr:` range requirement satisfiable only by yanked versions now surfaces the yanked diagnostic, matching Cargo/PyPI/Dart's behavior for the equivalent case (resolves #454)
 - **deps-core, deps-cargo, deps-lsp**: `cargo.workspace_registries`' `public_only`/`off` now enforced at connect time (resolved address) and on every redirect hop, not just the declared URL string at parse time, closing a DNS-rebinding bypass to RFC1918/CGNAT-range hosts (resolves #455) (#460)
 - **deps-core, deps-lsp**: the OSV vulnerability-fix code action's recommended target version is now independently verified against OSV before being offered, instead of only ever checking the registry's "latest" version (resolves #462) (#467)
+- **deps-github-actions, deps-core**: hover no longer renders a dead empty-URL link or a misleading "Press Cmd+. to update version" footer for a non-resolvable `uses:` ref (local composite action, Docker image) (resolves #474)
 
 ## [0.11.1] - 2026-09-01
 

--- a/crates/deps-core/src/lsp_helpers/hover.rs
+++ b/crates/deps-core/src/lsp_helpers/hover.rs
@@ -91,8 +91,16 @@ pub async fn generate_hover<R: Registry + ?Sized>(
     // FR-014: a resolved-but-not-crates.io source (e.g. Cargo's `AlternateRegistry`) must
     // not carry a link to the ecosystem's *default* registry — once live version data from
     // the real registry renders below, an unrelated link reads as confirmation it's real.
-    let url =
-        (!formatter.suppress_package_url(&dep_source)).then(|| formatter.package_url(dep.name()));
+    //
+    // `.filter(|u| !u.is_empty())`: an `EcosystemFormatter::package_url` implementation can
+    // return an empty string for a dependency name it can't turn into a real URL (e.g. a
+    // name that isn't a valid identity for that ecosystem's registry) without also
+    // overriding `suppress_package_url` — defense-in-depth so an empty URL can never render
+    // as a dead `[name]()` markdown link regardless of which ecosystem forgot the override
+    // (#474).
+    let url = (!formatter.suppress_package_url(&dep_source))
+        .then(|| formatter.package_url(dep.name()))
+        .filter(|u| !u.is_empty());
 
     // Pre-allocate with estimated capacity to reduce allocations
     let mut markdown = String::with_capacity(512);
@@ -355,7 +363,17 @@ pub async fn generate_hover<R: Registry + ?Sized>(
         }
     }
 
-    markdown.push_str("\n---\n⌨️ **Press `Cmd+.` to update version**");
+    // The footer advertises a `Cmd+.` code action — none is ever offered for a source that
+    // is deliberately non-resolvable (e.g. a local composite action or a Docker image ref),
+    // so rendering it unconditionally is misleading there (#474). Gated on `resolvable`
+    // alone, not on `available_versions`/`cached_latest` also being populated: a
+    // vulnerability-fix or unsatisfiable-fix code action (`code_actions.rs`) can exist from
+    // `versions.vulnerabilities` — populated independently of the registry fetch
+    // (`lifecycle.rs`) — even when both of those are empty (e.g. a registry fetch failure),
+    // so requiring them too would silently drop the footer while `Cmd+.` still offers a fix.
+    if resolvable {
+        markdown.push_str("\n---\n⌨️ **Press `Cmd+.` to update version**");
+    }
 
     Some(Hover {
         contents: HoverContents::Markup(MarkupContent {
@@ -2274,6 +2292,91 @@ mod tests {
         assert!(
             !content.value.contains("Recent versions"),
             "must not render a broken version section from an empty list; got: {}",
+            content.value
+        );
+    }
+
+    /// #474: the "Press `Cmd+.` to update version" footer advertises a code action that
+    /// only exists for a resolvable source with actual version data — a resolvable
+    /// `Registry` source with a live (even empty) fetch must still show it.
+    #[tokio::test]
+    async fn test_generate_hover_footer_shown_for_resolvable_source_with_live_versions() {
+        let registry = MockRegistryWithVersions {
+            versions: vec![MockVersionWithAge {
+                version: "1.2.3".into(),
+                yanked: false,
+                published_at: None,
+            }],
+        };
+        let parse_result = freshness_test_parse_result("serde");
+
+        let hover = generate_hover(
+            &parse_result,
+            Position::new(0, 2),
+            VersionData::new(&HashMap::new(), &HashMap::new()),
+            &registry,
+            &MockFormatter,
+            crate::freshness::FreshnessSettings::default(),
+            PublishTime::now(),
+        )
+        .await
+        .expect("hover should be generated for a dependency at the cursor");
+
+        let HoverContents::Markup(content) = hover.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(
+            content.value.contains("Press `Cmd+.` to update version"),
+            "a resolvable source with live version data must show the update footer; got: {}",
+            content.value
+        );
+    }
+
+    /// #474: a non-resolvable source (e.g. a local path or a Docker-style URL ref,
+    /// mirrored here by `DependencySource::Path`) offers no diagnostic, inlay hint, or
+    /// code action — the footer advertising `Cmd+.` must not render for it, even though a
+    /// cached `latest` value exists in `versions.cached` (which `resolvable.then(...)`
+    /// must gate *before* it ever reaches the footer condition).
+    #[tokio::test]
+    async fn test_generate_hover_footer_omitted_for_non_resolvable_source() {
+        use crate::parser::DependencySource;
+
+        let uri = crate::test_util::test_uri("/test/workflow.yml");
+        let parse_result = SingleDepParseResult {
+            dep: NonRegistryDep(
+                dep_at("local-action"),
+                DependencySource::Path {
+                    path: "./local-action".into(),
+                },
+            ),
+            uri,
+        };
+        let cached_versions = {
+            let mut m = HashMap::new();
+            m.insert("local-action".into(), PackageVersions::latest_only("9.9.9"));
+            m
+        };
+        let resolved_versions = HashMap::new();
+
+        let hover = generate_hover(
+            &parse_result,
+            Position::new(0, 2),
+            VersionData::new(&cached_versions, &resolved_versions),
+            &MockRegistry,
+            &MockFormatter,
+            crate::freshness::FreshnessSettings::default(),
+            PublishTime::now(),
+        )
+        .await
+        .expect("hover should still be generated for a non-resolvable-source dependency");
+
+        let HoverContents::Markup(content) = hover.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(
+            !content.value.contains("Press `Cmd+.` to update version"),
+            "a non-resolvable source offers no update code action, even with a cached \
+             latest value present; got: {}",
             content.value
         );
     }

--- a/crates/deps-github-actions/src/formatter.rs
+++ b/crates/deps-github-actions/src/formatter.rs
@@ -2,6 +2,7 @@
 
 use dashmap::DashMap;
 use deps_core::lsp_helpers::EcosystemFormatter;
+use deps_core::parser::DependencySource;
 use deps_core::{
     ConcreteVersion, Dependency, PackageName, VersionReq, lsp_helpers::warn_rejected_value,
 };
@@ -76,6 +77,29 @@ impl EcosystemFormatter for GithubActionsFormatter {
                 name.as_str(),
             );
             String::new()
+        }
+    }
+
+    /// Suppresses the hover heading link for a local composite action (`./x`,
+    /// [`DependencySource::Path`]) and a Docker image ref (`docker://...`) — neither has a
+    /// dependency name that [`Self::package_url`] can turn into a real URL, so without this
+    /// override hover renders a dead `[name]()` link instead of a plain heading (#474).
+    ///
+    /// A reusable-workflow call (`owner/repo/.github/workflows/x.yml@ref`) is a
+    /// [`DependencySource::Url`] too, but its `url` is always built from a valid
+    /// `owner/repo` identity (see `crate::parser`'s `is_reusable_workflow` branch) and so is
+    /// left unsuppressed; a Docker ref's `url` is the raw `docker://...` value and never
+    /// matches that shape.
+    fn suppress_package_url(&self, source: &DependencySource) -> bool {
+        match source {
+            DependencySource::Path { .. } => true,
+            DependencySource::Url { url } => !url.starts_with("https://github.com/"),
+            // `DependencySource` is `#[non_exhaustive]` (deps-core), so a catch-all arm is
+            // required by the compiler regardless — this crate cannot match it exhaustively
+            // by variant name. Every other source (`Registry`, `Git`, `Sdk`, `Workspace`,
+            // `CustomRegistry`, `AlternateRegistry`, and any future variant) defaults to an
+            // unsuppressed (linked) heading, same as before this override existed.
+            _ => false,
         }
     }
 
@@ -159,6 +183,209 @@ mod tests {
         GithubActionsFormatter {
             tag_index: Arc::new(DashMap::new()),
         }
+    }
+
+    // --- #474: hover suppress_package_url / footer regression coverage ---
+
+    #[test]
+    fn test_suppress_package_url_local_path_action() {
+        let fmt = formatter();
+        assert!(fmt.suppress_package_url(&DependencySource::Path {
+            path: "./local-action".into(),
+        }));
+    }
+
+    #[test]
+    fn test_suppress_package_url_docker_ref() {
+        let fmt = formatter();
+        assert!(fmt.suppress_package_url(&DependencySource::Url {
+            url: "docker://alpine:3.18".into(),
+        }));
+    }
+
+    #[test]
+    fn test_suppress_package_url_reusable_workflow_not_suppressed() {
+        let fmt = formatter();
+        assert!(!fmt.suppress_package_url(&DependencySource::Url {
+            url: "https://github.com/octo-org/repo".into(),
+        }));
+    }
+
+    #[test]
+    fn test_suppress_package_url_registry_not_suppressed() {
+        let fmt = formatter();
+        assert!(!fmt.suppress_package_url(&DependencySource::Registry));
+    }
+
+    /// A registry mock whose `get_versions` always succeeds with an empty list — enough
+    /// to drive `generate_hover`'s `resolvable && available_versions.is_some()` footer
+    /// gate (#474) without needing a real `Box<dyn Version>` fixture.
+    struct EmptyRegistry;
+
+    impl deps_core::Registry for EmptyRegistry {
+        fn get_versions<'a>(
+            &'a self,
+            _name: &'a PackageName,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = deps_core::Result<Vec<Box<dyn deps_core::Version>>>,
+                    > + Send
+                    + 'a,
+            >,
+        > {
+            Box::pin(async move { Ok(Vec::new()) })
+        }
+
+        fn get_latest_matching<'a>(
+            &'a self,
+            _name: &'a PackageName,
+            _req: &'a VersionReq,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = deps_core::Result<Option<Box<dyn deps_core::Version>>>,
+                    > + Send
+                    + 'a,
+            >,
+        > {
+            Box::pin(async move { Ok(None) })
+        }
+
+        fn search<'a>(
+            &'a self,
+            _query: &'a str,
+            _limit: usize,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = deps_core::Result<Vec<Box<dyn deps_core::Metadata>>>,
+                    > + Send
+                    + 'a,
+            >,
+        > {
+            Box::pin(async move { Ok(Vec::new()) })
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    /// Runs `generate_hover` end-to-end against a real parsed workflow line and the real
+    /// `GithubActionsFormatter`, mirroring the fixtures already used by `crate::parser`'s
+    /// own unit tests (`./local-action`, `docker://alpine:3.18`,
+    /// `octo-org/repo/.github/workflows/x.yml@v1`, `actions/checkout@v4`).
+    async fn hover_markdown_for(content: &str) -> String {
+        use deps_core::freshness::FreshnessSettings;
+        use deps_core::lsp_helpers::generate_hover;
+        use deps_core::{PublishTime, VersionData};
+        use std::collections::HashMap;
+        use tower_lsp_server::ls_types::HoverContents;
+
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let parse_result = crate::parser::parse_workflow_yaml(content, &uri).unwrap();
+        let cached = HashMap::new();
+        let resolved = HashMap::new();
+        let fmt = formatter();
+
+        // Cursor placed at the start of the (single) parsed dependency's own name range,
+        // rather than a hardcoded line/column, so this helper works for fixtures whose
+        // `uses:` line varies in position (top-level `steps:` vs. nested `jobs:.call:`).
+        let position = deps_core::ParseResult::dependencies(&parse_result)[0]
+            .name_range()
+            .start;
+
+        let hover = generate_hover(
+            &parse_result,
+            position,
+            VersionData::new(&cached, &resolved),
+            &EmptyRegistry,
+            &fmt,
+            FreshnessSettings::default(),
+            PublishTime::now(),
+        )
+        .await
+        .expect("hover should be generated for the dependency on this line");
+
+        let HoverContents::Markup(content) = hover.contents else {
+            panic!("expected markup hover contents");
+        };
+        content.value
+    }
+
+    /// Hover escapes every name it renders (`# `/`# [...]` heading) via
+    /// `deps_core::lsp_helpers::escape_markdown`, which backslash-escapes all ASCII
+    /// punctuation — building the expected heading through the same function keeps these
+    /// assertions from hardcoding that escaping rather than testing it.
+    fn escaped(name: &str) -> String {
+        deps_core::lsp_helpers::escape_markdown(name)
+    }
+
+    #[tokio::test]
+    async fn test_hover_local_path_action_has_plain_header_and_no_footer() {
+        let markdown = hover_markdown_for("steps:\n  - uses: ./local-action\n").await;
+        assert!(
+            markdown.starts_with(&format!("# {}\n", escaped("./local-action"))),
+            "expected a plain heading, not a dead link; got: {markdown}"
+        );
+        assert!(!markdown.contains('['), "must not render a markdown link");
+        assert!(
+            !markdown.contains("Press `Cmd+.`"),
+            "a local composite action offers no update code action; got: {markdown}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_hover_docker_ref_has_plain_header_and_no_footer() {
+        let markdown = hover_markdown_for("steps:\n  - uses: docker://alpine:3.18\n").await;
+        assert!(
+            markdown.starts_with(&format!("# {}\n", escaped("docker://alpine:3.18"))),
+            "expected a plain heading, not a dead link; got: {markdown}"
+        );
+        assert!(!markdown.contains('['), "must not render a markdown link");
+        assert!(
+            !markdown.contains("Press `Cmd+.`"),
+            "a Docker ref offers no update code action; got: {markdown}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_hover_reusable_workflow_keeps_real_link_and_no_footer() {
+        let markdown = hover_markdown_for(
+            "jobs:\n  call:\n    uses: octo-org/repo/.github/workflows/x.yml@v1\n",
+        )
+        .await;
+        assert!(
+            markdown.starts_with(&format!(
+                "# [{}](https://github.com/octo-org/repo)\n",
+                escaped("octo-org/repo")
+            )),
+            "reusable-workflow calls resolve to a real owner/repo identity and keep their \
+             link unchanged; got: {markdown}"
+        );
+        assert!(
+            !markdown.contains("Press `Cmd+.`"),
+            "a reusable-workflow call is non-resolvable, so no update code action exists; \
+             got: {markdown}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_hover_registry_action_keeps_link_and_footer() {
+        let markdown = hover_markdown_for("steps:\n  - uses: actions/checkout@v4\n").await;
+        assert!(
+            markdown.starts_with(&format!(
+                "# [{}](https://github.com/actions/checkout)\n",
+                escaped("actions/checkout")
+            )),
+            "non-regression: a normal Registry-sourced action keeps its link; got: {markdown}"
+        );
+        assert!(
+            markdown.contains("Press `Cmd+.`"),
+            "a resolvable Registry source with version data must still show the update \
+             footer; got: {markdown}"
+        );
     }
 
     fn dep(pin: Option<PinStyle>, name: &str, literal: Option<&str>) -> GithubActionsDependency {


### PR DESCRIPTION
## Summary

- `GithubActionsFormatter` now overrides `suppress_package_url` for `uses:` steps referencing a local composite action (`./x`, `DependencySource::Path`) and a Docker image ref (`docker://...`, a non-`https://github.com/` `DependencySource::Url`), so hover renders a plain heading instead of a dead `[name]()` markdown link with an empty URL.
- `deps-core::lsp_helpers::hover::generate_hover` now filters out any empty `package_url()` return before use, closing the same latent dead-link class in `deps-pypi`, `deps-swift`, and `deps-deno` (none of which override `suppress_package_url`) without touching those crates.
- The trailing "Press `Cmd+.` to update version" footer is now gated on `resolvable` alone, instead of also requiring `available_versions`/`cached_latest` to be populated — the stronger gate would have silently dropped the footer whenever an OSV vulnerability-fix/unsatisfiable-fix code action exists independently of registry/cache data (e.g. a registry fetch failure with OSV data already present), which is reachable for any ecosystem, not just GitHub Actions.

Reusable-workflow calls (`owner/repo/.github/workflows/x.yml@ref`) keep their real link (built from a valid `owner/repo` identity) but no longer show the footer, since that source form is also non-resolvable.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (3480/3480 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] 10 new regression tests covering hover for `./local-action`, `docker://alpine:3.18`, a reusable-workflow ref, and a normal resolvable `actions/checkout@v4` (non-regression), plus footer-gating unit tests in `deps-core`

Closes #474