### PR TITLE
fix(deps-core,deps-github-actions,deps-lsp): surface actionable rate-limit hint in registry diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-cargo, deps-lsp**: `cargo.workspace_registries`' `public_only`/`off` now enforced at connect time (resolved address) and on every redirect hop, not just the declared URL string at parse time, closing a DNS-rebinding bypass to RFC1918/CGNAT-range hosts (resolves #455) (#460)
 - **deps-core, deps-lsp**: the OSV vulnerability-fix code action's recommended target version is now independently verified against OSV before being offered, instead of only ever checking the registry's "latest" version (resolves #462) (#467)
 - **deps-github-actions, deps-core**: hover no longer renders a dead empty-URL link or a misleading "Press Cmd+. to update version" footer for a non-resolvable `uses:` ref (local composite action, Docker image) (resolves #474)
+- **deps-core, deps-github-actions, deps-lsp**: a rate-limited GitHub Actions registry lookup now surfaces its actionable hint (e.g. "set GITHUB_TOKEN") in the "Registry lookup failed" diagnostic instead of the generic fallback (resolves #478)
 
 ## [0.11.1] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-cargo, deps-lsp**: `cargo.workspace_registries`' `public_only`/`off` now enforced at connect time (resolved address) and on every redirect hop, not just the declared URL string at parse time, closing a DNS-rebinding bypass to RFC1918/CGNAT-range hosts (resolves #455) (#460)
 - **deps-core, deps-lsp**: the OSV vulnerability-fix code action's recommended target version is now independently verified against OSV before being offered, instead of only ever checking the registry's "latest" version (resolves #462) (#467)
 - **deps-github-actions, deps-core**: hover no longer renders a dead empty-URL link or a misleading "Press Cmd+. to update version" footer for a non-resolvable `uses:` ref (local composite action, Docker image) (resolves #474)
-- **deps-core, deps-github-actions, deps-lsp**: a rate-limited GitHub Actions registry lookup now surfaces its actionable hint (e.g. "set GITHUB_TOKEN") in the "Registry lookup failed" diagnostic instead of the generic fallback (resolves #478)
+- **deps-core, deps-github-actions, deps-lsp**: a rate-limited GitHub Actions registry lookup now surfaces its actionable hint (e.g. "set GITHUB_TOKEN") in the "Registry lookup failed" diagnostic instead of the generic fallback (resolves #478) (#485)
 
 ## [0.11.1] - 2026-09-01
 

--- a/crates/deps-core/src/error.rs
+++ b/crates/deps-core/src/error.rs
@@ -56,6 +56,13 @@ pub enum DepsError {
     #[error("cache error: {0}")]
     CacheError(String),
 
+    /// A registry request was rejected for exceeding a rate limit. Unlike other variants,
+    /// `message` is a pre-vetted, IP-free, actionable hint safe to surface verbatim in a
+    /// per-dependency diagnostic (see [`Self::fetch_failure`]) — never build one from a raw
+    /// registry error body, which can embed the caller's public IP (`github.rs:332-346`).
+    #[error("{message}")]
+    RateLimited { message: String },
+
     #[error("{package} not found on {registry}")]
     PackageNotFound {
         package: String,
@@ -147,6 +154,62 @@ impl DepsError {
             Self::PackageNotFound { .. } | Self::HttpStatus { status: 404, .. }
         )
     }
+
+    /// Classifies this error for the per-dependency "registry lookup failed" diagnostic
+    /// (#478), distinguishing a failure with a safe, actionable hint to show the user from
+    /// one whose raw text must never reach a diagnostic.
+    ///
+    /// **Security-load-bearing invariant**: [`FetchFailure::Actionable`] is produced *only*
+    /// from [`Self::RateLimited`]'s pre-vetted, IP-free canned message. Every other variant
+    /// must classify as [`FetchFailure::Transient`] — never call `.to_string()`/`Display` on
+    /// an arbitrary `DepsError` to build an `Actionable` value, since a raw `HttpStatus` or
+    /// `RegistryError` body can embed the caller's public IP (`github.rs:332-346`, exercised
+    /// by the `github` crate's `test_parse_tags_page_github_rate_limit_returns_error`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use deps_core::error::{DepsError, FetchFailure};
+    ///
+    /// let rate_limited = DepsError::RateLimited { message: "set GITHUB_TOKEN".into() };
+    /// assert_eq!(
+    ///     rate_limited.fetch_failure(),
+    ///     FetchFailure::Actionable("set GITHUB_TOKEN".into())
+    /// );
+    ///
+    /// let other = DepsError::CacheError("connection reset".into());
+    /// assert_eq!(other.fetch_failure(), FetchFailure::Transient);
+    /// ```
+    #[must_use]
+    pub fn fetch_failure(&self) -> FetchFailure {
+        match self {
+            Self::RateLimited { message } => FetchFailure::Actionable(message.clone()),
+            _ => FetchFailure::Transient,
+        }
+    }
+}
+
+/// Outcome of a registry fetch attempt for one dependency, as recorded in
+/// `DocumentState::fetch_failed` and rendered by
+/// [`crate::lsp_helpers::generate_diagnostics_from_cache`] (#478).
+///
+/// Replaces a bare `HashSet<PackageName>` membership check so the per-dependency diagnostic
+/// can distinguish a failure with a safe, user-actionable hint from an opaque one, without
+/// ever threading raw, potentially IP-bearing error text into the diagnostic (see
+/// [`DepsError::fetch_failure`]).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FetchFailure {
+    /// The fetch failed with a pre-vetted, safe-to-display hint (currently only produced
+    /// from [`DepsError::RateLimited`]).
+    Actionable(String),
+    /// The fetch failed for a reason with no safe user-facing detail to show — the
+    /// diagnostic falls back to a generic "lookup failed" message.
+    Transient,
+    /// The dependency was never actually queried (e.g. a name/source collision detected
+    /// before the fetch, see `deps-lsp`'s `dedup_dependencies_by_source`) — renders the
+    /// same generic "lookup failed" message as [`Self::Transient`], since the absence of
+    /// an attempt is not evidence the package doesn't exist.
+    NotAttempted,
 }
 
 /// Convenience type alias for `Result<T, DepsError>`.
@@ -276,6 +339,77 @@ mod tests {
             error
                 .to_string()
                 .starts_with("failed to parse PyPI response for flask:")
+        );
+    }
+
+    /// Exhaustive companion to the doc-test on [`DepsError::fetch_failure`]: every
+    /// variant other than [`DepsError::RateLimited`] must classify as
+    /// [`FetchFailure::Transient`]. This is the invariant the doc comment calls
+    /// security-load-bearing (a future variant wired to `Actionable` by mistake
+    /// could leak raw, potentially IP-bearing error text into a diagnostic), so it
+    /// must be a real test enumerating every variant, not just the 2-variant
+    /// doc-test spot check.
+    #[test]
+    fn test_fetch_failure_classifies_every_non_rate_limited_variant_as_transient() {
+        // A `reqwest::Error` built from an invalid URL — `RequestBuilder::build`
+        // is synchronous and fails on URL parsing alone, so this needs no network
+        // access or async runtime.
+        let reqwest_err = reqwest::Client::new()
+            .get("not a valid url")
+            .build()
+            .unwrap_err();
+        let json_err = serde_json::from_str::<serde_json::Value>("{invalid}").unwrap_err();
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "not found");
+
+        let non_rate_limited = [
+            DepsError::ParseError {
+                file_type: "Cargo.toml".into(),
+                source: Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, "bad")),
+            },
+            DepsError::RegistryError {
+                package: "flask".into(),
+                source: reqwest_err,
+            },
+            DepsError::CacheError("connection reset".into()),
+            DepsError::PackageNotFound {
+                package: "flask".into(),
+                registry: "PyPI",
+            },
+            DepsError::HttpStatus {
+                url: "https://example.com".into(),
+                status: 500,
+            },
+            DepsError::ApiResponse {
+                package: "flask".into(),
+                registry: "PyPI",
+                source: json_err,
+            },
+            DepsError::ResponseTooLarge {
+                url: "https://example.com".into(),
+                limit: 1024,
+            },
+            DepsError::InvalidVersionReq("bad range".into()),
+            DepsError::Io(io_err),
+            DepsError::Json(serde_json::from_str::<serde_json::Value>("{bad}").unwrap_err()),
+            DepsError::UnsupportedEcosystem("unknown".into()),
+            DepsError::AmbiguousEcosystem("file.txt".into()),
+            DepsError::InvalidUri("not a uri".into()),
+        ];
+
+        for error in non_rate_limited {
+            assert_eq!(
+                error.fetch_failure(),
+                FetchFailure::Transient,
+                "expected Transient for {error:?}"
+            );
+        }
+
+        let rate_limited = DepsError::RateLimited {
+            message: "set GITHUB_TOKEN to increase the rate limit".into(),
+        };
+        assert_eq!(
+            rate_limited.fetch_failure(),
+            FetchFailure::Actionable("set GITHUB_TOKEN to increase the rate limit".into())
         );
     }
 }

--- a/crates/deps-core/src/github.rs
+++ b/crates/deps-core/src/github.rs
@@ -103,11 +103,11 @@ pub fn validate_owner_repo(name: &str) -> Result<()> {
 /// (60 req/h per IP, vs 5000 req/h with a token).
 #[must_use]
 pub fn github_rate_limit_error() -> DepsError {
-    DepsError::CacheError(
-        "GitHub API rate limit exceeded. Set GITHUB_TOKEN to increase the limit (5000 req/h). \
-         Run: export GITHUB_TOKEN=$(gh auth token)"
+    DepsError::RateLimited {
+        message: "GitHub API rate limit exceeded. Set GITHUB_TOKEN to increase the limit \
+                   (5000 req/h). Run: export GITHUB_TOKEN=$(gh auth token)"
             .into(),
-    )
+    }
 }
 
 /// Shared cache, auth-header, and API-base state for a GitHub-tags-backed registry client.

--- a/crates/deps-core/src/lib.rs
+++ b/crates/deps-core/src/lib.rs
@@ -33,7 +33,7 @@ pub mod version_matcher;
 pub use cache::{BodyLimit, CachedResponse, HttpCache};
 pub use ecosystem::{Dependency, Ecosystem, EcosystemConfig, EcosystemId, ParseResult};
 pub use ecosystem_registry::EcosystemRegistry;
-pub use error::{DepsError, Result};
+pub use error::{DepsError, FetchFailure, Result};
 pub use freshness::{
     DEFAULT_COOLDOWN_SECS, FreshnessSettings, PublishTime, format_relative_age, is_within_cooldown,
 };

--- a/crates/deps-core/src/lsp_helpers/diagnostics.rs
+++ b/crates/deps-core/src/lsp_helpers/diagnostics.rs
@@ -4,8 +4,8 @@ use tower_lsp_server::ls_types::{
 
 use crate::osv::{ScanOutcome, diagnostic_severity_for};
 use crate::{
-    ConcreteVersion, Dependency, Deprecation, ParseResult, PublishTime, RemovalStatus, VersionReq,
-    format_relative_age, is_within_cooldown,
+    ConcreteVersion, Dependency, Deprecation, FetchFailure, ParseResult, PublishTime,
+    RemovalStatus, VersionReq, format_relative_age, is_within_cooldown,
 };
 
 use super::{EcosystemFormatter, RequirementMatcher, RequirementStatus, VersionData};
@@ -672,20 +672,32 @@ pub fn generate_diagnostics_from_cache(
                 // distinctly from a genuine "not found" so a transient registry
                 // outage or a malformed response (e.g. unparseable
                 // maven-metadata.xml) doesn't masquerade as "Unknown package".
-                let fetch_failed = formatter.can_resolve_source(&dep.source())
-                    && versions
-                        .fetch_failed
-                        .is_some_and(|f| f.contains(normalized_name.as_str()));
+                let fetch_failure = formatter
+                    .can_resolve_source(&dep.source())
+                    .then(|| {
+                        versions
+                            .fetch_failed
+                            .and_then(|f| f.get(normalized_name.as_str()))
+                    })
+                    .flatten();
                 let message = match formatter.validate_package_name(dep.name().as_str()) {
                     Err(reason) => Some(format!("Invalid package name '{}': {reason}", dep.name())),
-                    Ok(()) if fetch_failed => Some(format!(
-                        "Registry lookup failed for '{}'; package status could not be determined",
-                        dep.name()
-                    )),
-                    Ok(()) if formatter.can_resolve_source(&dep.source()) => {
-                        Some(format!("Unknown package '{}'", dep.name()))
-                    }
-                    Ok(()) => None,
+                    Ok(()) => match fetch_failure {
+                        Some(FetchFailure::Actionable(hint)) => Some(format!(
+                            "Registry lookup failed for '{}': {hint}",
+                            dep.name()
+                        )),
+                        Some(FetchFailure::Transient | FetchFailure::NotAttempted) => {
+                            Some(format!(
+                                "Registry lookup failed for '{}'; package status could not be \
+                             determined",
+                                dep.name()
+                            ))
+                        }
+                        None => formatter
+                            .can_resolve_source(&dep.source())
+                            .then(|| format!("Unknown package '{}'", dep.name())),
+                    },
                 };
                 if let Some(message) = message {
                     diagnostics.push(Diagnostic {
@@ -942,7 +954,7 @@ mod tests {
     use crate::lsp_helpers::*;
     use crate::{PackageName, VersionReq};
 
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     #[test]
@@ -1173,7 +1185,7 @@ mod tests {
 
         let cached_versions = HashMap::new();
         let resolved_versions = HashMap::new();
-        let fetch_failed = HashSet::from(["flaky-pkg".to_string()]);
+        let fetch_failed = HashMap::from([("flaky-pkg".to_string(), FetchFailure::Transient)]);
 
         let diagnostics = generate_diagnostics_from_cache(
             &parse_result,
@@ -1188,6 +1200,137 @@ mod tests {
         assert!(!diagnostics[0].message.contains("Unknown package"));
         assert!(diagnostics[0].message.contains("Registry lookup failed"));
         assert!(diagnostics[0].message.contains("flaky-pkg"));
+    }
+
+    #[test]
+    fn test_generate_diagnostics_from_cache_fetch_failed_actionable_shows_hint() {
+        use std::collections::HashMap;
+        use tower_lsp_server::ls_types::{Position, Range};
+
+        // #478: an `Actionable` fetch failure must surface its pre-vetted hint
+        // text in the diagnostic, not the generic fallback.
+        let formatter = MockFormatter;
+
+        let parse_result = MockParseResult {
+            deps: vec![MockDep {
+                name: "rate-limited-pkg".into(),
+                version_req: "1.0.0".into(),
+                version_range: Range::new(Position::new(0, 10), Position::new(0, 20)),
+                name_range: Range::new(Position::new(0, 0), Position::new(0, 16)),
+            }],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+
+        let cached_versions = HashMap::new();
+        let resolved_versions = HashMap::new();
+        let fetch_failed = HashMap::from([(
+            "rate-limited-pkg".to_string(),
+            FetchFailure::Actionable("set GITHUB_TOKEN to increase the rate limit".to_string()),
+        )]);
+
+        let diagnostics = generate_diagnostics_from_cache(
+            &parse_result,
+            VersionData::new(&cached_versions, &resolved_versions).with_fetch_failed(&fetch_failed),
+            &formatter,
+            crate::freshness::FreshnessSettings::default(),
+            DiagnosticSeverities::default(),
+            PublishTime::now(),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert!(!diagnostics[0].message.contains("Unknown package"));
+        assert!(
+            diagnostics[0]
+                .message
+                .contains("set GITHUB_TOKEN to increase the rate limit")
+        );
+        assert!(diagnostics[0].message.contains("rate-limited-pkg"));
+    }
+
+    #[test]
+    fn test_generate_diagnostics_from_cache_fetch_failed_transient_shows_generic_message() {
+        use std::collections::HashMap;
+        use tower_lsp_server::ls_types::{Position, Range};
+
+        // A `Transient` fetch failure has no safe detail to show, so it must
+        // fall back to the generic "package status could not be determined"
+        // message rather than leak anything failure-specific.
+        let formatter = MockFormatter;
+
+        let parse_result = MockParseResult {
+            deps: vec![MockDep {
+                name: "transient-pkg".into(),
+                version_req: "1.0.0".into(),
+                version_range: Range::new(Position::new(0, 10), Position::new(0, 20)),
+                name_range: Range::new(Position::new(0, 0), Position::new(0, 13)),
+            }],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+
+        let cached_versions = HashMap::new();
+        let resolved_versions = HashMap::new();
+        let fetch_failed = HashMap::from([("transient-pkg".to_string(), FetchFailure::Transient)]);
+
+        let diagnostics = generate_diagnostics_from_cache(
+            &parse_result,
+            VersionData::new(&cached_versions, &resolved_versions).with_fetch_failed(&fetch_failed),
+            &formatter,
+            crate::freshness::FreshnessSettings::default(),
+            DiagnosticSeverities::default(),
+            PublishTime::now(),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert!(!diagnostics[0].message.contains("Unknown package"));
+        assert!(
+            diagnostics[0]
+                .message
+                .contains("package status could not be determined")
+        );
+    }
+
+    #[test]
+    fn test_generate_diagnostics_from_cache_fetch_failed_not_attempted_shows_generic_message() {
+        use std::collections::HashMap;
+        use tower_lsp_server::ls_types::{Position, Range};
+
+        // #478 fix (impl-critic S1): `NotAttempted` (a source-collided
+        // dependency that was deliberately never queried) must render the
+        // SAME generic message as `Transient`, never "Unknown package" — the
+        // dependency's non-fetch is not evidence it doesn't exist.
+        let formatter = MockFormatter;
+
+        let parse_result = MockParseResult {
+            deps: vec![MockDep {
+                name: "collided-pkg".into(),
+                version_req: "1.0.0".into(),
+                version_range: Range::new(Position::new(0, 10), Position::new(0, 20)),
+                name_range: Range::new(Position::new(0, 0), Position::new(0, 12)),
+            }],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+
+        let cached_versions = HashMap::new();
+        let resolved_versions = HashMap::new();
+        let fetch_failed =
+            HashMap::from([("collided-pkg".to_string(), FetchFailure::NotAttempted)]);
+
+        let diagnostics = generate_diagnostics_from_cache(
+            &parse_result,
+            VersionData::new(&cached_versions, &resolved_versions).with_fetch_failed(&fetch_failed),
+            &formatter,
+            crate::freshness::FreshnessSettings::default(),
+            DiagnosticSeverities::default(),
+            PublishTime::now(),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert!(!diagnostics[0].message.contains("Unknown package"));
+        assert!(
+            diagnostics[0]
+                .message
+                .contains("package status could not be determined")
+        );
     }
 
     #[test]
@@ -1212,7 +1355,7 @@ mod tests {
 
         let cached_versions = HashMap::new();
         let resolved_versions = HashMap::new();
-        let fetch_failed = HashSet::from(["bad name".to_string()]);
+        let fetch_failed = HashMap::from([("bad name".to_string(), FetchFailure::Transient)]);
 
         let diagnostics = generate_diagnostics_from_cache(
             &parse_result,

--- a/crates/deps-core/src/lsp_helpers/mod.rs
+++ b/crates/deps-core/src/lsp_helpers/mod.rs
@@ -1,13 +1,13 @@
 //! Shared LSP response builders.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tower_lsp_server::ls_types::{Position, Range, TextEdit, Uri};
 
 use crate::osv::VulnerabilityMap;
 use crate::{
-    ConcreteVersion, Dependency, Deprecation, EcosystemId, InvalidPackageName, PackageName,
-    RemovalStatus, VersionReq,
+    ConcreteVersion, Dependency, Deprecation, EcosystemId, FetchFailure, InvalidPackageName,
+    PackageName, RemovalStatus, VersionReq,
 };
 
 mod code_actions;
@@ -201,7 +201,7 @@ pub struct VersionData<'a> {
     /// couldn't be asked" (#267) — a `cached` miss alone conflates both into
     /// a misleading "Unknown package" diagnostic. `None` when no fetch has
     /// run yet, same convention as [`Self::yanked`].
-    pub fetch_failed: Option<&'a HashSet<String>>,
+    pub fetch_failed: Option<&'a HashMap<String, FetchFailure>>,
     /// This document's ecosystem, when the caller has one to give. `None` in
     /// most test fixtures and a handful of ecosystem-crate self-tests that
     /// predate this field.
@@ -323,16 +323,16 @@ impl<'a> VersionData<'a> {
     ///
     /// ```
     /// use deps_core::VersionData;
-    /// use std::collections::{HashMap, HashSet};
+    /// use std::collections::HashMap;
     ///
     /// let cached = HashMap::new();
     /// let resolved = HashMap::new();
-    /// let fetch_failed = HashSet::new();
+    /// let fetch_failed = HashMap::new();
     /// let versions = VersionData::new(&cached, &resolved).with_fetch_failed(&fetch_failed);
     /// assert!(versions.fetch_failed.is_some());
     /// ```
     #[must_use]
-    pub fn with_fetch_failed(mut self, fetch_failed: &'a HashSet<String>) -> Self {
+    pub fn with_fetch_failed(mut self, fetch_failed: &'a HashMap<String, FetchFailure>) -> Self {
         self.fetch_failed = Some(fetch_failed);
         self
     }

--- a/crates/deps-github-actions/src/registry.rs
+++ b/crates/deps-github-actions/src/registry.rs
@@ -587,7 +587,34 @@ mod tests {
 
         let registry = mock_registry(&server.url(), false);
         let err = registry.get_versions("owner/repo").await.unwrap_err();
+        // Guards the variant itself (#478), not just the rendered text: a
+        // regression that left the old, differently-classified error type in
+        // place while keeping "GITHUB_TOKEN" in its `Display` text would pass
+        // a `to_string().contains(...)` check but must fail here.
+        assert!(
+            matches!(err, DepsError::RateLimited { .. }),
+            "expected DepsError::RateLimited, got {err:?}"
+        );
         assert!(err.to_string().contains("GITHUB_TOKEN"));
+
+        // Trace the real production error all the way to the diagnostic-facing
+        // classification: a rate-limited fetch must become an `Actionable`
+        // `FetchFailure` carrying the same hint, never `Transient`.
+        let failure = err.fetch_failure();
+        assert!(
+            matches!(&failure, deps_core::error::FetchFailure::Actionable(hint) if hint.contains("GITHUB_TOKEN")),
+            "expected Actionable hint mentioning GITHUB_TOKEN, got {failure:?}"
+        );
+
+        // And through the same `HashMap<String, FetchFailure>` shape
+        // `deps-lsp`'s document lifecycle threads into
+        // `generate_diagnostics_from_cache`.
+        let fetch_failed: HashMap<String, deps_core::error::FetchFailure> =
+            HashMap::from([("owner/repo".to_string(), failure)]);
+        assert!(matches!(
+            fetch_failed.get("owner/repo"),
+            Some(deps_core::error::FetchFailure::Actionable(_))
+        ));
     }
 
     #[tokio::test]

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -12,6 +12,7 @@ use deps_core::ConcreteVersion;
 use deps_core::Deprecation;
 use deps_core::Ecosystem;
 use deps_core::EcosystemId;
+use deps_core::FetchFailure;
 use deps_core::PackageName;
 use deps_core::PackageVersions;
 use deps_core::Registry;
@@ -978,7 +979,7 @@ struct FetchResult {
     /// Lets diagnostic generation (#267) distinguish "the registry said this
     /// package doesn't exist" from "the registry couldn't be asked" instead
     /// of conflating both into a misleading "Unknown package" diagnostic.
-    fetch_failed: HashSet<PackageName>,
+    fetch_failed: HashMap<PackageName, FetchFailure>,
     /// Number of packages that failed to fetch (timeout or error)
     failed_count: usize,
     /// First actionable error message (shown to user via `window/showMessage`)
@@ -1080,7 +1081,7 @@ async fn fetch_latest_versions_parallel(
                 .await;
 
                 let mut yanked: Option<(PackageName, ConcreteVersion, RemovalStatus)> = None;
-                let mut failed_name: Option<PackageName> = None;
+                let mut failed_name: Option<(PackageName, FetchFailure)> = None;
                 let mut deprecation: Option<(PackageName, Deprecation)> = None;
                 let version = match result {
                     Ok(Ok(versions)) => {
@@ -1191,7 +1192,7 @@ async fn fetch_latest_versions_parallel(
                                     // package") is not a fetch failure — only
                                     // an unanswerable request is (#267 C1).
                                     if !e.is_not_found() {
-                                        failed_name = Some(name.clone());
+                                        failed_name = Some((name.clone(), e.fetch_failure()));
                                     }
                                     None
                                 }
@@ -1202,7 +1203,7 @@ async fn fetch_latest_versions_parallel(
                                         timeout.as_secs()
                                     );
                                     failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                    failed_name = Some(name.clone());
+                                    failed_name = Some((name.clone(), FetchFailure::Transient));
                                     None
                                 }
                             }
@@ -1300,14 +1301,14 @@ async fn fetch_latest_versions_parallel(
                         // instead of "Unknown package", inverting the bug
                         // this field exists to fix.
                         if !e.is_not_found() {
-                            failed_name = Some(name.clone());
+                            failed_name = Some((name.clone(), e.fetch_failure()));
                         }
                         None
                     }
                     Err(_) => {
                         tracing::warn!(package = %name, "fetch timed out ({}s)", timeout.as_secs());
                         failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        failed_name = Some(name.clone());
+                        failed_name = Some((name.clone(), FetchFailure::Transient));
                         None
                     }
                 };
@@ -1326,7 +1327,7 @@ async fn fetch_latest_versions_parallel(
 
     let mut versions = HashMap::with_capacity(results.len());
     let mut yanked_versions = HashMap::new();
-    let mut fetch_failed = HashSet::new();
+    let mut fetch_failed = HashMap::new();
     let mut deprecations = HashMap::new();
     for (version, yanked, failed_name, deprecation) in results {
         if let Some((name, v)) = version {
@@ -1335,8 +1336,8 @@ async fn fetch_latest_versions_parallel(
         if let Some((name, v, status)) = yanked {
             yanked_versions.insert(name, (v, status));
         }
-        if let Some(name) = failed_name {
-            fetch_failed.insert(name);
+        if let Some((name, failure)) = failed_name {
+            fetch_failed.insert(name, failure);
         }
         if let Some((name, d)) = deprecation {
             deprecations.insert(name, d);
@@ -1584,15 +1585,23 @@ pub async fn handle_document_open(
             // `collided_names` (spec FR-011) are merged in alongside genuine fetch
             // failures so `generate_diagnostics_from_cache` reports "lookup could not
             // be determined" rather than a false "Unknown package" for a name that
-            // was deliberately never queried, not one that doesn't exist.
-            doc.update_fetch_failed(
-                fetch_result
+            // was deliberately never queried, not one that doesn't exist. Genuine
+            // failures are inserted first and `collided_names` uses `or_insert` so a
+            // collided name that normalizes to the same key as a genuine
+            // `Actionable`/`Transient` failure never clobbers it (impl-critic M2).
+            doc.update_fetch_failed({
+                let mut fetch_failed: HashMap<String, FetchFailure> = fetch_result
                     .fetch_failed
                     .into_iter()
-                    .chain(collided_names)
-                    .map(|name| formatter.normalize_package_name(&name))
-                    .collect(),
-            );
+                    .map(|(name, failure)| (formatter.normalize_package_name(&name), failure))
+                    .collect();
+                for name in collided_names {
+                    fetch_failed
+                        .entry(formatter.normalize_package_name(&name))
+                        .or_insert(FetchFailure::NotAttempted);
+                }
+                fetch_failed
+            });
             if success {
                 doc.set_loaded();
             } else {
@@ -1984,9 +1993,17 @@ pub async fn handle_document_change(
                 doc.yanked_versions
                     .insert(formatter.normalize_package_name(&name), version);
             }
-            for name in fetch_result.fetch_failed.into_iter().chain(collided_names) {
+            for (name, failure) in fetch_result.fetch_failed {
                 doc.fetch_failed
-                    .insert(formatter.normalize_package_name(&name));
+                    .insert(formatter.normalize_package_name(&name), failure);
+            }
+            // `or_insert` (not `insert`): a collided name normalizing to the same key
+            // as a genuine failure just recorded above must not clobber it
+            // (impl-critic M2).
+            for name in collided_names {
+                doc.fetch_failed
+                    .entry(formatter.normalize_package_name(&name))
+                    .or_insert(FetchFailure::NotAttempted);
             }
             merge_deprecations_after_fetch(
                 &mut doc,
@@ -2602,7 +2619,7 @@ mod tests {
         // be recorded the same way as a hard registry error.
         assert_eq!(
             result.fetch_failed,
-            HashSet::from([PackageName::new("slow-package")]),
+            HashMap::from([(PackageName::new("slow-package"), FetchFailure::Transient)]),
             "timed-out package must be recorded in fetch_failed"
         );
     }
@@ -3729,10 +3746,10 @@ mod tests {
         // "genuinely not found" instead of reporting "Unknown package".
         assert_eq!(
             result.fetch_failed,
-            HashSet::from([
-                PackageName::new("package-1"),
-                PackageName::new("package-2"),
-                PackageName::new("package-3"),
+            HashMap::from([
+                (PackageName::new("package-1"), FetchFailure::Transient),
+                (PackageName::new("package-2"), FetchFailure::Transient),
+                (PackageName::new("package-3"), FetchFailure::Transient),
             ]),
             "every errored package must be recorded in fetch_failed"
         );
@@ -3968,7 +3985,7 @@ mod tests {
         assert!(result.versions.is_empty());
         assert_eq!(
             result.fetch_failed,
-            HashSet::from([PackageName::new("flaky")]),
+            HashMap::from([(PackageName::new("flaky"), FetchFailure::Transient)]),
             "the fallback's own non-not-found error must be recorded in fetch_failed, \
              but its not-found error must not"
         );
@@ -4043,7 +4060,7 @@ mod tests {
         assert!(result.versions.is_empty());
         assert_eq!(
             result.fetch_failed,
-            HashSet::from([PackageName::new("slow-fallback")])
+            HashMap::from([(PackageName::new("slow-fallback"), FetchFailure::Transient)])
         );
         assert_eq!(result.failed_count, 1);
     }
@@ -5587,7 +5604,10 @@ time = "0.1.43"
 
             {
                 let mut doc = state.documents.get_mut(&uri).unwrap();
-                doc.update_fetch_failed(HashSet::from(["time".to_string()]));
+                doc.update_fetch_failed(HashMap::from([(
+                    "time".to_string(),
+                    FetchFailure::Transient,
+                )]));
             }
 
             let content2 = r#"[dependencies]
@@ -5618,7 +5638,7 @@ serde = "1.0"
             // carries `fetch_failed` across the edit, not just the final
             // (already-pruned) state below.
             assert!(
-                doc_state2.fetch_failed.contains("time"),
+                doc_state2.fetch_failed.contains_key("time"),
                 "preserve_cache must carry fetch_failed across an edit"
             );
 
@@ -5633,7 +5653,7 @@ serde = "1.0"
 
             let doc = state.get_document(&uri).unwrap();
             assert!(
-                !doc.fetch_failed.contains("time"),
+                !doc.fetch_failed.contains_key("time"),
                 "removed dependency's fetch_failed entry must be pruned"
             );
         }

--- a/crates/deps-lsp/src/document/state.rs
+++ b/crates/deps-lsp/src/document/state.rs
@@ -4,10 +4,10 @@ use deps_core::lockfile::LockFileCache;
 use deps_core::net_policy::RegistryAccessPolicy;
 use deps_core::osv::{OsvClient, VulnerabilityMap};
 use deps_core::{
-    ConcreteVersion, Deprecation, EcosystemId, EcosystemRegistry, PackageName, PackageVersions,
-    ParseResult, RemovalStatus,
+    ConcreteVersion, Deprecation, EcosystemId, EcosystemRegistry, FetchFailure, PackageName,
+    PackageVersions, ParseResult, RemovalStatus,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
@@ -79,7 +79,7 @@ pub struct DocumentState {
     /// outage isn't reported as "Unknown package". Cleared and repopulated by
     /// each fetch cycle; carried across document edits by `preserve_cache` so
     /// it doesn't flicker off on every keystroke, same as `yanked_versions`.
-    pub fetch_failed: HashSet<String>,
+    pub fetch_failed: HashMap<String, FetchFailure>,
     /// Last successful parse time
     pub parsed_at: Instant,
     /// Current loading state for registry data
@@ -235,7 +235,7 @@ impl DocumentState {
             vulnerabilities: VulnerabilityMap::new(),
             yanked_versions: HashMap::new(),
             deprecations: HashMap::new(),
-            fetch_failed: HashSet::new(),
+            fetch_failed: HashMap::new(),
             parsed_at: Instant::now(),
             loading_state: LoadingState::Idle,
             loading_started_at: None,
@@ -257,7 +257,7 @@ impl DocumentState {
             vulnerabilities: VulnerabilityMap::new(),
             yanked_versions: HashMap::new(),
             deprecations: HashMap::new(),
-            fetch_failed: HashSet::new(),
+            fetch_failed: HashMap::new(),
             parsed_at: Instant::now(),
             loading_state: LoadingState::Idle,
             loading_started_at: None,
@@ -318,7 +318,7 @@ impl DocumentState {
 
     /// Replaces the set of packages whose registry fetch errored or timed out
     /// (normalized-keyed, see [`Self::fetch_failed`]).
-    pub fn update_fetch_failed(&mut self, fetch_failed: HashSet<String>) {
+    pub fn update_fetch_failed(&mut self, fetch_failed: HashMap<String, FetchFailure>) {
         self.fetch_failed = fetch_failed;
     }
 


### PR DESCRIPTION
## Summary

- Opening a manifest with GitHub Actions dependencies (e.g. `.github/workflows/ci.yml`) under an unauthenticated GitHub API rate limit showed a generic "Registry lookup failed... package status could not be determined" diagnostic for every dependency, even though the server already computed the actionable remedy ("set GITHUB_TOKEN") and fired it once via a toast.
- Root cause: the per-dependency diagnostic only tracked failed package names (`HashSet<String>`), with no error detail, so it always fell back to the generic text. This was systemic in `deps-core`, applying to any non-not-found registry error across all supported ecosystems.
- Adds `DepsError::RateLimited { message }` (replacing a prior misuse of `DepsError::CacheError` as a string carrier) and a `FetchFailure { Actionable(String), Transient, NotAttempted }` classifier, then threads it through the `fetch_failed` carrier (`HashSet<String>` -> `HashMap<String, FetchFailure>`) in `deps-core` and `deps-lsp` so the specific hint reaches the inline diagnostic.
- Security-critical invariant: `Actionable` diagnostic text is produced only from `RateLimited`'s pre-vetted, canned message — never from `Display`/`to_string()` on any other error variant, since GitHub's raw rate-limit error body can embed the caller's public IP address.
- Fixed a regression caught during review: a source-collided dependency (`FetchFailure::NotAttempted`) was rendering a false "Unknown package" instead of the previous, correct generic fallback text.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (3510 passed)
- [x] `cargo test --doc --workspace --all-features`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New unit tests cover: `Actionable`/`Transient`/`NotAttempted` diagnostic rendering, an exhaustive `DepsError::fetch_failure()` classifier test over all non-`RateLimited` variants, and an end-to-end trace of a real `DepsError::RateLimited` through to the diagnostic carrier

Closes #478