### PR TITLE
fix(deps-core,deps-github-actions): stop hover footer from misleading under network.offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-lsp**: a client that never answers `workspace/applyEdit` for `deps-lsp.updateVersion` or `deps-lsp.updateAllOutdated` no longer permanently occupies a `workspace/executeCommand` concurrency slot; the request is now timeout-bounded (5s), same as #493's fix (resolves #496) (#498)
 - **deps-lsp**: `cold_start.rate_limit_ms` now actually rate-limits cold starts instead of being parsed and silently ignored in favor of a hardcoded 100ms interval (resolves #499) (#504)
 - **deps-github-actions**: resolve SHA-pin quickfix never firing for bare-major moving GitHub Actions tags (v3, v4) (resolves #503)
+- **deps-core, deps-github-actions**: hover no longer shows the "Press Cmd+. to update version" footer for a dependency with no actual data or code action while `network.offline` is set (resolves #501) (#506)
 
 ### Removed
 - **Breaking (pre-1.0, public API)**: **deps-lsp**: dropped the dead `CacheConfig::refresh_interval_secs` field — `HttpCache` has no local TTL concept to attach it to (resolves #492) (#498)

--- a/crates/deps-core/src/lsp_helpers/hover.rs
+++ b/crates/deps-core/src/lsp_helpers/hover.rs
@@ -37,6 +37,15 @@ fn version_age_suffix(version: &dyn Version, now: PublishTime) -> String {
 /// delaying the common case, which never reaches this fallback at all.
 const HOVER_FALLBACK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
+/// The `Cmd+.` update-footer markdown this function appends when a code action may exist
+/// for the hovered dependency.
+///
+/// `pub` (re-exported from `lsp_helpers`) so an ecosystem's own `generate_hover` override
+/// can restore it post-hoc for an action source this shared gate has no visibility into
+/// (e.g. GHA's `TagIndex`-driven SHA-pin quickfix, #501) without hand-copying the literal
+/// and risking drift between the two.
+pub const CMD_DOT_FOOTER: &str = "\n---\n⌨️ **Press `Cmd+.` to update version**";
+
 pub async fn generate_hover<R: Registry + ?Sized>(
     parse_result: &dyn ParseResult,
     position: Position,
@@ -305,15 +314,12 @@ pub async fn generate_hover<R: Registry + ?Sized>(
             .or_else(|| m.get(&normalized_name))
             .or_else(|| m.get(dep.name().as_str()))
     });
+    let deprecation = versions
+        .outcomes
+        .and_then(|o| o.deprecation(&normalized_name));
     // Package-level context (#205) renders before per-version security advisories:
     // deprecation is a property of the package, advisories of the version.
-    push_deprecation_hover_section(
-        &mut markdown,
-        formatter,
-        versions
-            .outcomes
-            .and_then(|o| o.deprecation(&normalized_name)),
-    );
+    push_deprecation_hover_section(&mut markdown, formatter, deprecation);
     push_vulnerability_hover_section(&mut markdown, vuln_outcome);
 
     if let Some(available_versions) = &available_versions {
@@ -373,8 +379,27 @@ pub async fn generate_hover<R: Registry + ?Sized>(
     // `versions.vulnerabilities` — populated independently of the registry fetch
     // (`lifecycle.rs`) — even when both of those are empty (e.g. a registry fetch failure),
     // so requiring them too would silently drop the footer while `Cmd+.` still offers a fix.
-    if resolvable {
-        markdown.push_str("\n---\n⌨️ **Press `Cmd+.` to update version**");
+    //
+    // Also gated on offline data availability (#501): `HttpCache` deliberately serves warm
+    // entries while offline (it force-enables caching in that mode), and doc-state fields —
+    // `versions.vulnerabilities`/`cached_latest`/deprecation — survive an online-to-offline
+    // transition via `preserve_cache`, so `Cmd+.` can still produce a real REFACTOR/fix/
+    // replacement action offline as long as *some* version, vulnerability, or deprecation
+    // data was actually rendered above. Only suppress when offline AND none of that data is
+    // present — a cold process with nothing cached yet, where no producer in
+    // `generate_code_actions` has anything to act on.
+    //
+    // `matches!(vuln_outcome, Some(ScanOutcome::Vulnerable(_)))`, not `vuln_outcome.is_some()`
+    // (#501 C5): offline does not skip the OSV scan, it lets it run and fail, which writes
+    // `ScanOutcome::Skipped(_)` for every dependency — `is_some()` would be true in exactly
+    // #501's own cold-start repro and only `Vulnerable` ever backs
+    // `build_vulnerability_fix_action` (`code_actions.rs`).
+    let has_offline_actionable_data = available_versions.as_ref().is_some_and(|v| !v.is_empty())
+        || cached_latest.is_some()
+        || matches!(vuln_outcome, Some(ScanOutcome::Vulnerable(_)))
+        || deprecation.is_some();
+    if resolvable && (!versions.offline || has_offline_actionable_data) {
+        markdown.push_str(CMD_DOT_FOOTER);
     }
 
     // `versions.offline` (issue #483): the OSV lookup that produced `ScanOutcome::Skipped`
@@ -2393,6 +2418,102 @@ mod tests {
             !content.value.contains("Press `Cmd+.` to update version"),
             "a non-resolvable source offers no update code action, even with a cached \
              latest value present; got: {}",
+            content.value
+        );
+    }
+
+    /// #501: while `network.offline` is set, `HttpCache` can still serve warm data and
+    /// doc-state (`versions.vulnerabilities`/`cached_latest`/deprecation) can still survive
+    /// the transition (see `test_generate_hover_footer_shown_when_offline_with_warm_cache_versions`),
+    /// so the footer isn't suppressed on `offline` alone — only when offline AND no such
+    /// actionable data exists at all. This test is that cold-start case: nothing cached,
+    /// nothing resolved, and the OSV scan's own offline failure (`Skipped(QueryFailed)`,
+    /// not `Vulnerable`) counts as "no data" too (#501 C5).
+    #[tokio::test]
+    async fn test_generate_hover_footer_omitted_when_offline_with_no_cached_data() {
+        use crate::osv::{ScanOutcome, SkipReason, VulnerabilityMap};
+
+        // Cold process, nothing cached yet (#501's actual repro): the registry fetch fails
+        // (offline, no warm `HttpCache` entry) and there is no cached/resolved/deprecation
+        // doc state either, so no `generate_code_actions` producer has anything to act on.
+        //
+        // `vulnerabilities` carries a `Skipped(QueryFailed)` entry rather than being empty
+        // (#501 C5): offline doesn't skip the OSV scan, it lets it run and fail, which is
+        // exactly what a real offline cold start writes for every dependency — the gate must
+        // not treat that `Skipped` presence as an actionable `Vulnerable` outcome.
+        let parse_result = freshness_test_parse_result("serde");
+        let mut vulns: VulnerabilityMap = VulnerabilityMap::new();
+        vulns.insert(
+            "serde".to_string(),
+            ScanOutcome::Skipped(SkipReason::QueryFailed),
+        );
+
+        let hover = generate_hover(
+            &parse_result,
+            Position::new(0, 2),
+            VersionData::new(&HashMap::new(), &HashMap::new())
+                .with_offline(true)
+                .with_vulnerabilities(&vulns),
+            &ErrorRegistry,
+            &MockFormatter,
+            crate::freshness::FreshnessSettings::default(),
+            PublishTime::now(),
+        )
+        .await
+        .expect("hover should be generated for a dependency at the cursor");
+
+        let HoverContents::Markup(content) = hover.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(
+            !content.value.contains("Press `Cmd+.` to update version"),
+            "no code action can be produced while offline with nothing cached, so the \
+             footer must not render; got: {}",
+            content.value
+        );
+        assert!(
+            content
+                .value
+                .contains("📴 *Offline: version and vulnerability data not checked*"),
+            "the existing offline notice must still render; got: {}",
+            content.value
+        );
+    }
+
+    /// #501 (impl-critic C1): `HttpCache` deliberately serves warm entries while offline, so
+    /// a `Cmd+.` REFACTOR "update to X" action is still genuinely available whenever a live
+    /// version list came back — the footer must not be suppressed just because
+    /// `versions.offline` is set.
+    #[tokio::test]
+    async fn test_generate_hover_footer_shown_when_offline_with_warm_cache_versions() {
+        let registry = MockRegistryWithVersions {
+            versions: vec![MockVersionWithAge {
+                version: "1.2.3".into(),
+                yanked: false,
+                published_at: None,
+            }],
+        };
+        let parse_result = freshness_test_parse_result("serde");
+
+        let hover = generate_hover(
+            &parse_result,
+            Position::new(0, 2),
+            VersionData::new(&HashMap::new(), &HashMap::new()).with_offline(true),
+            &registry,
+            &MockFormatter,
+            crate::freshness::FreshnessSettings::default(),
+            PublishTime::now(),
+        )
+        .await
+        .expect("hover should be generated for a dependency at the cursor");
+
+        let HoverContents::Markup(content) = hover.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(
+            content.value.contains("Press `Cmd+.` to update version"),
+            "a warm-cache live version list still offers a real REFACTOR action while \
+             offline, so the footer must render; got: {}",
             content.value
         );
     }

--- a/crates/deps-core/src/lsp_helpers/mod.rs
+++ b/crates/deps-core/src/lsp_helpers/mod.rs
@@ -26,7 +26,7 @@ pub use diagnostics::{
     compile_requirement_unless, generate_diagnostics_from_cache, requirement_is_unsatisfiable,
     truncate_for_diagnostic,
 };
-pub use hover::generate_hover;
+pub use hover::{CMD_DOT_FOOTER, generate_hover};
 pub use in_use_version::{concrete_pin_version, in_use_version, is_full_semver_shape};
 pub use inlay_hints::generate_inlay_hints;
 

--- a/crates/deps-github-actions/src/ecosystem.rs
+++ b/crates/deps-github-actions/src/ecosystem.rs
@@ -245,6 +245,41 @@ impl Ecosystem for GithubActionsEcosystem {
             let Some(gha_dep) = dep.as_any().downcast_ref::<GithubActionsDependency>() else {
                 return Some(hover);
             };
+
+            // #501 gap (tester finding): the shared `has_offline_actionable_data` gate in
+            // `deps_core::generate_hover` only sees `VersionData` and cannot see
+            // `formatter.tag_index` — GHA's "Pin to commit SHA" quickfix
+            // (`build_sha_pin_action`, wired into `generate_code_actions` above) is driven
+            // entirely by that separately-populated index, independent of `versions`. So a
+            // `PinStyle::Tag` step with a warm `TagIndex` entry has a real `Cmd+.` action
+            // while offline, even when the shared gate suppressed the footer for lack of any
+            // `VersionData` signal. Restores it post-hoc using the shared `CMD_DOT_FOOTER`
+            // constant (not a hand-copied literal) so the two can never drift apart.
+            // `is_plain_scalar` mirrors `build_sha_pin_action`'s own guard (FR-010, spec
+            // 031): for a quoted `uses:` scalar, `version_range` sits inside the quotes, so
+            // the quickfix withholds itself rather than corrupt the value — the footer must
+            // not advertise an action that was never actually offered.
+            if versions.offline
+                && gha_dep.pin == Some(PinStyle::Tag)
+                && gha_dep.is_plain_scalar
+                && let Some(tag) = gha_dep
+                    .version_req
+                    .as_ref()
+                    .map(deps_core::VersionReq::as_str)
+                && self
+                    .formatter
+                    .sha_pin_replacement_for(&gha_dep.name, tag)
+                    .is_some()
+                && let HoverContents::Markup(content) = &mut hover.contents
+                && !content
+                    .value
+                    .contains(deps_core::lsp_helpers::CMD_DOT_FOOTER)
+            {
+                content
+                    .value
+                    .push_str(deps_core::lsp_helpers::CMD_DOT_FOOTER);
+            }
+
             let Some(PinStyle::Sha { comment_tag }) = &gha_dep.pin else {
                 return Some(hover);
             };
@@ -884,5 +919,138 @@ mod tests {
         let spliced = splice_resolved_line(markdown, "v4.2.0", &"c".repeat(40));
         assert!(spliced.starts_with(markdown));
         assert!(spliced.contains("**Resolved**"));
+    }
+
+    /// #501 (tester finding): the shared `deps_core::generate_hover` gate only sees
+    /// `VersionData` and cannot know a `PinStyle::Tag` step still has a real "Pin to commit
+    /// SHA" quickfix available via the ecosystem-private `TagIndex`. Seeding the index
+    /// directly simulates a fetch that succeeded before the session went offline;
+    /// `cache.set_offline(true)` then makes the live fetch this call attempts fail without
+    /// touching the network (mirroring `HttpCache`'s real offline-cold behavior), so
+    /// `VersionData` carries no signal of its own and only the post-hoc restore can produce
+    /// the footer.
+    #[tokio::test]
+    async fn test_generate_hover_restores_footer_offline_for_tag_pin_with_warm_tag_index() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        cache.set_offline(true);
+        let eco = GithubActionsEcosystem::new(cache);
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let content = "steps:\n  - uses: actions/checkout@v4\n";
+        let parse_result = eco.parse_manifest(content, &uri).await.unwrap();
+
+        let mut index = crate::registry::TagIndex::default();
+        index.tag_to_sha.insert("v4".to_string(), "a".repeat(40));
+        eco.formatter.tag_index.insert(
+            deps_core::PackageName::new("actions/checkout"),
+            Arc::new(index),
+        );
+
+        let position = parse_result.dependencies()[0].name_range().start;
+        let cached = HashMap::new();
+        let resolved = HashMap::new();
+
+        let hover = eco
+            .generate_hover(
+                parse_result.as_ref(),
+                position,
+                deps_core::VersionData::new(&cached, &resolved).with_offline(true),
+                deps_core::FreshnessSettings::default(),
+            )
+            .await
+            .expect("hover should be generated for the dependency on this line");
+
+        let HoverContents::Markup(content) = hover.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(
+            content.value.contains("Press `Cmd+.` to update version"),
+            "a Tag-pinned step with a warm TagIndex entry still offers the SHA-pin quickfix \
+             while offline, so the footer must be restored even with no VersionData signal; \
+             got: {}",
+            content.value
+        );
+    }
+
+    /// A `PinStyle::Tag` step with no `TagIndex` entry (true cold start, nothing ever
+    /// resolved) must not have the footer restored — there is no quickfix to advertise.
+    #[tokio::test]
+    async fn test_generate_hover_footer_stays_omitted_offline_for_tag_pin_without_tag_index() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        cache.set_offline(true);
+        let eco = GithubActionsEcosystem::new(cache);
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let content = "steps:\n  - uses: actions/checkout@v4\n";
+        let parse_result = eco.parse_manifest(content, &uri).await.unwrap();
+
+        let position = parse_result.dependencies()[0].name_range().start;
+        let cached = HashMap::new();
+        let resolved = HashMap::new();
+
+        let hover = eco
+            .generate_hover(
+                parse_result.as_ref(),
+                position,
+                deps_core::VersionData::new(&cached, &resolved).with_offline(true),
+                deps_core::FreshnessSettings::default(),
+            )
+            .await
+            .expect("hover should be generated for the dependency on this line");
+
+        let HoverContents::Markup(content) = hover.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(
+            !content.value.contains("Press `Cmd+.` to update version"),
+            "no TagIndex entry exists, so there is no quickfix to restore the footer for; \
+             got: {}",
+            content.value
+        );
+    }
+
+    /// FR-010 (security audit finding, mirrored from
+    /// `test_build_sha_pin_action_no_quickfix_for_quoted_scalar`): a quoted `uses:` scalar
+    /// never gets the SHA-pin quickfix even on a `TagIndex` hit, since `version_range` sits
+    /// inside the quotes and editing it there would corrupt the value. The footer
+    /// restoration must withhold itself the same way `build_sha_pin_action` does, not just
+    /// check `pin`/`TagIndex` resolvability.
+    #[tokio::test]
+    async fn test_generate_hover_footer_not_restored_offline_for_quoted_tag_pin() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        cache.set_offline(true);
+        let eco = GithubActionsEcosystem::new(cache);
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let content = "steps:\n  - uses: \"actions/checkout@v4\"\n";
+        let parse_result = eco.parse_manifest(content, &uri).await.unwrap();
+
+        let mut index = crate::registry::TagIndex::default();
+        index.tag_to_sha.insert("v4".to_string(), "a".repeat(40));
+        eco.formatter.tag_index.insert(
+            deps_core::PackageName::new("actions/checkout"),
+            Arc::new(index),
+        );
+
+        let position = parse_result.dependencies()[0].name_range().start;
+        let cached = HashMap::new();
+        let resolved = HashMap::new();
+
+        let hover = eco
+            .generate_hover(
+                parse_result.as_ref(),
+                position,
+                deps_core::VersionData::new(&cached, &resolved).with_offline(true),
+                deps_core::FreshnessSettings::default(),
+            )
+            .await
+            .expect("hover should be generated for the dependency on this line");
+
+        let HoverContents::Markup(content) = hover.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(
+            !content.value.contains("Press `Cmd+.` to update version"),
+            "a quoted uses: scalar offers no SHA-pin quickfix even on a TagIndex hit, so the \
+             footer must not be restored; got: {}",
+            content.value
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #501

The `Cmd+.` hover footer advertised an update code action whenever a dependency's source was `resolvable`, regardless of whether any actual version, vulnerability, or deprecation data was ever fetched. Under `network.offline`, both the registry fetch and the OSV lookup can be blocked while `HttpCache` still serves warm entries, so the footer needs to reflect whether a code action is actually available rather than the raw offline flag alone.

- Gate the footer on offline AND absence of any actionable data (available versions, cached latest, a genuinely `Vulnerable` OSV outcome — not `Skipped`, which offline itself produces for every dependency by default when the OSV scan's HTTP call fails; and deprecation).
- Export the footer text as `CMD_DOT_FOOTER` from `deps-core::lsp_helpers` so it isn't hand-copied.
- GitHub Actions' "Pin to commit SHA" quickfix is invisible to that shared signal since it's driven by a local tag index rather than `VersionData` — its `generate_hover` override restores the footer post-hoc when offline and a resolvable pin exists, guarded the same way the quickfix itself is (plain scalar only, matching `build_sha_pin_action`'s FR-010 guard).

## Test plan

- [x] `cargo nextest run --workspace --all-features --no-fail-fast` — 3580+ tests pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] New regression tests: cold-start footer suppression (no cached data, offline), warm-cache footer still shown (offline with cached version/vuln data), GHA footer restoration (offline + resolvable tag pin), GHA footer withheld for a quoted `uses:` scalar