### PR TITLE
fix(deps-lsp): bound apply_edit timeout, remove dead cache.refresh_interval_secs field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-github-actions**: a tripped rate-limit gate no longer fans out one near-duplicate diagnostic per remaining dependency; fetch failures now collapse into a single diagnostic per manifest, naming every affected dependency via related information and still surfacing a shared actionable hint when one applies (resolves #479) (#489)
 - **deps-github-actions, deps-core**: hover release-age hint and cooldown diagnostic now fire for GitHub Actions — `GithubActionsRegistry` enriches tags-API versions with GitHub Release publish dates via a new shared `deps_core::github::ReleaseDatesCache`, also adopted by `deps-swift` (resolves #486) (#494)
 - **deps-lsp**: a client that never answers a server-initiated `workspace/inlayHint/refresh`, `workspace/codeLens/refresh`, `client/registerCapability`, or `workspace/diagnostic/refresh` request no longer permanently stalls the OSV vulnerability commit and diagnostics publish for that document; these requests are now capability-gated and timeout-bounded (5s) instead of awaited unconditionally on the critical path (resolves #493) (#495)
+- **deps-lsp**: a client that never answers `workspace/applyEdit` for `deps-lsp.updateVersion` or `deps-lsp.updateAllOutdated` no longer permanently occupies a `workspace/executeCommand` concurrency slot; the request is now timeout-bounded (5s), same as #493's fix (resolves #496)
+
+### Removed
+- **Breaking (pre-1.0, public API)**: **deps-lsp**: dropped the dead `CacheConfig::refresh_interval_secs` field — `HttpCache` has no local TTL concept to attach it to (resolves #492)
 
 ## [0.11.1] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,10 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-github-actions**: a tripped rate-limit gate no longer fans out one near-duplicate diagnostic per remaining dependency; fetch failures now collapse into a single diagnostic per manifest, naming every affected dependency via related information and still surfacing a shared actionable hint when one applies (resolves #479) (#489)
 - **deps-github-actions, deps-core**: hover release-age hint and cooldown diagnostic now fire for GitHub Actions — `GithubActionsRegistry` enriches tags-API versions with GitHub Release publish dates via a new shared `deps_core::github::ReleaseDatesCache`, also adopted by `deps-swift` (resolves #486) (#494)
 - **deps-lsp**: a client that never answers a server-initiated `workspace/inlayHint/refresh`, `workspace/codeLens/refresh`, `client/registerCapability`, or `workspace/diagnostic/refresh` request no longer permanently stalls the OSV vulnerability commit and diagnostics publish for that document; these requests are now capability-gated and timeout-bounded (5s) instead of awaited unconditionally on the critical path (resolves #493) (#495)
-- **deps-lsp**: a client that never answers `workspace/applyEdit` for `deps-lsp.updateVersion` or `deps-lsp.updateAllOutdated` no longer permanently occupies a `workspace/executeCommand` concurrency slot; the request is now timeout-bounded (5s), same as #493's fix (resolves #496)
+- **deps-lsp**: a client that never answers `workspace/applyEdit` for `deps-lsp.updateVersion` or `deps-lsp.updateAllOutdated` no longer permanently occupies a `workspace/executeCommand` concurrency slot; the request is now timeout-bounded (5s), same as #493's fix (resolves #496) (#498)
 
 ### Removed
-- **Breaking (pre-1.0, public API)**: **deps-lsp**: dropped the dead `CacheConfig::refresh_interval_secs` field — `HttpCache` has no local TTL concept to attach it to (resolves #492)
+- **Breaking (pre-1.0, public API)**: **deps-lsp**: dropped the dead `CacheConfig::refresh_interval_secs` field — `HttpCache` has no local TTL concept to attach it to (resolves #492) (#498)
 
 ## [0.11.1] - 2026-09-01
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,6 @@ Configure via LSP initialization options:
   },
   "cache": {
     "enabled": true,
-    "refresh_interval_secs": 300,
     "fetch_timeout_secs": 5,
     "max_concurrent_fetches": 20
   },

--- a/crates/deps-lsp/src/config.rs
+++ b/crates/deps-lsp/src/config.rs
@@ -228,7 +228,6 @@ impl DiagnosticsConfig {
 /// # Defaults
 ///
 /// - `enabled`: `true`
-/// - `refresh_interval_secs`: `300` (5 minutes)
 /// - `fetch_timeout_secs`: `10` (10 seconds per package)
 /// - `max_concurrent_fetches`: `20` (20 concurrent requests)
 ///
@@ -238,19 +237,15 @@ impl DiagnosticsConfig {
 /// use deps_lsp::config::CacheConfig;
 ///
 /// let config = CacheConfig {
-///     refresh_interval_secs: 600, // 10 minutes
 ///     enabled: true,
 ///     fetch_timeout_secs: 5,
 ///     max_concurrent_fetches: 20,
 /// };
 ///
-/// assert_eq!(config.refresh_interval_secs, 600);
+/// assert_eq!(config.fetch_timeout_secs, 5);
 /// ```
 #[derive(Debug, Clone, Deserialize)]
 pub struct CacheConfig {
-    // TODO(critic): refresh_interval_secs is parsed but never read (see #482 follow-up)
-    #[serde(default = "default_refresh_interval")]
-    pub refresh_interval_secs: u64,
     /// Whether `deps_core::cache::HttpCache`'s entry map is used at all (issue #482):
     /// `false` bypasses it entirely (fetch fresh every time, never store).
     ///
@@ -285,7 +280,6 @@ pub struct CacheConfig {
 impl Default for CacheConfig {
     fn default() -> Self {
         Self {
-            refresh_interval_secs: default_refresh_interval(),
             enabled: true,
             fetch_timeout_secs: default_fetch_timeout_secs(),
             max_concurrent_fetches: default_max_concurrent_fetches(),
@@ -397,10 +391,6 @@ const fn default_deprecated_severity() -> DiagnosticSeverity {
 
 const fn default_mutable_ref_pin_severity() -> DiagnosticSeverity {
     DiagnosticSeverity::HINT
-}
-
-const fn default_refresh_interval() -> u64 {
-    300 // 5 minutes
 }
 
 const fn default_fetch_timeout_secs() -> u64 {
@@ -909,12 +899,10 @@ mod tests {
     #[test]
     fn test_cache_config_deserialization() {
         let json = r#"{
-            "refresh_interval_secs": 600,
             "enabled": false
         }"#;
 
         let config: CacheConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(config.refresh_interval_secs, 600);
         assert!(!config.enabled);
     }
 
@@ -922,7 +910,6 @@ mod tests {
     fn test_cache_config_defaults() {
         let config = CacheConfig::default();
         assert!(config.enabled);
-        assert_eq!(config.refresh_interval_secs, 300);
         assert_eq!(config.fetch_timeout_secs, 5);
         assert_eq!(config.max_concurrent_fetches, 20);
     }
@@ -930,14 +917,12 @@ mod tests {
     #[test]
     fn test_cache_config_with_timeout_and_concurrency() {
         let json = r#"{
-            "refresh_interval_secs": 600,
             "enabled": true,
             "fetch_timeout_secs": 10,
             "max_concurrent_fetches": 50
         }"#;
 
         let config: CacheConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(config.refresh_interval_secs, 600);
         assert!(config.enabled);
         assert_eq!(config.fetch_timeout_secs, 10);
         assert_eq!(config.max_concurrent_fetches, 50);
@@ -957,7 +942,6 @@ mod tests {
                 "yanked_severity": 2
             },
             "cache": {
-                "refresh_interval_secs": 300,
                 "enabled": true
             }
         }"#;
@@ -968,7 +952,7 @@ mod tests {
             config.diagnostics.outdated_severity,
             DiagnosticSeverity::HINT
         );
-        assert_eq!(config.cache.refresh_interval_secs, 300);
+        assert!(config.cache.enabled);
     }
 
     #[test]

--- a/crates/deps-lsp/src/document/state.rs
+++ b/crates/deps-lsp/src/document/state.rs
@@ -23,6 +23,10 @@ use tower_lsp_server::ls_types::Uri;
 /// limit as the user keeps editing) and, via re-export, for the `initialized()`
 /// registration requests and `workspace/diagnostic/refresh` in `server.rs` (S1: same
 /// hang risk, an unresponsive client would otherwise stall those handlers forever).
+/// Also reused (not itself a "refresh") for `workspace/applyEdit` in `server.rs`'s
+/// `execute_command` handlers (issue #496): same directly-awaited hang risk, since a
+/// client that never answers `applyEdit` would otherwise permanently occupy one of
+/// `tower_lsp_server`'s limited `buffer_unordered` concurrency slots.
 pub(crate) const CLIENT_REFRESH_TIMEOUT: Duration = Duration::from_secs(5);
 
 // Re-export LoadingState from deps-core for convenience

--- a/crates/deps-lsp/src/server.rs
+++ b/crates/deps-lsp/src/server.rs
@@ -747,10 +747,16 @@ impl LanguageServer for Backend {
             && let Some(args) = params.arguments.first()
             && let Ok(update_args) = serde_json::from_value::<UpdateVersionArgs>(args.clone())
         {
-            if let Some(edit) = build_update_version_edit(&update_args)
-                && let Err(e) = self.client.apply_edit(edit).await
-            {
-                tracing::error!("Failed to apply edit: {:?}", e);
+            if let Some(edit) = build_update_version_edit(&update_args) {
+                match tokio::time::timeout(CLIENT_REFRESH_TIMEOUT, self.client.apply_edit(edit))
+                    .await
+                {
+                    Ok(Ok(_)) => {}
+                    Ok(Err(e)) => tracing::error!("Failed to apply edit: {:?}", e),
+                    Err(_) => tracing::warn!(
+                        "apply_edit for deps-lsp.updateVersion timed out after {CLIENT_REFRESH_TIMEOUT:?}"
+                    ),
+                }
             }
         } else if params.command == commands::UPDATE_ALL_OUTDATED
             && let Some(args) = params.arguments.first()
@@ -869,9 +875,9 @@ impl Backend {
 
         let edit = build_update_all_outdated_edit(&uri, version, edits, supports_document_changes);
 
-        match self.client.apply_edit(edit).await {
-            Ok(response) if response.applied => {}
-            Ok(response) => {
+        match tokio::time::timeout(CLIENT_REFRESH_TIMEOUT, self.client.apply_edit(edit)).await {
+            Ok(Ok(response)) if response.applied => {}
+            Ok(Ok(response)) => {
                 tracing::warn!(
                     "workspace/applyEdit for {:?} was rejected: {:?}",
                     uri,
@@ -884,12 +890,26 @@ impl Backend {
                     )
                     .await;
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 tracing::error!("Failed to apply edit for {:?}: {:?}", uri, e);
                 self.client
                     .show_message(
                         MessageType::WARNING,
                         "deps-lsp: failed to apply dependency updates",
+                    )
+                    .await;
+            }
+            Err(_) => {
+                tracing::warn!(
+                    "apply_edit for {:?} timed out after {CLIENT_REFRESH_TIMEOUT:?}",
+                    uri
+                );
+                self.client
+                    .show_message(
+                        MessageType::WARNING,
+                        format!(
+                            "deps-lsp: the editor did not respond to the update within {CLIENT_REFRESH_TIMEOUT:?}"
+                        ),
                     )
                     .await;
             }

--- a/crates/deps-lsp/tests/common/mod.rs
+++ b/crates/deps-lsp/tests/common/mod.rs
@@ -157,6 +157,17 @@ pub(crate) struct LspClient {
     /// Lets a test prove the server actually attempted the refresh (capability
     /// negotiation worked) even though the harness deliberately never answered it.
     unanswered_refresh_requests: u64,
+    /// When `false`, `auto_respond` receives (and counts, see
+    /// [`Self::unanswered_apply_edit_request_count`]) `workspace/applyEdit` requests
+    /// but never replies — simulating the exact client behavior issue #496 was filed
+    /// against (a client that never answers `workspace/applyEdit`). Defaults to
+    /// `true` (reply immediately), matching every other server-initiated request.
+    respond_to_apply_edit: bool,
+    /// Count of `workspace/applyEdit` requests received (and deliberately left
+    /// unanswered) while [`Self::respond_to_apply_edit`] is `false`. Lets a test
+    /// prove the server actually sent the edit even though the harness never
+    /// answered it.
+    unanswered_apply_edit_requests: u64,
 }
 
 impl LspClient {
@@ -181,6 +192,8 @@ impl LspClient {
             progress_create_requests: 0,
             respond_to_refresh_requests: true,
             unanswered_refresh_requests: 0,
+            respond_to_apply_edit: true,
+            unanswered_apply_edit_requests: 0,
         }
     }
 
@@ -207,6 +220,24 @@ impl LspClient {
     #[allow(dead_code)] // Used in notification_ordering tests
     pub(crate) fn unanswered_refresh_request_count(&self) -> u64 {
         self.unanswered_refresh_requests
+    }
+
+    /// Stop auto-answering `workspace/applyEdit` server-initiated requests: they
+    /// are received and counted (see
+    /// [`Self::unanswered_apply_edit_request_count`]) but never get a reply,
+    /// simulating issue #496's exact reproduction — a client that never answers
+    /// `workspace/applyEdit`. Must be called before the request that is expected
+    /// to trigger an edit.
+    #[allow(dead_code)] // Used in lsp_integration tests
+    pub(crate) fn stop_responding_to_apply_edit(&mut self) {
+        self.respond_to_apply_edit = false;
+    }
+
+    /// Number of `workspace/applyEdit` requests received (and deliberately left
+    /// unanswered) since [`Self::stop_responding_to_apply_edit`] was called.
+    #[allow(dead_code)] // Used in lsp_integration tests
+    pub(crate) fn unanswered_apply_edit_request_count(&self) -> u64 {
+        self.unanswered_apply_edit_requests
     }
 
     /// Get all captured notifications.
@@ -398,6 +429,12 @@ impl LspClient {
             | "workspace/codeLens/refresh"
             | "client/registerCapability" => {
                 json!({ "jsonrpc": "2.0", "id": id, "result": Value::Null })
+            }
+            "workspace/applyEdit" if !self.respond_to_apply_edit => {
+                // Simulate issue #496's client: receive the request but never
+                // reply to it, instead of answering immediately below.
+                self.unanswered_apply_edit_requests += 1;
+                return;
             }
             "workspace/applyEdit" => {
                 json!({ "jsonrpc": "2.0", "id": id, "result": { "applied": true } })

--- a/crates/deps-lsp/tests/lsp_integration.rs
+++ b/crates/deps-lsp/tests/lsp_integration.rs
@@ -616,3 +616,66 @@ serde = "1.0"
     assert!(hover1.get("error").is_none());
     assert!(hover2.get("error").is_none());
 }
+
+/// Regression test for issue #496: reproduces the exact client behavior the bug
+/// report was filed against — a client that never replies to a server-initiated
+/// `workspace/applyEdit` request.
+///
+/// Before the fix, `execute_command`'s `deps-lsp.updateVersion` handler awaited
+/// `client.apply_edit(edit)` inline with no timeout, so an unanswered request
+/// stalled the handler — and permanently occupied one of tower-lsp-server's
+/// limited `buffer_unordered` concurrency slots — forever. Today the call is
+/// bounded by `CLIENT_REFRESH_TIMEOUT` (5s), so `workspace/executeCommand` must
+/// still return well within `read_response`'s own 10s `READ_TIMEOUT` budget.
+/// `deps-lsp.updateVersion` needs no live document state (the edit is built
+/// entirely from the command's own arguments), so this skips `did_open`.
+#[test]
+fn test_execute_command_update_version_not_blocked_by_unanswered_apply_edit() {
+    let mut client = LspClient::spawn();
+    client.initialize();
+    client.stop_responding_to_apply_edit();
+
+    let start = std::time::Instant::now();
+    client.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 42,
+        "method": "workspace/executeCommand",
+        "params": {
+            "command": "deps-lsp.updateVersion",
+            "arguments": [{
+                "uri": "file:///test/Cargo.toml",
+                "range": {
+                    "start": {"line": 0, "character": 9},
+                    "end": {"line": 0, "character": 14}
+                },
+                "version": "1.2.3"
+            }]
+        }
+    }));
+
+    let response = client.read_response(Some(42));
+    let elapsed = start.elapsed();
+
+    assert_eq!(response["result"], json!(null));
+    assert!(
+        elapsed < Duration::from_secs(9),
+        "expected workspace/executeCommand to return within the 5s apply_edit \
+         timeout budget, took {elapsed:?} instead (possible regression: an \
+         unwrapped await here would hang until the harness's own 10s \
+         READ_TIMEOUT panics the test)"
+    );
+    assert!(
+        elapsed >= Duration::from_secs(4),
+        "expected workspace/executeCommand to wait out close to the full 5s \
+         apply_edit timeout before returning, took only {elapsed:?} — did \
+         apply_edit resolve some other way?"
+    );
+    assert!(
+        client.unanswered_apply_edit_request_count() >= 1,
+        "expected the server to have actually attempted workspace/applyEdit \
+         (proving the timeout, not some other short-circuit, is why the \
+         handler returned) even though the harness never answered it"
+    );
+
+    let _shutdown_response = client.shutdown();
+}


### PR DESCRIPTION
## Summary

Two independent P3 bug fixes in deps-lsp, same subsystem, no shared files.

- Wrap `execute_command`'s two `client.apply_edit(edit)` awaits (`UPDATE_VERSION` handler and `execute_update_all_outdated`) in `tokio::time::timeout(CLIENT_REFRESH_TIMEOUT, ...)`, mirroring #495's established pattern. Without this, a client that never answers `workspace/applyEdit` permanently occupies one of tower-lsp-server's `buffer_unordered` concurrency slots. On timeout, the toast now says the editor did not respond (an unknown outcome, not a confirmed apply failure).
- Remove the dead `cache.refresh_interval_secs` config field. `HttpCache` has no local TTL/staleness concept — it always issues a conditional GET (ETag/If-Modified-Since) unless offline; `fetched_at` is used only for LRU eviction. Wiring it in would mean inventing a new skip-network TTL window that conflicts with the existing always-revalidate design, so removal (the issue's own fallback proposal) is correct. Not a breaking change for existing user configs: `deny_unknown_fields` is scoped to `DepsConfig` only, so a config still carrying this field continues to parse and silently ignore it, same as before.

## Test plan

- [x] Added a regression test that withholds `workspace/applyEdit` responses via a new `LspClient::stop_responding_to_apply_edit()` test-harness switch and asserts `execute_command` still returns within the timeout bound instead of hanging (empirically verified: without the timeout wrap, the test panics on the harness's own 10s deadline instead of passing at ~5s)
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (3567 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Reviewed by rust-critic (two rounds: initial `significant` verdict on missing regression test, resolved and re-verified `approved`) and rust-code-reviewer (`approved`)

Closes #496
Closes #492