### PR TITLE
GitHub Actions: mutable-ref-pin security diagnostic with SHA-pin code action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-cargo, deps-lsp**: `[source.crates-io] replace-with` resolution to a sparse-index mirror — plain dependencies in a mirrored workspace now resolve against the mirror instead of crates.io, while still receiving crates.io-content-correct OSV scanning and hover links (resolves #441) (#447)
 - **deps-core, deps-cargo, deps-lsp**: new `cargo.workspace_registries` setting (`off`/`public_only`/`all`, default `public_only`) blocking workspace-declared registry/source URLs that resolve to loopback, link-local, cloud-metadata, RFC1918/CGNAT/ULA, or internal-name hosts, plus redirect-hop host reclassification shared by every ecosystem — closes the SSRF/reachability-probing sign-off from #443 (#447)
 - **deps-core, deps-npm, deps-composer, deps-lsp**: package-level deprecation/abandoned diagnostic and hover section (npm `deprecated`, Composer `abandoned`), plus a Composer-only "Replace with X" code action when a successor package is named (resolves #205) (#435)
-- **deps-github-actions, deps-core, deps-lsp**: mutable-ref-pin security diagnostic for a `uses:` step pinned to a tag, with a "Pin to commit SHA" code action rewriting it to `{sha} # {tag}` via the existing tag/SHA index (resolves #473)
+- **deps-github-actions, deps-core, deps-lsp**: mutable-ref-pin security diagnostic for a `uses:` step pinned to a tag, with a "Pin to commit SHA" code action rewriting it to `{sha} # {tag}` via the existing tag/SHA index (resolves #473) (#477)
 
 ### Changed
 - **repo**: root `Cargo.toml` `[workspace.dependencies]` is now fully, case-insensitively sorted alphabetically (resolves #442) (#444)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-cargo, deps-lsp**: `[source.crates-io] replace-with` resolution to a sparse-index mirror — plain dependencies in a mirrored workspace now resolve against the mirror instead of crates.io, while still receiving crates.io-content-correct OSV scanning and hover links (resolves #441) (#447)
 - **deps-core, deps-cargo, deps-lsp**: new `cargo.workspace_registries` setting (`off`/`public_only`/`all`, default `public_only`) blocking workspace-declared registry/source URLs that resolve to loopback, link-local, cloud-metadata, RFC1918/CGNAT/ULA, or internal-name hosts, plus redirect-hop host reclassification shared by every ecosystem — closes the SSRF/reachability-probing sign-off from #443 (#447)
 - **deps-core, deps-npm, deps-composer, deps-lsp**: package-level deprecation/abandoned diagnostic and hover section (npm `deprecated`, Composer `abandoned`), plus a Composer-only "Replace with X" code action when a successor package is named (resolves #205) (#435)
+- **deps-github-actions, deps-core, deps-lsp**: mutable-ref-pin security diagnostic for a `uses:` step pinned to a tag, with a "Pin to commit SHA" code action rewriting it to `{sha} # {tag}` via the existing tag/SHA index (resolves #473)
 
 ### Changed
 - **repo**: root `Cargo.toml` `[workspace.dependencies]` is now fully, case-insensitively sorted alphabetically (resolves #442) (#444)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,6 +553,7 @@ dependencies = [
  "deps-core",
  "mockito",
  "semver",
+ "serde_json",
  "tokio",
  "tokio-test",
  "tower-lsp-server",

--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ Configure via LSP initialization options:
     "yanked_severity": "warning",
     "unsatisfiable_severity": "warning",
     "deprecated_severity": "warning",
+    "mutable_ref_pin_severity": "hint",
+    "mutable_ref_pin_enabled": true,
     "vulnerabilities_enabled": true
   },
   "freshness": {
@@ -287,6 +289,9 @@ Configure via LSP initialization options:
 
 > [!NOTE]
 > `diagnostics.deprecated_severity` flags a dependency whose *package* — not a specific version — is reported as deprecated/abandoned (`This package is deprecated: <reason>`), with a matching hover section and, for Composer packages naming a successor, a "Replace with X" quick fix. Currently sourced from **npm**'s `deprecated` field and **Composer**'s `abandoned` field only. See [Package Deprecation Diagnostics](docs/ECOSYSTEM_GUIDE.md#package-deprecation-diagnostics-issue-205) for the full ecosystem coverage table and how this differs from the yanked diagnostic above.
+
+> [!NOTE]
+> `diagnostics.mutable_ref_pin_severity` flags a **GitHub Actions** `uses:` step pinned to a mutable ref (a tag, e.g. `actions/checkout@v4`) instead of a full commit SHA — a supply-chain hardening recommendation independent of the outdated-version check above (a step can be both up to date *and* mutable). Comes with a "Pin `<name>` to commit SHA" quick fix that rewrites the ref to `<sha> # <tag>`, when the tag's commit SHA is already known. Set `diagnostics.mutable_ref_pin_enabled` to `false` to turn the diagnostic off entirely — unlike the other diagnostics above, severity alone cannot silence it. GitHub Actions only; see [Mutable-Ref-Pin Diagnostic](docs/ECOSYSTEM_GUIDE.md#mutable-ref-pin-diagnostic-issue-473) for full details.
 
 ### Configuration reference
 

--- a/crates/deps-core/src/lsp_helpers/diagnostics.rs
+++ b/crates/deps-core/src/lsp_helpers/diagnostics.rs
@@ -29,13 +29,24 @@ pub const UNSATISFIABLE_DIAGNOSTIC_CODE: &str = "unsatisfiable-requirement";
 /// [`DiagnosticSeverity::INFORMATION`] message.
 const MAX_BLOCKED_REGISTRY_MESSAGE_VALUE_CHARS: usize = 128;
 
-/// Truncates `value` to at most `max_chars` characters, appending `…` when truncated, so an
-/// attacker-controlled string interpolated into a diagnostic message can never render an
-/// unbounded amount of text inline in the editor.
+/// Truncates `value` to at most `max_chars` characters, appending `…` when truncated.
 ///
-/// Counts characters, not bytes, so a truncation point never lands mid-character (`value` may
-/// contain multi-byte UTF-8).
-fn truncate_for_diagnostic(value: &str, max_chars: usize) -> std::borrow::Cow<'_, str> {
+/// So an attacker-controlled string interpolated into a diagnostic message can never
+/// render an unbounded amount of text inline in the editor. Counts characters, not bytes,
+/// so a truncation point never lands mid-character (`value` may contain multi-byte
+/// UTF-8). `pub`, not module-private: `deps-github-actions`' mutable-ref-pin diagnostic
+/// (issue #473) reuses this same chokepoint for its own attacker-controlled `name`/`tag`
+/// interpolation, rather than duplicating the truncation logic in a second crate.
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::lsp_helpers::truncate_for_diagnostic;
+///
+/// assert_eq!(truncate_for_diagnostic("short", 128), "short");
+/// assert_eq!(truncate_for_diagnostic(&"a".repeat(200), 5), "aaaaa…");
+/// ```
+pub fn truncate_for_diagnostic(value: &str, max_chars: usize) -> std::borrow::Cow<'_, str> {
     if value.chars().count() <= max_chars {
         return std::borrow::Cow::Borrowed(value);
     }
@@ -68,6 +79,8 @@ pub const DEPRECATED_DIAGNOSTIC_CODE: &str = "deprecated-package";
 /// assert_eq!(severities.yanked, DiagnosticSeverity::WARNING);
 /// assert_eq!(severities.unsatisfiable, DiagnosticSeverity::WARNING);
 /// assert_eq!(severities.deprecated, DiagnosticSeverity::WARNING);
+/// assert_eq!(severities.mutable_ref_pin, DiagnosticSeverity::HINT);
+/// assert!(severities.mutable_ref_pin_enabled);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DiagnosticSeverities {
@@ -82,6 +95,21 @@ pub struct DiagnosticSeverities {
     /// Severity for a dependency on a package the registry reports as
     /// deprecated/abandoned (issue #205).
     pub deprecated: DiagnosticSeverity,
+    /// Severity for a GitHub Actions `uses:` step pinned to a mutable ref (a tag)
+    /// instead of a full commit SHA (issue #473). Unused by every ecosystem except
+    /// `deps-github-actions` today — see that crate's
+    /// `MUTABLE_REF_PIN_DIAGNOSTIC_CODE` for the diagnostic this severity gates.
+    /// Tunes loudness only; see [`Self::mutable_ref_pin_enabled`] for the on/off
+    /// toggle.
+    pub mutable_ref_pin: DiagnosticSeverity,
+    /// Whether the mutable-ref-pin diagnostic (issue #473) runs at all, unused by
+    /// every ecosystem except `deps-github-actions`. Unlike every other field in
+    /// this struct, `mutable_ref_pin` alone cannot silence the diagnostic —
+    /// `DiagnosticSeverity` has no suppression value, and severity is never treated
+    /// as a suppression input anywhere in this codebase — so this diagnostic
+    /// additionally needs a real presence toggle, mirroring
+    /// `deps_lsp::config::DiagnosticsConfig::vulnerabilities_enabled`'s shape.
+    pub mutable_ref_pin_enabled: bool,
 }
 
 impl Default for DiagnosticSeverities {
@@ -92,6 +120,8 @@ impl Default for DiagnosticSeverities {
             yanked: DiagnosticSeverity::WARNING,
             unsatisfiable: DiagnosticSeverity::WARNING,
             deprecated: DiagnosticSeverity::WARNING,
+            mutable_ref_pin: DiagnosticSeverity::HINT,
+            mutable_ref_pin_enabled: true,
         }
     }
 }

--- a/crates/deps-core/src/lsp_helpers/mod.rs
+++ b/crates/deps-core/src/lsp_helpers/mod.rs
@@ -24,6 +24,7 @@ pub use code_lenses::{collect_update_all_edits, generate_code_lenses};
 pub use diagnostics::{
     DEPRECATED_DIAGNOSTIC_CODE, DiagnosticSeverities, UNSATISFIABLE_DIAGNOSTIC_CODE,
     compile_requirement_unless, generate_diagnostics_from_cache, requirement_is_unsatisfiable,
+    truncate_for_diagnostic,
 };
 pub use hover::generate_hover;
 pub use in_use_version::{concrete_pin_version, in_use_version, is_full_semver_shape};

--- a/crates/deps-github-actions/Cargo.toml
+++ b/crates/deps-github-actions/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 dashmap = { workspace = true }
 deps-core = { workspace = true }
 semver = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tower-lsp-server = { workspace = true }
 tracing = { workspace = true }

--- a/crates/deps-github-actions/README.md
+++ b/crates/deps-github-actions/README.md
@@ -26,6 +26,10 @@ implements `deps_core::Ecosystem`.
   fetch, not N, and a local rate-limit gate that stops hammering GitHub once a 403 is seen
 - **SHA-pin-aware code actions** — updating a `@<sha> # vX.Y.Z` pin writes both a new SHA
   and its matching tag comment, never silently downgrading a SHA pin to a bare tag
+- **Mutable-ref-pin security diagnostic** (issue #473) — a tag-pinned `uses:` step (e.g.
+  `@v4`) gets an additive, independent diagnostic recommending SHA pinning, plus a "Pin to
+  commit SHA" quick fix rewriting it to `@<sha> # <tag>` when the tag's commit is already
+  known; on by default, configurable via `mutable_ref_pin_severity`/`mutable_ref_pin_enabled`
 
 ## Installation
 
@@ -78,6 +82,10 @@ against the tag with zero SHA-to-tag network resolution.
   keystroke would burn the 60 req/hour unauthenticated budget fast
 - The unauthenticated GitHub API budget (60 req/hour) is per-IP and shared with any
   `deps-swift` traffic in the same process; set `GITHUB_TOKEN` to raise it to 5000 req/hour
+- The "Pin to commit SHA" quick fix is withheld for a quoted `uses:` value
+  (`uses: "actions/checkout@v4"`) — the ref sits inside the quotes there, and appending
+  `# <tag>` would corrupt the value instead of adding a YAML comment; the diagnostic still
+  fires, just without the automated fix
 
 ## License
 

--- a/crates/deps-github-actions/src/ecosystem.rs
+++ b/crates/deps-github-actions/src/ecosystem.rs
@@ -2,13 +2,18 @@
 
 use std::any::Any;
 use std::sync::Arc;
-use tower_lsp_server::ls_types::{Hover, HoverContents, Position, Uri};
+use tower_lsp_server::ls_types::{
+    CodeAction, CodeActionKind, Diagnostic, Hover, HoverContents, NumberOrString, Position,
+    TextEdit, Uri, WorkspaceEdit,
+};
 
 use deps_core::{
     Ecosystem, ParseResult as ParseResultTrait, Registry, Result,
     completion::Completions,
     lsp_helpers::{EcosystemFormatter, markdown_code_span},
 };
+
+use crate::MUTABLE_REF_PIN_DIAGNOSTIC_CODE;
 
 use crate::formatter::GithubActionsFormatter;
 use crate::registry::GithubActionsRegistry;
@@ -32,9 +37,7 @@ impl GithubActionsEcosystem {
     #[must_use]
     pub fn new(cache: Arc<deps_core::HttpCache>) -> Self {
         let registry = Arc::new(GithubActionsRegistry::new(cache));
-        let formatter = GithubActionsFormatter {
-            tag_index: registry.tag_index(),
-        };
+        let formatter = GithubActionsFormatter::new(registry.tag_index());
         Self {
             registry,
             formatter,
@@ -117,6 +120,74 @@ impl Ecosystem for GithubActionsEcosystem {
                 | CompletionContext::Feature { .. }
                 | CompletionContext::None => Completions::default(),
             }
+        })
+    }
+
+    /// Appends the mutable-ref-pin diagnostic (issue #473) to the shared default's
+    /// output, one per `PinStyle::Tag` step — an additive, independent signal from the
+    /// outdated-version diagnostic the shared default already computes (spec 031
+    /// NFR-004: this override never changes that behavior, only appends to it).
+    ///
+    /// Gated on `severities.mutable_ref_pin_enabled` (spec 031 FR-009, corrected during
+    /// implementation review): `severities.mutable_ref_pin` alone cannot silence this
+    /// diagnostic, since `DiagnosticSeverity` has no suppression value.
+    fn generate_diagnostics<'a>(
+        &'a self,
+        parse_result: &'a dyn ParseResultTrait,
+        versions: deps_core::VersionData<'a>,
+        _uri: &'a Uri,
+        freshness: deps_core::FreshnessSettings,
+        severities: deps_core::lsp_helpers::DiagnosticSeverities,
+    ) -> deps_core::ecosystem::BoxFuture<'a, Vec<Diagnostic>> {
+        Box::pin(async move {
+            let mut diagnostics = deps_core::lsp_helpers::generate_diagnostics_from_cache(
+                parse_result,
+                versions,
+                self.formatter(),
+                freshness,
+                severities,
+                deps_core::PublishTime::now(),
+            );
+            if severities.mutable_ref_pin_enabled {
+                diagnostics.extend(mutable_ref_pin_diagnostics(
+                    parse_result,
+                    severities.mutable_ref_pin,
+                ));
+            }
+            diagnostics
+        })
+    }
+
+    /// Appends the "Pin to commit SHA" quickfix (issue #473) to the shared default's
+    /// output when the position's dependency is a `PinStyle::Tag` step with a resolvable
+    /// `TagIndex` entry.
+    fn generate_code_actions<'a>(
+        &'a self,
+        parse_result: &'a dyn ParseResultTrait,
+        position: Position,
+        uri: &'a Uri,
+        versions: deps_core::VersionData<'a>,
+        content: &'a str,
+    ) -> deps_core::ecosystem::BoxFuture<'a, Vec<CodeAction>> {
+        Box::pin(async move {
+            let registry = self.registry();
+            let mut actions = deps_core::lsp_helpers::generate_code_actions(
+                parse_result,
+                position,
+                uri,
+                versions,
+                content,
+                registry.as_ref(),
+                self.formatter(),
+            )
+            .await;
+            actions.extend(build_sha_pin_action(
+                parse_result,
+                position,
+                uri,
+                &self.formatter,
+            ));
+            actions
         })
     }
 
@@ -250,9 +321,498 @@ fn splice_resolved_line(markdown: &str, resolved_tag: &str, sha: &str) -> String
     format!("{markdown}{line}")
 }
 
+/// Builds one mutable-ref-pin [`Diagnostic`] (issue #473) per `PinStyle::Tag` step in
+/// `parse_result` — `PinStyle::Sha`, `PinStyle::Branch`, and `None` steps produce no
+/// diagnostic (FR-003; `PinStyle::Branch` is out of scope for this iteration, see spec
+/// 031 §"Out of Scope").
+/// Maximum character count of `mutable_ref_pin_diagnostics`' interpolated `name`/`tag`
+/// values before truncation (security audit finding). Mirrors
+/// `deps_core::lsp_helpers::diagnostics`' `MAX_BLOCKED_REGISTRY_MESSAGE_VALUE_CHARS`
+/// precedent: nothing upstream caps a workflow file's `owner/repo` or ref text length, so
+/// this is the last chokepoint before either renders inline in the editor, re-sent on
+/// every `publishDiagnostics`.
+const MAX_MUTABLE_REF_PIN_MESSAGE_VALUE_CHARS: usize = 128;
+
+fn mutable_ref_pin_diagnostics(
+    parse_result: &dyn ParseResultTrait,
+    severity: tower_lsp_server::ls_types::DiagnosticSeverity,
+) -> Vec<Diagnostic> {
+    parse_result
+        .dependencies()
+        .into_iter()
+        .filter_map(|dep| {
+            let gha_dep = dep.as_any().downcast_ref::<GithubActionsDependency>()?;
+            if gha_dep.pin != Some(PinStyle::Tag) {
+                return None;
+            }
+            let range = gha_dep.version_range?;
+            let tag = gha_dep
+                .version_req
+                .as_ref()
+                .map(deps_core::VersionReq::as_str)?;
+            let name = deps_core::lsp_helpers::truncate_for_diagnostic(
+                gha_dep.name.as_str(),
+                MAX_MUTABLE_REF_PIN_MESSAGE_VALUE_CHARS,
+            );
+            let tag = deps_core::lsp_helpers::truncate_for_diagnostic(
+                tag,
+                MAX_MUTABLE_REF_PIN_MESSAGE_VALUE_CHARS,
+            );
+            Some(Diagnostic {
+                range,
+                severity: Some(severity),
+                message: format!(
+                    "{name} is pinned to the mutable tag ref `{tag}`; pin to a full commit \
+                     SHA to guard against tag mutation"
+                ),
+                code: Some(NumberOrString::String(
+                    MUTABLE_REF_PIN_DIAGNOSTIC_CODE.into(),
+                )),
+                source: Some("deps-lsp".into()),
+                ..Default::default()
+            })
+        })
+        .collect()
+}
+
+/// Builds the "Pin `{name}` to commit SHA" quickfix (issue #473, US-002) for the
+/// `PinStyle::Tag` dependency at `position`, if [`GithubActionsFormatter::sha_pin_replacement_for`]
+/// resolves its current tag against the shared `TagIndex`.
+///
+/// Returns `None` (no destructive/no-op edit, FR-005) when the dependency at `position`
+/// is not `PinStyle::Tag`, has no `version_range`, or the `TagIndex` lookup misses (cache
+/// miss — e.g. the document was opened before the registry fetch completed).
+fn build_sha_pin_action(
+    parse_result: &dyn ParseResultTrait,
+    position: Position,
+    uri: &Uri,
+    formatter: &GithubActionsFormatter,
+) -> Option<CodeAction> {
+    // Same lookup convention every other deps-lsp code action goes through (critic S2) —
+    // not a hand-rolled position check. The default (`version_range` only, GHA does not
+    // override it) is exactly right here: the diagnostic and the edit both anchor on
+    // `version_range`, never `name_range`.
+    let dep = parse_result
+        .dependencies()
+        .into_iter()
+        .find(|d| formatter.is_position_on_dependency(*d, position))?;
+
+    let gha_dep = dep.as_any().downcast_ref::<GithubActionsDependency>()?;
+    if gha_dep.pin != Some(PinStyle::Tag) {
+        return None;
+    }
+    // FR-010: for a quoted `uses:` scalar, `version_range` sits inside the quotes —
+    // writing `{sha} # {tag}` there corrupts the value instead of adding a YAML comment
+    // (security audit finding, spec 031 FR-010). Withhold rather than risk that edit.
+    if !gha_dep.is_plain_scalar {
+        return None;
+    }
+    let version_range = gha_dep.version_range?;
+    let tag = gha_dep
+        .version_req
+        .as_ref()
+        .map(deps_core::VersionReq::as_str)?;
+    let new_text = formatter.sha_pin_replacement_for(&gha_dep.name, tag)?;
+
+    let mut changes = std::collections::HashMap::new();
+    changes.insert(
+        uri.clone(),
+        vec![TextEdit {
+            range: version_range,
+            new_text,
+        }],
+    );
+
+    Some(CodeAction {
+        title: format!("Pin {} to commit SHA", gha_dep.name),
+        kind: Some(CodeActionKind::QUICKFIX),
+        edit: Some(WorkspaceEdit {
+            changes: Some(changes),
+            ..Default::default()
+        }),
+        data: Some(serde_json::json!({
+            "diagnostic_codes": [MUTABLE_REF_PIN_DIAGNOSTIC_CODE],
+            "diagnostic_range": version_range,
+        })),
+        ..Default::default()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+    use tower_lsp_server::ls_types::DiagnosticSeverity;
+
+    // --- issue #473: mutable-ref-pin diagnostic + "Pin to commit SHA" code action ---
+
+    fn mutable_ref_pin_code() -> NumberOrString {
+        NumberOrString::String(MUTABLE_REF_PIN_DIAGNOSTIC_CODE.into())
+    }
+
+    async fn diagnostics_for(content: &str) -> Vec<Diagnostic> {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = GithubActionsEcosystem::new(cache);
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let parse_result = eco.parse_manifest(content, &uri).await.unwrap();
+        let cached = HashMap::new();
+        let resolved = HashMap::new();
+
+        eco.generate_diagnostics(
+            parse_result.as_ref(),
+            deps_core::VersionData::new(&cached, &resolved),
+            &uri,
+            deps_core::FreshnessSettings::default(),
+            deps_core::lsp_helpers::DiagnosticSeverities::default(),
+        )
+        .await
+    }
+
+    /// SC-003/SC-004: one fixture workflow mixing every `PinStyle` variant — exactly the
+    /// `Tag` steps get the mutable-ref-pin diagnostic, and `Sha` steps (with or without a
+    /// comment) get none, in the same document.
+    #[tokio::test]
+    async fn test_generate_diagnostics_fixture_covers_every_pin_style() {
+        let content = format!(
+            "steps:\n\
+             \x20 - uses: actions/checkout@v4\n\
+             \x20 - uses: actions/setup-node@{sha} # v4.0.0\n\
+             \x20 - uses: actions/setup-node@{sha}\n\
+             \x20 - uses: some-org/some-action@main\n",
+            sha = "a".repeat(40)
+        );
+        let diagnostics = diagnostics_for(&content).await;
+        let mutable_count = diagnostics
+            .iter()
+            .filter(|d| d.code == Some(mutable_ref_pin_code()))
+            .count();
+        assert_eq!(
+            mutable_count, 1,
+            "exactly the one Tag-pinned step must get the diagnostic: {diagnostics:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_diagnostics_emits_mutable_ref_pin_for_tag_pin() {
+        let diagnostics = diagnostics_for("steps:\n  - uses: actions/checkout@v4\n").await;
+        let found = diagnostics
+            .iter()
+            .find(|d| d.code == Some(mutable_ref_pin_code()))
+            .expect("expected a mutable-ref-pin diagnostic for a tag pin");
+        assert_eq!(found.severity, Some(DiagnosticSeverity::HINT));
+        assert!(found.message.contains("actions/checkout"));
+    }
+
+    /// Security audit finding (low): a huge ref text (attacker-controlled workflow file,
+    /// no upstream length cap) must not render unbounded into the diagnostic message,
+    /// re-sent on every `publishDiagnostics`.
+    #[tokio::test]
+    async fn test_generate_diagnostics_mutable_ref_pin_message_caps_long_tag() {
+        let long_tag = format!("v{}", "1".repeat(10_000));
+        let content = format!("steps:\n  - uses: actions/checkout@{long_tag}\n");
+        let diagnostics = diagnostics_for(&content).await;
+
+        let found = diagnostics
+            .iter()
+            .find(|d| d.code == Some(mutable_ref_pin_code()))
+            .expect("expected a mutable-ref-pin diagnostic");
+        assert!(
+            found.message.len() < long_tag.len(),
+            "a 10,000-char tag must not render in full inside the diagnostic message"
+        );
+        assert!(found.message.contains('…'));
+    }
+
+    #[tokio::test]
+    async fn test_generate_diagnostics_no_mutable_ref_pin_for_sha_pin() {
+        let diagnostics = diagnostics_for(&format!(
+            "steps:\n  - uses: actions/checkout@{}\n",
+            "a".repeat(40)
+        ))
+        .await;
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.code == Some(mutable_ref_pin_code()))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_diagnostics_no_mutable_ref_pin_for_sha_with_comment_pin() {
+        let diagnostics = diagnostics_for(&format!(
+            "steps:\n  - uses: actions/checkout@{} # v4\n",
+            "a".repeat(40)
+        ))
+        .await;
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.code == Some(mutable_ref_pin_code()))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_diagnostics_no_mutable_ref_pin_for_branch_pin() {
+        let diagnostics = diagnostics_for("steps:\n  - uses: some-org/some-action@main\n").await;
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.code == Some(mutable_ref_pin_code()))
+        );
+    }
+
+    /// US-003/FR-006: a step both stale and mutable gets both diagnostics, independently,
+    /// with distinct codes — neither suppresses the other.
+    #[tokio::test]
+    async fn test_generate_diagnostics_mutable_and_outdated_coexist_with_distinct_codes() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = GithubActionsEcosystem::new(cache);
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let content = "steps:\n  - uses: actions/checkout@v3\n";
+        let parse_result = eco.parse_manifest(content, &uri).await.unwrap();
+
+        let mut cached = HashMap::new();
+        cached.insert(
+            deps_core::PackageName::new("actions/checkout"),
+            deps_core::PackageVersions {
+                latest: "v4".into(),
+                available: Arc::from(vec!["v4".into(), "v3".into()]),
+                yanked: Arc::from(Vec::new()),
+                published_at: None,
+            },
+        );
+        let resolved = HashMap::new();
+
+        let diagnostics = eco
+            .generate_diagnostics(
+                parse_result.as_ref(),
+                deps_core::VersionData::new(&cached, &resolved),
+                &uri,
+                deps_core::FreshnessSettings::default(),
+                deps_core::lsp_helpers::DiagnosticSeverities::default(),
+            )
+            .await;
+
+        assert_eq!(
+            diagnostics.len(),
+            2,
+            "expected both diagnostics: {diagnostics:?}"
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.code == Some(mutable_ref_pin_code()))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.code != Some(mutable_ref_pin_code())
+                    && d.message.contains("Newer version available"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_diagnostics_mutable_ref_pin_uses_configured_severity() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = GithubActionsEcosystem::new(cache);
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let content = "steps:\n  - uses: actions/checkout@v4\n";
+        let parse_result = eco.parse_manifest(content, &uri).await.unwrap();
+        let cached = HashMap::new();
+        let resolved = HashMap::new();
+        let severities = deps_core::lsp_helpers::DiagnosticSeverities {
+            mutable_ref_pin: DiagnosticSeverity::ERROR,
+            ..deps_core::lsp_helpers::DiagnosticSeverities::default()
+        };
+
+        let diagnostics = eco
+            .generate_diagnostics(
+                parse_result.as_ref(),
+                deps_core::VersionData::new(&cached, &resolved),
+                &uri,
+                deps_core::FreshnessSettings::default(),
+                severities,
+            )
+            .await;
+
+        let found = diagnostics
+            .iter()
+            .find(|d| d.code == Some(mutable_ref_pin_code()))
+            .expect("expected a mutable-ref-pin diagnostic");
+        assert_eq!(found.severity, Some(DiagnosticSeverity::ERROR));
+    }
+
+    /// FR-009 (corrected): `mutable_ref_pin_enabled: false` must suppress the diagnostic
+    /// entirely, since `mutable_ref_pin` severity alone has no way to.
+    #[tokio::test]
+    async fn test_generate_diagnostics_mutable_ref_pin_disabled_emits_nothing() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = GithubActionsEcosystem::new(cache);
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let content = "steps:\n  - uses: actions/checkout@v4\n";
+        let parse_result = eco.parse_manifest(content, &uri).await.unwrap();
+        let cached = HashMap::new();
+        let resolved = HashMap::new();
+        let severities = deps_core::lsp_helpers::DiagnosticSeverities {
+            mutable_ref_pin_enabled: false,
+            ..deps_core::lsp_helpers::DiagnosticSeverities::default()
+        };
+
+        let diagnostics = eco
+            .generate_diagnostics(
+                parse_result.as_ref(),
+                deps_core::VersionData::new(&cached, &resolved),
+                &uri,
+                deps_core::FreshnessSettings::default(),
+                severities,
+            )
+            .await;
+
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.code == Some(mutable_ref_pin_code())),
+            "mutable_ref_pin_enabled: false must suppress the diagnostic entirely: {diagnostics:?}"
+        );
+    }
+
+    /// Exercises `build_sha_pin_action` directly rather than through
+    /// `GithubActionsEcosystem::generate_code_actions`: the shared default that override
+    /// delegates to first drives a *live* registry fetch (to list "Update to X" actions),
+    /// which would overwrite a hand-seeded `TagIndex` fixture with real GitHub data before
+    /// this function ever runs.
+    #[test]
+    fn test_build_sha_pin_action_offers_quickfix_on_tag_index_hit() {
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let content = "steps:\n  - uses: actions/checkout@v4\n";
+        let parse_result = crate::parser::parse_workflow_yaml(content, &uri).unwrap();
+
+        let formatter = GithubActionsFormatter {
+            tag_index: Arc::new(dashmap::DashMap::new()),
+        };
+        let mut index = crate::registry::TagIndex::default();
+        index.tag_to_sha.insert("v4".to_string(), "a".repeat(40));
+        formatter.tag_index.insert(
+            deps_core::PackageName::new("actions/checkout"),
+            Arc::new(index),
+        );
+
+        let position = deps_core::ParseResult::dependencies(&parse_result)[0]
+            .version_range()
+            .unwrap()
+            .start;
+
+        let action = build_sha_pin_action(&parse_result, position, &uri, &formatter)
+            .expect("expected a Pin-to-commit-SHA quickfix");
+        assert!(action.title.contains("Pin") && action.title.contains("commit SHA"));
+        let edit = action.edit.as_ref().unwrap();
+        let text_edits = edit.changes.as_ref().unwrap().get(&uri).unwrap();
+        assert_eq!(text_edits.len(), 1);
+        assert_eq!(text_edits[0].new_text, format!("{} # v4", "a".repeat(40)));
+    }
+
+    /// Critic S2: the lookup now goes through the shared `is_position_on_dependency`
+    /// convention (`version_range` only, GHA does not override it) rather than a
+    /// hand-rolled check that also matched `name_range` — a cursor on the action *name*
+    /// must not offer this quickfix, matching every other deps-lsp code action's UX.
+    #[test]
+    fn test_build_sha_pin_action_cursor_on_name_range_offers_nothing() {
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let content = "steps:\n  - uses: actions/checkout@v4\n";
+        let parse_result = crate::parser::parse_workflow_yaml(content, &uri).unwrap();
+
+        let formatter = GithubActionsFormatter {
+            tag_index: Arc::new(dashmap::DashMap::new()),
+        };
+        let mut index = crate::registry::TagIndex::default();
+        index.tag_to_sha.insert("v4".to_string(), "a".repeat(40));
+        formatter.tag_index.insert(
+            deps_core::PackageName::new("actions/checkout"),
+            Arc::new(index),
+        );
+
+        let position = deps_core::ParseResult::dependencies(&parse_result)[0]
+            .name_range()
+            .start;
+
+        assert!(build_sha_pin_action(&parse_result, position, &uri, &formatter).is_none());
+    }
+
+    /// FR-005: a `TagIndex` cache miss must never offer a destructive/no-op edit.
+    #[test]
+    fn test_build_sha_pin_action_no_quickfix_on_tag_index_miss() {
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let content = "steps:\n  - uses: actions/checkout@v4\n";
+        let parse_result = crate::parser::parse_workflow_yaml(content, &uri).unwrap();
+
+        let formatter = GithubActionsFormatter {
+            tag_index: Arc::new(dashmap::DashMap::new()),
+        };
+
+        let position = deps_core::ParseResult::dependencies(&parse_result)[0]
+            .version_range()
+            .unwrap()
+            .start;
+
+        assert!(build_sha_pin_action(&parse_result, position, &uri, &formatter).is_none());
+    }
+
+    /// FR-005/plan §11: a `PinStyle::Branch` step must never get the SHA-pin quickfix,
+    /// even if a `TagIndex` entry happens to exist for its literal ref text.
+    #[test]
+    fn test_build_sha_pin_action_no_quickfix_for_branch_pin() {
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let content = "steps:\n  - uses: some-org/some-action@main\n";
+        let parse_result = crate::parser::parse_workflow_yaml(content, &uri).unwrap();
+
+        let formatter = GithubActionsFormatter {
+            tag_index: Arc::new(dashmap::DashMap::new()),
+        };
+        let mut index = crate::registry::TagIndex::default();
+        index.tag_to_sha.insert("main".to_string(), "a".repeat(40));
+        formatter.tag_index.insert(
+            deps_core::PackageName::new("some-org/some-action"),
+            Arc::new(index),
+        );
+
+        let position = deps_core::ParseResult::dependencies(&parse_result)[0]
+            .version_range()
+            .unwrap()
+            .start;
+
+        assert!(build_sha_pin_action(&parse_result, position, &uri, &formatter).is_none());
+    }
+
+    /// FR-010 (security audit finding): a quoted `uses:` scalar must never get the
+    /// SHA-pin quickfix, even on a `TagIndex` hit — writing `{sha} # {tag}` inside the
+    /// quotes would corrupt the value and make it re-parse as `PinStyle::Branch`.
+    #[test]
+    fn test_build_sha_pin_action_no_quickfix_for_quoted_scalar() {
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let content = "steps:\n  - uses: \"actions/checkout@v4\"\n";
+        let parse_result = crate::parser::parse_workflow_yaml(content, &uri).unwrap();
+        assert!(!parse_result.dependencies[0].is_plain_scalar);
+
+        let formatter = GithubActionsFormatter {
+            tag_index: Arc::new(dashmap::DashMap::new()),
+        };
+        let mut index = crate::registry::TagIndex::default();
+        index.tag_to_sha.insert("v4".to_string(), "a".repeat(40));
+        formatter.tag_index.insert(
+            deps_core::PackageName::new("actions/checkout"),
+            Arc::new(index),
+        );
+
+        let position = deps_core::ParseResult::dependencies(&parse_result)[0]
+            .version_range()
+            .unwrap()
+            .start;
+
+        assert!(
+            build_sha_pin_action(&parse_result, position, &uri, &formatter).is_none(),
+            "a quoted uses: scalar must withhold the quickfix even on a TagIndex hit"
+        );
+    }
 
     #[test]
     fn test_ecosystem_id_and_display_name() {

--- a/crates/deps-github-actions/src/formatter.rs
+++ b/crates/deps-github-actions/src/formatter.rs
@@ -16,7 +16,7 @@ use crate::types::{GithubActionsDependency, PinStyle};
 pub struct GithubActionsFormatter {
     /// Shared handle to [`crate::registry::GithubActionsRegistry`]'s tag/SHA
     /// cross-reference — read-only from here (`format_version_replacing_for`'s
-    /// `PinStyle::Sha` branch).
+    /// `PinStyle::Sha` branch and [`Self::sha_pin_replacement_for`]).
     pub(crate) tag_index: Arc<DashMap<PackageName, Arc<TagIndex>>>,
 }
 
@@ -32,6 +32,84 @@ fn match_v_prefix_style(current: &str, tag: &str) -> String {
         (true, false) => format!("v{tag}"),
         (false, true) => tag[1..].to_string(),
         _ => tag.to_string(),
+    }
+}
+
+impl GithubActionsFormatter {
+    /// Creates a new formatter over an already-populated (or empty) [`TagIndex`] map,
+    /// the same shared handle [`crate::registry::GithubActionsRegistry::tag_index`]
+    /// returns.
+    ///
+    /// `tag_index` stays `pub(crate)` (critic M1): this constructor is the intended
+    /// external construction path — a seeded `TagIndex` for a doctest/integration test
+    /// goes through [`crate::registry::TagIndex`]'s own already-`pub` fields, not
+    /// through widening this struct's field visibility.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::DashMap;
+    /// use deps_github_actions::GithubActionsFormatter;
+    /// use deps_github_actions::registry::TagIndex;
+    /// use deps_core::PackageName;
+    /// use std::sync::Arc;
+    ///
+    /// let tag_index = Arc::new(DashMap::new());
+    /// let mut index = TagIndex::default();
+    /// index.tag_to_sha.insert("v4".to_string(), "a".repeat(40));
+    /// tag_index.insert(PackageName::new("actions/checkout"), Arc::new(index));
+    ///
+    /// let formatter = GithubActionsFormatter::new(tag_index);
+    /// assert_eq!(
+    ///     formatter.sha_pin_replacement_for(&PackageName::new("actions/checkout"), "v4"),
+    ///     Some(format!("{} # v4", "a".repeat(40)))
+    /// );
+    /// ```
+    #[must_use]
+    pub fn new(tag_index: Arc<DashMap<PackageName, Arc<TagIndex>>>) -> Self {
+        Self { tag_index }
+    }
+
+    /// Looks up `tag`'s commit SHA for `name` in the shared [`TagIndex`], returning the
+    /// `{sha} # {tag}` replacement text a "Pin to commit SHA" code action (issue #473)
+    /// writes — `None` on a cache miss (no `TagIndex` entry for `name`, or no entry for
+    /// this specific `tag`).
+    ///
+    /// Deliberately separate from [`Self::format_version_replacing_for`]'s
+    /// `PinStyle::Tag` branch: that branch bumps to the *latest* tag (outdated-version
+    /// semantics — "update `v3` to `v4`"), while this pins the *current* tag to its own
+    /// SHA (mutability semantics — "harden `v4` to `<sha> # v4`"). The two operations
+    /// are independent (a step can need either, both, or neither) and must never be
+    /// conflated behind one method.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::DashMap;
+    /// use deps_github_actions::GithubActionsFormatter;
+    /// use deps_github_actions::registry::TagIndex;
+    /// use deps_core::PackageName;
+    /// use std::sync::Arc;
+    ///
+    /// let tag_index = Arc::new(DashMap::new());
+    /// let mut index = TagIndex::default();
+    /// index.tag_to_sha.insert("v4".to_string(), "a".repeat(40));
+    /// tag_index.insert(PackageName::new("actions/checkout"), Arc::new(index));
+    ///
+    /// let formatter = GithubActionsFormatter::new(tag_index);
+    /// // Miss: no entry for this tag.
+    /// assert_eq!(
+    ///     formatter.sha_pin_replacement_for(&PackageName::new("actions/checkout"), "v5"),
+    ///     None
+    /// );
+    /// ```
+    #[must_use]
+    pub fn sha_pin_replacement_for(&self, name: &PackageName, tag: &str) -> Option<String> {
+        let sha = self
+            .tag_index
+            .get(name)
+            .and_then(|index| index.tag_to_sha.get(tag).cloned())?;
+        Some(format!("{sha} # {tag}"))
     }
 }
 
@@ -57,13 +135,21 @@ impl EcosystemFormatter for GithubActionsFormatter {
         };
         match &gha_dep.pin {
             Some(PinStyle::Tag) => match_v_prefix_style(current, version.as_str()),
-            Some(PinStyle::Sha { .. }) => self
+            // `is_plain_scalar` guard (issue #473 sibling fix): for a quoted `uses:`
+            // scalar, `version_range` sits inside the quotes, so appending `# {tag}`
+            // would place a `#` inside the string instead of starting a YAML comment —
+            // the same corruption the mutable-ref-pin SHA-pin action guards against.
+            // Falls straight to the no-op fallback without even consulting `TagIndex`,
+            // identical to a cache miss.
+            Some(PinStyle::Sha { .. }) if gha_dep.is_plain_scalar => self
                 .tag_index
                 .get(dep.name())
                 .and_then(|index| index.tag_to_sha.get(version.as_str()).cloned())
                 .map(|sha| format!("{sha} # {}", version.as_str()))
                 .unwrap_or_else(|| dep.version_literal().unwrap_or(current).to_string()),
-            Some(PinStyle::Branch) | None => current.to_string(),
+            Some(PinStyle::Sha { .. } | PinStyle::Branch) | None => {
+                dep.version_literal().unwrap_or(current).to_string()
+            }
         }
     }
 
@@ -397,6 +483,7 @@ mod tests {
             version_literal: literal.map(str::to_string),
             pin,
             source: DependencySource::Registry,
+            is_plain_scalar: true,
         }
     }
 
@@ -516,6 +603,33 @@ mod tests {
         assert_eq!(new_text, format!("{} # v5.0.0", "deadbeef".repeat(5)));
     }
 
+    /// FR-010 sibling fix (security audit finding): a quoted-scalar SHA pin must fall
+    /// back to the no-op literal even on a `TagIndex` hit — never append `# {tag}` inside
+    /// the quotes.
+    #[test]
+    fn test_format_version_replacing_for_sha_quoted_scalar_falls_back_to_literal() {
+        let fmt = formatter();
+        let name = PackageName::new("actions/checkout");
+        let mut index = TagIndex::default();
+        index
+            .tag_to_sha
+            .insert("v5.0.0".to_string(), "deadbeef".repeat(5));
+        fmt.tag_index.insert(name, Arc::new(index));
+
+        let mut d = dep(
+            Some(PinStyle::Sha {
+                comment_tag: Some("v4.2.0".to_string()),
+            }),
+            "actions/checkout",
+            Some("oldsha # v4.2.0"),
+        );
+        d.is_plain_scalar = false;
+
+        let new_text =
+            fmt.format_version_replacing_for(&d, &ConcreteVersion::new("v5.0.0"), "v4.2.0");
+        assert_eq!(new_text, "oldsha # v4.2.0");
+    }
+
     #[test]
     fn test_format_version_replacing_for_sha_miss_returns_raw_literal_not_current() {
         // B1: on a TagIndex miss, the guard must compare byte-identical to the raw
@@ -544,6 +658,80 @@ mod tests {
             fmt.format_version_replacing_for(&d, &ConcreteVersion::new("v1.0.0"), "main"),
             "main"
         );
+    }
+
+    #[test]
+    fn test_sha_pin_replacement_for_hit() {
+        let fmt = formatter();
+        let name = PackageName::new("actions/checkout");
+        let mut index = TagIndex::default();
+        index.tag_to_sha.insert("v4".to_string(), "a".repeat(40));
+        fmt.tag_index.insert(name.clone(), Arc::new(index));
+
+        assert_eq!(
+            fmt.sha_pin_replacement_for(&name, "v4"),
+            Some(format!("{} # v4", "a".repeat(40)))
+        );
+    }
+
+    /// M5 (tasks.md T003 gotcha): `TagIndex.tag_to_sha` keys are exact tag strings as
+    /// published — a repository that tags without a `v` prefix must still hit.
+    #[test]
+    fn test_sha_pin_replacement_for_hit_without_v_prefix() {
+        let fmt = formatter();
+        let name = PackageName::new("owner/repo");
+        let mut index = TagIndex::default();
+        index.tag_to_sha.insert("2.1.0".to_string(), "b".repeat(40));
+        fmt.tag_index.insert(name.clone(), Arc::new(index));
+
+        assert_eq!(
+            fmt.sha_pin_replacement_for(&name, "2.1.0"),
+            Some(format!("{} # 2.1.0", "b".repeat(40)))
+        );
+    }
+
+    #[test]
+    fn test_sha_pin_replacement_for_miss_no_repo_entry() {
+        let fmt = formatter();
+        let name = PackageName::new("actions/checkout");
+        assert_eq!(fmt.sha_pin_replacement_for(&name, "v4"), None);
+    }
+
+    #[test]
+    fn test_sha_pin_replacement_for_miss_tag_not_indexed() {
+        let fmt = formatter();
+        let name = PackageName::new("actions/checkout");
+        let mut index = TagIndex::default();
+        index.tag_to_sha.insert("v4".to_string(), "a".repeat(40));
+        fmt.tag_index.insert(name.clone(), Arc::new(index));
+
+        assert_eq!(fmt.sha_pin_replacement_for(&name, "v5"), None);
+    }
+
+    /// SC-005: the "Pin to commit SHA" code action's replacement text must be
+    /// byte-identical to what `format_version_replacing_for`'s `PinStyle::Sha` branch
+    /// already produces for the same `(name, tag)` pair.
+    #[test]
+    fn test_sha_pin_replacement_for_matches_format_version_replacing_for_sha_branch() {
+        let fmt = formatter();
+        let name = PackageName::new("actions/checkout");
+        let mut index = TagIndex::default();
+        index.tag_to_sha.insert("v4".to_string(), "a".repeat(40));
+        fmt.tag_index.insert(name.clone(), Arc::new(index));
+
+        let via_sha_pin_action = fmt.sha_pin_replacement_for(&name, "v4").unwrap();
+
+        let sha_dep = dep(
+            Some(PinStyle::Sha {
+                comment_tag: Some("v3".to_string()),
+            }),
+            "actions/checkout",
+            Some("oldsha # v3"),
+        );
+        let via_outdated_sha_update =
+            fmt.format_version_replacing_for(&sha_dep, &ConcreteVersion::new("v4"), "v3");
+
+        assert_eq!(via_sha_pin_action, via_outdated_sha_update);
     }
 
     #[test]

--- a/crates/deps-github-actions/src/lib.rs
+++ b/crates/deps-github-actions/src/lib.rs
@@ -35,6 +35,18 @@ pub use types::{
     GithubActionsDependency, GithubActionsParseResult, GithubActionsVersion, PinStyle,
 };
 
+/// Stable [`tower_lsp_server::ls_types::Diagnostic::code`] for the mutable-ref-pin
+/// diagnostic (issue #473).
+///
+/// Flags a `uses:` step pinned to a tag rather than a full commit SHA, a supply-chain
+/// hardening recommendation distinct from the outdated-version check.
+///
+/// Local to this crate rather than a shared `deps-core` diagnostic kind — mirrors the
+/// shape of `deps_core::UNSATISFIABLE_DIAGNOSTIC_CODE`/`deps_core::DEPRECATED_DIAGNOSTIC_CODE`,
+/// but no second ecosystem needs the same "mutable ref" concept yet (spec 031's resolved
+/// Open Questions), so generalizing into `deps-core` would be premature.
+pub const MUTABLE_REF_PIN_DIAGNOSTIC_CODE: &str = "mutable-ref-pin";
+
 /// Whether `name` matches the `owner/repo` GitHub identifier shape this crate accepts:
 /// `[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+`, with neither segment being exactly `.`/`..` (see
 /// [`deps_core::is_dot_segment`]).

--- a/crates/deps-github-actions/src/parser.rs
+++ b/crates/deps-github-actions/src/parser.rs
@@ -366,6 +366,14 @@ fn build_dependency(
     char_offsets: &CharOffsets,
     candidate: UsesCandidate,
 ) -> Option<GithubActionsDependency> {
+    // Whether the *whole* `uses:` value scalar was written unquoted. For a quoted scalar,
+    // any `Range` computed below sits inside the quotes — a SHA-pin code action (issue
+    // #473) must not write `{sha} # {tag}` there, since the `#` would land inside the
+    // string rather than starting a YAML comment (spec 031 FR-010). Read once here and
+    // carried on every constructed dependency, mirroring the existing single-purpose
+    // `TScalarStyle::Plain` gate below for the SHA-with-comment case.
+    let is_plain_scalar = candidate.style == TScalarStyle::Plain;
+
     let value_start = char_offsets.byte_offset(candidate.char_index);
     let (raw_start, raw_end) = locate_value_span(content, value_start, &candidate.value)?;
 
@@ -409,6 +417,7 @@ fn build_dependency(
             source: DependencySource::Path {
                 path: trimmed_value,
             },
+            is_plain_scalar,
         }),
         ParsedUses::Docker => Some(GithubActionsDependency {
             name: trimmed_value.clone().into(),
@@ -418,6 +427,7 @@ fn build_dependency(
             version_literal: None,
             pin: None,
             source: DependencySource::Url { url: trimmed_value },
+            is_plain_scalar,
         }),
         ParsedUses::NoAt { name } => {
             let name_end = span_start + name.len();
@@ -429,6 +439,7 @@ fn build_dependency(
                 version_literal: None,
                 pin: None,
                 source: DependencySource::Registry,
+                is_plain_scalar,
             })
         }
         ParsedUses::Ref {
@@ -457,6 +468,7 @@ fn build_dependency(
                     source: DependencySource::Url {
                         url: format!("https://github.com/{name}"),
                     },
+                    is_plain_scalar,
                 });
             }
 
@@ -465,7 +477,7 @@ fn build_dependency(
                 let rest_of_line_end = rest_of_line.find('\n').unwrap_or(rest_of_line.len());
                 let rest_of_line = &rest_of_line[..rest_of_line_end];
 
-                let comment = (candidate.style == TScalarStyle::Plain)
+                let comment = is_plain_scalar
                     .then(|| extract_comment_tag(rest_of_line))
                     .flatten();
 
@@ -480,6 +492,7 @@ fn build_dependency(
                             comment_tag: Some(tag.to_string()),
                         }),
                         source: DependencySource::Registry,
+                        is_plain_scalar,
                     },
                     None => GithubActionsDependency {
                         name: name.into(),
@@ -489,6 +502,7 @@ fn build_dependency(
                         version_literal: None,
                         pin: Some(PinStyle::Sha { comment_tag: None }),
                         source: DependencySource::Registry,
+                        is_plain_scalar,
                     },
                 });
             }
@@ -506,6 +520,7 @@ fn build_dependency(
                 version_literal: None,
                 pin: Some(pin),
                 source: DependencySource::Registry,
+                is_plain_scalar,
             })
         }
         ParsedUses::Malformed => {
@@ -931,6 +946,24 @@ mod tests {
             dep.version_requirement().map(deps_core::VersionReq::as_str),
             Some("v4")
         );
+        // Security audit finding (issue #473, spec 031 FR-010): a quoted `uses:` scalar
+        // must be flagged so a SHA-pin code action never writes `{sha} # {tag}` inside
+        // the quotes.
+        assert!(!dep.is_plain_scalar);
+    }
+
+    #[test]
+    fn test_is_plain_scalar_true_for_unquoted_uses_value() {
+        let content = "steps:\n  - uses: actions/checkout@v4\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        assert!(result.dependencies[0].is_plain_scalar);
+    }
+
+    #[test]
+    fn test_is_plain_scalar_false_for_single_quoted_uses_value() {
+        let content = "steps:\n  - uses: 'actions/checkout@v4'\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        assert!(!result.dependencies[0].is_plain_scalar);
     }
 
     #[test]

--- a/crates/deps-github-actions/src/types.rs
+++ b/crates/deps-github-actions/src/types.rs
@@ -54,6 +54,17 @@ pub struct GithubActionsDependency {
     /// [`DependencySource::Path`] for `./local`, [`DependencySource::Url`] for
     /// `docker://image:tag` and a reusable-workflow call.
     pub source: DependencySource,
+    /// Whether the whole `uses:` value was written as a plain (unquoted) YAML scalar,
+    /// as opposed to single- or double-quoted (`uses: "actions/checkout@v4"`).
+    ///
+    /// For a quoted scalar, `version_range` spans text *inside* the quotes — writing
+    /// `{sha} # {tag}` there would place a `#` inside the string rather than starting a
+    /// YAML comment, producing a `uses:` value GitHub Actions rejects and that re-parses
+    /// as [`PinStyle::Branch`] (issue #473, spec 031 FR-010). A SHA-pin code action must
+    /// check this before writing any edit that assumes an unquoted YAML comment can
+    /// follow the ref text — see `crate::formatter::GithubActionsFormatter::sha_pin_replacement_for`'s
+    /// caller.
+    pub is_plain_scalar: bool,
 }
 
 impl deps_core::ecosystem::Dependency for GithubActionsDependency {
@@ -159,6 +170,7 @@ mod tests {
             version_literal: None,
             pin: Some(PinStyle::Tag),
             source: DependencySource::Registry,
+            is_plain_scalar: true,
         };
         assert_eq!(dep.name(), "actions/checkout");
         assert_eq!(
@@ -180,6 +192,7 @@ mod tests {
                 comment_tag: Some("v4.2.0".to_string()),
             }),
             source: DependencySource::Registry,
+            is_plain_scalar: true,
         };
         assert_eq!(dep.version_literal(), dep.version_literal.as_deref());
         assert_ne!(
@@ -217,6 +230,7 @@ mod tests {
                 version_literal: None,
                 pin: Some(PinStyle::Tag),
                 source: DependencySource::Registry,
+                is_plain_scalar: true,
             }],
             uri,
         };

--- a/crates/deps-lsp/src/config.rs
+++ b/crates/deps-lsp/src/config.rs
@@ -107,6 +107,8 @@ impl Default for InlayHintsConfig {
 /// - `yanked_severity`: `WARNING` - Dependencies using yanked versions
 /// - `unsatisfiable_severity`: `WARNING` - Dependencies whose requirement matches zero published versions
 /// - `deprecated_severity`: `WARNING` - Dependencies on a package the registry reports as deprecated/abandoned
+/// - `mutable_ref_pin_severity`: `HINT` - GitHub Actions `uses:` steps pinned to a mutable ref (tag) instead of a commit SHA
+/// - `mutable_ref_pin_enabled`: `true` - Whether the mutable-ref-pin diagnostic runs at all
 ///
 /// # Examples
 ///
@@ -120,6 +122,8 @@ impl Default for InlayHintsConfig {
 ///     yanked_severity: DiagnosticSeverity::ERROR,
 ///     unsatisfiable_severity: DiagnosticSeverity::ERROR,
 ///     deprecated_severity: DiagnosticSeverity::ERROR,
+///     mutable_ref_pin_severity: DiagnosticSeverity::ERROR,
+///     mutable_ref_pin_enabled: true,
 ///     vulnerabilities_enabled: true,
 /// };
 ///
@@ -143,6 +147,21 @@ pub struct DiagnosticsConfig {
     /// call. Matches the severity-only precedent set by the four fields above.
     #[serde(default = "default_deprecated_severity")]
     pub deprecated_severity: DiagnosticSeverity,
+    /// Severity for a GitHub Actions `uses:` step pinned to a mutable ref (a tag)
+    /// instead of a full commit SHA (issue #473). Tunes loudness only; see
+    /// `mutable_ref_pin_enabled` for the on/off toggle.
+    #[serde(default = "default_mutable_ref_pin_severity")]
+    pub mutable_ref_pin_severity: DiagnosticSeverity,
+    /// Whether the mutable-ref-pin diagnostic (issue #473) runs at all. Default
+    /// `true`. **Corrected during implementation review (spec 031 FR-009)**: unlike
+    /// `deprecated_severity`, this diagnostic *does* need a real `_enabled` toggle —
+    /// `DiagnosticSeverity` has no suppression value, and severity is never treated
+    /// as a suppression input anywhere in this codebase, so without this boolean the
+    /// diagnostic would be permanent and unremovable on every tag-pinned `uses:` step
+    /// (the dominant pinning style), even for teams that intentionally reject
+    /// SHA-pinning. Mirrors `vulnerabilities_enabled`'s exact shape.
+    #[serde(default = "default_true")]
+    pub mutable_ref_pin_enabled: bool,
     /// Whether to run the OSV.dev vulnerability scan and render its
     /// diagnostics/hover content. Default `true` (opt-out): `cargo audit`/
     /// `npm audit` run by default, and an opt-in gate would undercut the
@@ -159,6 +178,8 @@ impl Default for DiagnosticsConfig {
             yanked_severity: default_yanked_severity(),
             unsatisfiable_severity: default_unsatisfiable_severity(),
             deprecated_severity: default_deprecated_severity(),
+            mutable_ref_pin_severity: default_mutable_ref_pin_severity(),
+            mutable_ref_pin_enabled: true,
             vulnerabilities_enabled: true,
         }
     }
@@ -180,6 +201,8 @@ impl DiagnosticsConfig {
     /// assert_eq!(severities.yanked, config.yanked_severity);
     /// assert_eq!(severities.unsatisfiable, config.unsatisfiable_severity);
     /// assert_eq!(severities.deprecated, config.deprecated_severity);
+    /// assert_eq!(severities.mutable_ref_pin, config.mutable_ref_pin_severity);
+    /// assert_eq!(severities.mutable_ref_pin_enabled, config.mutable_ref_pin_enabled);
     /// ```
     #[must_use]
     pub const fn to_severities(&self) -> deps_core::DiagnosticSeverities {
@@ -189,6 +212,8 @@ impl DiagnosticsConfig {
             yanked: self.yanked_severity,
             unsatisfiable: self.unsatisfiable_severity,
             deprecated: self.deprecated_severity,
+            mutable_ref_pin: self.mutable_ref_pin_severity,
+            mutable_ref_pin_enabled: self.mutable_ref_pin_enabled,
         }
     }
 }
@@ -350,6 +375,10 @@ const fn default_unsatisfiable_severity() -> DiagnosticSeverity {
 
 const fn default_deprecated_severity() -> DiagnosticSeverity {
     DiagnosticSeverity::WARNING
+}
+
+const fn default_mutable_ref_pin_severity() -> DiagnosticSeverity {
+    DiagnosticSeverity::HINT
 }
 
 const fn default_refresh_interval() -> u64 {
@@ -778,6 +807,38 @@ mod tests {
         let json = r"{}";
         let config: DiagnosticsConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.deprecated_severity, DiagnosticSeverity::WARNING);
+    }
+
+    /// Severity default (issue #473) — see `mutable_ref_pin_enabled` tests below for the
+    /// separate on/off toggle, unlike `deprecated_severity`'s severity-only precedent.
+    #[test]
+    fn test_diagnostics_config_mutable_ref_pin_severity_defaults_hint() {
+        let config = DiagnosticsConfig::default();
+        assert_eq!(config.mutable_ref_pin_severity, DiagnosticSeverity::HINT);
+
+        let json = r"{}";
+        let config: DiagnosticsConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.mutable_ref_pin_severity, DiagnosticSeverity::HINT);
+    }
+
+    /// FR-009 (corrected during implementation review): mirrors
+    /// `test_diagnostics_config_vulnerabilities_enabled_defaults_true` — this diagnostic
+    /// does need a real `_enabled` toggle, since severity alone cannot suppress it.
+    #[test]
+    fn test_diagnostics_config_mutable_ref_pin_enabled_defaults_true() {
+        let config = DiagnosticsConfig::default();
+        assert!(config.mutable_ref_pin_enabled);
+
+        let json = r"{}";
+        let config: DiagnosticsConfig = serde_json::from_str(json).unwrap();
+        assert!(config.mutable_ref_pin_enabled);
+    }
+
+    #[test]
+    fn test_diagnostics_config_mutable_ref_pin_enabled_can_be_disabled() {
+        let json = r#"{ "mutable_ref_pin_enabled": false }"#;
+        let config: DiagnosticsConfig = serde_json::from_str(json).unwrap();
+        assert!(!config.mutable_ref_pin_enabled);
     }
 
     #[test]

--- a/crates/deps-lsp/src/document/osv_snapshot_tests.rs
+++ b/crates/deps-lsp/src/document/osv_snapshot_tests.rs
@@ -1,8 +1,14 @@
 //! `insta` snapshots pinning the OSV vulnerability-diagnostic shape across
 //! every ecosystem, per `architecture.md` §9 (NFR-003/SC-004 enforcement):
-//! since no ecosystem crate overrides `generate_diagnostics`, a divergence
-//! introduced by an ecosystem-specific formatter shows up here as a
-//! snapshot diff rather than needing a manual comparison pass.
+//! a divergence introduced by an ecosystem-specific formatter shows up here
+//! as a snapshot diff rather than needing a manual comparison pass. As of
+//! issue #473, `deps-github-actions` overrides `generate_diagnostics` too —
+//! but only to *append* an unrelated, independent mutable-ref-pin
+//! diagnostic after calling the exact same shared default this suite
+//! exercises for every other ecosystem, so the OSV shape itself stays
+//! covered by the same guarantee. `deps-github-actions` is not itself one
+//! of the ecosystems snapshotted below (pre-existing gap from #471, not
+//! introduced here).
 //!
 //! Hover is intentionally not snapshotted per ecosystem: `generate_hover`
 //! makes a real registry network call (`registry.get_versions`), which is

--- a/crates/deps-lsp/src/handlers/code_actions.rs
+++ b/crates/deps-lsp/src/handlers/code_actions.rs
@@ -106,22 +106,25 @@ pub async fn handle_code_actions(
 ///    is recomputed from the freshly re-parsed buffer. Requiring equality here would make
 ///    an in-flight edit break a binding that works today.
 /// 3. Only when two or more candidates remain — reachable because
-///    `UNSATISFIABLE_DIAGNOSTIC_CODE` is a constant shared by every unsatisfiable
-///    dependency in a document, unlike a unique advisory id — narrow to the candidates
-///    whose range *overlaps* `diagnostic_range`, so one action does not claim every
-///    unsatisfiable dependency in the document. Overlap, not equality, so a range shifted
-///    by an in-flight edit still matches. If the narrowing leaves nothing, fall back to
-///    the full code-matched set rather than binding nothing.
+///    `UNSATISFIABLE_DIAGNOSTIC_CODE` (and, since issue #473, GitHub Actions'
+///    `MUTABLE_REF_PIN_DIAGNOSTIC_CODE` — the more frequent case in practice, since it
+///    fires on every tag-pinned `uses:` step in a workflow) is a constant shared by
+///    every matching dependency in a document, unlike a unique advisory id — narrow to
+///    the candidates whose range *overlaps* `diagnostic_range`, so one action does not
+///    claim every same-code dependency in the document. Overlap, not equality, so a
+///    range shifted by an in-flight edit still matches. If the narrowing leaves nothing,
+///    fall back to the full code-matched set rather than binding nothing.
 ///
 /// `data` is cleared afterward regardless of whether a match was found, so a stale payload
 /// can never be mistaken for a still-resolvable action.
 ///
-/// Accepted tradeoff: because `UNSATISFIABLE_DIAGNOSTIC_CODE` is a constant, if the client's
-/// diagnostic list happens to contain exactly one unsatisfiable diagnostic and it belongs to
-/// a *different* dependency than the one this action targets, step 2 still binds it (no range
-/// check on a single candidate). This is cosmetic mis-attribution of the editor's "fix this
-/// problem" affordance only — the `TextEdit` itself always comes from this action's own
-/// `dep.version_range()`, so no incorrect edit is possible.
+/// Accepted tradeoff: because a diagnostic code can be a shared constant rather than a
+/// per-instance id (`UNSATISFIABLE_DIAGNOSTIC_CODE`, `MUTABLE_REF_PIN_DIAGNOSTIC_CODE`), if
+/// the client's diagnostic list happens to contain exactly one same-code diagnostic and it
+/// belongs to a *different* dependency than the one this action targets, step 2 still binds
+/// it (no range check on a single candidate). This is cosmetic mis-attribution of the
+/// editor's "fix this problem" affordance only — the `TextEdit` itself always comes from
+/// this action's own `dep.version_range()`, so no incorrect edit is possible.
 fn bind_diagnostics(actions: &mut [CodeAction], diagnostics: &[Diagnostic]) {
     for action in actions {
         let Some(data) = action.data.take() else {

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -586,6 +586,45 @@ message is shown verbatim, which is the useful part), just not an automated rena
 | Composer | Yes, with replace action | `abandoned` (bare `true`, or a string naming a successor package) |
 | Cargo, Go, PyPI, Bundler, Dart, Maven, Gradle, Swift, NuGet, Deno | Not yet | No registry-native package-level deprecation signal wired up yet (tracked as fast-follows; Dart's `isDiscontinued`/`replacedBy` and PyPI's PEP 792 `project-status` already exist on the wire and are the best next targets) |
 
+### Mutable-Ref-Pin Diagnostic (issue #473)
+
+**GitHub Actions only.** A `uses:` step pinned to a mutable ref — a tag (`actions/checkout@v4`)
+or, in a future iteration, a branch — can silently start running different code than the
+workflow file shows: a compromised or republished tag changes what CI executes without a single
+line of the workflow file changing. This is a distinct, additive signal from the outdated-version
+diagnostic above (configurable via `diagnostics.mutable_ref_pin_severity`, default HINT) — a step
+can be up to date on its tag and still vulnerable to tag mutation, so both diagnostics can fire
+independently on the same step with distinct codes:
+
+```
+actions/checkout is pinned to the mutable tag ref `v4`; pin to a full commit SHA to guard against tag mutation
+```
+
+Unlike every other diagnostic in this project, severity alone cannot silence this one —
+`DiagnosticSeverity` has no suppression value. Set `diagnostics.mutable_ref_pin_enabled` to
+`false` in initialization options to turn it off entirely for teams that intentionally accept
+tag pinning.
+
+**"Pin `<name>` to commit SHA" quick fix.** When offered, rewrites the step's ref to
+`<sha> # <tag>` — the exact same `{sha} # {tag}` shape the outdated-SHA-update quick fix already
+produces for a SHA-pinned step, reusing the tag/SHA cross-reference already populated by the
+existing outdated-version check (zero new network calls). The quick fix is withheld, not offered
+with a wrong or destructive edit, in two cases:
+
+- The tag's commit SHA is not yet known — e.g. the document was opened before the registry fetch
+  completed, or the tag was moved/deleted/is not a full `major.minor.patch` release the registry
+  indexes (a moving major-version ref like `v4` itself is frequently in this category — GitHub's
+  tags API lists `v4.3.1`, not a synthetic `v4` tag object).
+- The `uses:` value is a **quoted YAML scalar** (`uses: "actions/checkout@v4"`). The ref text
+  sits inside the quotes there, so appending `# <tag>` would place a `#` inside the string rather
+  than starting a YAML comment — a `uses:` value GitHub Actions rejects. Re-pin a quoted step by
+  hand, or remove the quotes first.
+
+**Out of scope for this iteration:** branch pins (`@main`) get no diagnostic yet — no
+tag-to-SHA-style index exists for branches, and adding one would require a new network call per
+branch; reusable-workflow calls (`owner/repo/.github/workflows/x.yml@ref`) and `./local`/
+`docker://` references are not resolvable refs and get no diagnostic either.
+
 ### npm Package Name Validation
 
 When a dependency in `package.json` fails to resolve against the npm registry, the diagnostic distinguishes between two cases instead of always reporting "Unknown package":

--- a/specs/031-github-actions-sha-pin-diagnostic/spec.md
+++ b/specs/031-github-actions-sha-pin-diagnostic/spec.md
@@ -113,10 +113,12 @@ what the existing outdated-version check already performs.
 - `./local` action references and `docker://image:tag` uses — both already
   excluded from version resolution in #471 for unrelated reasons (no
   resolvable ref) and are out of scope here for the same reason.
-- Workspace/client configuration to disable the diagnostic — it ships
-  on by default (consistent with every other deps-lsp diagnostic), using
-  the existing `DiagnosticSeverities`-style mechanism a user already has
-  to lower its severity or silence it; no new opt-in toggle is introduced.
+- ~~Workspace/client configuration to disable the diagnostic~~ — **superseded
+  by FR-009's correction**: it ships on by default, but *does* get a new
+  `mutable_ref_pin_enabled` boolean toggle (mirroring `vulnerabilities_enabled`),
+  because `DiagnosticSeverities` alone cannot silence a diagnostic in this
+  codebase. What remains out of scope is only a *severity-based* suppression
+  mechanism — none is introduced or assumed to exist beyond the toggle.
 
 ## 2. User Stories
 
@@ -190,7 +192,8 @@ Use EARS notation. Prefix with FR-NNN.
 | FR-006 | WHEN both the mutable-ref-pin diagnostic and the existing outdated-version diagnostic apply to the same step THE SYSTEM SHALL emit both independently, with distinct diagnostic codes/sources, and SHALL NOT suppress either one in favor of the other | must |
 | FR-007 | WHEN the mutable-ref-pin diagnostic's code action is applied THE SYSTEM SHALL preserve the step's existing trailing comment convention (`# {tag}`), matching the format already used by the outdated-SHA-update code action, so the two code actions are visually consistent to the user | should |
 | FR-008 | WHEN the mutable-ref-pin diagnostic fires THE SYSTEM SHALL use `Hint` severity by default, configurable through the same `DiagnosticSeverities`-style mechanism as other deps-lsp diagnostics (`crates/deps-core/src/lsp_helpers/diagnostics.rs`) | must |
-| FR-009 | THE SYSTEM SHALL emit the mutable-ref-pin diagnostic without requiring any new workspace or client configuration to opt in — it ships enabled by default, matching every other deps-lsp diagnostic | must |
+| FR-009 | THE SYSTEM SHALL ship the mutable-ref-pin diagnostic enabled by default, gated by a `mutable_ref_pin_enabled: bool` workspace/client config toggle (default `true`), mirroring the existing `vulnerabilities_enabled` precedent — *not* the four severity-only categories. **Corrected 2026-09-02 during implementation review**: the original wording assumed `DiagnosticSeverities` alone lets a user silence this diagnostic; that premise is false — `DiagnosticSeverity` (LSP) has no suppression value and severity is never treated as a suppression input anywhere in this codebase, so without this toggle the diagnostic would be permanent and unremovable for any repository using tag pins (the dominant style) | must |
+| FR-010 | WHEN the mutable-ref-pin diagnostic's code action would rewrite a `uses:` ref that is a quoted YAML scalar (single- or double-quoted) THE SYSTEM SHALL withhold the code action rather than write `{sha} # {tag}` inside the quotes — writing inside the quotes produces a `uses:` value GitHub Actions rejects, and the resulting corrupted ref re-parses as `PinStyle::Branch`, silently making the mutable-ref-pin diagnostic disappear on the very step it just broke. Found during implementation review (security audit); the parser already tracks scalar style (`parser.rs`'s `TScalarStyle::Plain` gate) for the analogous existing SHA-update case | must |
 
 ## 4. Non-Functional Requirements
 

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -52,7 +52,7 @@ status: moc
 | 028 | [[028-pypi-requirements-documentlinks-and-directory-layout/spec\|PyPI requirements.txt -r/-c documentLinks and requirements/*.txt directory-layout recognition]] | specify | shipped — enhancement/security-hardening, P3 (PR #458, issue #452) |
 | 029 | [[029-deno-jsr-yanked-exact-pin-restriction-drop/spec\|Drop the jsr: exact-pin-only restriction on the Deno yanked diagnostic]] | specify | shipped — bug, P2 (PR #459, issue #454) |
 | 030 | [[030-gitlab-ci-ecosystem/spec\|New ecosystem: GitLab CI/CD include: version pins]] | specify | draft — research/new ecosystem, P4, 8 open `[NEEDS CLARIFICATION]` items, blocked on #208 (issue #466 tracks implementation) |
-| 031 | [[031-github-actions-sha-pin-diagnostic/spec\|GitHub Actions mutable-ref-pin security diagnostic (SHA-pin recommendation)]] | tasks | draft — research/parity, P2, issue #473, implementation-ready (8 tasks) |
+| 031 | [[031-github-actions-sha-pin-diagnostic/spec\|GitHub Actions mutable-ref-pin security diagnostic (SHA-pin recommendation)]] | tasks | implemented — research/parity, P2, awaiting merge (PR #477, issue #473) |
 
 ## Completed Specs
 


### PR DESCRIPTION
## Summary

Adds a mutable-ref-pin security diagnostic to the `deps-github-actions` ecosystem crate: a `uses:` step pinned to a mutable tag ref (e.g. `actions/checkout@v4`) gets a distinct, additive diagnostic recommending conversion to a full commit SHA pin, independent of the existing outdated-version check. Comes with a "Pin to commit SHA" code action that rewrites the ref to `{sha} # {tag}`, reusing the tag/SHA cross-reference already populated by the existing outdated-version resolution path (zero new network calls).

- Ships enabled by default at `Hint` severity, with a new `mutable_ref_pin_enabled` config toggle — unlike the four existing severity-only diagnostic categories, `DiagnosticSeverity` has no suppression value in this codebase, so a real on/off toggle (mirroring `vulnerabilities_enabled`) is required for teams that intentionally prefer tag pins.
- The code action is withheld (not offered with a corrupting edit) for a quoted YAML `uses:` value, where the ref text sits inside the quotes and appending `# {tag}` would produce an invalid `uses:` value that GitHub Actions rejects.
- Branch pins (`@main`) are explicitly out of scope for this PR — no tag-to-SHA-style index exists for branches, and adding one would require a new network call.
- Diagnostic code/kind stays local to `deps-github-actions` — no shared `deps-core` abstraction is introduced ahead of a second ecosystem needing the same shape.

Spec, plan, and implementation tasks: `specs/031-github-actions-sha-pin-diagnostic/`.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (3506/3506 passed)
- [x] `cargo doc --no-deps --workspace` with `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links --deny warnings"`
- [x] Unit coverage for every `PinStyle` variant, severity default/override, `TagIndex` cache-miss withholding, quoted-scalar withholding, and independent co-occurrence with the outdated-version diagnostic
- [x] Live-verified against the real GitHub API: diagnostic/quick-fix behavior on a fixture mixing current-tag, stale-tag, SHA-with-comment, and quoted-tag pins
- [x] README.md, `crates/deps-github-actions/README.md`, and `docs/ECOSYSTEM_GUIDE.md` updated

Closes #473