### PR TITLE
fix(deps-lsp,deps-core): dominant-failure toast and collapsed fetch-failure diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-swift, deps-github-actions**: extracted the duplicated GitHub tags-API client (owner/repo validation, auth-header setup, tags pagination, page parsing) into a shared `deps_core::github` module; no external behavior change (resolves #472) (#476)
 - **Breaking (pre-1.0, public API)**: `deps-core`'s `GithubTagsClient::headers()` is now crate-private; authenticated GitHub requests go through the new `fetch_authenticated` method (trusted-origin-pinned), and the auth token is wrapped in a redacting `AuthToken` type that never leaks via `Debug`/`Display` (resolves #484) (#487)
 - **Breaking (pre-1.0, public API)**: `deps-core`, `deps-lsp` consolidate the yanked/deprecation/fetch-failure maps into one `DependencyOutcome`/`DependencyOutcomes` type; `VersionData`'s three `with_yanked`/`with_deprecations`/`with_fetch_failed` builders and fields collapse into `with_outcomes`/`outcomes`, removing triplicated re-keying and pruning logic (resolves #481) (#488)
+- **Breaking (pre-1.0, public API)**: `deps_core::lsp_helpers::generate_diagnostics_from_cache` gained a required `uri: &Uri` parameter, used to anchor `DiagnosticRelatedInformation` locations for collapsed fetch-failure diagnostics (resolves #479) (#489)
 
 ### Fixed
 - **deps-github-actions**: a tags-API page with one entry missing/malformed `commit.sha` no longer aborts the whole page's parse and silently truncates later pages — only that entry is now skipped (side effect of the #472 GitHub-tags-client extraction) (#476)
@@ -39,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-lsp**: the OSV vulnerability-fix code action's recommended target version is now independently verified against OSV before being offered, instead of only ever checking the registry's "latest" version (resolves #462) (#467)
 - **deps-github-actions, deps-core**: hover no longer renders a dead empty-URL link or a misleading "Press Cmd+. to update version" footer for a non-resolvable `uses:` ref (local composite action, Docker image) (resolves #474)
 - **deps-core, deps-github-actions, deps-lsp**: a rate-limited GitHub Actions registry lookup now surfaces its actionable hint (e.g. "set GITHUB_TOKEN") in the "Registry lookup failed" diagnostic instead of the generic fallback (resolves #478) (#485)
+- **deps-lsp**: the one-shot "failed to fetch" toast no longer reports a not-found race winner over a co-occurring actionable failure (e.g. rate limit) in the same batch, and now always states the affected package count (resolves #480)
+- **deps-core, deps-github-actions**: a tripped rate-limit gate no longer fans out one near-duplicate diagnostic per remaining dependency; fetch failures now collapse into a single diagnostic per manifest, naming every affected dependency via related information (resolves #479)
 
 ## [0.11.1] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-lsp**: the OSV vulnerability-fix code action's recommended target version is now independently verified against OSV before being offered, instead of only ever checking the registry's "latest" version (resolves #462) (#467)
 - **deps-github-actions, deps-core**: hover no longer renders a dead empty-URL link or a misleading "Press Cmd+. to update version" footer for a non-resolvable `uses:` ref (local composite action, Docker image) (resolves #474)
 - **deps-core, deps-github-actions, deps-lsp**: a rate-limited GitHub Actions registry lookup now surfaces its actionable hint (e.g. "set GITHUB_TOKEN") in the "Registry lookup failed" diagnostic instead of the generic fallback (resolves #478) (#485)
-- **deps-lsp**: the one-shot "failed to fetch" toast no longer reports a not-found race winner over a co-occurring actionable failure (e.g. rate limit) in the same batch, and now always states the affected package count (resolves #480)
-- **deps-core, deps-github-actions**: a tripped rate-limit gate no longer fans out one near-duplicate diagnostic per remaining dependency; fetch failures now collapse into a single diagnostic per manifest, naming every affected dependency via related information (resolves #479)
+- **deps-lsp**: the one-shot "failed to fetch" toast no longer reports a not-found race winner over a co-occurring actionable failure (e.g. rate limit) in the same batch, and now always states the affected package count (resolves #480) (#489)
+- **deps-core, deps-github-actions**: a tripped rate-limit gate no longer fans out one near-duplicate diagnostic per remaining dependency; fetch failures now collapse into a single diagnostic per manifest, naming every affected dependency via related information and still surfacing a shared actionable hint when one applies (resolves #479) (#489)
 
 ## [0.11.1] - 2026-09-01
 

--- a/crates/deps-core/src/ecosystem.rs
+++ b/crates/deps-core/src/ecosystem.rs
@@ -569,7 +569,7 @@ pub trait Ecosystem: Send + Sync + private::Sealed {
         &'a self,
         parse_result: &'a dyn ParseResult,
         versions: VersionData<'a>,
-        _uri: &'a Uri,
+        uri: &'a Uri,
         freshness: crate::freshness::FreshnessSettings,
         severities: crate::lsp_helpers::DiagnosticSeverities,
     ) -> BoxFuture<'a, Vec<Diagnostic>> {
@@ -578,6 +578,7 @@ pub trait Ecosystem: Send + Sync + private::Sealed {
                 parse_result,
                 versions,
                 self.formatter(),
+                uri,
                 freshness,
                 severities,
                 crate::freshness::PublishTime::now(),

--- a/crates/deps-core/src/lsp_helpers/code_lenses.rs
+++ b/crates/deps-core/src/lsp_helpers/code_lenses.rs
@@ -918,6 +918,7 @@ mod tests {
                 &pr,
                 versions,
                 &MockFormatter,
+                pr.uri(),
                 crate::FreshnessSettings::default(),
                 DiagnosticSeverities::default(),
                 PublishTime::now(),

--- a/crates/deps-core/src/lsp_helpers/diagnostics.rs
+++ b/crates/deps-core/src/lsp_helpers/diagnostics.rs
@@ -1,5 +1,6 @@
 use tower_lsp_server::ls_types::{
-    CodeDescription, Diagnostic, DiagnosticSeverity, NumberOrString, Uri,
+    CodeDescription, Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, Location,
+    NumberOrString, Uri,
 };
 
 use crate::osv::{ScanOutcome, diagnostic_severity_for};
@@ -471,6 +472,10 @@ fn requirement_matches_only_yanked(
 /// * `parse_result` - Parsed dependencies from manifest
 /// * `versions` - Latest (registry) and resolved (lock file) version maps, keyed by package name
 /// * `formatter` - Ecosystem-specific formatting and comparison logic
+/// * `uri` - Document URI, used only to anchor the [`Location`] of any
+///   [`DiagnosticRelatedInformation`] entries attached to a collapsed fetch-failure
+///   diagnostic (#479/#480 S2) — every other diagnostic here is scoped to the document
+///   it's published under implicitly and doesn't need it
 /// * `freshness` - Whether to differentiate an "outdated" diagnostic still within the
 ///   release cooldown window (severity is unaffected either way — see the "Newer version
 ///   available" message below)
@@ -483,12 +488,20 @@ pub fn generate_diagnostics_from_cache(
     parse_result: &dyn ParseResult,
     versions: VersionData<'_>,
     formatter: &dyn EcosystemFormatter,
+    uri: &Uri,
     freshness: crate::freshness::FreshnessSettings,
     severities: DiagnosticSeverities,
     now: PublishTime,
 ) -> Vec<Diagnostic> {
     let deps = parse_result.dependencies();
     let mut diagnostics = Vec::with_capacity(deps.len());
+    // Collected separately from `diagnostics`: buffered here so 2+ near-identical
+    // fetch failures collapse into one diagnostic instead of fanning out — but each
+    // entry keeps its own name, built message, and classification, since the
+    // collapse still needs to name every affected dependency (via
+    // `related_information`) and must never silently drop an `Actionable` hint
+    // (#478/#485's whole point) just because #479's collapse kicked in.
+    let mut fetch_failed_diagnostics: Vec<(String, Diagnostic, Option<FetchFailure>)> = Vec::new();
 
     // #443/plan-1b §1.7: a registry index blocked by `cargo.workspace_registries` must not
     // degrade silently — surface it as an informational diagnostic on the dependency's own
@@ -676,7 +689,7 @@ pub fn generate_diagnostics_from_cache(
                 // distinctly from a genuine "not found" so a transient registry
                 // outage or a malformed response (e.g. unparseable
                 // maven-metadata.xml) doesn't masquerade as "Unknown package".
-                let fetch_failure = formatter
+                let fetch_failure: Option<&FetchFailure> = formatter
                     .can_resolve_source(&dep.source())
                     .then(|| {
                         versions
@@ -684,33 +697,56 @@ pub fn generate_diagnostics_from_cache(
                             .and_then(|o| o.fetch_failure(normalized_name.as_str()))
                     })
                     .flatten();
-                let message = match formatter.validate_package_name(dep.name().as_str()) {
-                    Err(reason) => Some(format!("Invalid package name '{}': {reason}", dep.name())),
-                    Ok(()) => match fetch_failure {
-                        Some(FetchFailure::Actionable(hint)) => Some(format!(
-                            "Registry lookup failed for '{}': {hint}",
-                            dep.name()
-                        )),
-                        Some(FetchFailure::Transient | FetchFailure::NotAttempted) => {
-                            Some(format!(
-                                "Registry lookup failed for '{}'; package status could not be \
-                             determined",
-                                dep.name()
-                            ))
-                        }
-                        None => formatter
-                            .can_resolve_source(&dep.source())
-                            .then(|| format!("Unknown package '{}'", dep.name())),
-                    },
-                };
-                if let Some(message) = message {
-                    diagnostics.push(Diagnostic {
-                        range: dep.name_range(),
-                        severity: Some(severities.unknown),
-                        message,
-                        source: Some("deps-lsp".into()),
-                        ..Default::default()
-                    });
+                match formatter.validate_package_name(dep.name().as_str()) {
+                    Err(reason) => {
+                        diagnostics.push(Diagnostic {
+                            range: dep.name_range(),
+                            severity: Some(severities.unknown),
+                            message: format!("Invalid package name '{}': {reason}", dep.name()),
+                            source: Some("deps-lsp".into()),
+                            ..Default::default()
+                        });
+                    }
+                    // Deferred to `fetch_failed_diagnostics` (collapsed below the main
+                    // loop) rather than pushed inline like the other two arms: a fetch
+                    // failure is a registry-wide condition that can hit many
+                    // dependencies identically, so it is worth collapsing into one
+                    // diagnostic when it does (#479) — without ever dropping a
+                    // per-dependency `Actionable` hint (#478/#485).
+                    Ok(()) if fetch_failure.is_some() => {
+                        let message = match fetch_failure {
+                            Some(FetchFailure::Actionable(hint)) => {
+                                format!("Registry lookup failed for '{}': {hint}", dep.name())
+                            }
+                            Some(FetchFailure::Transient | FetchFailure::NotAttempted) | None => {
+                                format!(
+                                    "Registry lookup failed for '{}'; package status could not be determined",
+                                    dep.name()
+                                )
+                            }
+                        };
+                        fetch_failed_diagnostics.push((
+                            dep.name().to_string(),
+                            Diagnostic {
+                                range: dep.name_range(),
+                                severity: Some(severities.unknown),
+                                message,
+                                source: Some("deps-lsp".into()),
+                                ..Default::default()
+                            },
+                            fetch_failure.cloned(),
+                        ));
+                    }
+                    Ok(()) if formatter.can_resolve_source(&dep.source()) => {
+                        diagnostics.push(Diagnostic {
+                            range: dep.name_range(),
+                            severity: Some(severities.unknown),
+                            message: format!("Unknown package '{}'", dep.name()),
+                            source: Some("deps-lsp".into()),
+                            ..Default::default()
+                        });
+                    }
+                    Ok(()) => {}
                 }
             }
             continue;
@@ -862,6 +898,62 @@ pub fn generate_diagnostics_from_cache(
         }
     }
 
+    // A single fetch failure keeps its own per-dependency diagnostic (same range as
+    // before, though — unlike every other diagnostic in this function — no longer
+    // necessarily at the same position in the returned `Vec` in dependency order: it's
+    // now appended after the main loop rather than interleaved with it, so an assertion
+    // keyed on vec index rather than message content could be affected). More than one
+    // collapses into one combined diagnostic (on the first failing dependency's range)
+    // rather than fanning out N near-duplicates that all trace back to the same
+    // registry-wide condition (#479) — but unlike the first cut of this collapse, every
+    // *additional* failing dependency's name and location survive via
+    // `related_information` (#480 S2) instead of being silently dropped along with their
+    // per-line diagnostic marker.
+    match fetch_failed_diagnostics.len() {
+        0 => {}
+        1 => diagnostics.extend(fetch_failed_diagnostics.into_iter().map(|(_, d, _)| d)),
+        n => {
+            let (_, first, _) = &fetch_failed_diagnostics[0];
+            let range = first.range;
+            let severity = first.severity;
+            // Surface a shared/first actionable hint across the batch if one exists,
+            // so collapsing 2+ failures into one diagnostic never drops the specific,
+            // pre-vetted remedy #478/#485 introduced — only fall back to the generic
+            // message when nothing in the batch has one.
+            let shared_hint =
+                fetch_failed_diagnostics
+                    .iter()
+                    .find_map(|(_, _, failure)| match failure {
+                        Some(FetchFailure::Actionable(hint)) => Some(hint.clone()),
+                        _ => None,
+                    });
+            let message = match shared_hint {
+                Some(hint) => format!("Registry lookup failed for {n} packages: {hint}"),
+                None => format!(
+                    "Registry lookup failed for {n} packages; package status could not be determined"
+                ),
+            };
+            let related_information = fetch_failed_diagnostics[1..]
+                .iter()
+                .map(|(name, d, _)| DiagnosticRelatedInformation {
+                    location: Location {
+                        uri: uri.clone(),
+                        range: d.range,
+                    },
+                    message: format!("'{name}' also failed"),
+                })
+                .collect();
+            diagnostics.push(Diagnostic {
+                range,
+                severity,
+                message,
+                source: Some("deps-lsp".into()),
+                related_information: Some(related_information),
+                ..Default::default()
+            });
+        }
+    }
+
     diagnostics
 }
 
@@ -985,6 +1077,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -1052,6 +1145,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -1150,6 +1244,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -1196,6 +1291,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -1237,6 +1333,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -1250,6 +1347,254 @@ mod tests {
                 .contains("set GITHUB_TOKEN to increase the rate limit")
         );
         assert!(diagnostics[0].message.contains("rate-limited-pkg"));
+    }
+
+    #[test]
+    fn test_generate_diagnostics_from_cache_multiple_fetch_failed_collapse_into_one_diagnostic() {
+        use std::collections::HashMap;
+        use tower_lsp_server::ls_types::{Position, Range};
+
+        // #479: a registry-wide condition (e.g. a rate limit tripped by one dependency)
+        // can fail every remaining dependency identically. N near-duplicate
+        // per-dependency "Registry lookup failed" diagnostics carry no more information
+        // than one combined diagnostic — this asserts the 2+ case actually collapses,
+        // on the first failing dependency's range, with the count in the message.
+        let formatter = MockFormatter;
+
+        let name_range_1 = Range::new(Position::new(0, 0), Position::new(0, 8));
+        let name_range_2 = Range::new(Position::new(1, 0), Position::new(1, 8));
+        let name_range_3 = Range::new(Position::new(2, 0), Position::new(2, 8));
+
+        let parse_result = MockParseResult {
+            deps: vec![
+                MockDep {
+                    name: "flaky-1".into(),
+                    version_req: "1.0.0".into(),
+                    version_range: Range::new(Position::new(0, 10), Position::new(0, 20)),
+                    name_range: name_range_1,
+                },
+                MockDep {
+                    name: "flaky-2".into(),
+                    version_req: "1.0.0".into(),
+                    version_range: Range::new(Position::new(1, 10), Position::new(1, 20)),
+                    name_range: name_range_2,
+                },
+                MockDep {
+                    name: "flaky-3".into(),
+                    version_req: "1.0.0".into(),
+                    version_range: Range::new(Position::new(2, 10), Position::new(2, 20)),
+                    name_range: name_range_3,
+                },
+            ],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+
+        let cached_versions = HashMap::new();
+        let resolved_versions = HashMap::new();
+        let outcomes = DependencyOutcomes::new()
+            .with_fetch_failure("flaky-1", FetchFailure::Transient)
+            .with_fetch_failure("flaky-2", FetchFailure::Transient)
+            .with_fetch_failure("flaky-3", FetchFailure::Transient);
+
+        let diagnostics = generate_diagnostics_from_cache(
+            &parse_result,
+            VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
+            &formatter,
+            parse_result.uri(),
+            crate::freshness::FreshnessSettings::default(),
+            DiagnosticSeverities::default(),
+            PublishTime::now(),
+        );
+
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "3 fetch-failed dependencies must collapse into exactly one diagnostic, got: {diagnostics:?}"
+        );
+        assert!(
+            diagnostics[0]
+                .message
+                .contains("Registry lookup failed for 3 packages")
+        );
+        assert_eq!(
+            diagnostics[0].range, name_range_1,
+            "the combined diagnostic must sit on the first failing dependency's range"
+        );
+
+        // #480 S2: the collapse must not silently drop the other failing dependencies —
+        // each one beyond the first survives via `related_information`, keyed to its own
+        // name and `name_range`.
+        let related_information = diagnostics[0]
+            .related_information
+            .as_ref()
+            .expect("collapsed diagnostic must carry related_information for the dropped deps");
+        assert_eq!(
+            related_information.len(),
+            2,
+            "expected one related_information entry per additional failing dependency (n - 1)"
+        );
+        assert_eq!(related_information[0].location.range, name_range_2);
+        assert_eq!(related_information[0].location.uri, *parse_result.uri());
+        assert!(related_information[0].message.contains("flaky-2"));
+        assert_eq!(related_information[1].location.range, name_range_3);
+        assert_eq!(related_information[1].location.uri, *parse_result.uri());
+        assert!(related_information[1].message.contains("flaky-3"));
+    }
+
+    #[test]
+    fn test_generate_diagnostics_from_cache_two_fetch_failed_collapse_boundary() {
+        use std::collections::HashMap;
+        use tower_lsp_server::ls_types::{Position, Range};
+
+        // n==2 is the lowest n that collapses at all (n==1 stays a plain per-dependency
+        // diagnostic — see `test_generate_diagnostics_from_cache_fetch_failed_not_reported_as_unknown`
+        // above) — this confirms `related_information` is populated right at that
+        // threshold, not just once there are 3+ failures to fold in.
+        let formatter = MockFormatter;
+
+        let name_range_1 = Range::new(Position::new(0, 0), Position::new(0, 8));
+        let name_range_2 = Range::new(Position::new(1, 0), Position::new(1, 8));
+
+        let parse_result = MockParseResult {
+            deps: vec![
+                MockDep {
+                    name: "flaky-1".into(),
+                    version_req: "1.0.0".into(),
+                    version_range: Range::new(Position::new(0, 10), Position::new(0, 20)),
+                    name_range: name_range_1,
+                },
+                MockDep {
+                    name: "flaky-2".into(),
+                    version_req: "1.0.0".into(),
+                    version_range: Range::new(Position::new(1, 10), Position::new(1, 20)),
+                    name_range: name_range_2,
+                },
+            ],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+
+        let cached_versions = HashMap::new();
+        let resolved_versions = HashMap::new();
+        let outcomes = DependencyOutcomes::new()
+            .with_fetch_failure("flaky-1", FetchFailure::Transient)
+            .with_fetch_failure("flaky-2", FetchFailure::Transient);
+
+        let diagnostics = generate_diagnostics_from_cache(
+            &parse_result,
+            VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
+            &formatter,
+            parse_result.uri(),
+            crate::freshness::FreshnessSettings::default(),
+            DiagnosticSeverities::default(),
+            PublishTime::now(),
+        );
+
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "2 fetch-failed dependencies must already collapse into one diagnostic, got: {diagnostics:?}"
+        );
+        assert!(
+            diagnostics[0]
+                .message
+                .contains("Registry lookup failed for 2 packages")
+        );
+        let related_information = diagnostics[0]
+            .related_information
+            .as_ref()
+            .expect("the n==2 collapse must already carry related_information");
+        assert_eq!(
+            related_information.len(),
+            1,
+            "n==2 collapse must carry exactly one related_information entry (n - 1)"
+        );
+        assert_eq!(related_information[0].location.range, name_range_2);
+        assert_eq!(related_information[0].location.uri, *parse_result.uri());
+        assert!(related_information[0].message.contains("flaky-2"));
+    }
+
+    #[test]
+    fn test_generate_diagnostics_from_cache_multiple_fetch_failed_shared_actionable_hint() {
+        use std::collections::HashMap;
+        use tower_lsp_server::ls_types::{Position, Range};
+
+        // #478/#485 + #479: the motivating scenario for both — a rate-limit gate trips
+        // and fails every remaining dependency with the SAME `Actionable` hint. The
+        // #479 collapse must not silently drop that hint just because 2+ failures
+        // collapsed into one diagnostic.
+        let formatter = MockFormatter;
+
+        let name_range_1 = Range::new(Position::new(0, 0), Position::new(0, 8));
+        let name_range_2 = Range::new(Position::new(1, 0), Position::new(1, 8));
+        let name_range_3 = Range::new(Position::new(2, 0), Position::new(2, 8));
+
+        let parse_result = MockParseResult {
+            deps: vec![
+                MockDep {
+                    name: "flaky-1".into(),
+                    version_req: "1.0.0".into(),
+                    version_range: Range::new(Position::new(0, 10), Position::new(0, 20)),
+                    name_range: name_range_1,
+                },
+                MockDep {
+                    name: "flaky-2".into(),
+                    version_req: "1.0.0".into(),
+                    version_range: Range::new(Position::new(1, 10), Position::new(1, 20)),
+                    name_range: name_range_2,
+                },
+                MockDep {
+                    name: "flaky-3".into(),
+                    version_req: "1.0.0".into(),
+                    version_range: Range::new(Position::new(2, 10), Position::new(2, 20)),
+                    name_range: name_range_3,
+                },
+            ],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+
+        let cached_versions = HashMap::new();
+        let resolved_versions = HashMap::new();
+        let shared_hint = "set GITHUB_TOKEN to increase the rate limit".to_string();
+        let outcomes = DependencyOutcomes::new()
+            .with_fetch_failure("flaky-1", FetchFailure::Actionable(shared_hint.clone()))
+            .with_fetch_failure("flaky-2", FetchFailure::Actionable(shared_hint.clone()))
+            .with_fetch_failure("flaky-3", FetchFailure::Actionable(shared_hint.clone()));
+
+        let diagnostics = generate_diagnostics_from_cache(
+            &parse_result,
+            VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
+            &formatter,
+            parse_result.uri(),
+            crate::freshness::FreshnessSettings::default(),
+            DiagnosticSeverities::default(),
+            PublishTime::now(),
+        );
+
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "3 fetch-failed dependencies must still collapse into exactly one diagnostic, got: {diagnostics:?}"
+        );
+        assert!(
+            diagnostics[0].message.contains(&shared_hint),
+            "collapsed diagnostic must surface the shared actionable hint, got: {}",
+            diagnostics[0].message
+        );
+        assert!(
+            !diagnostics[0]
+                .message
+                .contains("package status could not be determined"),
+            "the actionable hint must replace, not accompany, the generic fallback message"
+        );
+        let related_information = diagnostics[0]
+            .related_information
+            .as_ref()
+            .expect("collapsed diagnostic must carry related_information for the dropped deps");
+        assert_eq!(
+            related_information.len(),
+            2,
+            "expected one related_information entry per additional failing dependency (n - 1)"
+        );
     }
 
     #[test]
@@ -1281,6 +1626,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -1325,6 +1671,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -1368,6 +1715,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -1404,6 +1752,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &formatter,
+            parse_result.uri(),
             crate::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -1441,6 +1790,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -1490,6 +1840,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -1544,6 +1895,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -1590,6 +1942,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings {
                 enabled: false,
                 ..crate::freshness::FreshnessSettings::default()
@@ -1643,6 +1996,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings {
                 enabled: true,
                 cooldown_secs: COOLDOWN_SECS,
@@ -1696,6 +2050,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings {
                 enabled: true,
                 cooldown_secs: COOLDOWN_SECS,
@@ -1738,6 +2093,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -1790,6 +2146,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -1837,6 +2194,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -1879,6 +2237,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             severities,
             PublishTime::now(),
@@ -1918,6 +2277,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -1958,6 +2318,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -2001,6 +2362,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -2065,6 +2427,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -2120,6 +2483,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -2194,6 +2558,7 @@ mod tests {
                 &parse_result,
                 versions,
                 &formatter,
+                parse_result.uri(),
                 crate::freshness::FreshnessSettings::default(),
                 severities,
                 PublishTime::now(),
@@ -2252,6 +2617,7 @@ mod tests {
                 &parse_result,
                 VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
                 &MockFormatter,
+                parse_result.uri(),
                 crate::freshness::FreshnessSettings::default(),
                 DiagnosticSeverities::default(),
                 PublishTime::now(),
@@ -2275,6 +2641,7 @@ mod tests {
             &registry_parse_result,
             VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
             &MockFormatter,
+            registry_parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -2313,6 +2680,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -2367,6 +2735,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -2422,6 +2791,7 @@ mod tests {
                 .with_outcomes(&outcomes)
                 .with_ecosystem(crate::EcosystemId::Cargo),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -2482,6 +2852,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
             &formatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -2525,6 +2896,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &StrictSemverFormatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -2569,6 +2941,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &StrictSemverFormatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -2626,6 +2999,7 @@ mod tests {
                 &parse_result,
                 VersionData::new(&cached_versions, &resolved_versions),
                 &ExactMatchFormatter,
+                parse_result.uri(),
                 crate::freshness::FreshnessSettings::default(),
                 DiagnosticSeverities::default(),
                 PublishTime::now(),
@@ -2649,6 +3023,7 @@ mod tests {
             &registry_parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &ExactMatchFormatter,
+            registry_parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -2684,6 +3059,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &MockFormatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -2705,6 +3081,7 @@ mod tests {
             &registry_parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &MockFormatter,
+            registry_parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -2741,6 +3118,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &RejectingFormatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -2777,6 +3155,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &MockFormatter,
+            parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -2798,6 +3177,7 @@ mod tests {
             &registry_parse_result,
             VersionData::new(&cached_versions, &resolved_versions),
             &MockFormatter,
+            registry_parse_result.uri(),
             crate::freshness::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -2846,6 +3226,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions).with_vulnerabilities(&vulns),
             &formatter,
+            parse_result.uri(),
             crate::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -2895,6 +3276,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions).with_vulnerabilities(&vulns),
             &formatter,
+            parse_result.uri(),
             crate::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -2981,6 +3363,7 @@ mod tests {
                 .with_vulnerabilities(&vulns)
                 .with_ecosystem(crate::EcosystemId::Cargo),
             &formatter,
+            parse_result.uri(),
             crate::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -3024,6 +3407,7 @@ mod tests {
             &parse_result,
             VersionData::new(&cached_versions, &resolved_versions).with_vulnerabilities(&vulns),
             &formatter,
+            parse_result.uri(),
             crate::FreshnessSettings::default(),
             DiagnosticSeverities::default(),
             PublishTime::now(),
@@ -3726,6 +4110,7 @@ mod tests {
                 &parse_result,
                 VersionData::new(&cached_versions, &resolved_versions),
                 &formatter,
+                parse_result.uri(),
                 crate::freshness::FreshnessSettings::default(),
                 DiagnosticSeverities::default(),
                 PublishTime::now(),
@@ -3789,6 +4174,7 @@ mod tests {
                 &parse_result,
                 VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
                 &formatter,
+                parse_result.uri(),
                 crate::freshness::FreshnessSettings::default(),
                 DiagnosticSeverities::default(),
                 PublishTime::now(),
@@ -3853,6 +4239,7 @@ mod tests {
                 &parse_result,
                 VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
                 &formatter,
+                parse_result.uri(),
                 crate::freshness::FreshnessSettings::default(),
                 DiagnosticSeverities::default(),
                 PublishTime::now(),
@@ -3924,6 +4311,7 @@ mod tests {
                 &parse_result,
                 VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
                 &formatter,
+                parse_result.uri(),
                 crate::freshness::FreshnessSettings::default(),
                 DiagnosticSeverities::default(),
                 PublishTime::now(),
@@ -3987,6 +4375,7 @@ mod tests {
                 &parse_result,
                 VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
                 &formatter,
+                parse_result.uri(),
                 crate::freshness::FreshnessSettings::default(),
                 DiagnosticSeverities::default(),
                 PublishTime::now(),
@@ -4065,6 +4454,7 @@ mod tests {
                 &parse_result,
                 VersionData::new(&cached_versions, &resolved_versions),
                 &formatter,
+                parse_result.uri(),
                 crate::freshness::FreshnessSettings::default(),
                 severities,
                 PublishTime::now(),
@@ -4107,6 +4497,7 @@ mod tests {
                 &parse_result,
                 VersionData::new(&cached_versions, &resolved_versions),
                 &formatter,
+                parse_result.uri(),
                 crate::freshness::FreshnessSettings::default(),
                 DiagnosticSeverities::default(),
                 PublishTime::now(),
@@ -4219,6 +4610,7 @@ mod tests {
                 &parse_result,
                 VersionData::new(&cached_versions, &resolved_versions),
                 &formatter,
+                parse_result.uri(),
                 crate::freshness::FreshnessSettings::default(),
                 DiagnosticSeverities::default(),
                 PublishTime::now(),
@@ -4265,6 +4657,7 @@ mod tests {
                 &parse_result,
                 VersionData::new(&cached_versions, &resolved_versions),
                 &formatter,
+                parse_result.uri(),
                 crate::freshness::FreshnessSettings::default(),
                 DiagnosticSeverities::default(),
                 PublishTime::now(),

--- a/crates/deps-github-actions/src/ecosystem.rs
+++ b/crates/deps-github-actions/src/ecosystem.rs
@@ -135,7 +135,7 @@ impl Ecosystem for GithubActionsEcosystem {
         &'a self,
         parse_result: &'a dyn ParseResultTrait,
         versions: deps_core::VersionData<'a>,
-        _uri: &'a Uri,
+        uri: &'a Uri,
         freshness: deps_core::FreshnessSettings,
         severities: deps_core::lsp_helpers::DiagnosticSeverities,
     ) -> deps_core::ecosystem::BoxFuture<'a, Vec<Diagnostic>> {
@@ -144,6 +144,7 @@ impl Ecosystem for GithubActionsEcosystem {
                 parse_result,
                 versions,
                 self.formatter(),
+                uri,
                 freshness,
                 severities,
                 deps_core::PublishTime::now(),

--- a/crates/deps-gradle/tests/integration_tests.rs
+++ b/crates/deps-gradle/tests/integration_tests.rs
@@ -227,6 +227,7 @@ spring-boot = { module = "org.springframework.boot:spring-boot-starter", version
         &parse_result,
         VersionData::new(&cached_versions, &resolved_versions),
         &formatter,
+        parse_result.uri(),
         deps_core::FreshnessSettings::default(),
         deps_core::DiagnosticSeverities::default(),
         deps_core::PublishTime::now(),

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -1045,6 +1045,22 @@ async fn fetch_latest_versions_parallel(
     let fetched = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let failed = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let first_error: Arc<std::sync::Mutex<Option<String>>> = Arc::new(std::sync::Mutex::new(None));
+    // Separate from `first_error` (#480): a not-found error is deliberately excluded
+    // from `fetch_failed` below (it isn't evidence of a registry-side problem), but
+    // without this, whichever concurrent fetch happened to finish first could still win
+    // the `first_error` race and put a misleading "not found" message in the one-time
+    // toast even when the batch's real, actionable failure is e.g. a rate limit hit by
+    // 20 other dependencies. Any error that *does* count toward `fetch_failed`
+    // (including a timeout) always wins the toast over a not-found, regardless of
+    // finishing order; only a not-found-only batch falls back to `first_error`.
+    //
+    // Unlike `first_error`, this is not a shared `Arc<Mutex>` written from inside the
+    // four match arms below — each task instead returns its own `(name, message)` via
+    // `failed_name`, and the priority error is derived by folding those in completion
+    // order once every task has finished (see the loop below). `fetch_failed` and the
+    // priority error are thereby always in sync by construction: both come from the
+    // same `failed_name` value, so a future edit to one can no longer silently drift
+    // from the other, which two independently hand-maintained writes could (#480).
     let timeout = Duration::from_secs(timeout_secs);
     let wildcard_req = deps_core::VersionReq::new("*");
     let check_yanked = registry.reports_yanked();
@@ -1076,7 +1092,7 @@ async fn fetch_latest_versions_parallel(
                 .await;
 
                 let mut yanked: Option<(PackageName, ConcreteVersion, RemovalStatus)> = None;
-                let mut failed_name: Option<(PackageName, FetchFailure)> = None;
+                let mut failed_name: Option<(PackageName, FetchFailure, String)> = None;
                 let mut deprecation: Option<(PackageName, Deprecation)> = None;
                 let version = match result {
                     Ok(Ok(versions)) => {
@@ -1187,7 +1203,8 @@ async fn fetch_latest_versions_parallel(
                                     // package") is not a fetch failure — only
                                     // an unanswerable request is (#267 C1).
                                     if !e.is_not_found() {
-                                        failed_name = Some((name.clone(), e.fetch_failure()));
+                                        failed_name =
+                                            Some((name.clone(), e.fetch_failure(), e.to_string()));
                                     }
                                     None
                                 }
@@ -1198,7 +1215,14 @@ async fn fetch_latest_versions_parallel(
                                         timeout.as_secs()
                                     );
                                     failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                    failed_name = Some((name.clone(), FetchFailure::Transient));
+                                    failed_name = Some((
+                                        name.clone(),
+                                        FetchFailure::Transient,
+                                        format!(
+                                            "{name}: registry request timed out after {}s",
+                                            timeout.as_secs()
+                                        ),
+                                    ));
                                     None
                                 }
                             }
@@ -1296,14 +1320,21 @@ async fn fetch_latest_versions_parallel(
                         // instead of "Unknown package", inverting the bug
                         // this field exists to fix.
                         if !e.is_not_found() {
-                            failed_name = Some((name.clone(), e.fetch_failure()));
+                            failed_name = Some((name.clone(), e.fetch_failure(), e.to_string()));
                         }
                         None
                     }
                     Err(_) => {
                         tracing::warn!(package = %name, "fetch timed out ({}s)", timeout.as_secs());
                         failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        failed_name = Some((name.clone(), FetchFailure::Transient));
+                        failed_name = Some((
+                            name.clone(),
+                            FetchFailure::Transient,
+                            format!(
+                                "{name}: registry request timed out after {}s",
+                                timeout.as_secs()
+                            ),
+                        ));
                         None
                     }
                 };
@@ -1324,6 +1355,10 @@ async fn fetch_latest_versions_parallel(
     let mut yanked_versions = HashMap::new();
     let mut fetch_failed = HashMap::new();
     let mut deprecations = HashMap::new();
+    // First actionable failure in completion order — `results` is collected from
+    // `buffer_unordered`, so its order already reflects real finishing order, the same
+    // order a shared `Arc<Mutex>` written from inside each task would have observed.
+    let mut priority_error: Option<String> = None;
     for (version, yanked, failed_name, deprecation) in results {
         if let Some((name, v)) = version {
             versions.insert(name, v);
@@ -1331,13 +1366,23 @@ async fn fetch_latest_versions_parallel(
         if let Some((name, v, status)) = yanked {
             yanked_versions.insert(name, (v, status));
         }
-        if let Some((name, failure)) = failed_name {
+        if let Some((name, failure, message)) = failed_name {
             fetch_failed.insert(name, failure);
+            if priority_error.is_none() {
+                priority_error = Some(message);
+            }
         }
         if let Some((name, d)) = deprecation {
             deprecations.insert(name, d);
         }
     }
+
+    // `priority_error` (an actual fetch failure — rate limit, timeout, outage, ...)
+    // always wins the toast over `first_error` (which may be a not-found race winner);
+    // `first_error` is the fallback only for a batch whose only failures were
+    // not-found (#480).
+    let error_message =
+        priority_error.or_else(|| first_error.lock().unwrap_or_else(|p| p.into_inner()).take());
 
     FetchResult {
         versions,
@@ -1345,7 +1390,7 @@ async fn fetch_latest_versions_parallel(
         fetch_failed,
         deprecations,
         failed_count: failed.load(std::sync::atomic::Ordering::Relaxed),
-        first_error: first_error.lock().unwrap_or_else(|p| p.into_inner()).take(),
+        first_error: error_message,
     }
 }
 
@@ -1600,16 +1645,18 @@ pub async fn handle_document_open(
             progress.end(success).await;
         }
 
-        // Notify user about failed packages
+        // Notify user about failed packages. `error_message` is always populated by
+        // `fetch_latest_versions_parallel` whenever `failed_count > 0` — every site that
+        // increments `failed_count` also sets either `priority_error` or `first_error`.
         if fetch_result.failed_count > 0 {
-            let message = if let Some(err) = &fetch_result.first_error {
-                format!("deps-lsp: {err}")
-            } else {
-                format!(
-                    "deps-lsp: {} package(s) failed to fetch (timeout or network error)",
-                    fetch_result.failed_count
-                )
-            };
+            let message = format!(
+                "deps-lsp: {} package(s) failed to fetch: {}",
+                fetch_result.failed_count,
+                fetch_result
+                    .first_error
+                    .as_deref()
+                    .unwrap_or("timeout or network error")
+            );
             client_clone
                 .show_message(MessageType::WARNING, message)
                 .await;
@@ -2000,16 +2047,18 @@ pub async fn handle_document_change(
             progress.end(success).await;
         }
 
-        // Notify user about failed packages
+        // Notify user about failed packages. `error_message` is always populated by
+        // `fetch_latest_versions_parallel` whenever `failed_count > 0` — every site that
+        // increments `failed_count` also sets either `priority_error` or `first_error`.
         if fetch_result.failed_count > 0 {
-            let message = if let Some(err) = &fetch_result.first_error {
-                format!("deps-lsp: {err}")
-            } else {
-                format!(
-                    "deps-lsp: {} package(s) failed to fetch (timeout or network error)",
-                    fetch_result.failed_count
-                )
-            };
+            let message = format!(
+                "deps-lsp: {} package(s) failed to fetch: {}",
+                fetch_result.failed_count,
+                fetch_result
+                    .first_error
+                    .as_deref()
+                    .unwrap_or("timeout or network error")
+            );
             client_clone
                 .show_message(MessageType::WARNING, message)
                 .await;
@@ -4043,6 +4092,261 @@ mod tests {
         assert_eq!(result.failed_count, 1);
     }
 
+    #[tokio::test]
+    async fn test_first_error_prefers_actionable_error_over_not_found_regardless_of_race_order() {
+        // #480: `first_error` is the batch's one-shot toast message. Before this fix it
+        // was simply whichever concurrent fetch finished first — so a fast not-found
+        // ("Unknown package") could outrank a slower but far more actionable error
+        // (e.g. a rate limit hit by every other package in the batch). Here the
+        // not-found resolves immediately while the actionable error resolves after a
+        // short delay, so it wins the finishing race; `priority_error` must still make
+        // the actionable error win the reported `first_error`.
+        use deps_core::{Metadata, Registry, Version};
+        use std::any::Any;
+        use std::time::Duration;
+
+        struct MixedErrorRegistry;
+
+        impl Registry for MixedErrorRegistry {
+            fn get_versions<'a>(
+                &'a self,
+                name: &'a deps_core::PackageName,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Version>>>>
+            {
+                Box::pin(async move {
+                    if name.as_str() == "typo-pkg" {
+                        Err(deps_core::error::DepsError::PackageNotFound {
+                            package: name.to_string(),
+                            registry: "mock",
+                        })
+                    } else {
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                        Err(deps_core::error::DepsError::CacheError(
+                            "rate limit exceeded".to_string(),
+                        ))
+                    }
+                })
+            }
+
+            fn get_latest_matching<'a>(
+                &'a self,
+                _name: &'a deps_core::PackageName,
+                _req: &'a deps_core::VersionReq,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Option<Box<dyn Version>>>>
+            {
+                Box::pin(async move { Ok(None) })
+            }
+
+            fn search<'a>(
+                &'a self,
+                _query: &'a str,
+                _limit: usize,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Metadata>>>>
+            {
+                Box::pin(async move { Ok(vec![]) })
+            }
+
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        let registry: Arc<dyn Registry> = Arc::new(MixedErrorRegistry);
+        let packages = vec![
+            PackageName::new("typo-pkg"),
+            PackageName::new("rate-limited"),
+        ];
+
+        let result = fetch_latest_versions_parallel(
+            registry,
+            with_registry_source(packages),
+            &HashMap::new(),
+            None,
+            deps_core::freshness::FreshnessSettings::default(),
+            5,
+            10,
+            None,
+        )
+        .await;
+
+        let err = result
+            .first_error
+            .expect("an actionable failure occurred and must be reported");
+        assert!(
+            err.contains("rate limit exceeded"),
+            "the actionable error must win the toast over the faster-finishing not-found, \
+             got: {err}"
+        );
+        assert!(
+            !err.contains("not found"),
+            "a not-found error must never outrank an actionable error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_first_error_falls_back_to_not_found_when_no_actionable_error_occurred() {
+        // #480 fallback path: `priority_error` is only populated by errors that also
+        // count toward `fetch_failed` (non-not-found). A batch whose only failures are
+        // not-found ones must still surface one via `first_error` instead of silently
+        // reporting nothing.
+        use deps_core::{Metadata, Registry, Version};
+        use std::any::Any;
+
+        struct AllNotFoundRegistry;
+
+        impl Registry for AllNotFoundRegistry {
+            fn get_versions<'a>(
+                &'a self,
+                name: &'a deps_core::PackageName,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Version>>>>
+            {
+                Box::pin(async move {
+                    Err(deps_core::error::DepsError::PackageNotFound {
+                        package: name.to_string(),
+                        registry: "mock",
+                    })
+                })
+            }
+
+            fn get_latest_matching<'a>(
+                &'a self,
+                _name: &'a deps_core::PackageName,
+                _req: &'a deps_core::VersionReq,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Option<Box<dyn Version>>>>
+            {
+                Box::pin(async move { Ok(None) })
+            }
+
+            fn search<'a>(
+                &'a self,
+                _query: &'a str,
+                _limit: usize,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Metadata>>>>
+            {
+                Box::pin(async move { Ok(vec![]) })
+            }
+
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        let registry: Arc<dyn Registry> = Arc::new(AllNotFoundRegistry);
+        let packages = vec![
+            PackageName::new("typo-pkg-1"),
+            PackageName::new("typo-pkg-2"),
+        ];
+
+        let result = fetch_latest_versions_parallel(
+            registry,
+            with_registry_source(packages),
+            &HashMap::new(),
+            None,
+            deps_core::freshness::FreshnessSettings::default(),
+            5,
+            10,
+            None,
+        )
+        .await;
+
+        assert!(
+            result.fetch_failed.is_empty(),
+            "not-found errors must never be recorded in fetch_failed"
+        );
+        let err = result
+            .first_error
+            .expect("a not-found-only batch must still fall back to reporting one via first_error");
+        assert!(err.contains("not found"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn test_timeout_only_batch_reports_first_error_alongside_failed_count() {
+        // #480 S1: the toast used to special-case a populated `first_error` as
+        // `format!("deps-lsp: {err}")`, entirely dropping `failed_count` from the
+        // message whenever `first_error` was `Some` — so a multi-package timeout batch
+        // (which always populates `first_error` via `priority_error`, unlike the
+        // not-found-only case) silently lost its count. The toast is now built
+        // unconditionally from both fields (`"{failed_count} package(s) failed to
+        // fetch: {first_error}"`), so this asserts the `FetchResult` data that feeds
+        // it: a batch where every package times out must report `failed_count` equal
+        // to the batch size *and* a populated, actionable `first_error` — both fields
+        // together, not one masking the other.
+        use deps_core::{Metadata, Registry, Version};
+        use std::any::Any;
+        use std::time::Duration;
+
+        struct AlwaysTimesOutRegistry;
+
+        impl Registry for AlwaysTimesOutRegistry {
+            fn get_versions<'a>(
+                &'a self,
+                _name: &'a deps_core::PackageName,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Version>>>>
+            {
+                Box::pin(async move {
+                    tokio::time::sleep(Duration::from_secs(10)).await;
+                    Ok(vec![])
+                })
+            }
+
+            fn get_latest_matching<'a>(
+                &'a self,
+                _name: &'a deps_core::PackageName,
+                _req: &'a deps_core::VersionReq,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Option<Box<dyn Version>>>>
+            {
+                Box::pin(async move {
+                    tokio::time::sleep(Duration::from_secs(10)).await;
+                    Ok(None)
+                })
+            }
+
+            fn search<'a>(
+                &'a self,
+                _query: &'a str,
+                _limit: usize,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Metadata>>>>
+            {
+                Box::pin(async move { Ok(vec![]) })
+            }
+
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        let registry: Arc<dyn Registry> = Arc::new(AlwaysTimesOutRegistry);
+        let packages = vec![
+            PackageName::new("slow-1"),
+            PackageName::new("slow-2"),
+            PackageName::new("slow-3"),
+        ];
+
+        let result = fetch_latest_versions_parallel(
+            registry,
+            with_registry_source(packages),
+            &HashMap::new(),
+            None,
+            deps_core::freshness::FreshnessSettings::default(),
+            1,
+            10,
+            None,
+        )
+        .await;
+
+        assert_eq!(
+            result.failed_count, 3,
+            "all 3 packages must count toward failed_count"
+        );
+        let err = result
+            .first_error
+            .expect("a timeout is actionable and must populate first_error, not just failed_count");
+        assert!(
+            err.contains("timed out"),
+            "first_error must be the actionable timeout message, got: {err}"
+        );
+    }
+
     // Composer-specific tests
     #[cfg(feature = "composer")]
     mod composer_tests {
@@ -4724,6 +5028,7 @@ dependencies = ["requests>=2.0.0"]
                 VersionData::new(&doc.cached_versions, &doc.resolved_versions)
                     .with_outcomes(&doc.outcomes),
                 formatter,
+                &uri,
                 deps_core::freshness::FreshnessSettings::default(),
                 DiagnosticSeverities::default(),
                 deps_core::PublishTime::now(),

--- a/crates/deps-pypi/src/ecosystem.rs
+++ b/crates/deps-pypi/src/ecosystem.rs
@@ -1376,6 +1376,7 @@ dependencies = []
                 &parse_result,
                 versions,
                 &formatter,
+                parse_result.uri(),
                 deps_core::FreshnessSettings::default(),
                 deps_core::DiagnosticSeverities::default(),
                 deps_core::PublishTime::now(),


### PR DESCRIPTION
## Summary

- The one-shot fetch-failure toast (`window/showMessage`) was set by whichever concurrent dependency fetch finished first, including not-found errors that are deliberately excluded from `fetch_failed` tracking. A batch of mostly rate-limited dependencies with one typo'd reference could misreport "not found" while every inline diagnostic said otherwise. `first_error` is now derived from the same per-task result that feeds `fetch_failed`, so a not-found error only wins the toast when it is the batch's only kind of failure; the toast now always states the affected package count.
- A tripped rate-limit gate (or any registry-wide condition) previously fanned out one near-identical diagnostic per remaining dependency. Fetch-failure diagnostics now collapse into one per manifest, attaching every additional dependency's name and location via `DiagnosticRelatedInformation` so nothing is silently dropped.
- Rebased onto #485 (the actual #478 fix, which landed on `main` mid-review) and reconciled with its new `FetchFailure` classifier: the collapsed diagnostic now also surfaces a shared `Actionable` rate-limit hint across the batch when present, instead of only ever falling back to the generic message — so #479's collapse never hides the remedy #485 introduced.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (3516 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --all-features`
- [x] New regression coverage: toast race-order (actionable failure beats not-found regardless of finish order, not-found-only batch still falls back), timeout-only batch toast count, diagnostic collapse at n=1/n=2/n=3, and a batch sharing one `Actionable` hint across all failures

Closes #480
Closes #479