### PR TITLE
fix(deps-lsp): wire cold_start.rate_limit_ms to the live ColdStartLimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-github-actions, deps-core**: hover release-age hint and cooldown diagnostic now fire for GitHub Actions — `GithubActionsRegistry` enriches tags-API versions with GitHub Release publish dates via a new shared `deps_core::github::ReleaseDatesCache`, also adopted by `deps-swift` (resolves #486) (#494)
 - **deps-lsp**: a client that never answers a server-initiated `workspace/inlayHint/refresh`, `workspace/codeLens/refresh`, `client/registerCapability`, or `workspace/diagnostic/refresh` request no longer permanently stalls the OSV vulnerability commit and diagnostics publish for that document; these requests are now capability-gated and timeout-bounded (5s) instead of awaited unconditionally on the critical path (resolves #493) (#495)
 - **deps-lsp**: a client that never answers `workspace/applyEdit` for `deps-lsp.updateVersion` or `deps-lsp.updateAllOutdated` no longer permanently occupies a `workspace/executeCommand` concurrency slot; the request is now timeout-bounded (5s), same as #493's fix (resolves #496) (#498)
+- **deps-lsp**: `cold_start.rate_limit_ms` now actually rate-limits cold starts instead of being parsed and silently ignored in favor of a hardcoded 100ms interval (resolves #499)
 
 ### Removed
 - **Breaking (pre-1.0, public API)**: **deps-lsp**: dropped the dead `CacheConfig::refresh_interval_secs` field — `HttpCache` has no local TTL concept to attach it to (resolves #492) (#498)

--- a/crates/deps-lsp/src/document/state.rs
+++ b/crates/deps-lsp/src/document/state.rs
@@ -9,7 +9,7 @@ use deps_core::{
 };
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tokio::task::JoinHandle;
 use tower_lsp_server::Client;
@@ -139,8 +139,11 @@ impl Clone for DocumentState {
 pub struct ColdStartLimiter {
     /// Maps URI to last cold start attempt time.
     last_attempts: DashMap<Uri, Instant>,
-    /// Minimum interval between cold start attempts for the same URI.
-    min_interval: Duration,
+    /// Minimum interval between cold start attempts for the same URI, in
+    /// milliseconds. Atomic so `set_min_interval` can live-update it from
+    /// `did_change_configuration` (issue #499) without disturbing in-flight
+    /// `allow_cold_start` callers.
+    min_interval_ms: AtomicU64,
 }
 
 impl ColdStartLimiter {
@@ -148,21 +151,31 @@ impl ColdStartLimiter {
     pub fn new(min_interval: Duration) -> Self {
         Self {
             last_attempts: DashMap::new(),
-            min_interval,
+            min_interval_ms: AtomicU64::new(min_interval.as_millis() as u64),
         }
+    }
+
+    /// Updates the minimum interval between cold start attempts.
+    ///
+    /// Takes effect on the next `allow_cold_start` call. Used to apply a
+    /// live-reloaded `cold_start.rate_limit_ms` (issue #499).
+    pub fn set_min_interval(&self, min_interval: Duration) {
+        self.min_interval_ms
+            .store(min_interval.as_millis() as u64, Ordering::Relaxed);
     }
 
     /// Returns true if cold start is allowed, false if rate limited.
     ///
     /// Updates the last attempt time if the cold start is allowed.
     pub fn allow_cold_start(&self, uri: &Uri) -> bool {
+        let min_interval = Duration::from_millis(self.min_interval_ms.load(Ordering::Relaxed));
         let now = Instant::now();
 
         // Check last attempt time
         if let Some(mut entry) = self.last_attempts.get_mut(uri) {
             let elapsed = now.duration_since(*entry);
-            if elapsed < self.min_interval {
-                let retry_after = self.min_interval.checked_sub(elapsed).unwrap();
+            if elapsed < min_interval {
+                let retry_after = min_interval.checked_sub(elapsed).unwrap();
                 tracing::warn!(
                     "Cold start rate limited for {:?} (retry after {:?})",
                     uri,
@@ -508,8 +521,13 @@ impl ServerState {
             Arc::clone(&registry_policy),
         );
 
-        // Create cold start limiter with default 100ms interval (10 req/sec per URI)
-        let cold_start_limiter = ColdStartLimiter::new(Duration::from_millis(100));
+        // Default interval, live-updated by `set_min_interval` once `initialize`/
+        // `did_change_configuration` parses a real `cold_start.rate_limit_ms` (issue
+        // #499). Sourced from `ColdStartConfig::default()` rather than a bare literal
+        // so this can never drift from `default_rate_limit_ms()`.
+        let cold_start_limiter = ColdStartLimiter::new(Duration::from_millis(
+            crate::config::ColdStartConfig::default().rate_limit_ms,
+        ));
 
         Self {
             documents: DashMap::new(),
@@ -1157,6 +1175,34 @@ mod tests {
             assert!(
                 limiter.allow_cold_start(&uri),
                 "Request after interval should be allowed"
+            );
+        }
+
+        /// Issue #499: `set_min_interval` must actually change rate-limiting
+        /// behavior, not just be stored inertly.
+        #[tokio::test]
+        async fn test_set_min_interval_changes_behavior() {
+            let limiter = ColdStartLimiter::new(Duration::from_millis(100));
+            let uri = deps_core::test_util::test_uri("/test.toml");
+
+            assert!(limiter.allow_cold_start(&uri), "First request allowed");
+            assert!(
+                !limiter.allow_cold_start(&uri),
+                "Second immediate request blocked under the original 100ms interval"
+            );
+
+            // `rate_limit_ms: 0` disables rate limiting entirely (`elapsed < ZERO` is
+            // never true), so this is deterministic regardless of scheduling jitter —
+            // no sleep needed, unlike a short nonzero interval would require.
+            limiter.set_min_interval(Duration::ZERO);
+
+            assert!(
+                limiter.allow_cold_start(&uri),
+                "Lowering the interval to 0 should allow every request immediately"
+            );
+            assert!(
+                limiter.allow_cold_start(&uri),
+                "A zero interval keeps allowing consecutive requests"
             );
         }
 

--- a/crates/deps-lsp/src/server.rs
+++ b/crates/deps-lsp/src/server.rs
@@ -391,6 +391,11 @@ impl LanguageServer for Backend {
                 .set_registry_policy(config.cargo.workspace_registries.to_policy());
             self.state.cache.set_offline(config.network.offline);
             self.state.cache.set_cache_enabled(config.cache.enabled);
+            self.state
+                .cold_start_limiter
+                .set_min_interval(std::time::Duration::from_millis(
+                    config.cold_start.rate_limit_ms,
+                ));
             *self.config.write().await = config;
         }
 
@@ -525,6 +530,11 @@ impl LanguageServer for Backend {
         // diagnostics under the stale flag values (critic M5).
         self.state.cache.set_offline(config.network.offline);
         self.state.cache.set_cache_enabled(config.cache.enabled);
+        self.state
+            .cold_start_limiter
+            .set_min_interval(std::time::Duration::from_millis(
+                config.cold_start.rate_limit_ms,
+            ));
         *self.config.write().await = config;
 
         // Hover/completion/code actions are computed on demand and pick up the new
@@ -1679,6 +1689,38 @@ mod tests {
             let result = backend.state.cache.get_cached(&url).await.unwrap();
             assert_eq!(result.as_ref(), b"fetched after returning online");
             resumed_mock.assert_async().await;
+        }
+
+        /// Issue #499: `cold_start.rate_limit_ms` was parsed into `DepsConfig` but
+        /// never reached the live `ColdStartLimiter`, which always used the
+        /// hardcoded 100ms interval it was constructed with. A live-reloaded,
+        /// shorter interval must actually change rate-limiting behavior.
+        #[tokio::test]
+        async fn test_did_change_configuration_updates_cold_start_rate_limit() {
+            let (service, _socket) = tower_lsp_server::LspService::build(Backend::new).finish();
+            let backend = service.inner();
+            let uri = deps_core::test_util::test_uri("/test.toml");
+
+            assert!(backend.state.cold_start_limiter.allow_cold_start(&uri));
+            assert!(
+                !backend.state.cold_start_limiter.allow_cold_start(&uri),
+                "second immediate request blocked under the default 100ms interval"
+            );
+
+            // `rate_limit_ms: 0` disables rate limiting entirely (`elapsed < ZERO` is
+            // never true), so the assertion below is deterministic regardless of
+            // scheduling jitter — no sleep, unlike a short nonzero interval would need.
+            backend
+                .did_change_configuration(DidChangeConfigurationParams {
+                    settings: serde_json::json!({ "cold_start": { "rate_limit_ms": 0 } }),
+                })
+                .await;
+            assert_eq!(backend.config.read().await.cold_start.rate_limit_ms, 0);
+
+            assert!(
+                backend.state.cold_start_limiter.allow_cold_start(&uri),
+                "rate_limit_ms: 0 should allow a cold start immediately, with no wait"
+            );
         }
 
         /// C1 regression: `did_change_configuration` makes a concurrent `config.write()`


### PR DESCRIPTION
## Summary

`ColdStartConfig.rate_limit_ms` was parsed from client settings, documented, and unit-tested, but was never read outside `config.rs`. The one production `ColdStartLimiter` was constructed once with a hardcoded `Duration::from_millis(100)` and never updated afterward, so the config field had zero effect on server behavior — the same class of bug as the already-fixed #224 and the dead `cache.refresh_interval_secs` field removed in #498.

- `ColdStartLimiter.min_interval` changed from a fixed `Duration` to an `AtomicU64` (millis), with a new `set_min_interval()` method.
- `set_min_interval` is called from both `Backend::initialize` and `Backend::did_change_configuration` in `server.rs`, mirroring the existing `set_registry_policy`/`set_offline`/`set_cache_enabled` live-config wiring pattern.
- `ServerState::new`'s initial interval is sourced from `ColdStartConfig::default().rate_limit_ms` instead of a bare `Duration::from_millis(100)` literal, so it can no longer silently drift from `default_rate_limit_ms()` if either changes independently.
- Two regression tests (`test_set_min_interval_changes_behavior`, `test_did_change_configuration_updates_cold_start_rate_limit`) use `rate_limit_ms: 0` with no `sleep`, proving a live config change measurably alters rate-limiting behavior — deterministically, and covering the zero-value edge case.

Closes #499

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (3577 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New regression tests fail without the fix (verified: they exercise real rate-limiter behavior, not a config round-trip)