### PR TITLE
refactor(deps-gradle): replace OnceLock+wrapper regex caching with LazyLock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: refactored `generate_diagnostics_from_cache`'s per-dependency checks into an explicit ordered rule pipeline; no behavior change (resolves #500)
 - **deps-core**: order-sensitive diagnostics tests now pin exact `diagnostics[i]` message/code instead of presence-only checks, closing a regression-detection gap left by #500's refactor; no behavior change (resolves #508) (#509)
 - **Breaking (pre-1.0, user-facing config)**: **deps-lsp**: `cargo.workspace_registries` is renamed to `registries.workspace_registries` (now also governs npm's `.npmrc` resolution); no compatibility alias, so a client still sending the old key falls back to defaults (resolves #502) (#510)
-- **deps-gradle**: simplified regex caching from `OnceLock` + wrapper functions to `LazyLock<Regex>`, matching the `deps-swift`/`deps-bundler`/`deps-go` idiom; no behavior change (resolves #511)
+- **deps-gradle**: simplified regex caching from `OnceLock` + wrapper functions to `LazyLock<Regex>`, matching the `deps-swift`/`deps-bundler`/`deps-go` idiom; no behavior change (resolves #511) (#514)
 
 ### Fixed
 - **deps-github-actions**: a tags-API page with one entry missing/malformed `commit.sha` no longer aborts the whole page's parse and silently truncates later pages — only that entry is now skipped (side effect of the #472 GitHub-tags-client extraction) (#476)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: refactored `generate_diagnostics_from_cache`'s per-dependency checks into an explicit ordered rule pipeline; no behavior change (resolves #500)
 - **deps-core**: order-sensitive diagnostics tests now pin exact `diagnostics[i]` message/code instead of presence-only checks, closing a regression-detection gap left by #500's refactor; no behavior change (resolves #508) (#509)
 - **Breaking (pre-1.0, user-facing config)**: **deps-lsp**: `cargo.workspace_registries` is renamed to `registries.workspace_registries` (now also governs npm's `.npmrc` resolution); no compatibility alias, so a client still sending the old key falls back to defaults (resolves #502) (#510)
+- **deps-gradle**: simplified regex caching from `OnceLock` + wrapper functions to `LazyLock<Regex>`, matching the `deps-swift`/`deps-bundler`/`deps-go` idiom; no behavior change (resolves #511)
 
 ### Fixed
 - **deps-github-actions**: a tags-API page with one entry missing/malformed `commit.sha` no longer aborts the whole page's parse and silently truncates later pages — only that entry is now skipped (side effect of the #472 GitHub-tags-client extraction) (#476)

--- a/crates/deps-gradle/src/parser/groovy.rs
+++ b/crates/deps-gradle/src/parser/groovy.rs
@@ -6,17 +6,25 @@ use crate::parser::{GradleParseResult, find_name_range, find_version_range};
 use crate::types::GradleDependency;
 use deps_core::Result;
 use regex::Regex;
-use std::sync::OnceLock;
+use std::sync::LazyLock;
 use tower_lsp_server::ls_types::Uri;
 
 /// Matches: implementation('group:artifact:version') or implementation("group:artifact:version")
-static RE_WITH_PARENS: OnceLock<Regex> = OnceLock::new();
+static RE_WITH_PARENS: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(\w+)\(\s*['"]([^:'"]+):([^:'"]+):([^'"]+)['"]\s*\)"#).expect("RE_WITH_PARENS")
+});
 /// Matches: implementation 'group:artifact:version' or implementation "group:artifact:version"
-static RE_WITHOUT_PARENS: OnceLock<Regex> = OnceLock::new();
+static RE_WITHOUT_PARENS: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(\w+)\s+['"]([^:'"]+):([^:'"]+):([^'"]+)['"]"#).expect("RE_WITHOUT_PARENS")
+});
 /// Matches: implementation 'group:artifact' or implementation "group:artifact" (no version)
-static RE_NO_VERSION_WITHOUT_PARENS: OnceLock<Regex> = OnceLock::new();
+static RE_NO_VERSION_WITHOUT_PARENS: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(\w+)\s+['"]([^:'"]+):([^:'"]+)['"]"#).expect("RE_NO_VERSION_WITHOUT_PARENS")
+});
 /// Matches: implementation('group:artifact') (no version, with parens)
-static RE_NO_VERSION_WITH_PARENS: OnceLock<Regex> = OnceLock::new();
+static RE_NO_VERSION_WITH_PARENS: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(\w+)\(\s*['"]([^:'"]+):([^:'"]+)['"]\s*\)"#).expect("RE_NO_VERSION_WITH_PARENS")
+});
 
 const CONFIGURATIONS: &[&str] = &[
     "implementation",
@@ -34,27 +42,6 @@ const CONFIGURATIONS: &[&str] = &[
     "testCompile",
     "provided",
 ];
-
-fn re_with_parens() -> &'static Regex {
-    RE_WITH_PARENS.get_or_init(|| {
-        Regex::new(r#"(\w+)\(\s*['"]([^:'"]+):([^:'"]+):([^'"]+)['"]\s*\)"#).unwrap()
-    })
-}
-
-fn re_without_parens() -> &'static Regex {
-    RE_WITHOUT_PARENS
-        .get_or_init(|| Regex::new(r#"(\w+)\s+['"]([^:'"]+):([^:'"]+):([^'"]+)['"]"#).unwrap())
-}
-
-fn re_no_version_without_parens() -> &'static Regex {
-    RE_NO_VERSION_WITHOUT_PARENS
-        .get_or_init(|| Regex::new(r#"(\w+)\s+['"]([^:'"]+):([^:'"]+)['"]"#).unwrap())
-}
-
-fn re_no_version_with_parens() -> &'static Regex {
-    RE_NO_VERSION_WITH_PARENS
-        .get_or_init(|| Regex::new(r#"(\w+)\(\s*['"]([^:'"]+):([^:'"]+)['"]\s*\)"#).unwrap())
-}
 
 pub fn parse_groovy_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
     let mut dependencies = Vec::new();
@@ -94,7 +81,7 @@ pub fn parse_groovy_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
         let mut matched_positions: Vec<usize> = Vec::new();
 
         // Pattern 1: with parens and version
-        for caps in re_with_parens().captures_iter(line) {
+        for caps in RE_WITH_PARENS.captures_iter(line) {
             let config = caps.get(1).map_or("", |m| m.as_str());
             if !CONFIGURATIONS.contains(&config) {
                 continue;
@@ -122,7 +109,7 @@ pub fn parse_groovy_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
         }
 
         // Pattern 2: without parens and with version
-        for caps in re_without_parens().captures_iter(line) {
+        for caps in RE_WITHOUT_PARENS.captures_iter(line) {
             let config = caps.get(1).map_or("", |m| m.as_str());
             if !CONFIGURATIONS.contains(&config) {
                 continue;
@@ -153,7 +140,7 @@ pub fn parse_groovy_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
         }
 
         // Pattern 3: with parens, no version
-        for caps in re_no_version_with_parens().captures_iter(line) {
+        for caps in RE_NO_VERSION_WITH_PARENS.captures_iter(line) {
             let config = caps.get(1).map_or("", |m| m.as_str());
             if !CONFIGURATIONS.contains(&config) {
                 continue;
@@ -181,7 +168,7 @@ pub fn parse_groovy_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
         }
 
         // Pattern 4: without parens, no version
-        for caps in re_no_version_without_parens().captures_iter(line) {
+        for caps in RE_NO_VERSION_WITHOUT_PARENS.captures_iter(line) {
             let config = caps.get(1).map_or("", |m| m.as_str());
             if !CONFIGURATIONS.contains(&config) {
                 continue;

--- a/crates/deps-gradle/src/parser/kotlin.rs
+++ b/crates/deps-gradle/src/parser/kotlin.rs
@@ -6,13 +6,17 @@ use crate::parser::{GradleParseResult, find_name_range, find_version_range};
 use crate::types::GradleDependency;
 use deps_core::Result;
 use regex::Regex;
-use std::sync::OnceLock;
+use std::sync::LazyLock;
 use tower_lsp_server::ls_types::Uri;
 
 /// Matches: implementation("group:artifact:version")
-static RE_WITH_VERSION: OnceLock<Regex> = OnceLock::new();
+static RE_WITH_VERSION: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(\w+)\(\s*"([^:"\s]+):([^:"\s]+):([^"]+)"\s*\)"#).expect("RE_WITH_VERSION")
+});
 /// Matches: implementation("group:artifact") — no version
-static RE_NO_VERSION: OnceLock<Regex> = OnceLock::new();
+static RE_NO_VERSION: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(\w+)\(\s*"([^:"\s]+):([^:"\s"]+)"\s*\)"#).expect("RE_NO_VERSION")
+});
 
 const CONFIGURATIONS: &[&str] = &[
     "implementation",
@@ -27,15 +31,6 @@ const CONFIGURATIONS: &[&str] = &[
     "ksp",
     "testCompileOnly",
 ];
-
-fn re_with_version() -> &'static Regex {
-    RE_WITH_VERSION
-        .get_or_init(|| Regex::new(r#"(\w+)\(\s*"([^:"\s]+):([^:"\s]+):([^"]+)"\s*\)"#).unwrap())
-}
-
-fn re_no_version() -> &'static Regex {
-    RE_NO_VERSION.get_or_init(|| Regex::new(r#"(\w+)\(\s*"([^:"\s]+):([^:"\s"]+)"\s*\)"#).unwrap())
-}
 
 pub fn parse_kotlin_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
     let mut dependencies = Vec::new();
@@ -77,7 +72,7 @@ pub fn parse_kotlin_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
         let line_u32 = line_idx as u32;
 
         // Try pattern with version first
-        for caps in re_with_version().captures_iter(line) {
+        for caps in RE_WITH_VERSION.captures_iter(line) {
             let config = caps.get(1).map_or("", |m| m.as_str());
             if !CONFIGURATIONS.contains(&config) {
                 continue;
@@ -105,7 +100,7 @@ pub fn parse_kotlin_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
 
         // Try pattern without version (only if no versioned match on this line)
         // Avoid double-matching lines that were already caught above
-        let already_matched: Vec<_> = re_with_version()
+        let already_matched: Vec<_> = RE_WITH_VERSION
             .captures_iter(line)
             .filter_map(|c| {
                 let config = c.get(1)?.as_str();
@@ -115,7 +110,7 @@ pub fn parse_kotlin_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
             })
             .collect();
 
-        for caps in re_no_version().captures_iter(line) {
+        for caps in RE_NO_VERSION.captures_iter(line) {
             let config = caps.get(1).map_or("", |m| m.as_str());
             if !CONFIGURATIONS.contains(&config) {
                 continue;

--- a/crates/deps-gradle/src/parser/settings.rs
+++ b/crates/deps-gradle/src/parser/settings.rs
@@ -6,17 +6,14 @@ use crate::parser::{GradleParseResult, utf16_len};
 use crate::types::GradleDependency;
 use deps_core::Result;
 use regex::Regex;
-use std::sync::OnceLock;
+use std::sync::LazyLock;
 use tower_lsp_server::ls_types::{Position, Range, Uri};
 
 /// Matches: id "plugin.id" version "1.0.0" (Groovy) or id("plugin.id") version "1.0.0" (Kotlin DSL)
-static RE_PLUGIN: OnceLock<Regex> = OnceLock::new();
-
-fn re_plugin() -> &'static Regex {
-    RE_PLUGIN.get_or_init(|| {
-        Regex::new(r#"id\s*\(?\s*['"]([^'"]+)['"]\s*\)?\s+version\s+['"]([^'"]+)['"]"#).unwrap()
-    })
-}
+static RE_PLUGIN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"id\s*\(?\s*['"]([^'"]+)['"]\s*\)?\s+version\s+['"]([^'"]+)['"]"#)
+        .expect("RE_PLUGIN")
+});
 
 /// Finds the LSP range of `plugin_id` within `line`.
 fn find_plugin_name_range(line: &str, line_idx: u32, plugin_id: &str) -> Range {
@@ -102,7 +99,7 @@ pub fn parse_settings(content: &str, uri: &Uri) -> Result<GradleParseResult> {
 
         let line_u32 = line_idx as u32;
 
-        for caps in re_plugin().captures_iter(line) {
+        for caps in RE_PLUGIN.captures_iter(line) {
             let plugin_id = caps.get(1).map_or("", |m| m.as_str()).to_string();
             let version = caps.get(2).map_or("", |m| m.as_str()).trim().to_string();
 


### PR DESCRIPTION
## Summary
- Replaces the `OnceLock<Regex>` + hand-written wrapper-fn pattern in `deps-gradle`'s three regex-based parsers (`settings.rs`, `kotlin.rs`, `groovy.rs`) with `LazyLock<Regex>` used directly at call sites, matching the idiom already used in `deps-swift`, `deps-bundler`, and `deps-go`.
- Wrapper functions deleted; `.unwrap()` replaced with `.expect("STATIC_NAME")` for a clearer panic message on the (unreachable, since patterns are compile-time literals) failure path.
- No regex patterns changed; this is a pure caching-mechanism refactor with zero behavior change.

## Verification
- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo nextest run --workspace --all-features --no-fail-fast` — 3645 passed, 0 failed
- Independently re-verified by a testing agent and an adversarial critic agent: all 6 migrated regex statics confirmed byte-identical old vs new, zero leftover references to the deleted wrapper functions.

Note: the testing pass surfaced a pre-existing, unrelated test-coverage gap (`RE_NO_VERSION_WITH_PARENS` in `groovy.rs` has no dedicated test) — out of scope for this refactor; will file a separate follow-up issue.

Closes #511