### PR TITLE
deps-pypi: PyPI private/custom index resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-lsp**: `cache.enabled: false` now actually bypasses the HTTP entry-map cache instead of being silently ignored (resolves #482) (#491)
 - **deps-core, deps-lsp, deps-maven**: new `network.offline` setting blocks every outbound registry/OSV/GitHub request, serving already-cached data where available (resolves #483) (#491)
 - **deps-npm, deps-core, deps-lsp**: npm `.npmrc` custom/private registry support — project/user-tier `registry=`/`@scope:registry=` overrides now resolve to live hover/diagnostic/completion data instead of none, failing closed on a bad entry rather than falling back to `registry.npmjs.org` (resolves #502) (#510)
+- **deps-pypi, deps-lsp**: PyPI private/custom index resolution — `requirements.txt` `--index-url`/`--extra-index-url`, Poetry `[[tool.poetry.source]]`, and uv `[tool.uv.index]`/`[tool.uv.sources]` now resolve to live hover/diagnostic/completion data instead of none, checking declared extras before the implicit `pypi.org` fallback and failing closed on a bad explicit entry rather than falling back to `pypi.org` (resolves #513)
 
 ### Changed
 - **repo**: root `Cargo.toml` `[workspace.dependencies]` is now fully, case-insensitively sorted alphabetically (resolves #442) (#444)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-lsp**: `cache.enabled: false` now actually bypasses the HTTP entry-map cache instead of being silently ignored (resolves #482) (#491)
 - **deps-core, deps-lsp, deps-maven**: new `network.offline` setting blocks every outbound registry/OSV/GitHub request, serving already-cached data where available (resolves #483) (#491)
 - **deps-npm, deps-core, deps-lsp**: npm `.npmrc` custom/private registry support — project/user-tier `registry=`/`@scope:registry=` overrides now resolve to live hover/diagnostic/completion data instead of none, failing closed on a bad entry rather than falling back to `registry.npmjs.org` (resolves #502) (#510)
-- **deps-pypi, deps-lsp**: PyPI private/custom index resolution — `requirements.txt` `--index-url`/`--extra-index-url`, Poetry `[[tool.poetry.source]]`, and uv `[tool.uv.index]`/`[tool.uv.sources]` now resolve to live hover/diagnostic/completion data instead of none, checking declared extras before the implicit `pypi.org` fallback and failing closed on a bad explicit entry rather than falling back to `pypi.org` (resolves #513)
+- **deps-pypi, deps-lsp**: PyPI private/custom index resolution — `requirements.txt` `--index-url`/`--extra-index-url`, Poetry `[[tool.poetry.source]]`, and uv `[tool.uv.index]`/`[tool.uv.sources]` now resolve to live hover/diagnostic/completion data instead of none, checking declared extras before the implicit `pypi.org` fallback and failing closed on a bad explicit entry rather than falling back to `pypi.org` (resolves #513) (#516)
 
 ### Changed
 - **repo**: root `Cargo.toml` `[workspace.dependencies]` is now fully, case-insensitively sorted alphabetically (resolves #442) (#444)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,6 +703,7 @@ name = "deps-pypi"
 version = "0.11.1"
 dependencies = [
  "criterion",
+ "dashmap",
  "deps-core",
  "insta",
  "mockito",
@@ -717,6 +718,7 @@ dependencies = [
  "toml-span",
  "tower-lsp-server",
  "tracing",
+ "url",
  "urlencoding",
 ]
 

--- a/crates/deps-core/src/error.rs
+++ b/crates/deps-core/src/error.rs
@@ -111,6 +111,20 @@ pub enum DepsError {
     /// that was blocked, for diagnostic/logging purposes.
     #[error("offline: request to {url} was blocked by network.offline")]
     Offline { url: String },
+
+    /// A multi-hop alternate/private-index chain's resolution was halted because a hop
+    /// returned a genuine transport error (5xx, timeout, connection failure) rather than a
+    /// clean "not found" — the chain deliberately does not fall through to a further, less
+    /// trusted hop in this case (`deps_pypi`'s FR-005(c)/NFR-003(3), #513). Carries no
+    /// arbitrary error text — mirrors [`Self::RateLimited`]'s pre-vetted-message precedent
+    /// (see [`Self::fetch_failure`]'s security-load-bearing invariant) — so its
+    /// classification there can safely be [`FetchFailure::Actionable`] with a fixed, safe
+    /// message, surfacing this case in hover/diagnostics instead of only a `tracing::warn!`.
+    #[error(
+        "index chain resolution halted by a transport error on one hop — not falling back \
+         to a less-trusted index"
+    )]
+    ChainResolutionHalted,
 }
 
 impl DepsError {
@@ -190,6 +204,13 @@ impl DepsError {
     pub fn fetch_failure(&self) -> FetchFailure {
         match self {
             Self::RateLimited { message } => FetchFailure::Actionable(message.clone()),
+            // Fixed, pre-vetted message — see `Self::ChainResolutionHalted`'s own doc for why
+            // this is safe to build as `Actionable` the same way `RateLimited` is.
+            Self::ChainResolutionHalted => FetchFailure::Actionable(
+                "index unreachable — resolution halted, not falling back to a less-trusted \
+                 index"
+                    .to_string(),
+            ),
             _ => FetchFailure::Transient,
         }
     }
@@ -384,13 +405,15 @@ mod tests {
         );
     }
 
-    /// Exhaustive companion to the doc-test on [`DepsError::fetch_failure`]: every
-    /// variant other than [`DepsError::RateLimited`] must classify as
-    /// [`FetchFailure::Transient`]. This is the invariant the doc comment calls
-    /// security-load-bearing (a future variant wired to `Actionable` by mistake
-    /// could leak raw, potentially IP-bearing error text into a diagnostic), so it
-    /// must be a real test enumerating every variant, not just the 2-variant
-    /// doc-test spot check.
+    /// Exhaustive companion to the doc-test on [`DepsError::fetch_failure`]: every variant
+    /// other than [`DepsError::RateLimited`] and [`DepsError::ChainResolutionHalted`] must
+    /// classify as [`FetchFailure::Transient`]. This is the invariant the doc comment calls
+    /// security-load-bearing (a future variant wired to `Actionable` by mistake could leak
+    /// raw, potentially IP-bearing error text into a diagnostic), so it must be a real test
+    /// enumerating every variant, not just a handful of spot checks. `ChainResolutionHalted`
+    /// is exempted from the "everything else is Transient" list — like `RateLimited`, it
+    /// carries no arbitrary payload, only a fixed, pre-vetted message, so it is safe to be
+    /// the second `Actionable`-producing variant (see its own doc and #513's M2 fix).
     #[test]
     fn test_fetch_failure_classifies_every_non_rate_limited_variant_as_transient() {
         // A `reqwest::Error` built from an invalid URL — `RequestBuilder::build`
@@ -455,6 +478,15 @@ mod tests {
         assert_eq!(
             rate_limited.fetch_failure(),
             FetchFailure::Actionable("set GITHUB_TOKEN to increase the rate limit".into())
+        );
+
+        assert_eq!(
+            DepsError::ChainResolutionHalted.fetch_failure(),
+            FetchFailure::Actionable(
+                "index unreachable — resolution halted, not falling back to a less-trusted \
+                 index"
+                    .to_string()
+            )
         );
     }
 }

--- a/crates/deps-lsp/src/lib.rs
+++ b/crates/deps-lsp/src/lib.rs
@@ -304,7 +304,16 @@ pub fn register_ecosystems(
     #[cfg(all(feature = "deno", not(feature = "npm")))]
     register!("deno", DenoEcosystem, registry, &cache);
 
-    register!("pypi", PypiEcosystem, registry, &cache);
+    // pypi is written out explicitly rather than via `register!` (spec 033, mirroring npm's
+    // spec 032 S3 precedent): that macro's `PypiEcosystem::new(cache)` would give pypi a
+    // default, disconnected `RegistryAccessPolicy` — its private-index reachability policy
+    // would never see a live `initialize`/`didChangeConfiguration` update.
+    #[cfg(feature = "pypi")]
+    registry.register(Arc::new(PypiEcosystem::with_policy(
+        Arc::new(PypiRegistry::new(Arc::clone(&cache))),
+        Arc::clone(&policy),
+    )));
+
     register!("go", GoEcosystem, registry, &cache);
     register!("bundler", BundlerEcosystem, registry, &cache);
     register!("dart", DartEcosystem, registry, &cache);

--- a/crates/deps-pypi/Cargo.toml
+++ b/crates/deps-pypi/Cargo.toml
@@ -12,7 +12,14 @@ publish = true
 [lints]
 workspace = true
 
+[features]
+# Gates the test-only https loopback carve-out in `config::PypiIndexUrl::new` for
+# downstream crates' own test builds (`cfg(test)` alone would not apply there) —
+# mirrors `deps-npm`'s identical `test-util` feature.
+test-util = []
+
 [dependencies]
+dashmap = { workspace = true }
 deps-core = { workspace = true }
 pep440_rs = { workspace = true }
 pep508_rs = { workspace = true }
@@ -24,6 +31,7 @@ tokio = { workspace = true }
 toml-span = { workspace = true }
 tower-lsp-server = { workspace = true }
 tracing = { workspace = true }
+url = { workspace = true }
 urlencoding = { workspace = true }
 
 [dev-dependencies]

--- a/crates/deps-pypi/src/config.rs
+++ b/crates/deps-pypi/src/config.rs
@@ -1,0 +1,896 @@
+//! Private/custom PyPI index resolution — `--index-url`/`--extra-index-url`
+//! (`requirements.txt`), Poetry `[[tool.poetry.source]]`, and uv
+//! `[tool.uv.index]`/`[tool.uv.sources]`.
+//!
+//! # Security model (read before touching this module)
+//!
+//! A `requirements.txt`/`pyproject.toml` index declaration is attacker-controlled the moment a
+//! hostile repository is cloned and opened — this LSP parses on file open, before any build
+//! ever runs. Phase 1 carries no authentication at all (spec Out of Scope: no URL userinfo, no
+//! `keyring`/`.netrc`), which closes the credential half of the threat model this module would
+//! otherwise have to solve, but two things still apply:
+//!
+//! - **No credential-shaped value is ever parsed.** [`PypiIndexUrl::new`] rejects any URL
+//!   carrying `username()`/`password()` outright (FR-006/FR-011) — there is no expansion step
+//!   for PyPI config (unlike npm's `${VAR}`), so [`InvalidEntry::raw`] and every
+//!   `tracing::warn!` here name the as-written value with any embedded userinfo stripped first
+//!   (see `redact_userinfo`) — the raw value is otherwise preserved so a warning or a
+//!   [`DependencySource::CustomRegistry`] naming an unresolved primary/named source still shows
+//!   the user what they actually typed, minus the credential.
+//! - **FR-005's resolution order is the load-bearing security invariant of this whole
+//!   feature.** Case (a) (an explicit `--index-url`/Poetry primary/uv `default`): the
+//!   explicit primary is checked first, then extras — a deliberate user choice, no
+//!   disclosure risk. Case (b) (no explicit primary, extras only): declared extras are
+//!   checked **before** the implicit public `pypi.org` fallback, never the reverse — this is
+//!   what stops a private package's name from being sent to `pypi.org` before the user's own
+//!   declared index has had a chance, and what stops a same-named public package from
+//!   silently shadowing a private one. See [`PypiIndexConfig::resolve_source_for`] and
+//!   [`ResolvedChain`]'s docs.
+//!
+//! See `specs/033-pypi-private-index-support/spec.md` FR-001–FR-014 and
+//! `specs/033-pypi-private-index-support/plan.md` §1/§3 for the design review this module
+//! implements.
+
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+
+use deps_core::net_policy::{HostClass, RegistryAccessPolicy, classify_host};
+use deps_core::parser::DependencySource;
+
+/// Whether `url`'s host is loopback (`127.0.0.1`, `localhost`, or `::1`) with an `http`
+/// scheme — the shape every `mockito::Server` binds to.
+///
+/// Only compiled into test builds — see `deps_npm::config::is_loopback_url`'s identical
+/// rationale, which this mirrors exactly.
+#[cfg(any(test, feature = "test-util"))]
+fn is_loopback_url(url: &url::Url) -> bool {
+    url.scheme() == "http" && matches!(url.host_str(), Some("127.0.0.1" | "localhost" | "::1"))
+}
+
+/// Why a candidate index URL failed [`PypiIndexUrl::new`]'s validation.
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum PypiIndexUrlError {
+    /// The value did not parse as a URL at all.
+    #[error("not a valid URL: {0}")]
+    InvalidUrl(String),
+    /// The URL's scheme is not `https` (the sole carve-out is a `cfg(test)`/`test-util`-only
+    /// `http` loopback host — see [`PypiIndexUrl::new`]).
+    #[error("index URL must use https, got scheme {0:?}")]
+    NotHttps(String),
+    /// The URL carries a `user:pass@`/`user@` component.
+    #[error("index URL must not carry userinfo")]
+    UserInfoPresent,
+    /// The candidate's host is blocked by the current
+    /// [`deps_core::net_policy::WorkspaceRegistryAccess`] policy.
+    #[error("index host class {class} blocked by registries.workspace_registries policy")]
+    BlockedHost {
+        /// The blocked host's classification.
+        class: HostClass,
+    },
+}
+
+/// A validated, normalized, https-only PyPI-protocol index URL with no embedded userinfo.
+///
+/// Mirrors `deps_npm::config::NpmRegistryIndex` (see FR-006/FR-011); kept `deps-pypi`-local
+/// rather than promoted to `deps-core` per this spec's Open Questions (consolidate only once a
+/// third near-identical type makes the duplication concrete).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PypiIndexUrl {
+    /// The validated URL, normalized by stripping a trailing `/` — matches
+    /// `simple_api_url`'s existing `{base}/{name}/` join convention (PEP 503).
+    normalized: String,
+}
+
+impl PypiIndexUrl {
+    /// Validates and normalizes `raw` against `policy`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PypiIndexUrlError`] if `raw` does not parse as a URL, is not `https` (outside
+    /// the `cfg(test)`/`test-util` loopback carve-out), carries a userinfo component, or
+    /// resolves to a host class the current `policy` blocks.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use deps_core::net_policy::RegistryAccessPolicy;
+    /// use deps_pypi::config::PypiIndexUrl;
+    ///
+    /// let policy = RegistryAccessPolicy::default();
+    /// assert!(PypiIndexUrl::new("https://pypi.mycorp.example/simple", &policy).is_ok());
+    /// assert!(PypiIndexUrl::new("http://pypi.mycorp.example/simple", &policy).is_err());
+    /// assert!(PypiIndexUrl::new("https://user:pass@pypi.mycorp.example", &policy).is_err());
+    /// ```
+    pub fn new(raw: &str, policy: &RegistryAccessPolicy) -> Result<Self, PypiIndexUrlError> {
+        let url =
+            url::Url::parse(raw).map_err(|_| PypiIndexUrlError::InvalidUrl(raw.to_string()))?;
+        let is_https = url.scheme() == "https";
+        #[cfg(any(test, feature = "test-util"))]
+        let is_https = is_https || is_loopback_url(&url);
+        if !is_https {
+            return Err(PypiIndexUrlError::NotHttps(url.scheme().to_string()));
+        }
+        if !url.username().is_empty() || url.password().is_some() {
+            return Err(PypiIndexUrlError::UserInfoPresent);
+        }
+        let class = classify_host(&url);
+        if !policy.get().allows(class) {
+            tracing::warn!(
+                url = raw,
+                ?class,
+                "workspace-declared PyPI index host blocked by registries.workspace_registries policy"
+            );
+            return Err(PypiIndexUrlError::BlockedHost { class });
+        }
+        let normalized = url.as_str().trim_end_matches('/').to_string();
+        Ok(Self { normalized })
+    }
+
+    /// The normalized index URL. Never carries a trailing `/`.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.normalized
+    }
+}
+
+impl std::fmt::Display for PypiIndexUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A present-but-unusable index entry — an invalid URL, a policy-blocked host, or a
+/// well-formed-but-non-https/userinfo-bearing value.
+///
+/// Carries the raw value as written, **with any embedded userinfo redacted** (M1 fix — see
+/// `redact_userinfo`), so [`PypiIndexConfig::resolve_source_for`] can build
+/// [`DependencySource::CustomRegistry`] for an explicit primary/named source, or log a warning
+/// naming what the user wrote for a dropped extra, without ever holding or surfacing the
+/// credential itself: a `CustomRegistry.url` can reach hover/diagnostics text, and a
+/// `UserInfoPresent` rejection is exactly the case where `raw` would otherwise still contain
+/// `user:pass@`.
+#[derive(Debug, Clone)]
+pub struct InvalidEntry {
+    /// The raw index value, as written in the source file, with any `user:pass@`/`user@`
+    /// userinfo component stripped.
+    pub raw: String,
+    /// Why it was rejected.
+    pub reason: PypiIndexUrlError,
+}
+
+/// Replaces any embedded `user:pass@`/`user@` userinfo component in `raw` with a fixed
+/// `***@` marker before it is ever logged or stored (M1 fix, FR-011/NFR-001, spec's exact
+/// `https://***@host/path` example).
+///
+/// A userinfo-bearing index URL is always rejected ([`PypiIndexUrlError::UserInfoPresent`]),
+/// but the *raw* value naming what was rejected must never itself carry the credential through
+/// to a `tracing::warn!` line or an [`InvalidEntry::raw`] a user might see surfaced as
+/// [`DependencySource::CustomRegistry`]'s `url` in hover/diagnostics text. A fixed marker
+/// (rather than stripping the component outright) keeps the redacted value visibly distinct
+/// from a URL that never carried userinfo at all, so a user can still tell *that* a credential
+/// was present and removed, without ever seeing what it was.
+///
+/// Returns `raw` unchanged when it doesn't parse as a URL, or parses but carries no userinfo —
+/// there is nothing to redact in either case, so every other [`PypiIndexUrlError`] variant's
+/// `raw` value is unaffected by this function.
+fn redact_userinfo(raw: &str) -> String {
+    let Ok(mut url) = url::Url::parse(raw) else {
+        return raw.to_string();
+    };
+    if url.username().is_empty() && url.password().is_none() {
+        return raw.to_string();
+    }
+    // `set_username`/`set_password` only fail for a cannot-be-a-base URL — never true here,
+    // since a URL with `username()`/`password()` set is always base-having by construction —
+    // but a hardcoded fallback marker is used instead of ever risking the original,
+    // credential-bearing string leaking through an unexpected `Err` path.
+    if url.set_username("***").is_err() || url.set_password(None).is_err() {
+        return "<redacted: index URL contained userinfo>".to_string();
+    }
+    url.as_str().to_string()
+}
+
+/// Validates and normalizes one raw index value, logging a `tracing::warn!` naming the raw
+/// value (userinfo redacted — see [`redact_userinfo`]) on failure. `pub(crate)`: every parser
+/// surface (`requirements.rs`, `pyproject.rs`) that discovers a candidate index value calls
+/// this before handing the result to a [`PypiIndexConfig`] setter.
+pub(crate) fn resolve_entry(
+    raw: &str,
+    policy: &RegistryAccessPolicy,
+) -> Result<PypiIndexUrl, InvalidEntry> {
+    PypiIndexUrl::new(raw, policy).map_err(|reason| {
+        let redacted = redact_userinfo(raw);
+        tracing::warn!(raw = %redacted, %reason, "PyPI index URL failed validation");
+        InvalidEntry {
+            raw: redacted,
+            reason,
+        }
+    })
+}
+
+/// One fully-resolved, ready-to-register routing chain — produced by
+/// [`PypiIndexConfig::resolved_chains`], consumed by
+/// `PypiRegistry::register_chain`/`register_named_source`.
+#[derive(Debug, Clone)]
+pub struct ResolvedChain {
+    /// Composite identity — becomes both the router's `alternates` map key and the
+    /// `DependencySource::AlternateRegistry.index` value for a plain (non-named-source)
+    /// dependency.
+    ///
+    /// For a primary/extras chain (case a/b): an opaque, single-line hashed token —
+    /// `format!("pypi-chain:{:016x}", digest)`, `digest` from
+    /// [`std::collections::hash_map::DefaultHasher`] over the ordered hop strings plus the
+    /// [`Self::implicit_public_fallback`] flag — **never** a newline-joined or otherwise
+    /// URL-shaped value: `deps-core`'s `AlternateRegistry.index` doc describes this field as
+    /// "the resolved index URL" for Cargo/npm, and a value that merely *looks* like a URL
+    /// (but isn't one) would violate that contract for any future reader — see plan.md's N6
+    /// fix. An explicit chain `[A, B]` and an implicit chain that happens to resolve to the
+    /// same hops `[A, B]` plus the fallback flag produce **different** keys (this is what
+    /// closes the C2 aliasing defect: two files sharing a primary but differing extras never
+    /// collide, and editing a file's extras changes its key on the next reparse).
+    ///
+    /// For a named-source chain (Poetry `source =`/uv `index =`): the source's own literal
+    /// URL, matching Cargo/npm's convention for a single resolved index.
+    pub key: String,
+    /// Ordered, already-validated hops. Hop 0 becomes the registered client's own
+    /// `simple_base`; the rest become its `fallback_chain`. Never empty — see
+    /// [`PypiIndexConfig::resolved_chains`]'s zero-hop handling.
+    pub hops: Vec<PypiIndexUrl>,
+    /// `true` only for a case-(b) chain (spec FR-005(b)) whose final hop is the implicit
+    /// public `pypi.org` root, appended at registration time rather than present in
+    /// [`Self::hops`] — `PypiRegistry::register_chain` builds that hop itself.
+    pub implicit_public_fallback: bool,
+}
+
+impl ResolvedChain {
+    fn chain(hops: Vec<PypiIndexUrl>, implicit_public_fallback: bool) -> Self {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        for hop in &hops {
+            hop.as_str().hash(&mut hasher);
+        }
+        implicit_public_fallback.hash(&mut hasher);
+        Self {
+            key: format!("pypi-chain:{:016x}", hasher.finish()),
+            hops,
+            implicit_public_fallback,
+        }
+    }
+
+    fn named_source(url: PypiIndexUrl) -> Self {
+        Self {
+            key: url.as_str().to_string(),
+            hops: vec![url],
+            implicit_public_fallback: false,
+        }
+    }
+}
+
+/// The effective case-(b) hop list (spec FR-005(b)): declared extras, in order, plus a final
+/// hop that is either a concrete uv `default = true` index or the implicit public fallback.
+struct CaseBChain {
+    hops: Vec<PypiIndexUrl>,
+    implicit_public_fallback: bool,
+}
+
+/// Resolved index configuration for one `requirements.txt`/`pyproject.toml` file.
+///
+/// Built once per parse (two-pass for `requirements.txt` — see `parser::requirements`'s
+/// module doc; single-pass for `pyproject.toml`, whose TOML tree is fully available before any
+/// dependency is resolved), consulted per-dependency via [`Self::resolve_source_for`].
+#[derive(Debug, Default)]
+pub struct PypiIndexConfig {
+    /// Explicit `--index-url`, a Poetry `primary`/`default`-priority source (including one
+    /// with no `priority` key at all — FR-007), or a Poetry `explicit`/unrecognized-priority
+    /// source contributes nothing here. uv **never** populates this field (FR-013's r3
+    /// correction) — a pure-uv config always routes through [`Self::case_b_chain`] instead.
+    /// `None` when no explicit primary is declared (spec FR-005(b) applies).
+    primary: Option<Result<PypiIndexUrl, InvalidEntry>>,
+    /// `--extra-index-url` values (declaration order preserved) plus Poetry
+    /// `supplemental`/`secondary`-priority sources plus every non-`default`/non-`explicit` uv
+    /// `[tool.uv.index]` entry — FR-005's fallback chain. An `Err(InvalidEntry)` here is
+    /// dropped (with a warning already logged by [`resolve_entry`]) rather than escalated,
+    /// per FR-006's extra-specific rule.
+    extras: Vec<Result<PypiIndexUrl, InvalidEntry>>,
+    /// uv's `default = true` index, if any (uv permits at most one) — uv's lowest-priority,
+    /// last-resort hop, replacing the implicit public fallback in that final slot. `None` for
+    /// every non-uv config, and for a uv config that declares no `default` entry (the
+    /// implicit public fallback is used instead).
+    tail_hop: Option<Result<PypiIndexUrl, InvalidEntry>>,
+    /// Poetry `[[tool.poetry.source]]` entries (all priorities, including `explicit`) keyed
+    /// by `name`, plus every uv `[tool.uv.index]` entry keyed by its own `name` — consulted
+    /// only when a dependency declares `source = "<name>"` (Poetry) or an `index = "<name>"`
+    /// uv-sources binding (FR-013), never auto-included in the primary/extras/tail chain.
+    named_sources: HashMap<String, Result<PypiIndexUrl, InvalidEntry>>,
+}
+
+impl PypiIndexConfig {
+    /// An empty config — every dependency resolves to plain [`DependencySource::Registry`],
+    /// byte-identical to today (US-004).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// FR-002: sets (overwriting any prior value) the explicit `--index-url`/Poetry
+    /// `primary`-equivalent primary. Matches pip's own `argparse` `store` semantics for
+    /// `--index-url` (not `append`, unlike `--extra-index-url`) — the last occurrence in a
+    /// file wins.
+    pub fn set_primary(&mut self, raw: &str, policy: &RegistryAccessPolicy) {
+        self.primary = Some(resolve_entry(raw, policy));
+    }
+
+    /// Like [`Self::set_primary`], but for a caller that already resolved (or is re-using an
+    /// already-resolved) candidate — avoids re-validating and double-logging a value that
+    /// must also be reachable as a named source (Poetry/uv).
+    ///
+    /// **First registration wins** (validator finding S3, fixes a silent-overwrite bug): a
+    /// second call is ignored, with a `tracing::warn!` naming the raw value that got dropped
+    /// — unlike [`Self::set_primary`] (`requirements.txt`'s `--index-url`, where pip's own
+    /// `argparse` `store` semantics make *last*-wins correct), Poetry has no documented
+    /// ordering for multiple `primary`/`default`-priority (or unlabeled) `[[tool.poetry.source]]`
+    /// entries, so silently picking whichever happened to parse last is an arbitrary,
+    /// non-deterministic-looking outcome — keeping the first and logging every later one is
+    /// deterministic and discoverable instead.
+    pub(crate) fn set_primary_resolved(&mut self, result: Result<PypiIndexUrl, InvalidEntry>) {
+        if self.primary.is_some() {
+            let raw = match &result {
+                Ok(url) => url.as_str(),
+                Err(invalid) => invalid.raw.as_str(),
+            };
+            tracing::warn!(
+                raw,
+                "multiple primary-priority index sources declared; keeping the first, \
+                 ignoring this one"
+            );
+            return;
+        }
+        self.primary = Some(result);
+    }
+
+    /// FR-003: appends an `--extra-index-url`/Poetry supplemental-priority/uv non-default
+    /// entry to the fallback chain, in declaration order.
+    pub fn add_extra(&mut self, raw: &str, policy: &RegistryAccessPolicy) {
+        self.extras.push(resolve_entry(raw, policy));
+    }
+
+    /// Like [`Self::add_extra`], but for an already-resolved candidate — see
+    /// [`Self::set_primary_resolved`]'s rationale.
+    pub(crate) fn add_extra_resolved(&mut self, result: Result<PypiIndexUrl, InvalidEntry>) {
+        self.extras.push(result);
+    }
+
+    /// FR-013: sets (overwriting any prior value — uv permits at most one) uv's
+    /// `default = true` index, an already-resolved candidate.
+    pub(crate) fn set_tail_hop_resolved(&mut self, result: Result<PypiIndexUrl, InvalidEntry>) {
+        self.tail_hop = Some(result);
+    }
+
+    /// FR-007/FR-013: registers a Poetry/uv named source, reachable via
+    /// [`Self::resolve_source_for`] with `Some(name)`. An already-resolved candidate — see
+    /// [`Self::set_primary_resolved`]'s rationale.
+    pub(crate) fn add_named_source_resolved(
+        &mut self,
+        name: String,
+        result: Result<PypiIndexUrl, InvalidEntry>,
+    ) {
+        self.named_sources.insert(name, result);
+    }
+
+    /// The valid (`Ok`) subset of [`Self::extras`], in declaration order.
+    fn valid_extras(&self) -> Vec<PypiIndexUrl> {
+        self.extras
+            .iter()
+            .filter_map(|e| e.as_ref().ok())
+            .cloned()
+            .collect()
+    }
+
+    /// The effective case-(b) chain (spec FR-005(b)), or `None` when this config has no
+    /// case-(b) declaration at all (no extras, no uv tail hop) — the "nothing declared"
+    /// state, distinct from "declared but every hop turned out invalid" (the zero-hop case,
+    /// which returns `Some` with an empty `hops`).
+    ///
+    /// An invalid uv `default` entry (`tail_hop` is `Some(Err(_))`) degrades to the implicit
+    /// public fallback rather than being dropped with no replacement — the same
+    /// fail-toward-availability rule FR-006 applies to every other extra.
+    fn case_b_chain(&self) -> Option<CaseBChain> {
+        if self.extras.is_empty() && self.tail_hop.is_none() {
+            return None;
+        }
+        let mut hops = self.valid_extras();
+        let implicit_public_fallback = match &self.tail_hop {
+            Some(Ok(tail)) => {
+                hops.push(tail.clone());
+                false
+            }
+            Some(Err(_)) | None => true,
+        };
+        Some(CaseBChain {
+            hops,
+            implicit_public_fallback,
+        })
+    }
+
+    /// FR-002/FR-003/FR-005/FR-006/FR-007/FR-013: resolves one dependency's
+    /// [`DependencySource`].
+    ///
+    /// `named_source` is `Some("internal")` for a dependency declaring `source = "internal"`
+    /// (Poetry) or an `index = "internal"` uv-sources binding; `None` for every other
+    /// dependency (routes through `primary`/`extras`/`tail_hop` per FR-005 instead).
+    ///
+    /// - A named-source reference resolves to that source's own URL, or
+    ///   [`DependencySource::CustomRegistry`] if the name is unresolved or the source is
+    ///   invalid (fail-closed, never a silent `pypi.org` fallback — FR-006).
+    /// - No override anywhere (no primary, no case-(b) declaration) -> plain
+    ///   [`DependencySource::Registry`] (US-004).
+    /// - An explicit primary present but invalid -> [`DependencySource::CustomRegistry`]
+    ///   (fail-closed — never falls through to the extras chain, matching an explicit
+    ///   `--index-url`'s *replace*, not *add*, semantics).
+    /// - Otherwise -> [`DependencySource::AlternateRegistry`] pointing at the chain
+    ///   [`ResolvedChain::key`] this same config's [`Self::resolved_chains`] registers.
+    #[must_use]
+    pub fn resolve_source_for(&self, named_source: Option<&str>) -> DependencySource {
+        if let Some(name) = named_source {
+            return match self.named_sources.get(name) {
+                Some(Ok(url)) => DependencySource::AlternateRegistry {
+                    index: url.as_str().to_string(),
+                    mirrors_crates_io: false,
+                },
+                Some(Err(invalid)) => DependencySource::CustomRegistry {
+                    url: invalid.raw.clone(),
+                },
+                None => DependencySource::CustomRegistry {
+                    url: name.to_string(),
+                },
+            };
+        }
+
+        match &self.primary {
+            Some(Ok(primary)) => {
+                let mut hops = vec![primary.clone()];
+                hops.extend(self.valid_extras());
+                DependencySource::AlternateRegistry {
+                    index: ResolvedChain::chain(hops, false).key,
+                    mirrors_crates_io: false,
+                }
+            }
+            Some(Err(invalid)) => DependencySource::CustomRegistry {
+                url: invalid.raw.clone(),
+            },
+            None => match self.case_b_chain() {
+                Some(chain) if !chain.hops.is_empty() => DependencySource::AlternateRegistry {
+                    index: ResolvedChain::chain(chain.hops, chain.implicit_public_fallback).key,
+                    mirrors_crates_io: false,
+                },
+                _ => DependencySource::Registry,
+            },
+        }
+    }
+
+    /// Every chain this config implies, ready for registration — FR-005(a)/(b) resolved to
+    /// concrete hop lists, plus one single-hop chain per valid named source. Empty when the
+    /// file declares nothing (US-004) or when every case-(b) hop turned out invalid with no
+    /// explicit primary (N5's zero-hop case — [`Self::resolve_source_for`] returns plain
+    /// `Registry` in that case, and there is nothing to register).
+    #[must_use]
+    pub fn resolved_chains(&self) -> Vec<ResolvedChain> {
+        let mut chains = Vec::new();
+
+        match &self.primary {
+            Some(Ok(primary)) => {
+                let mut hops = vec![primary.clone()];
+                hops.extend(self.valid_extras());
+                chains.push(ResolvedChain::chain(hops, false));
+            }
+            Some(Err(_)) => {}
+            None => {
+                if let Some(chain) = self.case_b_chain()
+                    && !chain.hops.is_empty()
+                {
+                    chains.push(ResolvedChain::chain(
+                        chain.hops,
+                        chain.implicit_public_fallback,
+                    ));
+                }
+            }
+        }
+
+        for url in self.named_sources.values().flatten() {
+            chains.push(ResolvedChain::named_source(url.clone()));
+        }
+
+        chains
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use deps_core::net_policy::WorkspaceRegistryAccess;
+
+    fn all_policy() -> RegistryAccessPolicy {
+        RegistryAccessPolicy::new(WorkspaceRegistryAccess::All)
+    }
+
+    fn off_policy() -> RegistryAccessPolicy {
+        RegistryAccessPolicy::new(WorkspaceRegistryAccess::Off)
+    }
+
+    // --- PypiIndexUrl ---
+
+    #[test]
+    fn test_index_url_accepts_https() {
+        let policy = all_policy();
+        assert!(PypiIndexUrl::new("https://pypi.mycorp.example/simple", &policy).is_ok());
+    }
+
+    #[test]
+    fn test_index_url_rejects_http_non_loopback() {
+        let policy = all_policy();
+        assert!(matches!(
+            PypiIndexUrl::new("http://pypi.mycorp.example/simple", &policy),
+            Err(PypiIndexUrlError::NotHttps(_))
+        ));
+    }
+
+    #[test]
+    fn test_index_url_accepts_http_loopback_under_test_cfg() {
+        let policy = all_policy();
+        assert!(PypiIndexUrl::new("http://127.0.0.1:9999/simple", &policy).is_ok());
+        assert!(PypiIndexUrl::new("http://localhost:9999/simple", &policy).is_ok());
+    }
+
+    #[test]
+    fn test_index_url_rejects_http_near_miss_loopback() {
+        let policy = all_policy();
+        assert!(matches!(
+            PypiIndexUrl::new("http://localhost.evil.com/simple", &policy),
+            Err(PypiIndexUrlError::NotHttps(_))
+        ));
+    }
+
+    #[test]
+    fn test_index_url_rejects_userinfo() {
+        let policy = all_policy();
+        assert!(matches!(
+            PypiIndexUrl::new("https://user:pass@pypi.mycorp.example/simple", &policy),
+            Err(PypiIndexUrlError::UserInfoPresent)
+        ));
+    }
+
+    #[test]
+    fn test_index_url_rejects_invalid_url() {
+        let policy = all_policy();
+        assert!(matches!(
+            PypiIndexUrl::new("not-a-valid-url", &policy),
+            Err(PypiIndexUrlError::InvalidUrl(_))
+        ));
+    }
+
+    #[test]
+    fn test_index_url_normalizes_trailing_slash() {
+        let policy = all_policy();
+        let with_slash = PypiIndexUrl::new("https://pypi.mycorp.example/simple/", &policy).unwrap();
+        let without_slash =
+            PypiIndexUrl::new("https://pypi.mycorp.example/simple", &policy).unwrap();
+        assert_eq!(with_slash, without_slash);
+        assert!(!with_slash.as_str().ends_with('/'));
+    }
+
+    #[test]
+    fn test_index_url_policy_matrix() {
+        assert!(PypiIndexUrl::new("https://127.0.0.1:9999/simple", &all_policy()).is_ok());
+        assert!(matches!(
+            PypiIndexUrl::new("https://127.0.0.1:9999/simple", &off_policy()),
+            Err(PypiIndexUrlError::BlockedHost { .. })
+        ));
+    }
+
+    // --- PypiIndexConfig::resolve_source_for / resolved_chains ---
+
+    #[test]
+    fn test_no_declaration_resolves_to_plain_registry() {
+        let config = PypiIndexConfig::new();
+        assert_eq!(config.resolve_source_for(None), DependencySource::Registry);
+        assert!(config.resolved_chains().is_empty());
+    }
+
+    /// FR-005(a): an explicit primary alone.
+    #[test]
+    fn test_case_a_primary_only() {
+        let policy = all_policy();
+        let mut config = PypiIndexConfig::new();
+        config.set_primary("https://pypi.mycorp.example/simple", &policy);
+
+        let source = config.resolve_source_for(None);
+        let DependencySource::AlternateRegistry {
+            index,
+            mirrors_crates_io,
+        } = source
+        else {
+            panic!("expected AlternateRegistry");
+        };
+        assert!(!mirrors_crates_io);
+        assert!(index.starts_with("pypi-chain:"));
+
+        let chains = config.resolved_chains();
+        assert_eq!(chains.len(), 1);
+        assert_eq!(chains[0].key, index);
+        assert_eq!(chains[0].hops.len(), 1);
+        assert!(!chains[0].implicit_public_fallback);
+    }
+
+    /// Validator finding S3: `set_primary_resolved` keeps the first registration when called
+    /// more than once — a second Poetry `primary`/`default`-priority source must not silently
+    /// overwrite the first.
+    #[test]
+    fn test_set_primary_resolved_keeps_first_on_duplicate() {
+        let policy = all_policy();
+        let mut config = PypiIndexConfig::new();
+        config.set_primary_resolved(resolve_entry("https://first.example/simple", &policy));
+        config.set_primary_resolved(resolve_entry("https://second.example/simple", &policy));
+
+        let chains = config.resolved_chains();
+        assert_eq!(chains.len(), 1);
+        assert_eq!(chains[0].hops.len(), 1);
+        assert_eq!(chains[0].hops[0].as_str(), "https://first.example/simple");
+    }
+
+    /// FR-005(a): primary + extras — no implicit public hop appended.
+    #[test]
+    fn test_case_a_primary_plus_extras() {
+        let policy = all_policy();
+        let mut config = PypiIndexConfig::new();
+        config.set_primary("https://primary.example/simple", &policy);
+        config.add_extra("https://extra.example/simple", &policy);
+
+        let chains = config.resolved_chains();
+        assert_eq!(chains.len(), 1);
+        assert_eq!(chains[0].hops.len(), 2);
+        assert_eq!(chains[0].hops[0].as_str(), "https://primary.example/simple");
+        assert_eq!(chains[0].hops[1].as_str(), "https://extra.example/simple");
+        assert!(!chains[0].implicit_public_fallback);
+    }
+
+    /// FR-005(b): extras only, no explicit primary — implicit public fallback is the last
+    /// hop.
+    #[test]
+    fn test_case_b_extras_only_no_primary() {
+        let policy = all_policy();
+        let mut config = PypiIndexConfig::new();
+        config.add_extra("https://extra.example/simple", &policy);
+
+        let source = config.resolve_source_for(None);
+        assert!(matches!(source, DependencySource::AlternateRegistry { .. }));
+
+        let chains = config.resolved_chains();
+        assert_eq!(chains.len(), 1);
+        assert_eq!(chains[0].hops.len(), 1);
+        assert!(chains[0].implicit_public_fallback);
+    }
+
+    /// N5/second critic pass: every extra dropped (e.g. policy-blocked) and no explicit
+    /// primary -> zero-hop case, degrades to plain `Registry`, nothing registered.
+    #[test]
+    fn test_zero_hop_case_degrades_to_plain_registry() {
+        let policy = off_policy();
+        let mut config = PypiIndexConfig::new();
+        config.add_extra("https://extra.example/simple", &policy);
+
+        assert_eq!(config.resolve_source_for(None), DependencySource::Registry);
+        assert!(config.resolved_chains().is_empty());
+    }
+
+    /// C2 regression: an explicit chain `[A, B]` and an implicit chain that resolves to the
+    /// same hops `[A, B]` (plus the fallback flag) must produce different keys.
+    #[test]
+    fn test_chain_key_distinguishes_explicit_from_implicit() {
+        let policy = all_policy();
+
+        let mut explicit = PypiIndexConfig::new();
+        explicit.set_primary("https://a.example/simple", &policy);
+        explicit.add_extra("https://b.example/simple", &policy);
+
+        let mut implicit = PypiIndexConfig::new();
+        implicit.add_extra("https://a.example/simple", &policy);
+        implicit.add_extra("https://b.example/simple", &policy);
+
+        let explicit_key = explicit.resolved_chains()[0].key.clone();
+        let implicit_key = implicit.resolved_chains()[0].key.clone();
+        assert_ne!(explicit_key, implicit_key);
+    }
+
+    /// C2 regression: two configs sharing a primary but differing extras produce different
+    /// keys.
+    #[test]
+    fn test_chain_key_differs_by_extras() {
+        let policy = all_policy();
+
+        let mut one = PypiIndexConfig::new();
+        one.set_primary("https://primary.example/simple", &policy);
+        one.add_extra("https://extra-a.example/simple", &policy);
+
+        let mut two = PypiIndexConfig::new();
+        two.set_primary("https://primary.example/simple", &policy);
+        two.add_extra("https://extra-b.example/simple", &policy);
+
+        assert_ne!(one.resolved_chains()[0].key, two.resolved_chains()[0].key);
+    }
+
+    /// An invalid explicit primary fails closed — never falls through to extras.
+    #[test]
+    fn test_invalid_primary_fails_closed() {
+        let policy = all_policy();
+        let mut config = PypiIndexConfig::new();
+        config.set_primary("not-a-valid-url", &policy);
+        config.add_extra("https://extra.example/simple", &policy);
+
+        assert_eq!(
+            config.resolve_source_for(None),
+            DependencySource::CustomRegistry {
+                url: "not-a-valid-url".to_string(),
+            }
+        );
+        assert!(config.resolved_chains().is_empty());
+    }
+
+    /// An invalid extra is dropped, not escalated to `CustomRegistry` — the primary still
+    /// resolves via its remaining valid hop(s) (S6-shaped: one bad extra must not break a
+    /// chain that still has a working hop).
+    #[test]
+    fn test_invalid_extra_dropped_not_escalated() {
+        let policy = all_policy();
+        let mut config = PypiIndexConfig::new();
+        config.set_primary("https://primary.example/simple", &policy);
+        config.add_extra("not-a-valid-url", &policy);
+
+        let chains = config.resolved_chains();
+        assert_eq!(chains.len(), 1);
+        assert_eq!(chains[0].hops.len(), 1);
+        assert_eq!(chains[0].hops[0].as_str(), "https://primary.example/simple");
+    }
+
+    /// Named source: resolves independently of primary/extras.
+    #[test]
+    fn test_named_source_resolves_independently() {
+        let policy = all_policy();
+        let mut config = PypiIndexConfig::new();
+        config.add_named_source_resolved(
+            "internal".to_string(),
+            resolve_entry("https://internal.example/simple", &policy),
+        );
+
+        let source = config.resolve_source_for(Some("internal"));
+        assert_eq!(
+            source,
+            DependencySource::AlternateRegistry {
+                index: "https://internal.example/simple".to_string(),
+                mirrors_crates_io: false,
+            }
+        );
+
+        let chains = config.resolved_chains();
+        assert_eq!(chains.len(), 1);
+        assert_eq!(chains[0].key, "https://internal.example/simple");
+    }
+
+    /// A `source = "<name>"` reference with no matching entry fails closed, not a silent
+    /// public-registry fallback.
+    #[test]
+    fn test_unresolved_named_source_fails_closed() {
+        let config = PypiIndexConfig::new();
+        assert_eq!(
+            config.resolve_source_for(Some("does-not-exist")),
+            DependencySource::CustomRegistry {
+                url: "does-not-exist".to_string(),
+            }
+        );
+    }
+
+    /// uv shape: a `default = true` entry is the last-resort hop, not checked first, and
+    /// never populates `primary`.
+    #[test]
+    fn test_uv_default_is_last_resort_not_primary() {
+        let policy = all_policy();
+        let mut config = PypiIndexConfig::new();
+        config.add_extra("https://non-default.example/simple", &policy);
+        config.set_tail_hop_resolved(resolve_entry("https://default.example/simple", &policy));
+
+        assert!(config.primary.is_none());
+
+        let chains = config.resolved_chains();
+        assert_eq!(chains.len(), 1);
+        assert_eq!(chains[0].hops.len(), 2);
+        assert_eq!(
+            chains[0].hops[0].as_str(),
+            "https://non-default.example/simple"
+        );
+        assert_eq!(chains[0].hops[1].as_str(), "https://default.example/simple");
+        assert!(!chains[0].implicit_public_fallback);
+    }
+
+    /// An invalid uv `default` entry degrades to the implicit public fallback rather than
+    /// leaving the chain with no final hop at all.
+    #[test]
+    fn test_uv_invalid_default_degrades_to_implicit_public() {
+        let policy = all_policy();
+        let mut config = PypiIndexConfig::new();
+        config.add_extra("https://non-default.example/simple", &policy);
+        config.set_tail_hop_resolved(resolve_entry("not-a-valid-url", &policy));
+
+        let chains = config.resolved_chains();
+        assert_eq!(chains.len(), 1);
+        assert_eq!(chains[0].hops.len(), 1);
+        assert!(chains[0].implicit_public_fallback);
+    }
+
+    /// NFR-001/SC-005 structural guarantee: a URL carrying userinfo is rejected at
+    /// construction (FR-011 — reject, never strip-and-proceed), so no [`PypiIndexUrl`] ever
+    /// exists whose `normalized` field holds a credential. `PypiIndexConfig`/`InvalidEntry`
+    /// have no `${VAR}`-expansion step (unlike npm) and no separate auth-shaped key field
+    /// anywhere in this module. See [`test_resolve_entry_redacts_userinfo_from_raw_and_log`]
+    /// below for the M1 fix: `InvalidEntry::raw` and the `tracing::warn!` line built from it
+    /// also never retain the credential itself, even though both otherwise preserve the raw,
+    /// as-written value.
+    #[test]
+    fn test_userinfo_rejected_never_retained_in_index_url() {
+        let policy = all_policy();
+        let err =
+            PypiIndexUrl::new("https://user:hunter2@pypi.example/simple", &policy).unwrap_err();
+        assert_eq!(err, PypiIndexUrlError::UserInfoPresent);
+    }
+
+    /// M1 fix: `resolve_entry`'s `InvalidEntry::raw` and its `tracing::warn!` line must never
+    /// carry a userinfo-bearing URL's credential through — both are built from
+    /// [`redact_userinfo`], not the untouched raw string, even though the raw value is
+    /// otherwise preserved (FR-006) so a warning or a `CustomRegistry.url` a user might see in
+    /// hover/diagnostics still names what they typed, minus the secret.
+    #[test]
+    fn test_resolve_entry_redacts_userinfo_from_raw_and_log() {
+        let policy = all_policy();
+        let log = deps_core::test_util::capture_tracing_output(|| {
+            let invalid =
+                resolve_entry("https://user:hunter2@pypi.example/simple", &policy).unwrap_err();
+            assert!(matches!(invalid.reason, PypiIndexUrlError::UserInfoPresent));
+            assert!(
+                !invalid.raw.contains("hunter2"),
+                "InvalidEntry::raw leaked the credential: {}",
+                invalid.raw
+            );
+            assert!(
+                !invalid.raw.contains("user:"),
+                "InvalidEntry::raw leaked the username: {}",
+                invalid.raw
+            );
+            assert!(
+                invalid.raw.contains("pypi.example"),
+                "host should survive redaction"
+            );
+        });
+        assert!(
+            !log.contains("hunter2"),
+            "tracing output leaked the credential: {log:?}"
+        );
+    }
+
+    /// [`redact_userinfo`] is a no-op for a value with no userinfo component (the common
+    /// case), and for a value that doesn't even parse as a URL (nothing to redact from).
+    #[test]
+    fn test_redact_userinfo_noop_cases() {
+        assert_eq!(
+            redact_userinfo("https://pypi.mycorp.example/simple"),
+            "https://pypi.mycorp.example/simple"
+        );
+        assert_eq!(redact_userinfo("not-a-valid-url"), "not-a-valid-url");
+    }
+
+    #[test]
+    fn test_redact_userinfo_strips_username_and_password() {
+        let redacted = redact_userinfo("https://user:hunter2@pypi.example/simple");
+        assert!(!redacted.contains("hunter2"));
+        assert!(!redacted.contains("user:"));
+        // Spec's exact example format: a fixed `***@` marker, not a bare stripped host — this
+        // keeps a redacted value visibly distinct from a URL that never carried userinfo.
+        assert_eq!(redacted, "https://***@pypi.example/simple");
+    }
+}

--- a/crates/deps-pypi/src/ecosystem.rs
+++ b/crates/deps-pypi/src/ecosystem.rs
@@ -11,12 +11,60 @@ use tower_lsp_server::ls_types::{CompletionItem, DocumentLink, Position, Range, 
 
 use deps_core::{
     Ecosystem, ParseResult as ParseResultTrait, Registry, Result, completion::Completions,
-    lsp_helpers::EcosystemFormatter,
+    lsp_helpers::EcosystemFormatter, parser::DependencySource,
 };
 
 use crate::formatter::PypiFormatter;
 use crate::parser::PypiParser;
 use crate::registry::PypiRegistry;
+
+/// The source(s) a `CompletionContext::Version`'s bare `package_name` joins back to within a
+/// manifest's already-parsed dependencies (validator finding #1 — mirrors
+/// `deps_npm::ecosystem`'s identical type).
+enum CompletionSource {
+    /// No dependency in the manifest has this exact name yet — most commonly because the
+    /// user is still typing a brand-new dependency line. Callers fall back to the
+    /// pre-existing public-registry-only behavior, unchanged.
+    NotInManifest,
+    /// Every occurrence of this name in the manifest agrees on one resolved source.
+    Resolved(DependencySource),
+    /// Two or more occurrences of this name resolve to different sources — callers must
+    /// offer no completions at all rather than picking one arbitrarily.
+    Ambiguous,
+}
+
+/// Joins `package_name` back to `parse_result.dependencies()` by name — the single choke
+/// point [`PypiEcosystem::complete_versions`] uses to decide whether a version-completion
+/// request may safely reach `pypi.org` at all (validator finding #1: without this,
+/// `complete_versions` fetched from the root `Public`-tier client unconditionally, sending an
+/// `AlternateRegistry`-sourced dependency's name to `pypi.org` on every keystroke, and still
+/// fetching from `pypi.org` for a `CustomRegistry`-sourced one that hover/diagnostics
+/// correctly fail closed for).
+///
+/// Mirrors `deps_npm::ecosystem`'s identical helper.
+fn resolve_completion_source(
+    parse_result: &dyn ParseResultTrait,
+    package_name: &deps_core::PackageName,
+) -> CompletionSource {
+    let mut sources = parse_result
+        .dependencies()
+        .into_iter()
+        .filter(|d| d.name() == package_name)
+        .map(deps_core::Dependency::source);
+
+    let Some(first) = sources.next() else {
+        return CompletionSource::NotInManifest;
+    };
+    if sources.all(|s| s == first) {
+        CompletionSource::Resolved(first)
+    } else {
+        tracing::warn!(
+            package = %package_name,
+            "ambiguous dependency source for version completion; offering none"
+        );
+        CompletionSource::Ambiguous
+    }
+}
 
 /// Which manifest shape a URI's basename identifies, so `parse_manifest` can
 /// dispatch to the right parser method and report the right `file_type` on
@@ -58,15 +106,42 @@ pub struct PypiEcosystem {
     registry: Arc<PypiRegistry>,
     parser: PypiParser,
     formatter: PypiFormatter,
+    /// The reachability policy every `parse_manifest` call threads through to
+    /// [`PypiParser::parse_content_with_policy`]/[`PypiParser::parse_requirements_with_policy`]
+    /// (spec FR-008). Defaulted to `RegistryAccessPolicy::default()` by [`Self::new`]; set
+    /// explicitly by [`Self::with_policy`] so `crate::lib::register_ecosystems`-equivalent
+    /// wiring in `deps-lsp` can share one process-wide `Arc<RegistryAccessPolicy>` handle
+    /// with `ServerState`, mirroring `deps_npm::ecosystem::NpmEcosystem`'s identical `context`
+    /// field.
+    policy: Arc<deps_core::net_policy::RegistryAccessPolicy>,
 }
 
 impl PypiEcosystem {
-    /// Creates a new PyPI ecosystem with the given HTTP cache.
+    /// Creates a new PyPI ecosystem with the given HTTP cache, using a fresh, default
+    /// (`public_only`) [`deps_core::net_policy::RegistryAccessPolicy`] private to this
+    /// ecosystem instance. Production use goes through [`Self::with_policy`] instead.
     pub fn new(cache: Arc<deps_core::HttpCache>) -> Self {
+        Self::with_policy(
+            Arc::new(PypiRegistry::new(cache)),
+            Arc::new(deps_core::net_policy::RegistryAccessPolicy::default()),
+        )
+    }
+
+    /// Creates a new PyPI ecosystem around an existing [`PypiRegistry`] instance, sharing
+    /// `policy`'s live reachability setting — the production constructor, used by
+    /// `deps-lsp`'s `register_ecosystems` so `initialize`/`workspace/didChangeConfiguration`
+    /// updating the same `Arc<RegistryAccessPolicy>` takes effect immediately, with no need
+    /// to reconstruct the ecosystem.
+    #[must_use]
+    pub fn with_policy(
+        registry: Arc<PypiRegistry>,
+        policy: Arc<deps_core::net_policy::RegistryAccessPolicy>,
+    ) -> Self {
         Self {
-            registry: Arc::new(PypiRegistry::new(cache)),
+            registry,
             parser: PypiParser::new(),
             formatter: PypiFormatter,
+            policy,
         }
     }
 
@@ -125,20 +200,48 @@ impl PypiEcosystem {
         })
     }
 
+    /// Completes version requirements for `package_name`, routed by the source that name
+    /// resolves to in `parse_result` (validator finding #1). An ambiguous, unresolved, or
+    /// unregistered-alternate source offers no completions rather than risking a private
+    /// package name lookup against `pypi.org` — the same leak class FR-006 closes for
+    /// hover/diagnostics/code-actions.
     async fn complete_versions(
         &self,
+        parse_result: &dyn ParseResultTrait,
         package_name: &deps_core::PackageName,
         prefix: &str,
         freshness: deps_core::FreshnessSettings,
     ) -> Vec<CompletionItem> {
-        deps_core::completion::complete_versions_generic(
-            self.registry.as_ref(),
-            package_name,
-            prefix,
-            &['>', '<', '=', '~', '!'],
-            freshness,
-        )
-        .await
+        match resolve_completion_source(parse_result, package_name) {
+            CompletionSource::Ambiguous => vec![],
+            CompletionSource::NotInManifest
+            | CompletionSource::Resolved(DependencySource::Registry) => {
+                deps_core::completion::complete_versions_generic(
+                    self.registry.as_ref(),
+                    package_name,
+                    prefix,
+                    &['>', '<', '=', '~', '!'],
+                    freshness,
+                )
+                .await
+            }
+            CompletionSource::Resolved(DependencySource::AlternateRegistry { index, .. }) => {
+                match self.registry.alternate_client(&index) {
+                    Some(client) => {
+                        deps_core::completion::complete_versions_generic(
+                            client.as_ref(),
+                            package_name,
+                            prefix,
+                            &['>', '<', '=', '~', '!'],
+                            freshness,
+                        )
+                        .await
+                    }
+                    None => vec![],
+                }
+            }
+            CompletionSource::Resolved(_) => vec![],
+        }
     }
 }
 
@@ -182,17 +285,38 @@ impl Ecosystem for PypiEcosystem {
         Box::pin(async move {
             let kind = PypiManifestKind::from_uri(uri);
             let result = match kind {
-                PypiManifestKind::PyProject => self.parser.parse_content(content, uri),
+                PypiManifestKind::PyProject => {
+                    self.parser
+                        .parse_content_with_policy(content, uri, &self.policy)
+                }
                 PypiManifestKind::Requirements => {
                     let require_strong_signal = self.matched_only_via_directory_pattern(uri);
-                    self.parser
-                        .parse_requirements(content, uri, require_strong_signal)
+                    self.parser.parse_requirements_with_policy(
+                        content,
+                        uri,
+                        require_strong_signal,
+                        &self.policy,
+                    )
                 }
             }
             .map_err(|e| deps_core::DepsError::ParseError {
                 file_type: kind.file_type().into(),
                 source: Box::new(e),
             })?;
+            // Registers every chain this file's --index-url/--extra-index-url/Poetry-source/
+            // uv-index declarations imply (spec FR-002/003/005/007/013) into the shared
+            // root registry — the only point where a per-document resolution and the
+            // long-lived `PypiRegistry` this ecosystem shares across every document ever
+            // meet. A file with no such declaration contributes an empty `resolved_chains`
+            // (US-004), so this loop is a no-op for the overwhelming majority of projects.
+            // `register_chain` handles both shapes uniformly: a primary/extras chain and a
+            // single-hop named-source registration (Poetry `source =`/uv `index =`) are both
+            // just `ResolvedChain`s whose hop-tree construction only differs in length — a
+            // named source's `key` is already its own literal URL (`ResolvedChain::named_source`),
+            // so there is no separate `register_named_source` call needed here.
+            for chain in &result.resolved_chains {
+                PypiRegistry::register_chain(&self.registry, chain);
+            }
             Ok(Box::new(result) as Box<dyn ParseResultTrait>)
         })
     }
@@ -244,7 +368,7 @@ impl Ecosystem for PypiEcosystem {
                     package_name,
                     prefix,
                 } => self
-                    .complete_versions(&package_name, &prefix, freshness)
+                    .complete_versions(parse_result, &package_name, &prefix, freshness)
                     .await
                     .into(),
                 CompletionContext::Feature { .. } | CompletionContext::None => {
@@ -365,6 +489,20 @@ mod tests {
 
     fn pkg(s: &str) -> deps_core::PackageName {
         deps_core::PackageName::new(s)
+    }
+
+    /// A `ParseResult` with no dependencies — `resolve_completion_source` always answers
+    /// `NotInManifest` for it, matching this feature's pre-existing (public-registry-only)
+    /// version-completion behavior. Used by tests that only exercise `complete_versions`
+    /// directly, with no manifest content to join against.
+    fn empty_parse_result() -> crate::parser::ParseResult {
+        crate::parser::ParseResult {
+            dependencies: Vec::new(),
+            workspace_root: None,
+            uri: deps_core::test_util::test_uri("/test/requirements.txt"),
+            document_links: Vec::new(),
+            resolved_chains: Vec::new(),
+        }
     }
 
     #[test]
@@ -678,6 +816,7 @@ mod tests {
             registry: Arc::new(PypiRegistry::with_index_url(cache, index_url)),
             parser: PypiParser::new(),
             formatter: PypiFormatter,
+            policy: Arc::new(deps_core::net_policy::RegistryAccessPolicy::default()),
         }
     }
 
@@ -856,6 +995,7 @@ mod tests {
 
         let results = ecosystem
             .complete_versions(
+                &empty_parse_result(),
                 &pkg("requests"),
                 "2.",
                 deps_core::FreshnessSettings::default(),
@@ -873,6 +1013,7 @@ mod tests {
 
         let results = ecosystem
             .complete_versions(
+                &empty_parse_result(),
                 &pkg("requests"),
                 ">=2.",
                 deps_core::FreshnessSettings::default(),
@@ -890,12 +1031,187 @@ mod tests {
         // Unknown package should return empty (graceful degradation)
         let results = ecosystem
             .complete_versions(
+                &empty_parse_result(),
                 &pkg("this-package-does-not-exist-12345"),
                 "1.0",
                 deps_core::FreshnessSettings::default(),
             )
             .await;
         assert!(results.is_empty());
+    }
+
+    /// A minimal single-dependency `ParseResult`, for the `resolve_completion_source` join
+    /// `complete_versions` performs — the source under test.
+    fn parse_result_with_dependency(
+        name: &str,
+        source: DependencySource,
+    ) -> crate::parser::ParseResult {
+        use tower_lsp_server::ls_types::{Position, Range};
+        crate::parser::ParseResult {
+            dependencies: vec![crate::types::PypiDependency {
+                name: pkg(name),
+                name_range: Range::new(Position::new(0, 0), Position::new(0, 0)),
+                version_req: None,
+                version_range: None,
+                extras: Vec::new(),
+                extras_range: None,
+                markers: None,
+                markers_range: None,
+                section: crate::types::PypiDependencySection::Requirements,
+                source,
+            }],
+            workspace_root: None,
+            uri: deps_core::test_util::test_uri("/test/requirements.txt"),
+            document_links: Vec::new(),
+            resolved_chains: Vec::new(),
+        }
+    }
+
+    /// Validator finding #1 (security H1 + impl-critic C1): a version-completion request for
+    /// an `AlternateRegistry`-sourced dependency must route through the resolved chain, never
+    /// through the root `Public`-tier client — fetching from the root would send the
+    /// dependency's name to `pypi.org` on every keystroke.
+    #[tokio::test]
+    async fn test_complete_versions_alternate_registry_routes_through_chain() {
+        let mut alt_server = mockito::Server::new_async().await;
+        let alt_mock = alt_server
+            .mock("GET", "/simple/mypkg/")
+            .with_status(200)
+            .with_body(r#"{"versions": ["1.0.0", "2.0.0"], "files": []}"#)
+            .create_async()
+            .await;
+
+        let cache = Arc::new(deps_core::HttpCache::new());
+        cache.set_registry_policy(deps_core::net_policy::WorkspaceRegistryAccess::All);
+        let root = Arc::new(PypiRegistry::new(Arc::clone(&cache)));
+        let policy = Arc::new(deps_core::net_policy::RegistryAccessPolicy::new(
+            deps_core::net_policy::WorkspaceRegistryAccess::All,
+        ));
+        let ecosystem = PypiEcosystem::with_policy(Arc::clone(&root), policy);
+
+        let base = crate::config::PypiIndexUrl::new(
+            &format!("{}/simple", alt_server.url()),
+            &deps_core::net_policy::RegistryAccessPolicy::new(
+                deps_core::net_policy::WorkspaceRegistryAccess::All,
+            ),
+        )
+        .unwrap();
+        let chain = crate::config::ResolvedChain {
+            key: "test-alt-chain".to_string(),
+            hops: vec![base],
+            implicit_public_fallback: false,
+        };
+        PypiRegistry::register_chain(&root, &chain);
+
+        let source = DependencySource::AlternateRegistry {
+            index: chain.key.clone(),
+            mirrors_crates_io: false,
+        };
+        let parse_result = parse_result_with_dependency("mypkg", source);
+
+        let results = ecosystem
+            .complete_versions(
+                &parse_result,
+                &pkg("mypkg"),
+                "",
+                deps_core::FreshnessSettings::default(),
+            )
+            .await;
+        assert!(
+            !results.is_empty(),
+            "expected version completions fetched from the alternate index"
+        );
+        alt_mock.assert_async().await;
+    }
+
+    /// Validator finding #1: a `CustomRegistry`-sourced dependency (an invalid/blocked
+    /// explicit index, US-005) must offer no version completions at all — never falling back
+    /// to `pypi.org`, matching hover/diagnostics' existing fail-closed behavior for it
+    /// (SC-004).
+    #[tokio::test]
+    async fn test_complete_versions_custom_registry_offers_nothing() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let ecosystem = PypiEcosystem::new(cache);
+
+        let source = DependencySource::CustomRegistry {
+            url: "not-a-valid-url".to_string(),
+        };
+        let parse_result = parse_result_with_dependency("mypkg", source);
+
+        let results = ecosystem
+            .complete_versions(
+                &parse_result,
+                &pkg("mypkg"),
+                "",
+                deps_core::FreshnessSettings::default(),
+            )
+            .await;
+        assert!(results.is_empty());
+    }
+
+    /// Validator finding #1: an `AlternateRegistry` source whose chain was never registered
+    /// (or whose registration is now stale) offers nothing rather than falling back to the
+    /// root client.
+    #[tokio::test]
+    async fn test_complete_versions_unregistered_alternate_offers_nothing() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let ecosystem = PypiEcosystem::new(cache);
+
+        let source = DependencySource::AlternateRegistry {
+            index: "pypi-chain:never-registered".to_string(),
+            mirrors_crates_io: false,
+        };
+        let parse_result = parse_result_with_dependency("mypkg", source);
+
+        let results = ecosystem
+            .complete_versions(
+                &parse_result,
+                &pkg("mypkg"),
+                "",
+                deps_core::FreshnessSettings::default(),
+            )
+            .await;
+        assert!(results.is_empty());
+    }
+
+    /// `resolve_completion_source`'s three-way classification, tested directly.
+    #[test]
+    fn test_resolve_completion_source_classification() {
+        let not_in_manifest = empty_parse_result();
+        assert!(matches!(
+            resolve_completion_source(&not_in_manifest, &pkg("mypkg")),
+            CompletionSource::NotInManifest
+        ));
+
+        let resolved = parse_result_with_dependency("mypkg", DependencySource::Registry);
+        assert!(matches!(
+            resolve_completion_source(&resolved, &pkg("mypkg")),
+            CompletionSource::Resolved(DependencySource::Registry)
+        ));
+
+        let ambiguous = crate::parser::ParseResult {
+            dependencies: vec![
+                parse_result_with_dependency("mypkg", DependencySource::Registry).dependencies[0]
+                    .clone(),
+                parse_result_with_dependency(
+                    "mypkg",
+                    DependencySource::AlternateRegistry {
+                        index: "https://a.example/simple".to_string(),
+                        mirrors_crates_io: false,
+                    },
+                )
+                .dependencies[0]
+                    .clone(),
+            ],
+            workspace_root: None,
+            uri: deps_core::test_util::test_uri("/test/requirements.txt"),
+            document_links: Vec::new(),
+            resolved_chains: Vec::new(),
+        };
+        assert!(matches!(
+            resolve_completion_source(&ambiguous, &pkg("mypkg")),
+            CompletionSource::Ambiguous
+        ));
     }
 
     #[tokio::test]
@@ -941,6 +1257,7 @@ mod tests {
         // Test that we respect the 20 result limit
         let results = ecosystem
             .complete_versions(
+                &empty_parse_result(),
                 &pkg("requests"),
                 "2",
                 deps_core::FreshnessSettings::default(),
@@ -1213,6 +1530,7 @@ dependencies = []
         // Empty prefix should show non-yanked versions (up to 20)
         let results = ecosystem
             .complete_versions(
+                &empty_parse_result(),
                 &pkg("nonexistent-package"),
                 "",
                 deps_core::FreshnessSettings::default(),
@@ -1230,6 +1548,7 @@ dependencies = []
         // Test PEP 440 operators are stripped correctly
         let results = ecosystem
             .complete_versions(
+                &empty_parse_result(),
                 &pkg("nonexistent-pkg"),
                 "~=2.0",
                 deps_core::FreshnessSettings::default(),
@@ -1246,6 +1565,7 @@ dependencies = []
         // Test != operator stripping
         let results = ecosystem
             .complete_versions(
+                &empty_parse_result(),
                 &pkg("nonexistent-pkg"),
                 "!=2.0",
                 deps_core::FreshnessSettings::default(),
@@ -1388,5 +1708,100 @@ dependencies = []
                 "no 'Unknown package' diagnostic should be emitted: {diagnostics:?}"
             );
         }
+    }
+
+    // --- T010: ecosystem wiring — parse_manifest registers resolved chains ---
+
+    fn parsed_dependencies(
+        result: &dyn ParseResultTrait,
+    ) -> Vec<(String, deps_core::parser::DependencySource)> {
+        result
+            .dependencies()
+            .into_iter()
+            .map(|d| (d.name().to_string(), d.source()))
+            .collect()
+    }
+
+    /// A file with no index declaration anywhere never constructs more than an empty
+    /// `PypiIndexConfig` and never calls `register_chain` (US-004).
+    #[tokio::test]
+    async fn test_parse_manifest_no_declaration_registers_nothing() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let ecosystem = PypiEcosystem::new(cache);
+        let uri = deps_core::test_util::test_uri("/project/requirements.txt");
+
+        let result = ecosystem
+            .parse_manifest("requests==2.31.0\n", &uri)
+            .await
+            .unwrap();
+
+        for (_, source) in parsed_dependencies(result.as_ref()) {
+            assert_eq!(source, DependencySource::Registry);
+        }
+    }
+
+    /// **Test A (S6, mixed chain)**: a chain with one policy-blocked hop and one valid hop
+    /// still resolves via the valid hop — a blocked extra must not break a chain that still
+    /// has a working remaining hop. Uses `public_only` (Global primary, RFC1918 extra) rather
+    /// than a literal `off` policy: `Off::allows` is unconditionally `false` for every host
+    /// class, so under a real `off` policy the "explicit valid primary" in this scenario
+    /// would *also* be blocked (there is no host class `off` ever allows) — `public_only`
+    /// exercises the identical code path (one hop blocked by policy, one hop not) without
+    /// that contradiction, and is the policy under which this mixed-chain scenario is
+    /// actually reachable in production.
+    #[tokio::test]
+    async fn test_parse_manifest_blocked_extra_does_not_break_chain_with_valid_primary() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let policy = Arc::new(deps_core::net_policy::RegistryAccessPolicy::new(
+            deps_core::net_policy::WorkspaceRegistryAccess::PublicOnly,
+        ));
+        let registry = Arc::new(PypiRegistry::new(Arc::clone(&cache)));
+        let ecosystem = PypiEcosystem::with_policy(Arc::clone(&registry), policy);
+        let uri = deps_core::test_util::test_uri("/project/requirements.txt");
+
+        let content = "--index-url https://pypi.mycorp.example/simple\n\
+                        --extra-index-url https://10.0.0.5/simple\n\
+                        requests==2.31.0\n";
+        let result = ecosystem.parse_manifest(content, &uri).await.unwrap();
+
+        let deps = parsed_dependencies(result.as_ref());
+        let (_, source) = deps.iter().find(|(name, _)| name == "requests").unwrap();
+        let DependencySource::AlternateRegistry { index, .. } = source else {
+            panic!("expected AlternateRegistry, got {source:?}");
+        };
+        // The registered chain must actually be reachable through the root registry this
+        // ecosystem shares — proving `parse_manifest` really called `register_chain`, not
+        // just that `resolve_source_for` computed the right `DependencySource` in isolation.
+        assert!(registry.alternate_client(index).is_some());
+    }
+
+    /// **Test B (N5, zero-hop)**: `workspace_registries = off`, a file declaring only
+    /// `--extra-index-url` entries (no explicit primary) — every extra is blocked, the chain
+    /// has zero hops, and every plain dependency in the file degrades to plain
+    /// `DependencySource::Registry` (not per-dependency fail-closed, not a structurally-broken
+    /// empty `AlternateRegistry`).
+    #[tokio::test]
+    async fn test_parse_manifest_all_extras_blocked_degrades_to_plain_registry() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let policy = Arc::new(deps_core::net_policy::RegistryAccessPolicy::new(
+            deps_core::net_policy::WorkspaceRegistryAccess::Off,
+        ));
+        let registry = Arc::new(PypiRegistry::new(Arc::clone(&cache)));
+        let ecosystem = PypiEcosystem::with_policy(Arc::clone(&registry), policy);
+        let uri = deps_core::test_util::test_uri("/project/requirements.txt");
+
+        let content = "--extra-index-url https://extra.example/simple\nrequests==2.31.0\n";
+        let result = ecosystem.parse_manifest(content, &uri).await.unwrap();
+
+        let deps = parsed_dependencies(result.as_ref());
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].1, DependencySource::Registry);
+
+        // Nothing was registered — a zero-hop config has no chain to register at all.
+        let downcast = result
+            .as_any()
+            .downcast_ref::<crate::parser::ParseResult>()
+            .unwrap();
+        assert!(downcast.resolved_chains.is_empty());
     }
 }

--- a/crates/deps-pypi/src/formatter.rs
+++ b/crates/deps-pypi/src/formatter.rs
@@ -142,6 +142,19 @@ impl PackageRendering for PypiFormatter {
 
         position.character >= start_char && position.character <= end_char
     }
+
+    /// FR-009/validator finding #2: suppresses the hover heading's `pypi.org` project link
+    /// for anything but plain public-registry content. Without this override (the trait
+    /// default is unconditionally `false`), a private-index dependency's hover would render
+    /// a `pypi.org` link right next to its actual private-index version data — once live
+    /// data renders alongside it, an unrelated `pypi.org` link reads as false confirmation
+    /// the link is real. Mirrors `NpmFormatter`'s/`CargoFormatter`'s identical override,
+    /// reusing `SourcePolicy::source_is_public_registry_content`'s default (`Registry` only
+    /// — PyPI has no crates.io-style verified-mirror concept for `AlternateRegistry` to
+    /// except).
+    fn suppress_package_url(&self, source: &deps_core::DependencySource) -> bool {
+        !self.source_is_public_registry_content(source)
+    }
 }
 
 impl RequirementResolution for PypiFormatter {
@@ -184,7 +197,28 @@ impl DiagnosticMessages for PypiFormatter {}
 
 impl DiagnosticPolicy for PypiFormatter {}
 
-impl SourcePolicy for PypiFormatter {}
+impl SourcePolicy for PypiFormatter {
+    /// FR-009: gates hover/diagnostics/code-actions on a resolved `AlternateRegistry`
+    /// (private-index) source, in addition to the plain public `Registry` default —
+    /// mirrors `NpmFormatter::can_resolve_source` exactly. `CustomRegistry` (an unresolved
+    /// or invalid explicit index — FR-006) is deliberately not accepted here: it falls
+    /// through to the default `is_version_resolvable() == false`, keeping the existing
+    /// fail-closed gate intact.
+    ///
+    /// Known cosmetic limitation (M1, not fixed): a plain dependency in an extras-only file
+    /// (FR-005(b)) is classified `AlternateRegistry` at parse time, before the winning hop
+    /// is known — if it actually resolves via the implicit public fallback, its `pypi.org`
+    /// hover link is still suppressed by `PackageRendering::suppress_package_url` (correct
+    /// for the private-index case this feature exists for, cosmetically over-cautious only
+    /// for this one edge case). Accepted for phase 1; documented in `ECOSYSTEM_GUIDE.md`.
+    fn can_resolve_source(&self, source: &deps_core::DependencySource) -> bool {
+        matches!(
+            source,
+            deps_core::DependencySource::Registry
+                | deps_core::DependencySource::AlternateRegistry { .. }
+        )
+    }
+}
 
 impl OsvNaming for PypiFormatter {}
 
@@ -212,6 +246,45 @@ fn truncate_release_to_match(source_version: &str, latest: &str) -> Option<Strin
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// FR-009: `Registry` and `AlternateRegistry` both resolve; `CustomRegistry` and every
+    /// non-registry source stay fail-closed via the default `is_version_resolvable()`.
+    #[test]
+    fn test_can_resolve_source() {
+        let formatter = PypiFormatter;
+        assert!(formatter.can_resolve_source(&deps_core::DependencySource::Registry));
+        assert!(
+            formatter.can_resolve_source(&deps_core::DependencySource::AlternateRegistry {
+                index: "pypi-chain:deadbeef".to_string(),
+                mirrors_crates_io: false,
+            })
+        );
+        assert!(
+            !formatter.can_resolve_source(&deps_core::DependencySource::CustomRegistry {
+                url: "https://pypi.mycorp.example/simple".to_string(),
+            })
+        );
+    }
+
+    /// Validator finding #2 (security H2): a private-index (`AlternateRegistry`) dependency's
+    /// hover must suppress the `pypi.org` project link; a plain public-registry dependency
+    /// must not.
+    #[test]
+    fn test_suppress_package_url() {
+        let formatter = PypiFormatter;
+        assert!(!formatter.suppress_package_url(&deps_core::DependencySource::Registry));
+        assert!(
+            formatter.suppress_package_url(&deps_core::DependencySource::AlternateRegistry {
+                index: "pypi-chain:deadbeef".to_string(),
+                mirrors_crates_io: false,
+            })
+        );
+        assert!(
+            formatter.suppress_package_url(&deps_core::DependencySource::CustomRegistry {
+                url: "https://pypi.mycorp.example/simple".to_string(),
+            })
+        );
+    }
 
     #[test]
     fn test_normalize_package_name() {

--- a/crates/deps-pypi/src/lib.rs
+++ b/crates/deps-pypi/src/lib.rs
@@ -102,6 +102,7 @@
 //! mypy = "^1.0"
 //! ```
 
+pub mod config;
 pub mod ecosystem;
 pub mod error;
 pub mod formatter;
@@ -113,6 +114,7 @@ mod search;
 pub mod types;
 
 // Re-export commonly used types
+pub use config::{PypiIndexConfig, PypiIndexUrl};
 pub use ecosystem::PypiEcosystem;
 pub use error::{PypiError, Result};
 pub use formatter::PypiFormatter;

--- a/crates/deps-pypi/src/parser/mod.rs
+++ b/crates/deps-pypi/src/parser/mod.rs
@@ -365,6 +365,12 @@ pub struct ParseResult {
     /// `-r`/`-c` file references found in a requirements file (always empty
     /// for `pyproject.toml`).
     pub document_links: Vec<RequirementRef>,
+    /// Every private-index chain this file's `--index-url`/`--extra-index-url`/Poetry-source/
+    /// uv-index declarations imply (spec FR-002/003/005/007/013), ready for
+    /// `PypiRegistry::register_chain`/`register_named_source` — the only point where this
+    /// per-document resolution and the long-lived, shared `PypiRegistry` router meet (see
+    /// `PypiEcosystem::parse_manifest`). Empty for a file with no such declaration (US-004).
+    pub resolved_chains: Vec<crate::config::ResolvedChain>,
 }
 
 impl deps_core::ParseResult for ParseResult {

--- a/crates/deps-pypi/src/parser/pyproject.rs
+++ b/crates/deps-pypi/src/parser/pyproject.rs
@@ -2,11 +2,42 @@
 //! build-system requires.
 
 use super::{ParseResult, PypiParser, normalize_marker_string, span_start, span_to_range};
+use crate::config::PypiIndexConfig;
 use crate::error::Result;
 use crate::types::{PypiDependency, PypiDependencySection, PypiDependencySource};
 use deps_core::lsp_helpers::LineOffsetTable;
+use deps_core::net_policy::RegistryAccessPolicy;
+use std::collections::HashMap;
 use toml_span::value::{Table, Value};
 use tower_lsp_server::ls_types::Uri;
+
+/// Everything a `pyproject.toml` parse needs to resolve a dependency's PyPI index routing
+/// (spec FR-002/003/005/006/007/013) — built once from the TOML tree's `[[tool.poetry.source]]`
+/// and `[tool.uv.index]`/`[tool.uv.sources]` tables (see [`PypiParser::parse_content_with_policy`]),
+/// then threaded through every dependency-parsing function below.
+struct IndexContext<'a> {
+    /// The primary/extras/named-source router (FR-005's chain rules).
+    config: &'a PypiIndexConfig,
+    /// `[tool.uv.sources] <dep> = { index = "<name>" }` bindings, keyed by dependency name
+    /// (FR-013) — the uv analogue of Poetry's per-dependency `source = "<name>"` key.
+    uv_named_by_dep: &'a HashMap<String, String>,
+}
+
+impl IndexContext<'_> {
+    /// Resolves `dep`'s source through `self.config`, **only** when `dep.source` is still the
+    /// PEP 508-string-parser default `Registry` — a dependency already routed to Git/Path/Url
+    /// (a direct reference) has no PyPI index concept and is left untouched.
+    fn resolve(&self, dep: &mut PypiDependency) {
+        if dep.source != PypiDependencySource::Registry {
+            return;
+        }
+        let named = self
+            .uv_named_by_dep
+            .get(dep.name.as_str())
+            .map(String::as_str);
+        dep.source = self.config.resolve_source_for(named);
+    }
+}
 
 impl PypiParser {
     /// Parse pyproject.toml content and extract all dependencies.
@@ -30,6 +61,23 @@ impl PypiParser {
     /// let result = parser.parse_content(&content, &uri).unwrap();
     /// ```
     pub fn parse_content(&self, content: &str, uri: &Uri) -> Result<ParseResult> {
+        self.parse_content_with_policy(content, uri, &RegistryAccessPolicy::default())
+    }
+
+    /// Like [`Self::parse_content`], but resolves `[[tool.poetry.source]]`/
+    /// `[tool.uv.index]`/`[tool.uv.sources]` index declarations (spec FR-002/003/005–007/013)
+    /// against `policy` rather than the default (`public_only`) — the production entry point
+    /// `PypiEcosystem` calls, threading through its own live `RegistryAccessPolicy` handle.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::parse_content`].
+    pub fn parse_content_with_policy(
+        &self,
+        content: &str,
+        uri: &Uri,
+        policy: &RegistryAccessPolicy,
+    ) -> Result<ParseResult> {
         if let Err(depth) =
             deps_core::check_toml_nesting_depth(content, deps_core::MAX_TOML_NESTING_DEPTH)
         {
@@ -57,8 +105,30 @@ impl PypiParser {
                     workspace_root: None,
                     uri: uri.clone(),
                     document_links: Vec::new(),
+                    resolved_chains: Vec::new(),
                 });
             }
+        };
+
+        // Index declarations are resolved from the full TOML tree up front — unlike
+        // requirements.txt's line-oriented two-pass parse, a TOML document has no
+        // "position relative to a dependency" concept at all, so this single pass over
+        // `tool.poetry`/`tool.uv` before any dependency is parsed already gives every
+        // dependency function the fully-collected config (spec FR-007/FR-013).
+        let mut config = PypiIndexConfig::new();
+        let mut uv_named_by_dep: HashMap<String, String> = HashMap::new();
+        if let Some(tool_table) = get_table(root_table, "tool") {
+            if let Some(poetry) = get_table(tool_table, "poetry") {
+                collect_poetry_sources(poetry, &mut config, policy);
+            }
+            if let Some(uv) = get_table(tool_table, "uv") {
+                collect_uv_index(uv, &mut config, policy);
+                collect_uv_sources(uv, &mut uv_named_by_dep);
+            }
+        }
+        let ctx = IndexContext {
+            config: &config,
+            uv_named_by_dep: &uv_named_by_dep,
         };
 
         // Parse build-system requires (PEP 517/518)
@@ -67,30 +137,47 @@ impl PypiParser {
                 build_system,
                 content,
                 &line_table,
+                &ctx,
             )?);
         }
 
         // Parse PEP 621 format
         if let Some(project) = get_table(root_table, "project") {
-            dependencies.extend(self.parse_pep621_dependencies(project, content, &line_table)?);
+            dependencies.extend(self.parse_pep621_dependencies(
+                project,
+                content,
+                &line_table,
+                &ctx,
+            )?);
             dependencies.extend(self.parse_pep621_optional_dependencies(
                 project,
                 content,
                 &line_table,
+                &ctx,
             )?);
         }
 
         // Parse PEP 735 dependency-groups format
         if let Some(dep_groups) = get_table(root_table, "dependency-groups") {
-            dependencies.extend(self.parse_dependency_groups(dep_groups, content, &line_table)?);
+            dependencies.extend(self.parse_dependency_groups(
+                dep_groups,
+                content,
+                &line_table,
+                &ctx,
+            )?);
         }
 
         // Parse Poetry format
         if let Some(tool_table) = get_table(root_table, "tool")
             && let Some(poetry) = get_table(tool_table, "poetry")
         {
-            dependencies.extend(self.parse_poetry_dependencies(poetry, content, &line_table)?);
-            dependencies.extend(self.parse_poetry_groups(poetry, content, &line_table)?);
+            dependencies.extend(self.parse_poetry_dependencies(
+                poetry,
+                content,
+                &line_table,
+                &ctx,
+            )?);
+            dependencies.extend(self.parse_poetry_groups(poetry, content, &line_table, &ctx)?);
         }
 
         Ok(ParseResult {
@@ -98,6 +185,7 @@ impl PypiParser {
             workspace_root: None,
             uri: uri.clone(),
             document_links: Vec::new(),
+            resolved_chains: config.resolved_chains(),
         })
     }
 
@@ -107,6 +195,7 @@ impl PypiParser {
         build_system: &Table<'_>,
         content: &str,
         line_table: &LineOffsetTable,
+        ctx: &IndexContext<'_>,
     ) -> Result<Vec<PypiDependency>> {
         let Some(requires_val) = build_system.get("requires") else {
             return Ok(Vec::new());
@@ -128,6 +217,7 @@ impl PypiParser {
                 ) {
                     Ok(mut dep) => {
                         dep.section = PypiDependencySection::BuildSystem;
+                        ctx.resolve(&mut dep);
                         dependencies.push(dep);
                     }
                     Err(e) => {
@@ -150,6 +240,7 @@ impl PypiParser {
         project: &Table<'_>,
         content: &str,
         line_table: &LineOffsetTable,
+        ctx: &IndexContext<'_>,
     ) -> Result<Vec<PypiDependency>> {
         let Some(deps_val) = project.get("dependencies") else {
             return Ok(Vec::new());
@@ -171,6 +262,7 @@ impl PypiParser {
                 ) {
                     Ok(mut dep) => {
                         dep.section = PypiDependencySection::Dependencies;
+                        ctx.resolve(&mut dep);
                         dependencies.push(dep);
                     }
                     Err(e) => {
@@ -193,6 +285,7 @@ impl PypiParser {
         project: &Table<'_>,
         content: &str,
         line_table: &LineOffsetTable,
+        ctx: &IndexContext<'_>,
     ) -> Result<Vec<PypiDependency>> {
         let Some(opt_deps_val) = project.get("optional-dependencies") else {
             return Ok(Vec::new());
@@ -218,6 +311,7 @@ impl PypiParser {
                                 dep.section = PypiDependencySection::OptionalDependencies {
                                     group: group_key.name.to_string(),
                                 };
+                                ctx.resolve(&mut dep);
                                 dependencies.push(dep);
                             }
                             Err(e) => {
@@ -250,6 +344,7 @@ impl PypiParser {
         dep_groups: &Table<'_>,
         content: &str,
         line_table: &LineOffsetTable,
+        ctx: &IndexContext<'_>,
     ) -> Result<Vec<PypiDependency>> {
         let mut dependencies = Vec::new();
 
@@ -267,6 +362,7 @@ impl PypiParser {
                                 dep.section = PypiDependencySection::DependencyGroup {
                                     group: group_key.name.to_string(),
                                 };
+                                ctx.resolve(&mut dep);
                                 dependencies.push(dep);
                             }
                             Err(e) => {
@@ -292,6 +388,7 @@ impl PypiParser {
         poetry: &Table<'_>,
         content: &str,
         line_table: &LineOffsetTable,
+        ctx: &IndexContext<'_>,
     ) -> Result<Vec<PypiDependency>> {
         let Some(deps_val) = poetry.get("dependencies") else {
             return Ok(Vec::new());
@@ -312,7 +409,14 @@ impl PypiParser {
 
             let position = span_start(content, line_table, name_key.span);
 
-            match self.parse_poetry_dependency(name, value, Some(position), content, line_table) {
+            match self.parse_poetry_dependency(
+                name,
+                value,
+                Some(position),
+                content,
+                line_table,
+                ctx,
+            ) {
                 Ok(mut dep) => {
                     dep.section = PypiDependencySection::PoetryDependencies;
                     dependencies.push(dep);
@@ -332,6 +436,7 @@ impl PypiParser {
         poetry: &Table<'_>,
         content: &str,
         line_table: &LineOffsetTable,
+        ctx: &IndexContext<'_>,
     ) -> Result<Vec<PypiDependency>> {
         let Some(group_val) = poetry.get("group") else {
             return Ok(Vec::new());
@@ -359,6 +464,7 @@ impl PypiParser {
                         Some(position),
                         content,
                         line_table,
+                        ctx,
                     ) {
                         Ok(mut dep) => {
                             dep.section = PypiDependencySection::PoetryGroup {
@@ -390,6 +496,7 @@ impl PypiParser {
         base_position: Option<tower_lsp_server::ls_types::Position>,
         content: &str,
         line_table: &LineOffsetTable,
+        ctx: &IndexContext<'_>,
     ) -> Result<PypiDependency> {
         use tower_lsp_server::ls_types::{Position, Range};
 
@@ -444,6 +551,9 @@ impl PypiParser {
                 _ => (None, None),
             };
 
+            // String-form Poetry dependencies have no `source =` key of their own — resolve
+            // through the primary/extras chain only (FR-002/003/005), same as a plain PEP
+            // 621/requirements.txt dependency.
             return Ok(PypiDependency {
                 name: name.into(),
                 name_range,
@@ -454,7 +564,7 @@ impl PypiParser {
                 markers,
                 markers_range,
                 section: PypiDependencySection::PoetryDependencies,
-                source: PypiDependencySource::Registry,
+                source: ctx.config.resolve_source_for(None),
             });
         }
 
@@ -508,7 +618,11 @@ impl PypiParser {
                         .to_string(),
                 }
             } else {
-                PypiDependencySource::Registry
+                // FR-007: a `source = "<name>"` key routes to that named Poetry source;
+                // absent, the dependency routes through the primary/extras chain like any
+                // other plain dependency.
+                let source_name = table.get("source").and_then(|s| s.as_str());
+                ctx.config.resolve_source_for(source_name)
             };
 
             return Ok(PypiDependency {
@@ -534,6 +648,123 @@ impl PypiParser {
 /// Get a nested table value by key from a toml-span Table.
 fn get_table<'a>(table: &'a Table<'a>, key: &str) -> Option<&'a Table<'a>> {
     table.get(key)?.as_table()
+}
+
+/// Parses `[[tool.poetry.source]]` entries (`name`, `url`, `priority`) into `config` (spec
+/// FR-007). Every entry — **including** an `explicit`-priority one — is registered as a named
+/// source, reachable via a dependency's own `source = "<name>"` key, regardless of priority.
+/// Additionally routed into `config`'s primary/extras chain per the corrected priority
+/// mapping (plan.md's decision table, verified live against current Poetry documentation):
+/// `primary`/`default`/**no `priority` key at all** -> primary; `supplemental`/`secondary` ->
+/// extras; `explicit` -> named source only, never auto-included in the chain. An entry
+/// missing `name` or `url` is skipped outright — there is nothing to register it under.
+fn collect_poetry_sources(
+    poetry: &Table<'_>,
+    config: &mut PypiIndexConfig,
+    policy: &RegistryAccessPolicy,
+) {
+    let Some(sources) = poetry.get("source").and_then(Value::as_array) else {
+        return;
+    };
+
+    for entry in sources {
+        let Some(table) = entry.as_table() else {
+            continue;
+        };
+        let Some(name) = table.get("name").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(url) = table.get("url").and_then(Value::as_str) else {
+            continue;
+        };
+        let priority = table.get("priority").and_then(Value::as_str);
+
+        let resolved = crate::config::resolve_entry(url, policy);
+        config.add_named_source_resolved(name.to_string(), resolved.clone());
+
+        match priority {
+            None | Some("primary" | "default") => config.set_primary_resolved(resolved),
+            Some("supplemental" | "secondary") => config.add_extra_resolved(resolved),
+            Some(_) => {} // "explicit" or any other value: named-source only
+        }
+    }
+}
+
+/// Parses `[tool.uv.index]` entries (`name`, `url`, `default`, `explicit`) into `config`
+/// (spec FR-013). Every entry is always registered as a named source (reachable via
+/// `[tool.uv.sources] <dep> = { index = "<name>" }`, via [`collect_uv_sources`] — works for
+/// both `default`/`explicit` and plain entries per FR-013). Routing beyond that depends on
+/// the entry's own flags, verified live against `docs.astral.sh/uv/concepts/indexes/`:
+/// `explicit = true` -> named-source only, never auto-included; `default = true` (uv permits
+/// at most one) -> the chain's last-resort tail hop, **never** `config.primary` — a pure-uv
+/// config never populates that slot, always routing through the FR-005(b) shape instead;
+/// neither flag set -> an automatic chain hop (the `--extra-index-url` analogue). An entry
+/// missing `name` or `url` is skipped outright.
+fn collect_uv_index(uv: &Table<'_>, config: &mut PypiIndexConfig, policy: &RegistryAccessPolicy) {
+    let Some(entries) = uv.get("index").and_then(Value::as_array) else {
+        return;
+    };
+
+    for entry in entries {
+        let Some(table) = entry.as_table() else {
+            continue;
+        };
+        let Some(name) = table.get("name").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(url) = table.get("url").and_then(Value::as_str) else {
+            continue;
+        };
+        let is_default = table.get("default").and_then(Value::as_bool) == Some(true);
+        let is_explicit = table.get("explicit").and_then(Value::as_bool) == Some(true);
+
+        let resolved = crate::config::resolve_entry(url, policy);
+        // Validator finding S4: keyed by the PEP 503-normalized name, not the raw TOML
+        // value — `[tool.uv.sources] { index = "<name>" }` bindings are matched against this
+        // same normalized form in `collect_uv_sources` below, so a casing/separator
+        // difference between the two declarations (`Flask-SQLAlchemy` vs `flask-sqlalchemy`)
+        // no longer silently fails the binding.
+        config.add_named_source_resolved(crate::name::normalize(name), resolved.clone());
+
+        if is_explicit {
+            // Named-source only — never auto-included in the chain.
+        } else if is_default {
+            config.set_tail_hop_resolved(resolved);
+        } else {
+            config.add_extra_resolved(resolved);
+        }
+    }
+}
+
+/// Parses `[tool.uv.sources] <dep> = { index = "<name>" }` bindings into `uv_named_by_dep`,
+/// keyed by dependency name (spec FR-013) — the uv analogue of Poetry's per-dependency
+/// `source = "<name>"` key. Every other `[tool.uv.sources]` shape (`git =`, `path =`,
+/// `workspace = true`, or any table without an `index =` key) is deliberately not recognized
+/// here — dependency provenance, not registry routing, explicitly out of this feature's
+/// scope (spec Out of Scope).
+fn collect_uv_sources(uv: &Table<'_>, uv_named_by_dep: &mut HashMap<String, String>) {
+    let Some(sources) = uv.get("sources").and_then(Value::as_table) else {
+        return;
+    };
+
+    for (dep_key, value) in sources {
+        if let Some(table) = value.as_table()
+            && let Some(index_name) = table.get("index").and_then(Value::as_str)
+        {
+            // Validator finding S4: both sides normalized per PEP 503 — the dependency-name
+            // key (so it matches `dep.name.as_str()`, itself already PEP 508-normalized —
+            // see `PypiDependency::name`'s own doc) and the target index name (so it matches
+            // `collect_uv_index`'s normalized `named_sources` key above). Without this, a
+            // casing/separator mismatch between `[tool.uv.sources]`'s own key and the actual
+            // parsed dependency name would silently miss the binding, falling through to
+            // `resolve_source_for(None)` — for a file with no other index declared, that
+            // resolves to plain `pypi.org`, exactly the leak this feature exists to prevent.
+            uv_named_by_dep.insert(
+                crate::name::normalize(&dep_key.name),
+                crate::name::normalize(index_name),
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -2129,5 +2360,374 @@ dependencies = [
         assert_eq!(dep.name, "pkg");
         assert_eq!(dep.markers, Some(raw_marker));
         assert!(dep.markers_range.is_some());
+    }
+
+    // --- T004: Poetry [[tool.poetry.source]] + per-dependency source = (FR-007) ---
+
+    fn parse_with_all_policy(content: &str) -> ParseResult {
+        let policy = deps_core::net_policy::RegistryAccessPolicy::new(
+            deps_core::net_policy::WorkspaceRegistryAccess::All,
+        );
+        PypiParser::new()
+            .parse_content_with_policy(content, &test_uri(), &policy)
+            .unwrap()
+    }
+
+    #[test]
+    fn test_poetry_unlabeled_source_is_primary() {
+        // No `priority` key at all -> primary (FR-007 corrected mapping), so every plain
+        // dependency in the file routes through it.
+        let content = r#"
+[[tool.poetry.source]]
+name = "internal"
+url = "https://pypi.mycorp.example/simple"
+
+[tool.poetry.dependencies]
+requests = "^2.28.0"
+"#;
+        let result = parse_with_all_policy(content);
+        let dep = result
+            .dependencies
+            .iter()
+            .find(|d| d.name == "requests")
+            .unwrap();
+        assert!(matches!(
+            dep.source,
+            PypiDependencySource::AlternateRegistry { .. }
+        ));
+    }
+
+    /// Validator finding S3: two primary-priority Poetry sources must not silently pick an
+    /// arbitrary (last-declared) one — the first registered wins, verified end-to-end via the
+    /// registered chain's sole hop.
+    #[test]
+    fn test_poetry_multiple_primary_sources_keeps_first() {
+        let content = r#"
+[[tool.poetry.source]]
+name = "first"
+url = "https://first.example/simple"
+
+[[tool.poetry.source]]
+name = "second"
+url = "https://second.example/simple"
+priority = "primary"
+
+[tool.poetry.dependencies]
+requests = "^2.28.0"
+"#;
+        let result = parse_with_all_policy(content);
+        let dep = result
+            .dependencies
+            .iter()
+            .find(|d| d.name == "requests")
+            .unwrap();
+        let PypiDependencySource::AlternateRegistry { index, .. } = &dep.source else {
+            panic!("expected AlternateRegistry, got {:?}", dep.source);
+        };
+
+        let chain = result
+            .resolved_chains
+            .iter()
+            .find(|c| &c.key == index)
+            .expect("chain must be registered");
+        assert_eq!(chain.hops.len(), 1);
+        assert_eq!(chain.hops[0].as_str(), "https://first.example/simple");
+    }
+
+    #[test]
+    fn test_poetry_explicit_source_via_dependency_key() {
+        let content = r#"
+[[tool.poetry.source]]
+name = "internal"
+url = "https://pypi.mycorp.example/simple"
+priority = "explicit"
+
+[tool.poetry.dependencies]
+flask = { version = "^3.0", source = "internal" }
+requests = "^2.28.0"
+"#;
+        let result = parse_with_all_policy(content);
+        let flask = result
+            .dependencies
+            .iter()
+            .find(|d| d.name == "flask")
+            .unwrap();
+        assert_eq!(
+            flask.source,
+            PypiDependencySource::AlternateRegistry {
+                index: "https://pypi.mycorp.example/simple".to_string(),
+                mirrors_crates_io: false,
+            }
+        );
+
+        // An `explicit`-priority source is never auto-included in the chain — an unrelated
+        // dependency with no `source =` key stays plain `Registry`.
+        let requests = result
+            .dependencies
+            .iter()
+            .find(|d| d.name == "requests")
+            .unwrap();
+        assert_eq!(requests.source, PypiDependencySource::Registry);
+    }
+
+    #[test]
+    fn test_poetry_source_reference_with_no_matching_entry_fails_closed() {
+        let content = r#"
+[tool.poetry.dependencies]
+flask = { version = "^3.0", source = "does-not-exist" }
+"#;
+        let result = parse_with_all_policy(content);
+        assert_eq!(
+            result.dependencies[0].source,
+            PypiDependencySource::CustomRegistry {
+                url: "does-not-exist".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_poetry_supplemental_priority_is_extra_not_primary() {
+        let content = r#"
+[[tool.poetry.source]]
+name = "extra"
+url = "https://extra.example/simple"
+priority = "supplemental"
+
+[tool.poetry.dependencies]
+requests = "^2.28.0"
+"#;
+        let result = parse_with_all_policy(content);
+        // No primary declared, but a supplemental source exists -> case (b): still routes
+        // through an AlternateRegistry chain (extras + implicit public), not plain Registry.
+        assert!(matches!(
+            result.dependencies[0].source,
+            PypiDependencySource::AlternateRegistry { .. }
+        ));
+    }
+
+    // --- T005: uv [tool.uv.index] + [tool.uv.sources] (FR-013) ---
+
+    #[test]
+    fn test_uv_plain_entry_is_automatic_extra() {
+        let content = r#"
+[[tool.uv.index]]
+name = "extra"
+url = "https://extra.example/simple"
+
+[project]
+dependencies = ["requests>=2.28.0"]
+"#;
+        let result = parse_with_all_policy(content);
+        assert!(matches!(
+            result.dependencies[0].source,
+            PypiDependencySource::AlternateRegistry { .. }
+        ));
+    }
+
+    /// FR-013's corrected mapping: `default = true` is uv's lowest-priority, last-resort
+    /// hop — checked *after* every non-default entry, and never populates `primary`. A
+    /// package present on both a non-default entry and the `default` entry must resolve via
+    /// the non-default one (asserted at the `PypiIndexConfig` level in `config.rs`; here we
+    /// assert the parse-level contract: a pure-uv config never produces `CustomRegistry`'s
+    /// primary-fail-closed shape, since `primary` is never populated).
+    #[test]
+    fn test_uv_default_entry_is_last_resort_not_primary() {
+        let content = r#"
+[[tool.uv.index]]
+name = "non-default"
+url = "https://non-default.example/simple"
+
+[[tool.uv.index]]
+name = "default-index"
+url = "https://default.example/simple"
+default = true
+
+[project]
+dependencies = ["requests>=2.28.0"]
+"#;
+        let result = parse_with_all_policy(content);
+        // Both entries route through the same case-(b)-shaped chain (AlternateRegistry, not
+        // CustomRegistry) — proving `default = true` did not populate `primary` (which would
+        // make an invalid primary fail closed instead, a structurally different source).
+        assert!(matches!(
+            result.dependencies[0].source,
+            PypiDependencySource::AlternateRegistry { .. }
+        ));
+    }
+
+    #[test]
+    fn test_uv_explicit_entry_named_source_only() {
+        let content = r#"
+[[tool.uv.index]]
+name = "internal"
+url = "https://pypi.mycorp.example/simple"
+explicit = true
+
+[tool.uv.sources]
+mypkg = { index = "internal" }
+
+[project]
+dependencies = ["mypkg>=1.0.0", "requests>=2.28.0"]
+"#;
+        let result = parse_with_all_policy(content);
+        let mypkg = result
+            .dependencies
+            .iter()
+            .find(|d| d.name == "mypkg")
+            .unwrap();
+        assert_eq!(
+            mypkg.source,
+            PypiDependencySource::AlternateRegistry {
+                index: "https://pypi.mycorp.example/simple".to_string(),
+                mirrors_crates_io: false,
+            }
+        );
+
+        // An `explicit` entry is never auto-included — an unrelated dependency stays plain
+        // `Registry`.
+        let requests = result
+            .dependencies
+            .iter()
+            .find(|d| d.name == "requests")
+            .unwrap();
+        assert_eq!(requests.source, PypiDependencySource::Registry);
+    }
+
+    /// Validator finding S4: a casing/separator mismatch between `[tool.uv.index]`'s `name`
+    /// and `[tool.uv.sources]`'s `index = "<name>"` value must not silently break the
+    /// binding — both are matched PEP 503-normalized. Without this fix, `mypkg` would fall
+    /// through to `resolve_source_for(None)` and, with no other index declared, resolve as
+    /// plain `pypi.org` — the exact leak this feature exists to prevent for an `explicit`
+    /// index a dependency is supposed to be routed to deliberately.
+    #[test]
+    fn test_uv_sources_index_binding_normalizes_name_mismatch() {
+        let content = r#"
+[[tool.uv.index]]
+name = "Internal-Index"
+url = "https://pypi.mycorp.example/simple"
+explicit = true
+
+[tool.uv.sources]
+mypkg = { index = "internal_index" }
+
+[project]
+dependencies = ["mypkg>=1.0.0"]
+"#;
+        let result = parse_with_all_policy(content);
+        let mypkg = result
+            .dependencies
+            .iter()
+            .find(|d| d.name == "mypkg")
+            .unwrap();
+        assert_eq!(
+            mypkg.source,
+            PypiDependencySource::AlternateRegistry {
+                index: "https://pypi.mycorp.example/simple".to_string(),
+                mirrors_crates_io: false,
+            }
+        );
+    }
+
+    /// Same fix, verified against the dependency-name side of the binding: a casing mismatch
+    /// between `[tool.uv.sources]`'s own TOML key and the actual normalized dependency name
+    /// must not defeat the binding either.
+    #[test]
+    fn test_uv_sources_dependency_key_normalizes_name_mismatch() {
+        let content = r#"
+[[tool.uv.index]]
+name = "internal"
+url = "https://pypi.mycorp.example/simple"
+explicit = true
+
+[tool.uv.sources]
+"Flask-SQLAlchemy" = { index = "internal" }
+
+[project]
+dependencies = ["flask-sqlalchemy>=1.0.0"]
+"#;
+        let result = parse_with_all_policy(content);
+        let dep = result
+            .dependencies
+            .iter()
+            .find(|d| d.name == "flask-sqlalchemy")
+            .unwrap();
+        assert_eq!(
+            dep.source,
+            PypiDependencySource::AlternateRegistry {
+                index: "https://pypi.mycorp.example/simple".to_string(),
+                mirrors_crates_io: false,
+            }
+        );
+    }
+
+    /// `[tool.uv.sources] { index = "<name>" }` also works for a non-`explicit` entry (FR-013
+    /// says "works for both explicit and non-explicit named entries").
+    #[test]
+    fn test_uv_sources_index_binding_works_for_non_explicit_entry() {
+        let content = r#"
+[[tool.uv.index]]
+name = "extra"
+url = "https://extra.example/simple"
+
+[tool.uv.sources]
+mypkg = { index = "extra" }
+
+[project]
+dependencies = ["mypkg>=1.0.0"]
+"#;
+        let result = parse_with_all_policy(content);
+        assert_eq!(
+            result.dependencies[0].source,
+            PypiDependencySource::AlternateRegistry {
+                index: "https://extra.example/simple".to_string(),
+                mirrors_crates_io: false,
+            }
+        );
+    }
+
+    /// Every other `[tool.uv.sources]` shape (`git =`, `path =`, `workspace = true`) has no
+    /// effect — confirmed by a dependency whose binding uses one of these shapes still
+    /// resolving as a plain dependency (its own PEP 508 string form is unaffected, since
+    /// `[tool.uv.sources]` never overrides a dependency's own declared version/extras — only
+    /// registry routing).
+    #[test]
+    fn test_uv_sources_non_index_shapes_have_no_routing_effect() {
+        let content = r#"
+[tool.uv.sources]
+git-pkg = { git = "https://github.com/example/git-pkg" }
+path-pkg = { path = "../path-pkg" }
+workspace-pkg = { workspace = true }
+
+[project]
+dependencies = ["git-pkg>=1.0.0", "path-pkg>=1.0.0", "workspace-pkg>=1.0.0"]
+"#;
+        let result = parse_with_all_policy(content);
+        for dep in &result.dependencies {
+            assert_eq!(
+                dep.source,
+                PypiDependencySource::Registry,
+                "{} should be unaffected by a non-index uv.sources shape",
+                dep.name
+            );
+        }
+    }
+
+    /// US-004: a `pyproject.toml` with no index declaration anywhere is unaffected —
+    /// byte-identical to today's behavior.
+    #[test]
+    fn test_no_index_declaration_pyproject_is_plain_registry() {
+        let content = r#"
+[project]
+dependencies = ["requests>=2.28.0"]
+
+[tool.poetry.dependencies]
+flask = "^3.0"
+"#;
+        let result = PypiParser::new()
+            .parse_content(content, &test_uri())
+            .unwrap();
+        for dep in &result.dependencies {
+            assert_eq!(dep.source, PypiDependencySource::Registry);
+        }
     }
 }

--- a/crates/deps-pypi/src/parser/requirements.rs
+++ b/crates/deps-pypi/src/parser/requirements.rs
@@ -12,9 +12,11 @@
 //! diagnostics.
 
 use super::{ParseResult, PypiParser, RequirementRef};
+use crate::config::PypiIndexConfig;
 use crate::error::Result;
 use crate::types::{PypiDependencySection, PypiDependencySource};
 use deps_core::lsp_helpers::LineOffsetTable;
+use deps_core::net_policy::RegistryAccessPolicy;
 use tower_lsp_server::ls_types::{Range, Uri};
 
 /// Pip option tokens recognized on an option line (a line whose first
@@ -117,6 +119,35 @@ impl PypiParser {
         uri: &Uri,
         require_strong_signal: bool,
     ) -> Result<ParseResult> {
+        self.parse_requirements_with_policy(
+            content,
+            uri,
+            require_strong_signal,
+            &RegistryAccessPolicy::default(),
+        )
+    }
+
+    /// Like [`Self::parse_requirements`], but resolves `--index-url`/`--extra-index-url`
+    /// declarations (spec FR-001–FR-006) against `policy` rather than the default
+    /// (`public_only`) — the production entry point `PypiEcosystem` calls, threading through
+    /// its own live `RegistryAccessPolicy` handle.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::parse_requirements`] — never actually errs.
+    pub fn parse_requirements_with_policy(
+        &self,
+        content: &str,
+        uri: &Uri,
+        require_strong_signal: bool,
+        policy: &RegistryAccessPolicy,
+    ) -> Result<ParseResult> {
+        // Two-pass parse (fixes S2): pip applies `--index-url`/`--extra-index-url`
+        // file-wide, not from-this-line-down, so every declaration must be collected before
+        // any dependency's source is resolved — a dependency declared *before* a late
+        // `--index-url` line must still route through it.
+        let config = collect_index_config(content, policy);
+
         let line_table = LineOffsetTable::new(content);
         let mut dependencies = Vec::new();
         let mut document_links = Vec::new();
@@ -253,6 +284,13 @@ impl PypiParser {
                     {
                         strong_signal = true;
                     }
+                    // FR-002/003/005/006: a plain registry-sourced dependency routes through
+                    // this file's collected `--index-url`/`--extra-index-url` config; a
+                    // Git/Path/Url-sourced one is untouched — those have no PyPI index
+                    // routing concept.
+                    if dep.source == PypiDependencySource::Registry {
+                        dep.source = config.resolve_source_for(None);
+                    }
                     dependencies.push(dep);
                 }
                 // A length-cap rejection is "we refused to parse this",
@@ -287,8 +325,72 @@ impl PypiParser {
             workspace_root: None,
             uri: uri.clone(),
             document_links: if keep { document_links } else { Vec::new() },
+            // Any `--index-url`/`--extra-index-url` occurrence sets `strong_signal` (it's a
+            // `KNOWN_OPTIONS` entry), so `keep` is always true whenever `config` has anything
+            // to register — gating on `keep` here only ever discards chains for a prose file
+            // that was never going to register any, never a real one.
+            resolved_chains: if keep {
+                config.resolved_chains()
+            } else {
+                Vec::new()
+            },
         })
     }
+}
+
+/// Pass 1 of the two-pass parse (fixes S2): scans every physical line of `content` and
+/// collects every `--index-url <url>`/`--index-url=<url>`/`-i <url>`/`--extra-index-url
+/// <url>`/`--extra-index-url=<url>` occurrence into a [`PypiIndexConfig`], regardless of its
+/// position relative to any dependency line. Mirrors [`PypiParser::parse_requirements_with_policy`]'s
+/// main loop's comment-stripping/trimming, but does not need continuation-joining: an
+/// option's target is read from its own physical line only, matching pip's own line-oriented
+/// option grammar (a continued `--index-url` value is not a realistic real-world shape).
+fn collect_index_config(content: &str, policy: &RegistryAccessPolicy) -> PypiIndexConfig {
+    let mut config = PypiIndexConfig::new();
+
+    for (line_idx, raw_line) in content.lines().enumerate() {
+        // A leading BOM on the first physical line is not ASCII/Unicode whitespace, so
+        // `str::trim()` alone never removes it — without stripping it here the same way the
+        // main parsing loop below does, a file starting with a BOM immediately followed by
+        // `--index-url`/`--extra-index-url` would have that line's leading token read as
+        // `"\u{feff}--index-url"` (fails the `starts_with('-')` check) and silently skip the
+        // whole declaration, leaving every dependency in the file resolving against
+        // `pypi.org` instead (validator finding S1).
+        let line = if line_idx == 0 {
+            raw_line.strip_prefix('\u{feff}').unwrap_or(raw_line)
+        } else {
+            raw_line
+        };
+        let without_comment = strip_comment(line);
+        let trimmed = without_comment.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let Some(first_token) = trimmed.split_whitespace().next() else {
+            continue;
+        };
+        if !first_token.starts_with('-') {
+            continue;
+        }
+
+        let option_name = first_token.split('=').next().unwrap_or(first_token);
+        if !matches!(option_name, "--index-url" | "-i" | "--extra-index-url") {
+            continue;
+        }
+
+        let Some((target, _offset)) = extract_option_target(first_token, trimmed) else {
+            continue;
+        };
+
+        match option_name {
+            "--index-url" | "-i" => config.set_primary(target, policy),
+            "--extra-index-url" => config.add_extra(target, policy),
+            _ => unreachable!("matched above"),
+        }
+    }
+
+    config
 }
 
 /// Extracts the target path/URL text and its byte offset within `text` for a
@@ -299,13 +401,25 @@ impl PypiParser {
 /// no target text at all (a bare `-r` with nothing after it).
 fn extract_option_target<'a>(first_token: &str, text: &'a str) -> Option<(&'a str, usize)> {
     if let Some(eq_idx) = first_token.find('=') {
-        let target = &text[eq_idx + 1..];
+        let after_eq = &text[eq_idx + 1..];
+        // Bounded to just this token's own value (validator finding S2) — a later option on
+        // the same line (e.g. `--index-url=https://x --trusted-host x`) must not be swallowed
+        // into the value, which could otherwise silently produce a mangled-but-technically-
+        // parseable URL once whitespace gets percent-encoded rather than a clean parse
+        // failure.
+        let value_end = after_eq.find(char::is_whitespace).unwrap_or(after_eq.len());
+        let target = &after_eq[..value_end];
         return (!target.is_empty()).then_some((target, eq_idx + 1));
     }
 
     let rest = &text[first_token.len()..];
     let leading_ws = rest.len() - rest.trim_start().len();
-    let target = rest.trim();
+    let after_ws = &rest[leading_ws..];
+    // Same bound as the `=`-spelling branch above — stop at the next whitespace run rather
+    // than capturing the rest of the line, which would otherwise include any further option
+    // present on the same line.
+    let value_end = after_ws.find(char::is_whitespace).unwrap_or(after_ws.len());
+    let target = &after_ws[..value_end];
     (!target.is_empty()).then_some((target, first_token.len() + leading_ws))
 }
 
@@ -375,6 +489,18 @@ mod tests {
     fn parse_strict(content: &str) -> ParseResult {
         PypiParser::new()
             .parse_requirements(content, &test_uri(), true)
+            .unwrap()
+    }
+
+    fn all_policy() -> RegistryAccessPolicy {
+        RegistryAccessPolicy::new(deps_core::net_policy::WorkspaceRegistryAccess::All)
+    }
+
+    /// Like [`parse`], but threading an explicit policy through
+    /// [`PypiParser::parse_requirements_with_policy`] — the entry point T003's own tests use.
+    fn parse_with_policy(content: &str, policy: &RegistryAccessPolicy) -> ParseResult {
+        PypiParser::new()
+            .parse_requirements_with_policy(content, &test_uri(), false, policy)
             .unwrap()
     }
 
@@ -1116,5 +1242,209 @@ mod tests {
         let content = "requests==2.31.0\n";
         let result = parse_strict(content);
         assert_eq!(result.dependencies.len(), 1);
+    }
+
+    // --- T003: --index-url / --extra-index-url / -i capture (FR-001, US-001, US-002) ---
+
+    #[test]
+    fn test_index_url_routes_every_dependency() {
+        let content = "--index-url https://pypi.mycorp.example/simple\nrequests==2.31.0\n";
+        let result = parse_with_policy(content, &all_policy());
+        assert_eq!(result.dependencies.len(), 1);
+        assert!(matches!(
+            result.dependencies[0].source,
+            PypiDependencySource::AlternateRegistry { .. }
+        ));
+    }
+
+    /// `--index-url=<url>` (equals spelling) is captured identically to the space-separated
+    /// form.
+    #[test]
+    fn test_index_url_equals_spelling() {
+        let content = "--index-url=https://pypi.mycorp.example/simple\nrequests==2.31.0\n";
+        let result = parse_with_policy(content, &all_policy());
+        assert!(matches!(
+            result.dependencies[0].source,
+            PypiDependencySource::AlternateRegistry { .. }
+        ));
+    }
+
+    /// `-i` is pip's short alias for `--index-url`.
+    #[test]
+    fn test_short_dash_i_alias() {
+        let content = "-i https://pypi.mycorp.example/simple\nrequests==2.31.0\n";
+        let result = parse_with_policy(content, &all_policy());
+        assert!(matches!(
+            result.dependencies[0].source,
+            PypiDependencySource::AlternateRegistry { .. }
+        ));
+    }
+
+    /// S2 regression: a dependency declared *before* a late `--index-url` line still routes
+    /// through it — the two-pass parse's whole reason for existing.
+    #[test]
+    fn test_index_url_after_dependency_line_still_routes_it() {
+        let content = "requests==2.31.0\n--index-url https://pypi.mycorp.example/simple\n";
+        let result = parse_with_policy(content, &all_policy());
+        assert_eq!(result.dependencies.len(), 1);
+        assert!(
+            matches!(
+                result.dependencies[0].source,
+                PypiDependencySource::AlternateRegistry { .. }
+            ),
+            "dependency declared before a late --index-url must still resolve through it, \
+             got {:?}",
+            result.dependencies[0].source
+        );
+    }
+
+    /// FR-005(b): `--extra-index-url` alone, no explicit primary — routes through the
+    /// extras+implicit-public chain, not plain `Registry`.
+    #[test]
+    fn test_extra_index_url_alone_routes_through_chain() {
+        let content = "--extra-index-url https://extra.example/simple\nrequests==2.31.0\n";
+        let result = parse_with_policy(content, &all_policy());
+        assert!(matches!(
+            result.dependencies[0].source,
+            PypiDependencySource::AlternateRegistry { .. }
+        ));
+    }
+
+    /// FR-006: an explicit `--index-url` that fails validation fails closed
+    /// (`CustomRegistry`), not a silent `pypi.org` fallback — the #248-class regression.
+    #[test]
+    fn test_invalid_index_url_fails_closed() {
+        let content = "--index-url not-a-valid-url\nrequests==2.31.0\n";
+        let result = parse_with_policy(content, &all_policy());
+        assert_eq!(
+            result.dependencies[0].source,
+            PypiDependencySource::CustomRegistry {
+                url: "not-a-valid-url".to_string(),
+            }
+        );
+    }
+
+    /// US-004: no `--index-url`/`--extra-index-url` anywhere -> every dependency stays plain
+    /// `Registry`, byte-identical to pre-feature behavior.
+    #[test]
+    fn test_no_index_declaration_is_plain_registry() {
+        let result = parse("requests==2.31.0\nflask>=3.0\n");
+        assert_eq!(result.dependencies.len(), 2);
+        for dep in &result.dependencies {
+            assert_eq!(dep.source, PypiDependencySource::Registry);
+        }
+    }
+
+    /// Existing `KNOWN_OPTIONS` classification (e.g. `--pre`, `--no-index`) is unaffected by
+    /// the new capture logic — an unrelated recognized option still contributes no index
+    /// routing.
+    #[test]
+    fn test_unrelated_known_option_does_not_affect_routing() {
+        let content = "--pre\nrequests==2.31.0\n";
+        let result = parse_with_policy(content, &all_policy());
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(
+            result.dependencies[0].source,
+            PypiDependencySource::Registry
+        );
+    }
+
+    /// A direct URL/Git-sourced dependency is untouched by index routing — those have no
+    /// PyPI index concept.
+    #[test]
+    fn test_git_sourced_dependency_untouched_by_index_config() {
+        let content = "--index-url https://pypi.mycorp.example/simple\nname @ https://example.com/name.tar.gz\n";
+        let result = parse_with_policy(content, &all_policy());
+        assert_eq!(result.dependencies.len(), 1);
+        assert!(matches!(
+            result.dependencies[0].source,
+            PypiDependencySource::Url { .. }
+        ));
+    }
+
+    /// Validator finding S1: a UTF-8 BOM on the first physical line must not defeat
+    /// `--index-url` capture — without stripping it in pass 1, `"\u{feff}--index-url"` fails
+    /// the `starts_with('-')` check and the whole declaration is silently skipped.
+    #[test]
+    fn test_index_url_after_bom_on_first_line_still_captured() {
+        let content = "\u{feff}--index-url https://pypi.mycorp.example/simple\nrequests==2.31.0\n";
+        let result = parse_with_policy(content, &all_policy());
+        assert_eq!(result.dependencies.len(), 1);
+        assert!(
+            matches!(
+                result.dependencies[0].source,
+                PypiDependencySource::AlternateRegistry { .. }
+            ),
+            "BOM must not defeat --index-url capture, got {:?}",
+            result.dependencies[0].source
+        );
+    }
+
+    /// Validator finding S2: a multi-option line must not let a later option's token(s) leak
+    /// into the earlier option's captured value — `extract_option_target` must bound the
+    /// value to the current token only, not the rest of the line. Tested directly against
+    /// `extract_option_target`, since the parsed-config-level chain key is an opaque hash
+    /// that can't itself distinguish a clean value from a mangled one.
+    #[test]
+    fn test_extract_option_target_space_separated_stops_at_next_option() {
+        let text =
+            "--index-url https://pypi.mycorp.example/simple --trusted-host pypi.mycorp.example";
+        let (target, _offset) = extract_option_target("--index-url", text).unwrap();
+        assert_eq!(target, "https://pypi.mycorp.example/simple");
+    }
+
+    /// Same bug (S2), `--opt=value` equals-spelling with a trailing option on the same line.
+    #[test]
+    fn test_extract_option_target_equals_separated_stops_at_next_option() {
+        let text =
+            "--index-url=https://pypi.mycorp.example/simple --trusted-host pypi.mycorp.example";
+        let first_token = text.split_whitespace().next().unwrap();
+        let (target, _offset) = extract_option_target(first_token, text).unwrap();
+        assert_eq!(target, "https://pypi.mycorp.example/simple");
+    }
+
+    /// End-to-end confirmation that the fix actually reaches `PypiIndexConfig`: a chain built
+    /// from a multi-option line resolves via a clean single-hop URL, not a policy-rejected
+    /// mangled one (the mangled form, once percent-encoded, is a different — and differently
+    /// classified — URL, so this would fail closed to `CustomRegistry` if the bug regressed).
+    #[test]
+    fn test_index_url_multi_option_line_does_not_swallow_trailing_options() {
+        let content = "--index-url https://pypi.mycorp.example/simple --trusted-host pypi.mycorp.example\nrequests==2.31.0\n";
+        let result = parse_with_policy(content, &all_policy());
+        assert_eq!(result.dependencies.len(), 1);
+        assert!(
+            matches!(
+                result.dependencies[0].source,
+                PypiDependencySource::AlternateRegistry { .. }
+            ),
+            "a mangled URL would still validate as *some* URL but registers a different \
+             chain than the clean one — got {:?}",
+            result.dependencies[0].source
+        );
+    }
+
+    /// Same bug (S2), `--extra-index-url=<url>` equals-spelling with a trailing option on the
+    /// same line.
+    #[test]
+    fn test_extra_index_url_equals_multi_option_line_does_not_swallow_trailing_options() {
+        let content = "--extra-index-url=https://extra.example/simple --trusted-host extra.example\nrequests==2.31.0\n";
+        let result = parse_with_policy(content, &all_policy());
+        assert_eq!(result.dependencies.len(), 1);
+        assert!(matches!(
+            result.dependencies[0].source,
+            PypiDependencySource::AlternateRegistry { .. }
+        ));
+    }
+
+    /// T012 test gap #12: `--extra-index-url=<url>` equals-spelling is captured identically
+    /// to the space-separated form (only `--index-url=` was previously covered).
+    #[test]
+    fn test_extra_index_url_equals_spelling() {
+        let content = "--extra-index-url=https://extra.example/simple\nrequests==2.31.0\n";
+        let result = parse_with_policy(content, &all_policy());
+        assert!(matches!(
+            result.dependencies[0].source,
+            PypiDependencySource::AlternateRegistry { .. }
+        ));
     }
 }

--- a/crates/deps-pypi/src/registry.rs
+++ b/crates/deps-pypi/src/registry.rs
@@ -9,8 +9,13 @@
 //!
 //! All HTTP requests are cached aggressively using ETag/Last-Modified headers.
 
+use crate::config::{PypiIndexUrl, ResolvedChain};
 use crate::types::{PypiPackage, PypiVersion};
-use deps_core::{DepsError, HttpCache, Result, lsp_helpers::warn_rejected_value};
+use dashmap::DashMap;
+use deps_core::parser::DependencySource;
+use deps_core::{
+    DepsError, FreshnessSettings, HttpCache, Result, lsp_helpers::warn_rejected_value,
+};
 use pep440_rs::{Version, VersionSpecifiers};
 use serde::Deserialize;
 use std::any::Any;
@@ -33,6 +38,33 @@ pub(crate) const SIMPLE_API_ACCEPT: &str = "application/vnd.pypi.simple.v1+json"
 
 /// Display name for PyPI used in not-found and API-response error messages.
 pub const REGISTRY: &str = "PyPI";
+
+/// Upper bound on [`PypiRegistry::alternates`]' entry count. Generous for any realistic
+/// project's private-index configuration count; exists only to keep this map, keyed by
+/// workspace-controlled chain identities, from growing unbounded for the process lifetime.
+/// Mirrors `deps-npm`'s identical `MAX_ALTERNATE_REGISTRIES`. Once at capacity, a *new* chain
+/// is simply never registered (see [`PypiRegistry::register_chain`]) — a dependency resolved
+/// to an unregistered chain degrades to [`DepsError::PackageNotFound`], never to a
+/// `pypi.org` lookup by name (spec FR-010).
+///
+/// Note (plan.md §1's risk note): this cap counts distinct *chain identities*
+/// ([`ResolvedChain::key`]), not distinct index URLs — a monorepo with many files declaring
+/// different `--extra-index-url` combinations against the same primary could exhaust it
+/// faster than a simpler one-registration-per-URL model.
+const MAX_ALTERNATE_REGISTRIES: usize = 256;
+
+/// Which transport a [`PypiRegistry`] instance fetches through (spec FR-008).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PypiRegistryTier {
+    /// `pypi.org` (or a test override) — `HttpCache::get_cached_with_headers`, today's path,
+    /// unchanged.
+    Public,
+    /// A `requirements.txt`/`pyproject.toml`-declared private index —
+    /// `HttpCache::get_cached_workspace_with_headers`, so every redirect hop is re-classified
+    /// against the live [`deps_core::net_policy::RegistryAccessPolicy`] (mirrors
+    /// `deps-npm`'s identical `WorkspaceDeclared` routing).
+    WorkspaceDeclared,
+}
 
 /// Base URL for package pages on pypi.org
 pub const PYPI_URL: &str = "https://pypi.org/project";
@@ -57,16 +89,29 @@ pub fn package_url(name: &str) -> String {
     format!("{}/{}", PYPI_URL, urlencoding::encode(&normalized))
 }
 
-/// Builds the Simple API request URL for `normalized`'s version listing.
+/// Builds the Simple API request URL for `normalized`'s version listing against `base`.
+///
+/// `base` is `PYPI_SIMPLE_BASE` for the public registry, or a resolved
+/// [`PypiIndexUrl`]'s own `simple_base` for a private/alternate index — the C4 fix (see
+/// `crates/deps-pypi/src/registry.rs`'s `PypiRegistry::simple_base` doc): version fetches
+/// must be parameterized on the index actually configured, not hardcoded to `pypi.org`.
+/// `metadata_url` deliberately stays unparameterized — see `metadata_url`'s own doc.
 ///
 /// The name segment is URL-encoded (matching `package_url`) since
 /// `name::normalize` only collapses `-`/`_`/`.` separators and leaves
 /// characters like `/`, `?`, `#` untouched.
-fn simple_api_url(normalized: &str) -> String {
-    format!("{PYPI_SIMPLE_BASE}/{}/", urlencoding::encode(normalized))
+fn simple_api_url(base: &str, normalized: &str) -> String {
+    format!("{base}/{}/", urlencoding::encode(normalized))
 }
 
 /// Builds the JSON API request URL for `normalized`'s package metadata.
+///
+/// Always built from the module-level `PYPI_BASE` constant, never parameterized on a
+/// resolved private index's base — `PYPI_BASE`/`PYPI_SIMPLE_BASE` are different URL roots
+/// (`/pypi` vs `/simple`), so parameterizing this on a private index's `simple_base` would
+/// 404. This is also moot in practice: [`PypiRegistry::get_package_metadata`] is tier-guarded
+/// off for any `WorkspaceDeclared` client (T008), so this is only ever reached by the public
+/// root.
 fn metadata_url(normalized: &str) -> String {
     format!("{PYPI_BASE}/{}/json", urlencoding::encode(normalized))
 }
@@ -128,10 +173,44 @@ pub struct PypiRegistry {
     cache: Arc<HttpCache>,
     /// Base URL for the package-name search index (see [`Self::search`]).
     /// Injectable for tests, mirroring `NuGetRegistry::with_service_index_url`.
+    ///
+    /// **Unchanged meaning** — package-name *search*-index base only, consumed solely by
+    /// `search`/`warm_search_index`. Distinct from [`Self::simple_base`] below (the C4 fix):
+    /// do not reuse one for the other.
     index_url: String,
+    /// Version-fetch base for **this client's own hop**, consumed only by
+    /// [`simple_api_url`] (PEP 503/691 Simple API). `PYPI_SIMPLE_BASE` for the public root;
+    /// a resolved [`PypiIndexUrl`]'s own URL for a private/alternate hop.
+    ///
+    /// New field (fixes C4, plan.md's second critic pass finding N3): an earlier draft
+    /// reused [`Self::index_url`] as if it were the version-fetch base — but that field is
+    /// `crate::search::SIMPLE_INDEX_URL`, consumed only by `search`/`warm_search_index`, so
+    /// an alternate client would have silently kept fetching `pypi.org` for every version
+    /// lookup. Deliberately does **not** parameterize `metadata_url` too — see that
+    /// function's own doc for why (different URL root, would 404).
+    simple_base: String,
     /// Build-once, in-memory package-name search index (issue #419). See
-    /// `crate::search` for the full design.
+    /// `crate::search` for the full design. Never populated for a `WorkspaceDeclared`-tier
+    /// client — `search`/`warm_search_index` are tier-guarded off before ever reaching it
+    /// (T008).
     index: Arc<crate::search::IndexCell>,
+    /// Which transport [`Self::get_versions`]/[`Self::search`] fetch through (spec FR-008).
+    tier: PypiRegistryTier,
+    /// Resolved chain-router clients, keyed by [`ResolvedChain::key`] (a primary/extras
+    /// chain) or by a named source's own URL (Poetry `source =`/uv `index =`). Only the root
+    /// (`Public`-tier) instance this crate constructs via [`Self::new`] ever registers into
+    /// this or is ever looked up by [`Self::alternate_client`] — a chain-hop leaf's own map
+    /// is always empty by construction (never populated by [`Self::with_base`]), the same
+    /// invariant `deps-npm`'s `NpmRegistry::alternates` documents. `Arc<DashMap<..>>` (not a
+    /// bare `DashMap`) since `PypiRegistry` is `Clone` — a bare field would silently fork the
+    /// map.
+    alternates: Arc<DashMap<String, Arc<Self>>>,
+    /// Resolved, already-constructed hop clients this instance falls through to when it
+    /// (hop 0) misses (spec FR-005, fixes C1). Empty for the `Public`-tier root and every
+    /// named-source/leaf client — populated only on the *head* client
+    /// [`Self::register_chain`] builds for a multi-hop chain. Never looked up by string key at
+    /// fetch time; `Self::get_versions_chained` walks this `Vec` positionally.
+    fallback_chain: Vec<Arc<Self>>,
 }
 
 impl PypiRegistry {
@@ -144,12 +223,235 @@ impl PypiRegistry {
     /// rather than the real [`crate::search::SIMPLE_INDEX_URL`]. `pub(crate)` so
     /// tests elsewhere in the crate (`crate::ecosystem`) can point it at a mock
     /// server; mirrors `NuGetRegistry::with_service_index_url`.
+    ///
+    /// Always `Public`-tier with an empty `fallback_chain`: this is the pre-existing entry
+    /// point every non-alternate-index test in the workspace already uses. A test exercising
+    /// the private-index chain path constructs its mock client via [`Self::with_base`]
+    /// instead, so it goes through the workspace-gated transport (FR-008) and exercises the
+    /// same production routing.
     pub(crate) fn with_index_url(cache: Arc<HttpCache>, index_url: String) -> Self {
         Self {
             cache,
             index_url,
+            simple_base: PYPI_SIMPLE_BASE.to_string(),
             index: Arc::new(crate::search::IndexCell::new()),
+            tier: PypiRegistryTier::Public,
+            alternates: Arc::new(DashMap::new()),
+            fallback_chain: Vec::new(),
         }
+    }
+
+    /// Test-only: constructs a `Public`-tier root client with `simple_base` pointed at a
+    /// mock server, so the implicit public fallback hop (spec FR-005(b)) can be exercised in
+    /// a behavioral test — request order/count via mockito — without ever contacting the real
+    /// `pypi.org`. Mirrors [`PypiIndexUrl`]'s identical `cfg(test)`/`test-util`-gated loopback
+    /// carve-out (validator finding #9).
+    ///
+    /// [`Self::register_chain`]'s implicit-public-fallback hop is built from `root`'s own
+    /// `simple_base` (not the hardcoded `PYPI_SIMPLE_BASE` constant), so registering a chain
+    /// against a root constructed this way makes that hop resolve to the mock server too —
+    /// the same code path production uses, just pointed elsewhere.
+    #[cfg(any(test, feature = "test-util"))]
+    #[must_use]
+    pub fn with_public_base_for_test(cache: Arc<HttpCache>, simple_base: String) -> Self {
+        Self {
+            cache,
+            index_url: crate::search::SIMPLE_INDEX_URL.to_string(),
+            simple_base,
+            index: Arc::new(crate::search::IndexCell::new()),
+            tier: PypiRegistryTier::Public,
+            alternates: Arc::new(DashMap::new()),
+            fallback_chain: Vec::new(),
+        }
+    }
+
+    /// Creates a [`PypiRegistry`] client for one resolved private-index hop — an ordinary
+    /// production constructor, `WorkspaceDeclared`-tier so it fetches through
+    /// `HttpCache::get_cached_workspace_with_headers` (FR-008's redirect-hop gating) instead
+    /// of the ungated transport.
+    ///
+    /// `fallback_chain` is empty for every call except the *head* client
+    /// [`Self::register_chain`] builds for a multi-hop chain — every other hop (a chain's own
+    /// leaf hops, or a single-hop named-source client) is a dead end with nothing further to
+    /// fall through to, matching plan.md §1's "leaf clients are never themselves looked up by
+    /// key, only walked positionally" design. Its own `alternates` map starts empty and is
+    /// never populated — only the root ever registers a chain (see `Self::alternates`'s
+    /// doc).
+    #[must_use]
+    pub fn with_base(
+        cache: Arc<HttpCache>,
+        simple_base: &PypiIndexUrl,
+        fallback_chain: Vec<Arc<Self>>,
+    ) -> Self {
+        Self {
+            cache,
+            index_url: crate::search::SIMPLE_INDEX_URL.to_string(),
+            simple_base: simple_base.as_str().to_string(),
+            index: Arc::new(crate::search::IndexCell::new()),
+            tier: PypiRegistryTier::WorkspaceDeclared,
+            alternates: Arc::new(DashMap::new()),
+            fallback_chain,
+        }
+    }
+
+    /// Builds the full hop tree for one [`ResolvedChain`] and inserts the head into
+    /// `root.alternates` under `chain.key`. Idempotent per key (a repeat registration for the
+    /// same key is a no-op), capacity-capped at `MAX_ALTERNATE_REGISTRIES`.
+    ///
+    /// Called only from `PypiEcosystem::parse_manifest` over
+    /// `PypiIndexConfig::resolved_chains()`, at parse time only. Takes `root: &Arc<Self>` as a
+    /// plain parameter rather than `&self` (fixes N1, second critic pass) — `self: &Arc<Self>`
+    /// receivers are unstable, and building the implicit-public final hop needs an owned
+    /// `Arc<Self>`; `PypiEcosystem` already holds `registry: Arc<PypiRegistry>` and passes it
+    /// here directly.
+    ///
+    /// The implicit-public final hop (when `chain.implicit_public_fallback` is set) is a
+    /// **freshly-constructed `Public`-tier client** ([`Self::new`], same URL/transport as the
+    /// root), never `Arc::clone(root)` — cloning the root would create a
+    /// root→alternates→head→fallback_chain→root reference cycle (N1's second half).
+    pub fn register_chain(root: &Arc<Self>, chain: &ResolvedChain) {
+        let Some((first_hop, rest_hops)) = chain.hops.split_first() else {
+            // Defensive: `PypiIndexConfig::resolved_chains` never produces an empty-hop
+            // chain (the zero-hop case resolves to plain `DependencySource::Registry`
+            // instead, with nothing to register).
+            return;
+        };
+
+        // Read before `entry()`: `DashMap::len` read-locks every shard, and `entry()` holds
+        // a write guard on one — checking capacity from inside the `Vacant` arm would
+        // self-deadlock on that shard (mirrors `deps-npm::NpmRegistry::register_alternate`).
+        let at_capacity = root.alternates.len() >= MAX_ALTERNATE_REGISTRIES;
+
+        if let dashmap::mapref::entry::Entry::Vacant(slot) =
+            root.alternates.entry(chain.key.clone())
+        {
+            if at_capacity {
+                tracing::warn!(
+                    key = %chain.key,
+                    cap = MAX_ALTERNATE_REGISTRIES,
+                    "PyPI alternate registry cap reached; not registering a new chain"
+                );
+                return;
+            }
+
+            let mut fallback_chain: Vec<Arc<Self>> = rest_hops
+                .iter()
+                .map(|hop| Arc::new(Self::with_base(Arc::clone(&root.cache), hop, Vec::new())))
+                .collect();
+            if chain.implicit_public_fallback {
+                // Built from `root`'s own `simple_base`/`index_url` rather than
+                // `Self::new(..)`'s hardcoded `PYPI_SIMPLE_BASE` (validator finding #9) — in
+                // production `root` is always constructed via `Self::new`, so this is the
+                // exact same URL either way; in a test built via
+                // `Self::with_public_base_for_test`, this hop follows the root to a mock
+                // server, making the implicit-fallback ordering behaviorally testable.
+                fallback_chain.push(Arc::new(Self {
+                    cache: Arc::clone(&root.cache),
+                    index_url: root.index_url.clone(),
+                    simple_base: root.simple_base.clone(),
+                    index: Arc::new(crate::search::IndexCell::new()),
+                    tier: PypiRegistryTier::Public,
+                    alternates: Arc::new(DashMap::new()),
+                    fallback_chain: Vec::new(),
+                }));
+            }
+
+            let head = Self::with_base(Arc::clone(&root.cache), first_hop, fallback_chain);
+            slot.insert(Arc::new(head));
+        }
+    }
+
+    /// Registers a single-hop named-source client (Poetry `source =`/uv `index =`, spec
+    /// FR-007/FR-013) under `index`'s own URL into `root.alternates`. Same
+    /// idempotency/capacity rules and `root: &Arc<Self>` parameter shape as
+    /// [`Self::register_chain`].
+    pub fn register_named_source(root: &Arc<Self>, index: &PypiIndexUrl) {
+        let key = index.as_str().to_string();
+        let at_capacity = root.alternates.len() >= MAX_ALTERNATE_REGISTRIES;
+
+        if let dashmap::mapref::entry::Entry::Vacant(slot) = root.alternates.entry(key.clone()) {
+            if at_capacity {
+                tracing::warn!(
+                    key = %key,
+                    cap = MAX_ALTERNATE_REGISTRIES,
+                    "PyPI alternate registry cap reached; not registering a new named source"
+                );
+                return;
+            }
+            slot.insert(Arc::new(Self::with_base(
+                Arc::clone(&root.cache),
+                index,
+                Vec::new(),
+            )));
+        }
+    }
+
+    /// The registered client for `index` (a [`ResolvedChain::key`] or a named source's own
+    /// URL), if any — read-only, performs no registration, no validation.
+    ///
+    /// Intentionally only ever meaningful on the **root** — a chain-hop leaf's own
+    /// `alternates` map is always empty by construction ([`Self::with_base`] never populates
+    /// it), so calling this on a non-root client always returns `None`, documenting the
+    /// invariant rather than a bug: `Self::get_versions_chained` never calls this on
+    /// `self`, only walks the already-resolved `Self::fallback_chain` positionally.
+    #[must_use]
+    pub fn alternate_client(&self, index: &str) -> Option<Arc<Self>> {
+        self.alternates.get(index).map(|entry| Arc::clone(&entry))
+    }
+
+    /// FR-005/NFR-006: tries `self` (hop 0) first, then each already-resolved
+    /// `Self::fallback_chain` entry in order — no further map lookup at any point (verifies
+    /// [`Self::register_chain`]'s C1 fix actually resolves a hop end to end).
+    ///
+    /// Implements the plan's three-way failure taxonomy: `Ok(versions)` with `versions`
+    /// non-empty is terminal success; `Err(PackageNotFound)` or `Ok(versions)` with `versions`
+    /// empty (some PEP 503 indexes answer `200` with an empty listing for an unknown project)
+    /// continues to the next hop; any other `Err` (5xx, timeout, network error) is terminal,
+    /// propagated immediately — this is the confirmed trade-off (N4, second critic pass):
+    /// applied to a case-(b) chain (no explicit primary, hop 0 is a declared extra), an
+    /// unreachable hop 0 halts resolution for every dependency in that file, public ones
+    /// included, rather than silently falling through to `pypi.org` (which would leak the
+    /// package's name to the public index precisely when the private index is merely
+    /// unreachable — the exact disclosure NFR-003(2) exists to prevent). This terminal case
+    /// returns [`DepsError::ChainResolutionHalted`] (M2 fix) rather than the underlying
+    /// transport error unchanged — deps-core's `RateLimited`-precedented mechanism for a safe,
+    /// fixed diagnostic hint (`DepsError::fetch_failure` -> `FetchFailure::Actionable`) that
+    /// reaches hover/diagnostics text, not just the `tracing::warn!` below (which still logs
+    /// the real underlying error for debugging) — this is NFR-003(3)'s required
+    /// distinguishable diagnostic.
+    async fn get_versions_chained(&self, name: &str) -> Result<Vec<PypiVersion>> {
+        let mut last_miss: Result<Vec<PypiVersion>> = Err(DepsError::PackageNotFound {
+            package: name.to_string(),
+            registry: REGISTRY,
+        });
+
+        for hop in std::iter::once(self).chain(self.fallback_chain.iter().map(Arc::as_ref)) {
+            match hop.get_versions(name).await {
+                Ok(versions) if !versions.is_empty() => return Ok(versions),
+                Ok(empty) => last_miss = Ok(empty),
+                Err(DepsError::PackageNotFound { .. }) => {
+                    last_miss = Err(DepsError::PackageNotFound {
+                        package: name.to_string(),
+                        registry: REGISTRY,
+                    });
+                }
+                Err(other) => {
+                    tracing::warn!(
+                        package = name,
+                        error = %other,
+                        "PyPI alternate-index chain resolution halted on a transport error \
+                         — not falling back to pypi.org or the next configured index"
+                    );
+                    // M2 fix: returns deps-core's pre-vetted-message `ChainResolutionHalted`
+                    // rather than propagating `other` unchanged, so the diagnostic/hover path
+                    // (via `DepsError::fetch_failure`) can safely surface a fixed, safe hint
+                    // instead of only this log line — see this method's own doc.
+                    return Err(DepsError::ChainResolutionHalted);
+                }
+            }
+        }
+
+        last_miss
     }
 
     /// Fetches all versions for a package from PyPI's Simple API (PEP 691).
@@ -197,12 +499,17 @@ impl PypiRegistry {
                 registry: REGISTRY,
             });
         }
-        let url = simple_api_url(&normalized);
-        let data = self
-            .cache
-            .get_cached_with_headers(&url, &[(reqwest::header::ACCEPT, SIMPLE_API_ACCEPT)])
-            .await
-            .map_err(|e| not_found_or(e, name))?;
+        let url = simple_api_url(&self.simple_base, &normalized);
+        let headers = [(reqwest::header::ACCEPT, SIMPLE_API_ACCEPT)];
+        let data = match self.tier {
+            PypiRegistryTier::Public => self.cache.get_cached_with_headers(&url, &headers).await,
+            PypiRegistryTier::WorkspaceDeclared => {
+                self.cache
+                    .get_cached_workspace_with_headers(&url, &headers)
+                    .await
+            }
+        }
+        .map_err(|e| not_found_or(e, name))?;
 
         parse_simple_api_response(name, &data)
     }
@@ -303,7 +610,16 @@ impl PypiRegistry {
         let cache = Arc::clone(&self.cache);
         let index_url = self.index_url.clone();
         let index = Arc::clone(&self.index);
+        let tier = self.tier;
         async move {
+            // T008 (fixes S4/M3): a `WorkspaceDeclared`-tier client never performs a
+            // package-*name* search — an unguarded search would trigger a full
+            // project-listing download from the private host (the multi-MB Simple index,
+            // not a single-package fetch). Enforced here rather than relied on via the call
+            // graph, mirroring `deps-npm::NpmRegistry::search`'s identical guard.
+            if tier == PypiRegistryTier::WorkspaceDeclared {
+                return Ok(Vec::new());
+            }
             if normalized.is_empty() {
                 return Ok(Vec::new());
             }
@@ -329,6 +645,11 @@ impl PypiRegistry {
     /// completion), so the index is typically already built by the time the user
     /// starts typing a package name.
     pub fn warm_search_index(&self) {
+        // T008: mirrors `Self::search`'s tier guard — never triggers `trigger_index_build`'s
+        // full-listing download for a private index client.
+        if self.tier == PypiRegistryTier::WorkspaceDeclared {
+            return;
+        }
         crate::search::trigger_index_build(
             Arc::clone(&self.cache),
             self.index_url.clone(),
@@ -344,7 +665,19 @@ impl PypiRegistry {
     /// - HTTP request fails
     /// - Package does not exist
     /// - JSON parsing fails
+    /// - `self` is `WorkspaceDeclared`-tier (T008, fixes S4/M3) — this method is `pub`,
+    ///   ungated, and unrouted by any in-workspace caller today, but a future call site
+    ///   reaching it on a private-index client would otherwise send that client's package
+    ///   name to `pypi.org`'s JSON API (`metadata_url` is always built from the hardcoded
+    ///   `PYPI_BASE`, never parameterized — see `metadata_url`'s doc) — closed here before
+    ///   any such call site exists, not relied on via the call graph
     pub async fn get_package_metadata(&self, name: &str) -> Result<PypiPackage> {
+        if self.tier == PypiRegistryTier::WorkspaceDeclared {
+            return Err(DepsError::PackageNotFound {
+                package: name.to_string(),
+                registry: REGISTRY,
+            });
+        }
         let normalized = crate::name::normalize(name);
         if normalized.is_empty() {
             warn_rejected_value(
@@ -397,6 +730,95 @@ impl deps_core::Registry for PypiRegistry {
         Box::pin(async move {
             let version = Self::get_latest_matching(self, name.as_str(), req.as_str()).await?;
             Ok(version.map(|v| Box::new(v) as Box<dyn deps_core::Version>))
+        })
+    }
+
+    /// Dispatches by `source` (spec FR-010): an `AlternateRegistry` whose index has a
+    /// registered client routes through `Self::get_versions_chained` (FR-005's chain
+    /// walk); one with **no** registered client is `PackageNotFound`, never a fall back to
+    /// `pypi.org` (PyPI always sets `mirrors_crates_io: false`, so Cargo's mirror-degradation
+    /// arm is dead here and must not be written — falling back would send a private package
+    /// name to the public index, the exact #248-class leak this feature closes). Every other
+    /// source keeps today's public-registry path unchanged.
+    fn get_versions_from<'a>(
+        &'a self,
+        name: &'a deps_core::PackageName,
+        source: &'a DependencySource,
+        freshness: FreshnessSettings,
+    ) -> deps_core::ecosystem::BoxFuture<
+        'a,
+        deps_core::error::Result<Vec<Box<dyn deps_core::Version>>>,
+    > {
+        Box::pin(async move {
+            match source {
+                DependencySource::AlternateRegistry { index, .. } => {
+                    match self.alternate_client(index) {
+                        Some(client) => {
+                            let versions = client.get_versions_chained(name.as_str()).await?;
+                            Ok(versions
+                                .into_iter()
+                                .map(|v| Box::new(v) as Box<dyn deps_core::Version>)
+                                .collect())
+                        }
+                        None => Err(DepsError::PackageNotFound {
+                            package: name.to_string(),
+                            registry: "alternate registry (not registered)",
+                        }),
+                    }
+                }
+                _ => deps_core::Registry::get_versions_with(self, name, freshness).await,
+            }
+        })
+    }
+
+    /// `get_versions_from`'s `get_latest_matching`-shaped counterpart — same dispatch, same
+    /// "never fall back to `pypi.org` for an unregistered `AlternateRegistry`" invariant.
+    ///
+    /// Derived from `Self::get_versions_chained` +
+    /// [`Registry::select_latest_matching`](deps_core::Registry::select_latest_matching) (fixes
+    /// M4) rather than an independent per-hop version-matching walk: the winning hop (first
+    /// hop with a non-empty version list) is selected once by
+    /// `Self::get_versions_chained`, and matching happens only within that single hop's
+    /// list. If the winning hop has no version matching `req`, that is terminal (`Ok(None)`),
+    /// not a trigger to search later hops for a "better" match — continuing would reintroduce
+    /// the cross-index version comparison this design avoids for the same
+    /// dependency-confusion reasons FR-005(b)'s ordering exists.
+    fn get_latest_matching_from<'a>(
+        &'a self,
+        name: &'a deps_core::PackageName,
+        source: &'a DependencySource,
+        req: &'a deps_core::VersionReq,
+        _minimum_stability: Option<&'a str>,
+    ) -> deps_core::ecosystem::BoxFuture<
+        'a,
+        deps_core::error::Result<Option<Box<dyn deps_core::Version>>>,
+    > {
+        Box::pin(async move {
+            match source {
+                DependencySource::AlternateRegistry { index, .. } => {
+                    match self.alternate_client(index) {
+                        Some(client) => {
+                            let versions: Vec<Box<dyn deps_core::Version>> = client
+                                .get_versions_chained(name.as_str())
+                                .await?
+                                .into_iter()
+                                .map(|v| Box::new(v) as Box<dyn deps_core::Version>)
+                                .collect();
+                            let idx = client.select_latest_matching(&versions, req);
+                            Ok(idx.and_then(|i| versions.into_iter().nth(i)))
+                        }
+                        None => Err(DepsError::PackageNotFound {
+                            package: name.to_string(),
+                            registry: "alternate registry (not registered)",
+                        }),
+                    }
+                }
+                _ => {
+                    let version =
+                        Self::get_latest_matching(self, name.as_str(), req.as_str()).await?;
+                    Ok(version.map(|v| Box::new(v) as Box<dyn deps_core::Version>))
+                }
+            }
         })
     }
 
@@ -1187,7 +1609,7 @@ mod tests {
         // `normalize_package_name` only collapses `-`/`_`/`.` separators and
         // leaves characters like `/` untouched, so the URL builder itself
         // must encode them to prevent smuggling extra path segments.
-        let url = simple_api_url("evil/../secret");
+        let url = simple_api_url(PYPI_SIMPLE_BASE, "evil/../secret");
         assert!(url.starts_with(PYPI_SIMPLE_BASE));
         assert!(!url.contains("/../"));
         assert_eq!(url, format!("{PYPI_SIMPLE_BASE}/evil%2F..%2Fsecret/"));
@@ -1212,7 +1634,7 @@ mod tests {
         deps_core::test_util::assert_dot_segment_gated_or_contained_transformed(
             |seg| {
                 let normalized = crate::name::normalize(seg);
-                (!normalized.is_empty()).then(|| simple_api_url(&normalized))
+                (!normalized.is_empty()).then(|| simple_api_url(PYPI_SIMPLE_BASE, &normalized))
             },
             crate::name::normalize,
             "pypi.org",
@@ -1239,11 +1661,11 @@ mod tests {
     #[test]
     fn test_simple_api_url_normal_names() {
         assert_eq!(
-            simple_api_url("requests"),
+            simple_api_url(PYPI_SIMPLE_BASE, "requests"),
             "https://pypi.org/simple/requests/"
         );
         assert_eq!(
-            simple_api_url("zope-interface"),
+            simple_api_url(PYPI_SIMPLE_BASE, "zope-interface"),
             "https://pypi.org/simple/zope-interface/"
         );
     }
@@ -1669,5 +2091,705 @@ mod tests {
             .await
             .unwrap();
         assert!(no_match.is_empty());
+    }
+
+    // --- T006/T007/T008: private-index chain infrastructure ---
+
+    fn all_policy() -> deps_core::net_policy::RegistryAccessPolicy {
+        deps_core::net_policy::RegistryAccessPolicy::new(
+            deps_core::net_policy::WorkspaceRegistryAccess::All,
+        )
+    }
+
+    /// Builds a validated [`PypiIndexUrl`] for a `mockito` loopback server — requires both
+    /// the `cfg(test)` loopback carve-out and an `All` runtime policy.
+    fn index_url(raw: &str) -> PypiIndexUrl {
+        PypiIndexUrl::new(raw, &all_policy()).unwrap()
+    }
+
+    /// C4 fix: an alternate client's version fetch must hit the configured private host, not
+    /// `pypi.org` — proven by asserting the `simple_base`-derived request lands on the mock
+    /// server, not by absence-of-request on a `pypi.org` mock (which this crate's existing
+    /// tests never contact anyway).
+    #[tokio::test]
+    async fn test_with_base_fetches_configured_host_not_pypi_org() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/simple/flask/")
+            .with_status(200)
+            .with_body(r#"{"versions": ["3.0.0"], "files": []}"#)
+            .create_async()
+            .await;
+
+        let cache = Arc::new(HttpCache::new());
+        cache.set_registry_policy(deps_core::net_policy::WorkspaceRegistryAccess::All);
+        let base = index_url(&format!("{}/simple", server.url()));
+        let client = PypiRegistry::with_base(Arc::clone(&cache), &base, Vec::new());
+
+        let versions = client.get_versions("flask").await.unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].version.as_str(), "3.0.0");
+        mock.assert_async().await;
+    }
+
+    /// FR-005(a)/NFR-006: an explicit-primary chain resolves via hop 0 first — a package
+    /// present there never reaches the extra.
+    #[tokio::test]
+    async fn test_get_versions_from_case_a_primary_wins() {
+        use deps_core::PackageName;
+
+        let mut primary_server = mockito::Server::new_async().await;
+        let primary_mock = primary_server
+            .mock("GET", "/simple/pkg/")
+            .with_status(200)
+            .with_body(r#"{"versions": ["1.0.0"], "files": []}"#)
+            .create_async()
+            .await;
+
+        let mut extra_server = mockito::Server::new_async().await;
+        let extra_mock = extra_server
+            .mock("GET", "/simple/pkg/")
+            .with_status(200)
+            .with_body(r#"{"versions": ["9.9.9"], "files": []}"#)
+            .expect(0)
+            .create_async()
+            .await;
+
+        let cache = Arc::new(HttpCache::new());
+        cache.set_registry_policy(deps_core::net_policy::WorkspaceRegistryAccess::All);
+        let root = Arc::new(PypiRegistry::new(Arc::clone(&cache)));
+
+        let primary = index_url(&format!("{}/simple", primary_server.url()));
+        let extra = index_url(&format!("{}/simple", extra_server.url()));
+        let chain = crate::config::ResolvedChain {
+            key: "test-chain-a".to_string(),
+            hops: vec![primary, extra],
+            implicit_public_fallback: false,
+        };
+        PypiRegistry::register_chain(&root, &chain);
+
+        let source = DependencySource::AlternateRegistry {
+            index: chain.key.clone(),
+            mirrors_crates_io: false,
+        };
+        let versions = deps_core::Registry::get_versions_from(
+            root.as_ref(),
+            &PackageName::new("pkg"),
+            &source,
+            deps_core::FreshnessSettings::default(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].version_string().as_str(), "1.0.0");
+
+        primary_mock.assert_async().await;
+        extra_mock.assert_async().await;
+    }
+
+    /// S5 failure taxonomy: hop 0 misses (`PackageNotFound`, a 404) -> falls through to hop 1.
+    #[tokio::test]
+    async fn test_get_versions_chained_falls_through_on_package_not_found() {
+        let mut hop0_server = mockito::Server::new_async().await;
+        let hop0_mock = hop0_server
+            .mock("GET", "/simple/pkg/")
+            .with_status(404)
+            .create_async()
+            .await;
+
+        let mut hop1_server = mockito::Server::new_async().await;
+        let hop1_mock = hop1_server
+            .mock("GET", "/simple/pkg/")
+            .with_status(200)
+            .with_body(r#"{"versions": ["2.0.0"], "files": []}"#)
+            .create_async()
+            .await;
+
+        let cache = Arc::new(HttpCache::new());
+        cache.set_registry_policy(deps_core::net_policy::WorkspaceRegistryAccess::All);
+        let hop1 = Arc::new(PypiRegistry::with_base(
+            Arc::clone(&cache),
+            &index_url(&format!("{}/simple", hop1_server.url())),
+            Vec::new(),
+        ));
+        let head = PypiRegistry::with_base(
+            Arc::clone(&cache),
+            &index_url(&format!("{}/simple", hop0_server.url())),
+            vec![hop1],
+        );
+
+        let versions = head.get_versions_chained("pkg").await.unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].version.as_str(), "2.0.0");
+
+        hop0_mock.assert_async().await;
+        hop1_mock.assert_async().await;
+    }
+
+    /// S5 failure taxonomy: hop 0 answers `200` with an empty listing (not a 404) -> treated
+    /// identically to `PackageNotFound`, falls through.
+    #[tokio::test]
+    async fn test_get_versions_chained_falls_through_on_empty_listing() {
+        let mut hop0_server = mockito::Server::new_async().await;
+        let hop0_mock = hop0_server
+            .mock("GET", "/simple/pkg/")
+            .with_status(200)
+            .with_body(r#"{"versions": [], "files": []}"#)
+            .create_async()
+            .await;
+
+        let mut hop1_server = mockito::Server::new_async().await;
+        let hop1_mock = hop1_server
+            .mock("GET", "/simple/pkg/")
+            .with_status(200)
+            .with_body(r#"{"versions": ["2.0.0"], "files": []}"#)
+            .create_async()
+            .await;
+
+        let cache = Arc::new(HttpCache::new());
+        cache.set_registry_policy(deps_core::net_policy::WorkspaceRegistryAccess::All);
+        let hop1 = Arc::new(PypiRegistry::with_base(
+            Arc::clone(&cache),
+            &index_url(&format!("{}/simple", hop1_server.url())),
+            Vec::new(),
+        ));
+        let head = PypiRegistry::with_base(
+            Arc::clone(&cache),
+            &index_url(&format!("{}/simple", hop0_server.url())),
+            vec![hop1],
+        );
+
+        let versions = head.get_versions_chained("pkg").await.unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].version.as_str(), "2.0.0");
+
+        hop0_mock.assert_async().await;
+        hop1_mock.assert_async().await;
+    }
+
+    /// N4/second critic pass: a genuine transport error (5xx) on hop 0 is terminal — the
+    /// chain does **not** try hop 1, even though hop 1 would have succeeded. This is the
+    /// case-(b) "unreachable declared extra halts resolution for the whole file" trade-off,
+    /// exercised directly at the chain-walk level.
+    #[tokio::test]
+    async fn test_get_versions_chained_terminates_on_transport_error_never_tries_next_hop() {
+        let mut hop0_server = mockito::Server::new_async().await;
+        let hop0_mock = hop0_server
+            .mock("GET", "/simple/pkg/")
+            .with_status(503)
+            .create_async()
+            .await;
+
+        let mut hop1_server = mockito::Server::new_async().await;
+        let hop1_mock = hop1_server
+            .mock("GET", "/simple/pkg/")
+            .with_status(200)
+            .with_body(r#"{"versions": ["2.0.0"], "files": []}"#)
+            .expect(0)
+            .create_async()
+            .await;
+
+        let cache = Arc::new(HttpCache::new());
+        cache.set_registry_policy(deps_core::net_policy::WorkspaceRegistryAccess::All);
+        let hop1 = Arc::new(PypiRegistry::with_base(
+            Arc::clone(&cache),
+            &index_url(&format!("{}/simple", hop1_server.url())),
+            Vec::new(),
+        ));
+        let head = PypiRegistry::with_base(
+            Arc::clone(&cache),
+            &index_url(&format!("{}/simple", hop0_server.url())),
+            vec![hop1],
+        );
+
+        let err = head.get_versions_chained("pkg").await.unwrap_err();
+        // M2 fix: a terminal transport error is reported as `ChainResolutionHalted` — not
+        // `PackageNotFound` (which would wrongly trigger "continue to next hop" logic
+        // anywhere else this error might be inspected), and not the raw underlying transport
+        // error either (which `DepsError::fetch_failure` cannot safely classify as
+        // `Actionable` — see `ChainResolutionHalted`'s own doc).
+        assert!(
+            matches!(err, DepsError::ChainResolutionHalted),
+            "expected ChainResolutionHalted, got: {err:?}"
+        );
+        // NFR-003(3): this must reach hover/diagnostics as a distinguishable, safe hint via
+        // deps-core's established `fetch_failure` -> `Actionable` mechanism, not stay
+        // log-only.
+        assert_eq!(
+            err.fetch_failure(),
+            deps_core::error::FetchFailure::Actionable(
+                "index unreachable — resolution halted, not falling back to a less-trusted \
+                 index"
+                    .to_string()
+            )
+        );
+
+        hop0_mock.assert_async().await;
+        hop1_mock.assert_async().await;
+    }
+
+    /// NFR-003(3): the terminal-transport-error path logs a distinguishable diagnostic
+    /// naming the halted-chain behavior, not a generic fetch-failed message.
+    #[tokio::test]
+    async fn test_transport_error_logs_distinguishable_diagnostic() {
+        let mut hop0_server = mockito::Server::new_async().await;
+        let hop0_mock = hop0_server
+            .mock("GET", "/simple/pkg/")
+            .with_status(503)
+            .create_async()
+            .await;
+
+        let cache = Arc::new(HttpCache::new());
+        cache.set_registry_policy(deps_core::net_policy::WorkspaceRegistryAccess::All);
+        let head = PypiRegistry::with_base(
+            Arc::clone(&cache),
+            &index_url(&format!("{}/simple", hop0_server.url())),
+            Vec::new(),
+        );
+
+        let log = deps_core::test_util::capture_tracing_output_async(async {
+            head.get_versions_chained("pkg").await.unwrap_err();
+        })
+        .await;
+        assert!(
+            log.contains("not falling back to pypi.org"),
+            "expected a distinguishable halted-chain diagnostic, got: {log:?}"
+        );
+
+        hop0_mock.assert_async().await;
+    }
+
+    /// Zero-hop `ResolvedChain::hops` (defensive — `PypiIndexConfig` never actually produces
+    /// one) is a no-op registration, not a panic.
+    #[test]
+    fn test_register_chain_empty_hops_is_noop() {
+        let cache = Arc::new(HttpCache::new());
+        let root = Arc::new(PypiRegistry::new(cache));
+        let chain = crate::config::ResolvedChain {
+            key: "empty".to_string(),
+            hops: Vec::new(),
+            implicit_public_fallback: false,
+        };
+        PypiRegistry::register_chain(&root, &chain);
+        assert!(root.alternate_client("empty").is_none());
+    }
+
+    /// `register_chain` is idempotent per key — a second registration for the same key is a
+    /// no-op (mirrors `deps-npm::NpmRegistry::register_alternate`'s identical guarantee).
+    #[test]
+    fn test_register_chain_idempotent() {
+        let cache = Arc::new(HttpCache::new());
+        let root = Arc::new(PypiRegistry::new(cache));
+        let chain = crate::config::ResolvedChain {
+            key: "dup".to_string(),
+            hops: vec![index_url("https://a.example/simple")],
+            implicit_public_fallback: false,
+        };
+        PypiRegistry::register_chain(&root, &chain);
+        let first = root.alternate_client("dup").unwrap();
+        PypiRegistry::register_chain(&root, &chain);
+        let second = root.alternate_client("dup").unwrap();
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    /// `MAX_ALTERNATE_REGISTRIES` cap: once reached, a new chain is not registered (degrades
+    /// to `PackageNotFound` at fetch time, never a silent public fallback).
+    #[test]
+    fn test_register_chain_capacity_cap() {
+        let cache = Arc::new(HttpCache::new());
+        let root = Arc::new(PypiRegistry::new(cache));
+        for i in 0..MAX_ALTERNATE_REGISTRIES {
+            let chain = crate::config::ResolvedChain {
+                key: format!("chain-{i}"),
+                hops: vec![index_url("https://a.example/simple")],
+                implicit_public_fallback: false,
+            };
+            PypiRegistry::register_chain(&root, &chain);
+        }
+        let overflow = crate::config::ResolvedChain {
+            key: "overflow".to_string(),
+            hops: vec![index_url("https://b.example/simple")],
+            implicit_public_fallback: false,
+        };
+        PypiRegistry::register_chain(&root, &overflow);
+        assert!(root.alternate_client("overflow").is_none());
+    }
+
+    /// The C1 invariant: a chain-hop leaf's own `alternates` map is always empty — calling
+    /// `alternate_client` on a non-root client returns `None` for everything, documented as
+    /// intentional (T006), not a bug.
+    #[test]
+    fn test_alternate_client_only_meaningful_on_root() {
+        let cache = Arc::new(HttpCache::new());
+        let root = Arc::new(PypiRegistry::new(Arc::clone(&cache)));
+        let chain = crate::config::ResolvedChain {
+            key: "chain".to_string(),
+            hops: vec![index_url("https://a.example/simple")],
+            implicit_public_fallback: false,
+        };
+        PypiRegistry::register_chain(&root, &chain);
+        let head = root.alternate_client("chain").unwrap();
+        assert!(head.alternate_client("chain").is_none());
+    }
+
+    /// N1's fix: the implicit-public final hop is a fresh `Public`-tier leaf, not
+    /// `Arc::clone(&root)` — dropping the root (and every other strong reference) after
+    /// registering an implicit-fallback chain must actually deallocate it, proving there is
+    /// no root->alternates->head->fallback_chain->root reference cycle.
+    #[test]
+    fn test_implicit_public_hop_does_not_create_reference_cycle() {
+        let cache = Arc::new(HttpCache::new());
+        let root = Arc::new(PypiRegistry::new(Arc::clone(&cache)));
+        let root_weak = Arc::downgrade(&root);
+
+        let chain = crate::config::ResolvedChain {
+            key: "implicit".to_string(),
+            hops: vec![index_url("https://a.example/simple")],
+            implicit_public_fallback: true,
+        };
+        PypiRegistry::register_chain(&root, &chain);
+
+        drop(root);
+        assert!(
+            root_weak.upgrade().is_none(),
+            "root must deallocate once its only strong reference is dropped — a cycle would \
+             keep it alive"
+        );
+    }
+
+    /// FR-005(b)/N1: `register_chain` with `implicit_public_fallback: true` appends a
+    /// freshly-constructed `Public`-tier leaf (same URL/transport as `pypi.org`) as the
+    /// chain's final hop — verified structurally rather than by dispatching a live
+    /// `get_versions_from` call, since walking off the end of this chain would otherwise
+    /// contact the real `pypi.org` from a unit test.
+    #[test]
+    fn test_register_chain_implicit_public_fallback_hop_shape() {
+        let cache = Arc::new(HttpCache::new());
+        cache.set_registry_policy(deps_core::net_policy::WorkspaceRegistryAccess::All);
+        let root = Arc::new(PypiRegistry::new(Arc::clone(&cache)));
+
+        let extra = index_url("https://extra.example/simple");
+        let chain = crate::config::ResolvedChain {
+            key: "case-b".to_string(),
+            hops: vec![extra],
+            implicit_public_fallback: true,
+        };
+        PypiRegistry::register_chain(&root, &chain);
+
+        let head = root.alternate_client("case-b").unwrap();
+        assert_eq!(head.simple_base, "https://extra.example/simple");
+        assert_eq!(head.fallback_chain.len(), 1);
+        assert_eq!(head.fallback_chain[0].tier, PypiRegistryTier::Public);
+        assert_eq!(head.fallback_chain[0].simple_base, PYPI_SIMPLE_BASE);
+    }
+
+    /// T012's explicit "must" criterion (validator finding #9), now actually testable via
+    /// `Self::with_public_base_for_test`: FR-005(b) — a package present on **both** a
+    /// declared extra and the (mocked) implicit public fallback resolves via the extra, and
+    /// the public mock is **never contacted** for that name. `expect(0)` on the public mock
+    /// makes this a hard request-count assertion, not just a check of the final result.
+    #[tokio::test]
+    async fn test_case_b_extra_wins_over_implicit_public_request_count_asserted() {
+        use deps_core::PackageName;
+
+        let mut extra_server = mockito::Server::new_async().await;
+        let extra_mock = extra_server
+            .mock("GET", "/simple/mypkg/")
+            .with_status(200)
+            .with_body(r#"{"versions": ["1.0.0"], "files": []}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut public_server = mockito::Server::new_async().await;
+        let public_mock = public_server
+            .mock("GET", mockito::Matcher::Any)
+            .expect(0)
+            .create_async()
+            .await;
+
+        let cache = Arc::new(HttpCache::new());
+        cache.set_registry_policy(deps_core::net_policy::WorkspaceRegistryAccess::All);
+        let root = Arc::new(PypiRegistry::with_public_base_for_test(
+            Arc::clone(&cache),
+            format!("{}/simple", public_server.url()),
+        ));
+
+        let extra = index_url(&format!("{}/simple", extra_server.url()));
+        let chain = crate::config::ResolvedChain {
+            key: "case-b-request-count".to_string(),
+            hops: vec![extra],
+            implicit_public_fallback: true,
+        };
+        PypiRegistry::register_chain(&root, &chain);
+
+        let source = DependencySource::AlternateRegistry {
+            index: chain.key.clone(),
+            mirrors_crates_io: false,
+        };
+        let versions = deps_core::Registry::get_versions_from(
+            root.as_ref(),
+            &PackageName::new("mypkg"),
+            &source,
+            deps_core::FreshnessSettings::default(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(versions.len(), 1);
+
+        extra_mock.assert_async().await;
+        public_mock.assert_async().await;
+    }
+
+    /// The mirror scenario: the extra misses (404), so the chain correctly falls through to
+    /// the (mocked) implicit public fallback — proving the ordering is "extra first, public
+    /// last", not "public only" or "extra only".
+    #[tokio::test]
+    async fn test_case_b_falls_through_to_implicit_public_when_extra_misses() {
+        use deps_core::PackageName;
+
+        let mut extra_server = mockito::Server::new_async().await;
+        let extra_mock = extra_server
+            .mock("GET", "/simple/mypkg/")
+            .with_status(404)
+            .create_async()
+            .await;
+
+        let mut public_server = mockito::Server::new_async().await;
+        let public_mock = public_server
+            .mock("GET", "/simple/mypkg/")
+            .with_status(200)
+            .with_body(r#"{"versions": ["9.9.9"], "files": []}"#)
+            .create_async()
+            .await;
+
+        let cache = Arc::new(HttpCache::new());
+        cache.set_registry_policy(deps_core::net_policy::WorkspaceRegistryAccess::All);
+        let root = Arc::new(PypiRegistry::with_public_base_for_test(
+            Arc::clone(&cache),
+            format!("{}/simple", public_server.url()),
+        ));
+
+        let extra = index_url(&format!("{}/simple", extra_server.url()));
+        let chain = crate::config::ResolvedChain {
+            key: "case-b-fallthrough".to_string(),
+            hops: vec![extra],
+            implicit_public_fallback: true,
+        };
+        PypiRegistry::register_chain(&root, &chain);
+
+        let source = DependencySource::AlternateRegistry {
+            index: chain.key.clone(),
+            mirrors_crates_io: false,
+        };
+        let versions = deps_core::Registry::get_versions_from(
+            root.as_ref(),
+            &PackageName::new("mypkg"),
+            &source,
+            deps_core::FreshnessSettings::default(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].version_string().as_str(), "9.9.9");
+
+        extra_mock.assert_async().await;
+        public_mock.assert_async().await;
+    }
+
+    /// Validator finding #10: a happy-path test for `get_latest_matching_from` — only the
+    /// unregistered-alternate failure case was previously tested. Derived from
+    /// `get_versions_chained` (M4, no independent chain walk), so this also confirms that
+    /// path picks the right version out of the winning hop's list.
+    #[tokio::test]
+    async fn test_get_latest_matching_from_alternate_registry_happy_path() {
+        use deps_core::PackageName;
+
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/simple/pkg/")
+            .with_status(200)
+            .with_body(r#"{"versions": ["1.0.0", "1.5.0", "2.0.0"], "files": []}"#)
+            .create_async()
+            .await;
+
+        let cache = Arc::new(HttpCache::new());
+        cache.set_registry_policy(deps_core::net_policy::WorkspaceRegistryAccess::All);
+        let root = Arc::new(PypiRegistry::new(Arc::clone(&cache)));
+
+        let chain = crate::config::ResolvedChain {
+            key: "latest-matching-happy-path".to_string(),
+            hops: vec![index_url(&format!("{}/simple", server.url()))],
+            implicit_public_fallback: false,
+        };
+        PypiRegistry::register_chain(&root, &chain);
+
+        let source = DependencySource::AlternateRegistry {
+            index: chain.key.clone(),
+            mirrors_crates_io: false,
+        };
+        let latest = deps_core::Registry::get_latest_matching_from(
+            root.as_ref(),
+            &PackageName::new("pkg"),
+            &source,
+            &deps_core::VersionReq::new(">=1.0.0,<2.0.0"),
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            latest.map(|v| v.version_string().to_string()),
+            Some("1.5.0".to_string())
+        );
+        mock.assert_async().await;
+    }
+
+    /// Validator finding #11: a 3+-hop chain — every prior test caps at 2 hops. Confirms
+    /// `get_versions_chained` correctly walks past a second miss to reach a third, winning
+    /// hop, and that both earlier hops were actually queried in order (not skipped).
+    #[tokio::test]
+    async fn test_three_hop_chain_falls_through_to_third_hop() {
+        let mut hop0_server = mockito::Server::new_async().await;
+        let hop0_mock = hop0_server
+            .mock("GET", "/simple/pkg/")
+            .with_status(404)
+            .create_async()
+            .await;
+
+        let mut hop1_server = mockito::Server::new_async().await;
+        let hop1_mock = hop1_server
+            .mock("GET", "/simple/pkg/")
+            .with_status(200)
+            .with_body(r#"{"versions": [], "files": []}"#)
+            .create_async()
+            .await;
+
+        let mut hop2_server = mockito::Server::new_async().await;
+        let hop2_mock = hop2_server
+            .mock("GET", "/simple/pkg/")
+            .with_status(200)
+            .with_body(r#"{"versions": ["3.0.0"], "files": []}"#)
+            .create_async()
+            .await;
+
+        let cache = Arc::new(HttpCache::new());
+        cache.set_registry_policy(deps_core::net_policy::WorkspaceRegistryAccess::All);
+        // `fallback_chain` is a flat list of every hop after hop 0, all direct children of
+        // the head — never nested per-hop (that's how `register_chain` actually builds it;
+        // `get_versions_chained` only ever walks `self.fallback_chain` one level deep, not
+        // recursively).
+        let hop1 = Arc::new(PypiRegistry::with_base(
+            Arc::clone(&cache),
+            &index_url(&format!("{}/simple", hop1_server.url())),
+            Vec::new(),
+        ));
+        let hop2 = Arc::new(PypiRegistry::with_base(
+            Arc::clone(&cache),
+            &index_url(&format!("{}/simple", hop2_server.url())),
+            Vec::new(),
+        ));
+        let head = PypiRegistry::with_base(
+            Arc::clone(&cache),
+            &index_url(&format!("{}/simple", hop0_server.url())),
+            vec![hop1, hop2],
+        );
+
+        let versions = head.get_versions_chained("pkg").await.unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].version.as_str(), "3.0.0");
+
+        hop0_mock.assert_async().await;
+        hop1_mock.assert_async().await;
+        hop2_mock.assert_async().await;
+    }
+
+    /// `AlternateRegistry` with no registered client -> `PackageNotFound`, never a public
+    /// fallback (FR-010).
+    #[tokio::test]
+    async fn test_get_versions_from_unregistered_alternate_never_falls_back() {
+        use deps_core::PackageName;
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PypiRegistry::new(cache);
+        let source = DependencySource::AlternateRegistry {
+            index: "pypi-chain:never-registered".to_string(),
+            mirrors_crates_io: false,
+        };
+        let result = deps_core::Registry::get_versions_from(
+            &registry,
+            &PackageName::new("pkg"),
+            &source,
+            deps_core::FreshnessSettings::default(),
+        )
+        .await;
+        assert!(matches!(result, Err(DepsError::PackageNotFound { .. })));
+
+        let result = deps_core::Registry::get_latest_matching_from(
+            &registry,
+            &PackageName::new("pkg"),
+            &source,
+            &deps_core::VersionReq::new("*"),
+            None,
+        )
+        .await;
+        assert!(matches!(result, Err(DepsError::PackageNotFound { .. })));
+    }
+
+    // --- T008: tier guard on search/warm_search_index/get_package_metadata ---
+
+    #[tokio::test]
+    async fn test_search_on_workspace_declared_tier_issues_no_request() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .expect(0)
+            .create_async()
+            .await;
+
+        let cache = Arc::new(HttpCache::new());
+        cache.set_registry_policy(deps_core::net_policy::WorkspaceRegistryAccess::All);
+        let base = index_url(&format!("{}/simple", server.url()));
+        let client = PypiRegistry::with_base(Arc::clone(&cache), &base, Vec::new());
+
+        assert!(client.search("flask", 10).await.unwrap().is_empty());
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_warm_search_index_on_workspace_declared_tier_issues_no_request() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .expect(0)
+            .create_async()
+            .await;
+
+        let cache = Arc::new(HttpCache::new());
+        cache.set_registry_policy(deps_core::net_policy::WorkspaceRegistryAccess::All);
+        let base = index_url(&format!("{}/simple", server.url()));
+        let client = PypiRegistry::with_base(Arc::clone(&cache), &base, Vec::new());
+
+        client.warm_search_index();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_get_package_metadata_on_workspace_declared_tier_issues_no_request() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", mockito::Matcher::Any)
+            .expect(0)
+            .create_async()
+            .await;
+
+        let cache = Arc::new(HttpCache::new());
+        cache.set_registry_policy(deps_core::net_policy::WorkspaceRegistryAccess::All);
+        let base = index_url(&format!("{}/simple", server.url()));
+        let client = PypiRegistry::with_base(Arc::clone(&cache), &base, Vec::new());
+
+        let err = client.get_package_metadata("flask").await.unwrap_err();
+        assert!(matches!(err, DepsError::PackageNotFound { .. }));
+        mock.assert_async().await;
     }
 }

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -10,7 +10,7 @@ deps-lsp provides comprehensive LSP support for 13 package ecosystems:
 |-----------|----------|-----------------|--------------|----------|
 | **Cargo** | Rust | `Cargo.toml` | `Cargo.lock` | Hover, inlay hints, completion, code actions, diagnostics, code lens, feature flag completion, alternate/private registry resolution via `.cargo/config.toml` (see below) |
 | **npm** | JavaScript/TypeScript | `package.json` | `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml` | Hover, inlay hints, completion, code actions, diagnostics, code lens, custom/private registry resolution via `.npmrc` (see below) |
-| **PyPI** | Python | `pyproject.toml`, `requirements.txt`, `constraints.txt` (also recognized under a `requirements/` directory, e.g. `requirements/base.txt`) | `poetry.lock`, `uv.lock` | Hover with PEP 508 environment marker display ("Active when: `<marker>`"), inlay hints, completion, code actions, diagnostics, code lens, document links for `-r`/`-c`/`--requirement`/`--constraint` file references |
+| **PyPI** | Python | `pyproject.toml`, `requirements.txt`, `constraints.txt` (also recognized under a `requirements/` directory, e.g. `requirements/base.txt`) | `poetry.lock`, `uv.lock` | Hover with PEP 508 environment marker display ("Active when: `<marker>`"), inlay hints, completion, code actions, diagnostics, code lens, document links for `-r`/`-c`/`--requirement`/`--constraint` file references, private/custom index resolution via `--index-url`/`--extra-index-url`, Poetry `[[tool.poetry.source]]`, and uv `[tool.uv.index]`/`[tool.uv.sources]` (see below) |
 | **Go** | Go | `go.mod` | `go.sum` | Hover, inlay hints, completion, code actions, diagnostics, code lens, pseudo-version support |
 | **Bundler** | Ruby | `Gemfile` | `Gemfile.lock` | Hover, inlay hints, completion, code actions, diagnostics, code lens |
 | **Dart** | Dart | `pubspec.yaml` | `pubspec.lock` | Hover with corrected version ordering (prereleases sort below base release — see below), inlay hints, completion, code actions, diagnostics, code lens |
@@ -66,10 +66,12 @@ worse than the pre-existing crates.io answer.
 workspace-declared registry index (the `registry`/`registry-index` alias path, or a
 `[source]` mirror) is checked against this setting before it is ever fetched — a
 hostile cloned repository can write both, and this LSP parses on file open, before
-any build runs. This setting is shared with npm's `.npmrc` resolution below (one
-process-wide `HttpCache` policy governs every ecosystem's workspace-declared
-registry fetches — see [npm Custom/Private Registries](#npm-customprivate-registries)
-for what that sharing means in practice). Three values:
+any build runs. This setting is shared with npm's `.npmrc` resolution and PyPI's
+custom-index resolution below (one process-wide `HttpCache` policy governs every
+ecosystem's workspace-declared registry fetches — see
+[npm Custom/Private Registries](#npm-customprivate-registries) and
+[PyPI Custom/Private Indexes](#pypi-customprivate-indexes) for what that sharing
+means in practice). Three values:
 
 | Value | Behavior |
 |-------|----------|
@@ -166,6 +168,119 @@ setting's own doc above.
 - `.yarnrc`/`.yarnrc.yml` (Yarn Berry's own config format) and pnpm-specific
   extensions to `.npmrc` are not read; a standard `.npmrc` present in the
   workspace is still honored either way.
+
+### PyPI Custom/Private Indexes
+
+A PyPI/pip dependency whose applicable index is overridden via `requirements.txt`
+`--index-url`/`--extra-index-url`, Poetry's `[[tool.poetry.source]]`, or uv's
+`[tool.uv.index]`/`[tool.uv.sources]` gets the same hover/diagnostic/completion
+value a plain `pypi.org` dependency gets — instead of showing no version data, or
+(before this feature) silently checking the wrong (public) index.
+
+**Resolution order — the security-relevant rule**: whether an explicit
+`--index-url` (or Poetry `primary`/`default`-priority source, or a uv index with
+`default = true`) is present in the file determines the order every plain
+dependency is checked in:
+
+- **An explicit primary is declared**: that index is checked first, then every
+  `--extra-index-url`/supplemental source, in declaration order. No implicit
+  `pypi.org` hop is appended — `--index-url` *replaces* the default index (matching
+  pip's own semantics), so a file that wants `pypi.org` reachable alongside an
+  explicit primary must list it as an extra itself.
+- **No explicit primary, but extras exist**: declared extras are checked *before*
+  the implicit `pypi.org` fallback, which is always checked last. This is
+  deliberately the reverse of what might seem intuitive, and is the whole point of
+  this feature's design: it stops a private-only package's name from ever being
+  sent to `pypi.org` before the user's own declared index has had a chance, and
+  stops a same-named public package from silently shadowing a private one the user
+  explicitly configured (the "dependency confusion" attack shape). This diverges
+  from pip's own resolver, which pip's docs describe as having no defined
+  precedence between `--index-url` and `--extra-index-url` and explicitly warn is
+  unsafe for private packages for exactly this reason.
+
+uv's `default = true` index follows this same "no explicit primary" shape: it is
+uv's own lowest-priority, last-resort index — checked *after* every other declared
+uv index, replacing the implicit `pypi.org` slot, never checked first the way an
+explicit `--index-url` primary is.
+
+**Poetry named sources**: a dependency declaring `source = "<name>"` (Poetry) or a
+`[tool.uv.sources] <dep> = { index = "<name>" }` binding (uv) resolves directly
+against that one named source, with no fallback to any other index — a deliberate,
+single-hop route. A Poetry source with no `priority` key is treated as `primary`
+(matching current Poetry documentation); `explicit`-priority Poetry sources and
+`explicit = true` uv indexes are reachable only by name, never auto-included in the
+extras chain.
+
+**Authentication**: phase 1 carries **no** authentication at all — the same
+Cargo/npm precedent. Any index URL with embedded userinfo (`https://user:pass@…`)
+is rejected outright rather than stripped-and-used; `keyring`/`.netrc` are not
+detected or acknowledged. This means an auth-gated private feed (e.g. Azure
+Artifacts) is not reachable end-to-end until a follow-up auth spec ships — the
+routing/fallback mechanism itself still works correctly for any unauthenticated
+private index (an internal mirror behind network-level access control, or a devpi
+instance with anonymous read).
+
+**Fail-closed on misconfiguration**: an explicit `--index-url`, Poetry
+primary/named source, or uv `default`/named index that fails validation (not
+`https`, malformed, or blocked by the reachability policy below) shows no version
+data for every affected dependency — never a silent fallback to `pypi.org`. An
+invalid `--extra-index-url`/supplemental/non-default entry, by contrast, is simply
+dropped from the fallback chain (with a logged warning) rather than failing the
+whole dependency closed, since an extra is additive/optional by definition — the
+remaining valid hops (including the implicit `pypi.org` fallback, if applicable)
+still serve the dependency.
+
+**Availability trade-off of the security fix above**: a genuine transport error
+(timeout, 5xx, connection refused) on any hop — including a declared extra that
+happens to be hop 0 in the no-explicit-primary case — halts resolution for that
+dependency rather than silently falling through to the next hop. Applied to a file
+with only `--extra-index-url` entries, an unreachable extra (a developer off the
+corporate VPN, say) means every dependency in that file loses its version data,
+including ordinary public ones with no relation to the private index. This is
+intentional, not a bug: falling through on a transport failure would send every
+affected package's name to `pypi.org` precisely when the private index is merely
+unreachable — the same disclosure the resolution-order rule above exists to
+prevent. A distinguishable log message ("extra index unreachable — resolution
+halted, not falling back to pypi.org") accompanies this case so it can be told
+apart from a genuinely missing package.
+
+**Reachability policy**: governed by the same `registries.workspace_registries`
+setting documented above for Cargo/npm — the same `"public_only"`/`"off"`/`"all"`
+values, the same shared process-wide `HttpCache` policy. Only *explicitly-declared*
+indexes (a primary, every extra, every named source) are gated; the implicit
+`pypi.org` fallback used by the no-explicit-primary case is never itself subject
+to this setting, since it is the same public-tier client every plain dependency
+already uses. What this means in practice depends on whether the file declares an
+explicit `--index-url` primary:
+
+- **No explicit primary, extras only**: `workspace_registries = "off"` blocks
+  every declared extra, and — since there is no implicit-fallback slot to lose —
+  every plain dependency in the file degrades gracefully to resolving against
+  `pypi.org` directly, exactly as if the file declared nothing at all.
+- **An explicit `--index-url` primary**: an explicit primary *replaces* the
+  default index rather than adding to it (FR-005(a)), so there is no implicit
+  `pypi.org` hop to fall back to. If `off` blocks that primary, it fails closed
+  (`CustomRegistry`, FR-006) and **every** dependency in the file loses version
+  data — `off` does not silently degrade to public resolution here, unlike the
+  extras-only case above.
+
+**Known limitations**:
+- Editing a file's index declarations does not take effect until it is next
+  reparsed (edited, or the document reopened) — there is no dedicated file watcher
+  for it yet.
+- `pip.conf`/`pip.ini` and `PIP_INDEX_URL`/`PIP_EXTRA_INDEX_URL` environment
+  variables are not read at all — a project relying solely on those (rather than
+  in-file `--index-url` flags) sees no improvement from this feature.
+- `-r`/`-c` include propagation is not implemented: a file included via `-r
+  base.txt` does not inherit the includer's index declarations, and vice versa.
+- A `[tool.uv.sources]` binding is only recognized for the `index = "<name>"`
+  shape — `git =`, `path =`, and `workspace = true` bindings are a distinct
+  concept (dependency provenance, not registry routing) and are not read.
+- **Cosmetic limitation**: a plain dependency in an extras-only file is classified
+  as resolved via the alternate-index chain at parse time, before the winning hop
+  is actually known — if it ends up resolving via the implicit `pypi.org`
+  fallback, its hover heading still omits the `pypi.org` project link (the same
+  suppression a genuinely private dependency gets). No data-correctness impact.
 
 ### Yanked-Version Diagnostics
 

--- a/specs/033-pypi-private-index-support/plan.md
+++ b/specs/033-pypi-private-index-support/plan.md
@@ -1,0 +1,892 @@
+---
+aliases:
+  - PyPI Private Index Plan
+tags:
+  - sdd
+  - plan
+  - pypi
+  - security
+created: 2026-09-02
+status: draft
+related:
+  - "[[spec]]"
+  - "[[constitution]]"
+---
+
+# Technical Plan: PyPI Private/Custom Index Resolution
+
+> [!info] References
+> **Spec**: [[spec]]
+> **Issue**: #513
+> **Closest analogue**: [[032-npm-npmrc-registry-support/plan|032 npm .npmrc plan]] — structural template for this plan; deviations are called out explicitly where PyPI's config surface differs from npm's.
+
+> [!warning] Revision History
+> **r2 (2026-09-02)** — full rewrite of §1/§3 after a `rust-critic` design review
+> found 4 Critical and 7 Significant defects in r1, verified against the live
+> `deps-npm`/`deps-pypi` source and against pip's and Poetry's own documentation:
+> - **C1**: r1's chain-fallback lookup called `self.alternate_client(...)` from
+>   an *alternate* client instance, whose `alternates` map is always empty by
+>   the npm invariant it copied — every hop resolved to `None`. Fixed by
+>   resolving the chain to `Vec<Arc<PypiRegistry>>` (concrete clients) once, at
+>   registration time on the root, instead of `Vec<PypiIndexUrl>` needing a
+>   second lookup at fetch time.
+> - **C2**: r1 keyed the shared `alternates` map by primary URL alone, but the
+>   value carried per-file `fallback_chain` state — two files sharing a primary
+>   with different extras would alias onto one chain, and an edited
+>   `--extra-index-url` would never take effect (contradicting FR-012). Fixed
+>   by keying on the full ordered-hop chain identity.
+> - **C3 (security-relevant)**: r1's "implicit primary" rule made `pypi.org`
+>   the primary — checked *before* declared extras — whenever a file had
+>   `--extra-index-url` but no explicit `--index-url` (the exact US-002 Azure
+>   Artifacts scenario). Verified against pip's own docs: pip states
+>   "there is no priority in the locations that are searched... the best
+>   match... is selected" and explicitly warns `--extra-index-url` is unsafe
+>   for private packages for exactly this reason. r1's claim that
+>   primary-then-extras "matches pip's own documented default precedence
+>   intent" was wrong. Fixed by inverting the implicit case: declared extras
+>   are checked before the implicit public fallback, never the reverse — see
+>   [[spec#FR-005|spec FR-005]]'s r2 text.
+> - **C4**: r1 reused `PypiRegistry.index_url`, which is the package-name
+>   *search*-index URL (`crate::search::SIMPLE_INDEX_URL`), as if it were the
+>   version-fetch base. Version fetches actually go through the free function
+>   `simple_api_url` + module const `PYPI_SIMPLE_BASE`
+>   (`crates/deps-pypi/src/registry.rs:65-67,200`), which r1 never
+>   parameterized — an alternate client would have silently kept fetching
+>   `pypi.org`. Fixed by adding a distinct `simple_base` field.
+> - **S1**: r1's Poetry unlabeled-source → `supplemental` mapping was verified
+>   against current Poetry docs and found backwards — Poetry documents
+>   unlabeled sources as `primary`. Fixed in [[spec#FR-007|spec FR-007]].
+> - **S2, S4, S5, S6, S7**: position-independent `--index-url` capture (two-pass
+>   parsing), a tier guard on `search`/`warm_search_index`/`get_package_metadata`
+>   for workspace-declared clients, a precise PackageNotFound-vs-genuine-error
+>   failure taxonomy, never gating the implicit public fallback behind
+>   `workspace_registries`, and a `test-util` feature for integration tests —
+>   all folded into this revision, detailed inline below.
+> - Also brought `uv`'s `[tool.uv.sources] { index = "<name>" }` shape into
+>   scope (was previously excluded, leaving named uv indexes unreachable) —
+>   see [[spec#FR-013|spec FR-013]] r2.
+>
+> Full critic findings: `.local/handoff/2026-09-02T21-55-03-critic.md`.
+> **r1 (2026-09-02)** — initial plan, superseded above.
+>
+> **r3 (2026-09-02)** — a second critic pass on r2 (verdict: downgraded from
+> `critical` to `significant` — all 16 r1 findings confirmed genuinely fixed,
+> no redesign needed) found 6 new Significant defects introduced by r2's own
+> fixes, all closed in this revision:
+> - **N1**: `register_chain` cannot construct the implicit-public final hop as
+>   specified (`self: &Arc<Self>` receivers are unstable, and `Arc::clone` of
+>   the root creates a root↔head reference cycle). Fixed: takes `root:
+>   &Arc<Self>` as a plain parameter (the ecosystem already holds one), and
+>   the final hop is a freshly-built `Public`-tier client (identical ungated
+>   behavior, no cycle) rather than a clone of the root itself.
+> - **N2**: the uv `default`/`explicit` mapping was backwards — verified live
+>   against `docs.astral.sh/uv/concepts/indexes/`. Non-`default`/non-`explicit`
+>   `[tool.uv.index]` entries are searched automatically (chain hops, not
+>   named-only); `default = true` is uv's *lowest-priority, last-resort*
+>   index, replacing the implicit public fallback in the final chain slot —
+>   not a checked-first primary. Fixed in FR-013 and §1/§3 below.
+> - **N3**: T006 (r2) parameterized both `simple_api_url` *and* `metadata_url`
+>   on the new `simple_base` field, but `PYPI_BASE`/`PYPI_SIMPLE_BASE` are
+>   different roots — that would 404 the public client's metadata fetch.
+>   Fixed: only `simple_api_url` takes `simple_base`; `metadata_url` is
+>   untouched (and already tier-guarded off for alternates by T008 regardless).
+> - **N4**: the failure taxonomy's "any other `Err` is terminal" rule means an
+>   unreachable declared extra (FR-005(b), no explicit primary) now halts
+>   resolution for *every* dependency in that file, public ones included —
+>   strictly worse than today for that failure mode. Confirmed as an
+>   intentional trade-off (the alternative — falling through on transport
+>   failure — would leak every affected package's name to `pypi.org`
+>   whenever the private index is merely unreachable, exactly what NFR-003(2)
+>   exists to prevent) and now explicitly documented with a required
+>   distinguishable diagnostic (spec FR-005(c)/NFR-003(3)).
+> - **N5**: a zero-hop chain (every extra dropped, e.g. under
+>   `workspace_registries = off`, with no explicit primary) was undefined —
+>   exactly the scenario T010's own test exercises. Fixed: resolves to plain
+>   `DependencySource::Registry`, `resolved_chains()` emits nothing for it.
+> - **N6**: the newline-joined, `<pypi.org>`-suffixed chain-key violates
+>   `deps-core`'s documented contract for `AlternateRegistry.index` ("the
+>   resolved index URL") — latent (no consumer renders it today) but a
+>   shared-type invariant future readers rely on. Fixed: chain sources now
+>   store an opaque, single-line hashed token (`pypi-chain:<hex digest>`),
+>   never a value that looks like or claims to be a URL; spec.md's Data Model
+>   section now documents this as a stated widening of the field's doc
+>   comment (not a type change).
+> - Two minor findings also folded in: the missing second half of the Poetry
+>   citation (FR-007 — "if you configure at least one primary source, the
+>   implicit PyPI source is disabled", load-bearing for why case (a) appends
+>   no public hop) and an explicit note that the "supplemental" stop
+>   condition approximates Poetry's version-aware one.
+>
+> Full second-pass findings: `.local/handoff/2026-09-02T22-18-42-critic.md`.
+
+## 1. Architecture
+
+### Approach
+
+Parse-time resolution, identical in spirit to Cargo/npm: each `deps-pypi` parser
+resolves every dependency's `DependencySource` using a per-file
+`PypiIndexConfig` built from whatever index declarations are present in that
+file.
+
+**The two-pass fix (S2) applies to `requirements.rs` only.** `requirements.txt`
+is line-oriented, so pass 1 collects every `--index-url`/`--extra-index-url`
+occurrence across the whole file regardless of line position, and pass 2
+resolves every dependency's source using the fully-collected config — this
+matters because pip applies index options file-wide, not from-this-line-down,
+and an r1 draft that resolved sources in a single top-to-bottom pass would
+have left dependencies declared *before* a late `--index-url` line silently
+unrouted. **`pyproject.toml` needs no such restructuring** (clarified
+2026-09-02, second critic pass): `toml_edit`/`toml_span` already parses the
+whole document before `pyproject.rs` does anything with it, so Poetry's
+`[[tool.poetry.source]]` and uv's `[tool.uv.index]`/`[tool.uv.sources]` tables
+are simply read once, in full, before dependency resolution begins — there is
+no line-position hazard to guard against there, and no "second pass" to add.
+
+No new `DependencySource` variant and no `deps-pypi`-local source enum — every
+resolved state lands in exactly one of the three existing `deps-core` states:
+
+- `DependencySource::Registry` — no index override anywhere in the file (US-004,
+  byte-identical to today).
+- `DependencySource::AlternateRegistry { index, mirrors_crates_io: false }` — a
+  successfully validated, policy-permitted index or chain. Reused for
+  `--index-url`, `--extra-index-url` (additively, see below), Poetry sources,
+  and uv indexes.
+- `DependencySource::CustomRegistry { url }` — an **explicit primary**
+  (`--index-url`, Poetry `primary`/`default` source, uv `default = true`
+  index) or a **named-source reference** (Poetry `source = "<name>"`, uv
+  `index = "<name>"`) that is invalid/policy-blocked (FR-006), fails closed,
+  never falls back to `pypi.org` (closes the #248 bug class). An invalid
+  **extra** (`--extra-index-url`, a supplemental/secondary Poetry source) is
+  *not* treated this way — see FR-006's r2 text: it is dropped from the chain
+  with a warning, not escalated to a whole-dependency failure, since an extra
+  is additive/optional by definition.
+
+### The FR-005 resolution-order rule (corrected in r2 — read this section first)
+
+`--extra-index-url`'s additive, multi-index fallback has no single-index
+equivalent in npm's or Cargo's data model — both of those ecosystems resolve a
+dependency to exactly one concrete index at parse time. The *routing decision*
+(which index actually served the package) cannot always be known at parse
+time — it depends on which index the package name is found on. This plan
+pushes that fallback into the registry client, not into `DependencySource`
+(see Key Design Decisions), and resolves a "plain" dependency (no
+per-dependency source binding) to `AlternateRegistry { index: <chain-key> }`.
+
+Two sub-cases, per spec FR-005(a)/(b):
+
+- **(a) Explicit primary present** (`--index-url`, or a Poetry `primary`/
+  `default`-priority source, or a uv index with `default = true`): the chain
+  is `[primary, ...extras]`, in that order. **No implicit public hop is
+  appended** — an explicit `--index-url` *replaces* the default index per
+  pip's own semantics (`--extra-index-url` *adds* to it), so a file that wants
+  `pypi.org` reachable alongside an explicit primary must list it as an extra
+  itself. This direction was never problematic (r1 had it right): the user
+  explicitly chose this index, so checking it first is the deliberate,
+  requested behavior — no name-disclosure or confusion-inversion risk.
+- **(b) No explicit primary, but extras exist**: the chain is
+  `[...extras, <implicit public fallback>]`, extras in declaration order,
+  the public `pypi.org` root **always last**. This is the corrected direction
+  (r1 had it backwards): a private-only package name (US-002) is checked
+  against the user's own declared indexes first and is never sent to
+  `pypi.org` before that, and a same-named public package can never silently
+  shadow a private one the user explicitly configured. See spec NFR-003's r2
+  text for the full security rationale and the pip-documentation citation
+  that drove this correction.
+
+A file with **no** `--index-url`/`--extra-index-url`/Poetry-source/uv-index
+declaration anywhere never enters either case — every dependency stays plain
+`DependencySource::Registry`, byte-identical to today (US-004), and the
+registry's `alternates` map is never touched.
+
+**Zero-hop chain (fixes N5)**: if every extra in a case-(b) file is dropped
+(FR-006 — e.g. all blocked by `workspace_registries = off`) and no explicit
+primary was ever declared, the resulting chain would have zero hops. This is
+explicitly defined, not left implicit: `resolve_source_for` returns plain
+`DependencySource::Registry` in this case (byte-identical to a file with no
+declarations at all — this also incidentally avoids M1's suppressed hover
+link for exactly the dependencies that end up resolving publicly anyway), and
+`resolved_chains()` emits nothing for it.
+
+A Poetry `source = "<name>"` / uv `index = "<name>"`-scoped dependency
+resolves directly to that named source's own URL as a single-hop chain (chain
+length 1) — no implicit fallback to public or to other named sources (matches
+US-003: a named source is a direct, deliberate route).
+
+**uv's chain shape is its own third case (fixes N2)**: uv has no
+`--index-url`-equivalent "explicit primary checked first" concept at all — its
+own documented model is "every non-`explicit` index is searched automatically,
+with the `default = true` index always checked *last* regardless of
+declaration position, replacing the implicit `pypi.org` slot rather than
+occupying the primary slot." Concretely, a uv config's chain is built as:
+`[...every [tool.uv.index] entry that is neither default nor explicit, in
+declaration order..., <default entry if one exists, else the implicit public
+fallback>]`. This always routes through the FR-005(b)-shaped chain model
+(`PypiIndexConfig.primary` stays `None` for pure-uv configs — uv never
+populates it), never through (a)'s primary-first model. An `explicit = true`
+entry is parsed into `named_sources` only, consulted via `[tool.uv.sources] {
+index = "<name>" }` (FR-013), exactly like a Poetry `explicit`-priority
+source.
+
+### Chain resolution mechanism (fixes C1)
+
+The shared `alternates: Arc<DashMap<String, Arc<PypiRegistry>>>` map lives
+**only on the root** (`Public`-tier) `PypiRegistry` instance that
+`PypiEcosystem` holds and that every `get_versions_from`/`get_latest_matching_from`
+call is actually dispatched through (this mirrors the npm invariant precisely:
+"only the root registry ever registers or looks up further alternates").
+Registration and chain-building happen **once, at parse time, entirely on the
+root**:
+
+1. For each `ResolvedChain` produced by `PypiIndexConfig::resolved_chains()`
+   (see §3), construct a self-contained tree of `PypiRegistry` leaf clients:
+   hop 0 becomes the returned client's own `simple_base`/`tier`; hops 1..N-1
+   become freshly-constructed leaf `Arc<PypiRegistry>` clients (each with an
+   *empty* `fallback_chain` — they are never themselves looked up by key,
+   only walked positionally); if `implicit_public_fallback` is set, the very
+   last hop is a **freshly-constructed `Public`-tier client** (`simple_base:
+   PYPI_SIMPLE_BASE.to_string()`, same ungated transport as the root — fixes
+   N1: r2 specified `Arc::clone(&root)` here, but that both requires an
+   `Arc<Self>` unobtainable from `&self` — `self: &Arc<Self>` receivers are
+   unstable — and creates a root→`alternates`→head→`fallback_chain`→root
+   reference cycle. A fresh `Public`-tier leaf is behaviorally identical —
+   same URL, same tier, same lack of gating — with neither problem).
+2. The resulting head client (hop 0 + the rest of the tree in its own
+   `fallback_chain: Vec<Arc<PypiRegistry>>`) is inserted into the root's
+   `alternates` map under `ResolvedChain::key` — the **only** thing
+   `DependencySource::AlternateRegistry { index }` needs to look up.
+3. A named-source (Poetry/uv) resolution registers a single-hop leaf (empty
+   `fallback_chain`) under that source's own URL as the key.
+
+Registration is performed by an associated function that takes the root
+explicitly rather than as `&self` (fixes N1's second issue): `PypiRegistry::
+register_chain(root: &Arc<Self>, chain: &ResolvedChain)` and `PypiRegistry::
+register_named_source(root: &Arc<Self>, index: &PypiIndexUrl)`. `PypiEcosystem`
+already holds `registry: Arc<PypiRegistry>` and passes it directly at both
+call sites — no new plumbing needed.
+
+No further map lookup happens at fetch time — `get_versions_chained`
+(a private helper, not a trait method) tries `self.get_versions_with(name,
+freshness)` first (using `self`'s own `simple_base`/`tier` — correctly hits
+hop 0), then walks `self.fallback_chain` in order, calling each already-resolved
+hop's own `get_versions_with` directly. Stops at the first hop whose result is
+neither `PackageNotFound` nor an empty version list (see the Failure Taxonomy
+subsection below); returns the last hop's answer if every hop misses.
+
+Leaf clients built for hops 1..N-1 of one chain are **not** deduplicated
+against leaves built for other chains that happen to reference the same URL
+(a deliberate simplification over trying to safely mutate/share leaves across
+chains, which would reopen a C2-shaped aliasing risk at the leaf level). The
+underlying `HttpCache` (shared `Arc<HttpCache>`, keyed by URL) still
+deduplicates the actual HTTP-level caching regardless of how many small
+`PypiRegistry` wrapper structs reference the same URL, so this costs a few
+extra lightweight allocations, not extra network requests.
+
+### Chain-key identity (fixes C2, and its representation fixes N6)
+
+`ResolvedChain::key` is derived from the ordered hops plus the
+`implicit_public_fallback` flag, so an explicit-primary chain `[A, B]` can
+never collide with an implicit chain that resolves to the same `[A, B]` but
+additionally wants the public root appended. Two files with the same primary
+but *different* extras therefore produce different keys and register
+independently; editing a file's `--extra-index-url` list changes its
+`ResolvedChain::key` on the next reparse, so FR-012's "stale until reparse"
+promise is now literally true (the *old* key's registration lingers unused in
+the map — harmless, bounded by the existing `MAX_ALTERNATE_REGISTRIES = 256`
+cap) rather than being silently reused (r1's C2 bug).
+
+**Representation (fixes N6, second critic pass)**: r2 built this key by
+joining the hop URLs with `"\n"` and a `"\n<pypi.org>"` suffix — a value that
+looks like a URL (and would appear so in a `tracing::warn!` log line) but is
+not one, violating `deps-core`'s documented contract for
+`DependencySource::AlternateRegistry.index` ("the resolved index URL" —
+`crates/deps-core/src/parser.rs:890-896`). No `deps-core` consumer renders or
+parses this field today, so the violation is latent, not live — but it is a
+shared type whose stated invariant future readers rely on. r3 uses an opaque,
+single-line hashed token instead: `format!("pypi-chain:{:016x}", digest)`,
+where `digest` is computed by hashing the ordered hop strings and the
+`implicit_public_fallback` flag through `std::collections::hash_map::
+DefaultHasher` (no new dependency — this only needs to be stable within one
+running process for map-key purposes, not across restarts or Rust versions).
+spec.md's Data Model section is updated to document this as a stated
+widening of `AlternateRegistry.index`'s doc comment (a chain source stores an
+opaque parser-owned routing key, not a URL; a single-hop named-source
+dependency still stores a literal URL, matching Cargo/npm's convention) — a
+documentation change, not a type change, so it does not touch the "Never
+widen the trait surface" boundary.
+
+**Risk note**: because the cap now counts distinct *chain identities* rather
+than distinct index *URLs*, a large multi-config monorepo with many files
+declaring different extras combinations against the same primary could
+exhaust the 256-entry cap faster than Cargo/npm's simpler one-registration-
+per-URL model. Acceptable for phase 1 (npm's own cap was chosen without this
+concern applying); revisit if it proves too low in practice.
+
+### Failure taxonomy (fixes S5)
+
+`get_versions_chained`/`get_latest_matching_chained` distinguish three
+outcomes per hop:
+
+1. **`Ok(versions)` with `versions` non-empty** → terminal, this hop's answer
+   wins.
+2. **`Err(PackageNotFound)`, or `Ok(versions)` with `versions` empty** (some
+   PEP 503 indexes answer `200` with an empty listing for an unknown project
+   rather than `404` — both must trigger fallthrough identically) → continue
+   to the next hop.
+3. **Any other `Err`** (5xx, timeout, network error, malformed response) →
+   **terminal, propagated immediately** — does *not* fall through to the next
+   hop. A broken/unreachable primary must surface as an error, not be
+   silently masked by a lucky extra that happens to answer; this also means
+   an unauthenticated 401/403 (the real Azure Artifacts case, see SC-002's r2
+   caveat) terminates the chain rather than silently trying `pypi.org` next.
+
+**Confirmed trade-off (fixes N4, second critic pass)**: rule 3 applied to a
+case-(b) chain (FR-005(b), no explicit primary — hop 0 is a declared extra)
+means an unreachable extra (a developer off the corporate VPN, say) halts
+resolution for *every* dependency in that file, ordinary public ones
+included — strictly worse for that one failure mode than today's behavior
+(where everything just resolves against `pypi.org`). This is confirmed
+intentional, not an oversight: the alternative (falling through to `pypi.org`
+on transport failure) would send every affected package's name to the public
+index precisely when the private index is merely unreachable — exactly the
+disclosure NFR-003(2) exists to prevent, and arguably the more likely
+real-world trigger for that disclosure than a genuinely missing package
+(SC-004's regression scenario). Per NFR-003(3), THE SYSTEM SHALL surface a
+distinguishable diagnostic for this case (e.g. "extra index unreachable —
+resolution halted, not falling back to pypi.org") rather than a generic fetch
+error, so a developer can tell it apart from a genuinely broken/nonexistent
+package. Connection timeout and 5xx are treated identically (both terminal) —
+no further split by failure kind for phase 1.
+
+`get_latest_matching_chained` is derived from `get_versions_chained` +
+the existing `select_latest_matching`/`select_latest_matching_with_context`
+helpers (fixes M4) rather than re-implementing its own walk — this removes
+the risk of hover and diagnostics disagreeing on "latest" via two different
+code paths, a failure mode both npm and the shared `deps-core` helpers already
+go out of their way to avoid. The one semantic choice this requires: if the
+*winning* hop (first hop with a non-empty version list) has no version
+matching the requirement, that is **terminal** — `Ok(None)`, not a trigger to
+keep searching later hops for a "better" match. Continuing to search would
+reintroduce exactly the cross-index version comparison this design avoids for
+security reasons (dependency confusion is fundamentally a "which index's
+version wins" problem).
+
+### Tier guard on search endpoints (fixes S4, M3, M5)
+
+`search`, `warm_search_index`, and `get_package_metadata` are all overridden
+(or gated inline) to return empty/no-op immediately for any `WorkspaceDeclared`-
+tier `PypiRegistry` instance — mirroring `NpmRegistry::search`'s existing tier
+guard and its documented rationale ("enforced here rather than relied on via
+the call graph"). Without this, an unguarded `search`/`warm_search_index` on
+an alternate client would trigger a full project-listing download from the
+private host (the multi-MB Simple index, not a single-package fetch), and
+`get_package_metadata` (currently `pub`, ungated, unrouted, and unused by any
+in-workspace caller today — confirmed latent by the critic review) would send
+a private package name to `pypi.org`'s JSON API the moment any future call
+site reaches it. Once this guard is in place, per-leaf `IndexCell` allocation
+(M5) is harmless — it is never populated for a workspace-declared client.
+
+### `workspace_registries = off` never gates the implicit public hop *itself* (fixes S6) — narrowed 2026-09-02
+
+Because the implicit public fallback hop is a **freshly-constructed
+`Public`-tier client** (same `simple_base`, same ungated transport as the
+root — not an `Arc::clone` of the root itself, see N1's fix above) rather
+than a `PypiIndexUrl` that would need to pass `classify_host`/
+`RegistryAccessPolicy` validation, setting `workspace_registries = off`
+blocks only the *explicitly-declared* primary/extras/named sources (which
+correctly fail validation and drop out of the chain or fail closed per
+FR-006) — it never touches the public hop's own gate. **This is a narrower
+claim than "off never blocks ordinary public-package resolution in the
+file"** (validator finding, second pass) — whether public resolution
+survives depends on whether a case-(a) explicit primary is present, since
+case (a) never has an implicit public hop to fall back to at all:
+
+- **A file with only extras declared** (no explicit primary), all now
+  blocked: the chain has zero hops. Per N5's fix (see above), every plain
+  dependency in that file resolves as plain `DependencySource::Registry` —
+  there is no per-package distinction at parse time, so this is *every*
+  dependency in the file, not just the "ordinary" ones, degrading gracefully
+  to the same behavior as a file with no declarations at all, rather than
+  failing closed for the whole file. **Here, and only here, is "off never
+  blocks public resolution" actually true.**
+- **A file with an explicit primary** plus a blocked extra, where the
+  *primary itself* is still valid under the current policy: the chain still
+  has a working hop (the primary), so every dependency resolves via it
+  exactly as under `public_only`/`all` — only the extra's contribution is
+  lost. This is Test A's scenario, and it requires the primary to pass
+  validation — under literal `off` (which blocks every host class
+  unconditionally), no primary ever passes, so this outcome is only reached
+  under `public_only`/`all` with a *different*, still-blocked extra.
+- **A file with an explicit primary that itself fails validation** (always
+  true under literal `off`, since `off` blocks every host class): FR-005(a)
+  means an explicit primary *replaces* the default index rather than adding
+  to it, so there is no implicit public hop in this case at all — the
+  primary fails closed to `CustomRegistry` (FR-006) and **every** dependency
+  in the file loses version data. `off` does **not** degrade to public
+  resolution here.
+
+r1's design routed *every* dependency in an extras-carrying file through the
+gated chain regardless of whether any hop remained valid, which would have
+made `off` incorrectly break public resolution project-wide for such a file
+in every case — this is fixed by construction in r2/r3's chain-hop design
+(a chain either keeps working via its remaining valid hops, or degrades to
+plain `Registry` once it has none left), not by an extra check.
+
+### Alternatives considered and rejected
+
+- *Widen `AlternateRegistry` with a `Vec<String>` fallback field* — rejected: a
+  `deps-core` trait/type change the spec's "Never" boundary explicitly forbids
+  ("widen the `deps-core` `Registry`/`EcosystemFormatter` trait surface"); every
+  hook this feature needs already exists generically.
+- *Resolve the winning index at parse time by eagerly probing every configured
+  index* — rejected: turns every parse into N network calls before any hover/
+  diagnostic can render, violating NFR-004's zero-regression-cost bar and adding
+  latency Cargo/npm never pay.
+- *(r1, superseded)* Look up each fallback hop by string key at fetch time via
+  `self.alternate_client(...)` — rejected in r2: structurally broken (C1), since
+  an alternate client's own `alternates` map is always empty by the same
+  invariant npm relies on.
+- *(r1, superseded)* Key the `alternates` map by primary URL alone — rejected
+  in r2: collides across files with differing extras and defeats FR-012's
+  reparse-staleness contract (C2).
+
+### Component Diagram
+
+```mermaid
+graph TD
+    A[requirements.txt / pyproject.toml] -->|two-pass parse| B[PypiIndexConfig]
+    B -->|resolve_source_for| C[DependencySource]
+    B -->|resolved_chains| R[Root PypiRegistry: register chain tree]
+    C -->|AlternateRegistry index| D[root.alternate_client chain-key]
+    D -->|hop 0: self.get_versions_with| F1[HttpCache.get_cached_workspace_with_headers]
+    D -->|hop 1..N-1: fallback_chain resolved Arc leaf| F2[same fetch path, no re-lookup]
+    D -->|final hop, implicit case only| PUB[Arc clone of root: ungated public fetch]
+    F1 -->|net_policy gate at registration| G[classify_host / RegistryAccessPolicy]
+    F2 -->|net_policy gate at registration| G
+    C -->|Registry| H[root public-tier fetch, unchanged]
+    C -->|CustomRegistry| I[fail closed - no fetch]
+```
+
+### Key Design Decisions
+
+| Decision | Choice | Rationale | Alternatives Considered |
+|----------|--------|-----------|--------------------------|
+| Fallback-chain location | Registry-client-side (`fallback_chain: Vec<Arc<PypiRegistry>>`, resolved once at registration), not in `DependencySource` | Keeps `deps-core` untouched; matches the "Never widen deps-core trait surface" boundary | Widen `AlternateRegistry` with a chain field (deps-core change, rejected); eager multi-index probe at parse time (latency regression, rejected) |
+| Chain resolution timing | Resolve every hop to a concrete `Arc<PypiRegistry>` **once, at registration time on the root** — no further map lookup at fetch time | Fixes r1's C1 defect (an alternate client's own `alternates` map is always empty) | Look up each hop by string key at fetch time (r1, structurally broken) |
+| Implicit-case ordering | Declared extras checked **before** the implicit public `pypi.org` fallback | Fixes r1's C3 defect — verified against pip's own docs (no precedence, `--extra-index-url` documented as unsafe for private packages); avoids name-disclosure and confusion-inversion | Implicit-primary-first (r1, verified backwards against pip's docs and rejected) |
+| Chain-key identity | An opaque, single-line hashed token (`pypi-chain:<hex digest>` of the ordered hops + fallback flag), never a URL-shaped value | Fixes r1's C2 defect (prevents cross-file aliasing, honors FR-012) *and* N6 (second critic pass — a `"\n"`-joined URL-shaped key violated `deps-core`'s documented `AlternateRegistry.index` contract) | Primary-URL-only key (r1, collides across files with differing extras); newline-joined URL-shaped key (r2, contract violation, latent) |
+| `register_chain`/`register_named_source` signature | Associated functions taking `root: &Arc<Self>` as a plain parameter, not `&self` | Fixes N1 (second critic pass) — `self: &Arc<Self>` receivers are unstable, and constructing the implicit-public final hop needs an owned `Arc<Self>` | `fn register_chain(&self, ...)` (r2) with `Arc::clone(&root)` for the final hop — unstable receiver type, plus a root↔head reference cycle |
+| Implicit-public final hop | A freshly-constructed `Public`-tier leaf client (same URL, same ungated transport) | Fixes N1's second half — behaviorally identical to cloning the root, without the reference cycle `Arc::clone(&root)` would create | `Arc::clone(&root)` (r2, creates a root→alternates→head→fallback_chain→root cycle) |
+| Version-fetch base | New `simple_base: String` field, distinct from the existing `index_url` (search-index URL), consumed **only** by `simple_api_url` | Fixes r1's C4 defect — `index_url` is `crate::search::SIMPLE_INDEX_URL`, consumed only by `search`/`warm_search_index`. Narrowed to `simple_api_url` only (not `metadata_url`) to fix N6/N3 (second critic pass) — `PYPI_BASE`/`PYPI_SIMPLE_BASE` are different roots; parameterizing `metadata_url` too would 404 | Reuse `index_url` as both search base and fetch base (r1, silently kept fetching `pypi.org`); parameterize `metadata_url` on `simple_base` too (r2, wrong root, would 404) |
+| Invalid-entry handling | Explicit primary/named-source: fail closed (`CustomRegistry`, unchanged from r1). Invalid **extra**: drop from the chain with a warning, do not fail the whole dependency | An extra is additive/optional by definition; one misconfigured extra must not block resolution via the primary or remaining valid hops | Fail the whole chain closed on any invalid entry (r1's original FR-006 wording, too strict for extras) |
+| Transport-failure handling mid-chain | Terminal — propagated immediately, never falls through to the next hop, even on a case-(b) extra | Confirmed intentional (N4, second critic pass) — falling through would leak the affected package's name to `pypi.org` whenever the private index is merely unreachable, the exact disclosure NFR-003(2) prevents; a distinguishable diagnostic (NFR-003(3)) offsets the availability cost | Fall through to the next hop on any error (rejected — reopens the name-disclosure risk C3 fixed); split by error kind (connect-timeout falls through, 5xx terminal) — considered, rejected as unneeded phase-1 nuance |
+| Zero-hop chain (every extra dropped, no explicit primary) | Resolves to plain `DependencySource::Registry`, `resolved_chains()` emits nothing | Fixes N5 (second critic pass) — was undefined, exactly the scenario the `workspace_registries = off` test exercises | Leave undefined (r2, would pin whichever behavior the developer happened to implement) |
+| Poetry `priority` mapping (Poetry has 5 documented values: `primary`, `default`, `secondary` (deprecated), `supplemental`, `explicit`) | `primary`/`default`/**no `priority` key** → primary-equivalent (`--index-url`-equivalent); `supplemental`/`secondary` → extra-equivalent; `explicit` → named-source-only, never auto-included. When a primary/default source exists, **no implicit public hop is appended** (Poetry: "the implicit PyPI source is disabled") | Fixes r1's S1 defect — verified live against current Poetry docs ("Sources without a priority are considered primary sources, too" / "if you configure at least one primary source, the implicit PyPI source is disabled" — the second sentence added to close N7) | Unlabeled → `supplemental` (r1, verified backwards) |
+| uv scope and mapping | `[tool.uv.index]` entries that are neither `default` nor `explicit` → chain hops (extras-equivalent, automatic); `default = true` → last-resort hop replacing the implicit-public slot; `explicit = true` → named-source only, reached via `[tool.uv.sources] { index = "<name>" }` (FR-013) | Fixes r2's N2 defect — verified live against `docs.astral.sh/uv/concepts/indexes/`; r2 had put every non-default entry in `named_sources` only (unreachable) and mapped `default = true` to the checked-first primary slot (backwards — it's uv's lowest-priority slot) | Index-declaration tables only, no per-dependency binding (r1, left named uv indexes dead code); non-default entries named-source-only, default-as-primary (r2, both backwards vs uv's own docs) |
+| Search/metadata endpoints on workspace-declared clients | Hard tier guard: no-op/empty, never fetched | Fixes S4/M3 — prevents a full private-index listing download and a latent private-name-to-`pypi.org` leak through `get_package_metadata` | Rely on the call graph never reaching these (r1 had no guard at all; rejected per this project's own "a gate before a match proves coverage of that function only" principle) |
+| Config scope | Per-file (per `requirements.txt`/`pyproject.toml`), not per-workspace | Matches spec's edge-case table; avoids inventing a new workspace-aggregation concept `deps-core` has no precedent for | Workspace-wide merged config (rejected — no PyPI analogue to Cargo's `.cargo/config.toml` or npm's ancestor-walked `.npmrc`) |
+| `-r`/`-c` include propagation | Not implemented — documented known limitation | Confirmed 2026-09-02: keeps phase-1 scope contained, matches per-file model | Propagate config along the include graph (deferred, real scope growth) |
+| `pip.conf`/env vars | Not read at all (Out of Scope, unchanged from spec) | Explicit spec decision; no plan-level work needed | N/A |
+
+## 2. Project Structure
+
+```
+crates/deps-pypi/
+├── Cargo.toml                  (MODIFIED — add `test-util = []` feature, fixes S7)
+└── src/
+    ├── config.rs               (NEW — PypiIndexUrl, PypiIndexConfig, InvalidEntry,
+    │                             ResolvedChain, validation against net_policy,
+    │                             requirements.txt and pyproject.toml
+    │                             index-declaration parsing glue)
+    ├── registry.rs             (MODIFIED — PypiRegistryTier, alternates map,
+    │                             simple_base field, with_base, register_chain,
+    │                             alternate_client, fallback_chain: Vec<Arc<Self>>,
+    │                             get_versions_from/get_latest_matching_from
+    │                             overrides, get_versions_chained/
+    │                             get_latest_matching_chained, tier guards on
+    │                             search/warm_search_index/get_package_metadata)
+    ├── formatter.rs            (MODIFIED — PypiFormatter::can_resolve_source
+    │                             override)
+    ├── ecosystem.rs            (MODIFIED — threads each parser's resolved
+    │                             index config into the pipeline (two-pass
+    │                             only for requirements.rs — see §1), registers
+    │                             resolved chains
+    │                             with the root registry, wires deps-lsp's shared
+    │                             RegistryAccessPolicy through)
+    ├── parser/
+    │   ├── requirements.rs     (MODIFIED — two-pass: collect --index-url/
+    │   │                        --extra-index-url/-i values file-wide first,
+    │   │                        then resolve every dependency's source)
+    │   └── pyproject.rs        (MODIFIED — parse [[tool.poetry.source]] table +
+    │                             per-dependency `source = "<name>"` key;
+    │                             parse [tool.uv.index] table entries +
+    │                             [tool.uv.sources] `index = "<name>"` key)
+    └── lib.rs                  (MODIFIED — re-export PypiIndexConfig/PypiIndexUrl
+                                  if any cross-crate test util needs them, mirroring
+                                  npm's `#[cfg(any(test, feature = "test-util"))]`
+                                  loopback carve-out)
+```
+
+No `deps-core` or `deps-lsp/src/config.rs` changes — `registries.workspace_registries`
+/ `RegistryAccessPolicy` / `classify_host` are already shared, cross-ecosystem
+infrastructure (per the npm/Cargo work); this feature only *consumes* them.
+
+## 3. Data Model
+
+```rust
+// crates/deps-pypi/src/config.rs (NEW)
+
+/// Why an index URL could not be resolved into a fetchable `PypiIndexUrl`.
+pub enum PypiIndexUrlError {
+    InvalidUrl,
+    NotHttps,
+    UserInfoPresent,
+    BlockedHost { class: deps_core::net_policy::HostClass },
+}
+
+/// A validated, normalized, https-only PyPI-protocol index URL with no
+/// embedded userinfo. Mirrors `NpmRegistryIndex` exactly (see FR-006/FR-011);
+/// kept `deps-pypi`-local rather than promoted to `deps-core` per this
+/// spec's Open Questions (consolidate only once a third near-identical type
+/// makes the duplication concrete).
+pub struct PypiIndexUrl {
+    normalized: String,
+}
+
+impl PypiIndexUrl {
+    /// Validates `raw` against `policy`: must parse as an `https` URL (loopback
+    /// carve-out under `#[cfg(any(test, feature = "test-util"))]` only, never in
+    /// release builds), must carry no `username()`/`password()`, and its host
+    /// must be permitted by `classify_host`/`policy.get().allows(class)`.
+    pub fn new(raw: &str, policy: &deps_core::net_policy::RegistryAccessPolicy)
+        -> Result<Self, PypiIndexUrlError> { /* ... */ }
+
+    pub fn as_str(&self) -> &str { &self.normalized }
+}
+
+/// A present-but-unusable index entry, carrying what FR-006 needs to build
+/// `CustomRegistry` (explicit primary/named source) or to warn-and-drop
+/// (extra) — the raw, unexpanded value only.
+pub struct InvalidEntry {
+    pub raw: String,
+    pub reason: PypiIndexUrlError,
+}
+
+/// Resolved index configuration for one `requirements.txt` or `pyproject.toml`
+/// file. Built once per parse (two-pass, see §1), consulted per-dependency.
+pub struct PypiIndexConfig {
+    /// Explicit `--index-url`, or a Poetry `primary`/`default`-priority
+    /// source (including one with no `priority` key at all — FR-007 r2), or
+    /// a uv `[tool.uv.index]` entry with `default = true`. `None` when no
+    /// explicit primary is declared (spec FR-005(b) applies instead).
+    primary: Option<Result<PypiIndexUrl, InvalidEntry>>,
+    /// `--extra-index-url` values (declaration order preserved) plus Poetry
+    /// `supplemental`/`secondary`-priority sources — FR-005's fallback
+    /// chain. An `Err(InvalidEntry)` here is dropped (with a warning) rather
+    /// than escalated, per FR-006's extra-specific rule.
+    extras: Vec<Result<PypiIndexUrl, InvalidEntry>>,
+    /// Poetry `[[tool.poetry.source]]` entries keyed by `name` (all
+    /// priorities, including `explicit`) plus uv `[tool.uv.index]` entries
+    /// keyed by their own `name`, consulted only when a dependency declares
+    /// `source = "<name>"` (Poetry) or `[tool.uv.sources] foo = { index =
+    /// "<name>" }` (uv) — never auto-included in the primary/extras chain.
+    named_sources: std::collections::HashMap<String, Result<PypiIndexUrl, InvalidEntry>>,
+}
+
+impl PypiIndexConfig {
+    /// FR-002/003/005/006/007/013: resolves one dependency's
+    /// `DependencySource`. `named_source` is `Some("internal")` for a
+    /// dependency declaring `source = "internal"` (Poetry) or an `index =
+    /// "internal"` uv-sources binding; `None` for every other dependency
+    /// (routes through `primary`+`extras` per FR-005 instead).
+    pub fn resolve_source_for(&self, named_source: Option<&str>)
+        -> deps_core::parser::DependencySource { /* ... */ }
+
+    /// Every chain this config implies, ready for registration —
+    /// FR-005(a)/(b) resolved to concrete hop lists. Empty when the file
+    /// declares no primary and no extras (US-004 — nothing to register).
+    pub fn resolved_chains(&self) -> Vec<ResolvedChain> { /* ... */ }
+}
+
+/// One fully-resolved, ready-to-register routing chain.
+pub struct ResolvedChain {
+    /// Composite identity — becomes both the `alternates` map key and the
+    /// `DependencySource::AlternateRegistry.index` value. An opaque,
+    /// single-line token — `format!("pypi-chain:{:016x}", digest)`, where
+    /// `digest` hashes the ordered hop strings plus `implicit_public_fallback`
+    /// through `std::collections::hash_map::DefaultHasher` (fixes C2's
+    /// aliasing *and* N6's URL-shaped-key contract violation — see §1;
+    /// never a literal URL, unlike a single-hop named-source registration).
+    pub key: String,
+    /// Ordered, already-validated hops. Hop 0 becomes the registered
+    /// client's own `simple_base`; the rest become its `fallback_chain`.
+    /// Never empty for a chain produced by `primary`/`extras`; exactly
+    /// one entry for a named-source chain.
+    pub hops: Vec<PypiIndexUrl>,
+    /// True only for spec FR-005(b) — no explicit primary was declared, so
+    /// the existing Public-tier root is appended as the final, ungated hop
+    /// at registration time (see §1's "workspace_registries = off" fix).
+    pub implicit_public_fallback: bool,
+}
+```
+
+```rust
+// crates/deps-pypi/src/registry.rs (MODIFIED)
+
+enum PypiRegistryTier {
+    Public,             // fetches via HttpCache::get_cached_with_headers
+    WorkspaceDeclared,  // fetches via HttpCache::get_cached_workspace_with_headers,
+                        // re-classifying every redirect hop (existing HttpCache
+                        // behavior, reused as-is — no deps-core change)
+}
+
+pub struct PypiRegistry {
+    cache: Arc<HttpCache>,
+    index_url: String,        // UNCHANGED meaning — package-name *search* index
+                               // base (crate::search::SIMPLE_INDEX_URL by default),
+                               // consumed only by search/warm_search_index
+    simple_base: String,      // NEW (fixes C4) — version-fetch base for THIS
+                               // client's own hop, consumed ONLY by
+                               // simple_api_url (PEP 503/691 Simple API).
+                               // Public tier: PYPI_SIMPLE_BASE. Unused on a
+                               // client only ever reached via fallback_chain.
+                               // Does NOT parameterize metadata_url — fixes
+                               // N3 (second critic pass): PYPI_BASE and
+                               // PYPI_SIMPLE_BASE are different roots
+                               // (/pypi vs /simple), so metadata_url stays
+                               // hardcoded to PYPI_BASE and is unreachable
+                               // for any WorkspaceDeclared client anyway
+                               // (T008's tier guard disables it entirely).
+    index: Arc<crate::search::IndexCell>,
+    tier: PypiRegistryTier,                          // NEW
+    alternates: Arc<DashMap<String, Arc<Self>>>,      // NEW, root-owned only,
+                                                       // keyed by ResolvedChain::key
+                                                       // or a named source's own URL
+    fallback_chain: Vec<Arc<Self>>,                   // NEW, resolved concrete
+                                                       // clients (fixes C1) — empty
+                                                       // for Public tier and every
+                                                       // leaf/named-source client
+}
+
+impl PypiRegistry {
+    /// Production constructor for one hop (leaf or head). `fallback_chain` is
+    /// empty for every call except the head of a multi-hop chain.
+    pub fn with_base(cache: Arc<HttpCache>, simple_base: &PypiIndexUrl,
+        fallback_chain: Vec<Arc<Self>>) -> Self { /* tier: WorkspaceDeclared */ }
+
+    /// Builds the full hop tree for one `ResolvedChain` and inserts the head
+    /// into `root.alternates` under `chain.key`. Idempotent per key (a repeat
+    /// registration for the same key is a no-op), capacity-capped at
+    /// `MAX_ALTERNATE_REGISTRIES = 256` (matching npm's cap — see §1's risk
+    /// note on this cap now counting chain identities). Called only from
+    /// `PypiEcosystem::parse_manifest` over `PypiIndexConfig::resolved_chains()`,
+    /// at parse time only. Takes `root: &Arc<Self>` as a plain parameter
+    /// (fixes N1, second critic pass) rather than `&self` — `self: &Arc<Self>`
+    /// receivers are unstable, and building the implicit-public final hop
+    /// needs an owned `Arc<Self>`; `PypiEcosystem` already holds
+    /// `registry: Arc<PypiRegistry>` and passes it here directly.
+    fn register_chain(root: &Arc<Self>, chain: &ResolvedChain) { /* ... */ }
+
+    /// Registers a single-hop named-source client under its own URL, into
+    /// `root.alternates`. Same idempotency/capacity rules and `root:
+    /// &Arc<Self>` parameter shape as `register_chain`.
+    fn register_named_source(root: &Arc<Self>, index: &PypiIndexUrl) { /* ... */ }
+
+    fn alternate_client(&self, index: &str) -> Option<Arc<Self>> { /* map lookup */ }
+
+    /// FR-005/NFR-006: tries `self` (hop 0) first, then each resolved
+    /// `fallback_chain` entry in order. See §1's Failure Taxonomy for the
+    /// exact PackageNotFound-vs-genuine-error stop condition.
+    async fn get_versions_chained(&self, name: &PackageName, freshness: FreshnessSettings)
+        -> Result<Vec<Box<dyn Version>>> { /* ... */ }
+
+    /// Derived from `get_versions_chained` + `select_latest_matching[_with_context]`
+    /// (fixes M4) — never re-walks the chain independently.
+    async fn get_latest_matching_chained(&self, name: &PackageName, req: &VersionReq,
+        minimum_stability: Option<&str>) -> Result<Option<Box<dyn Version>>> { /* ... */ }
+}
+
+impl deps_core::Registry for PypiRegistry {
+    fn get_versions_from<'a>(&'a self, name: &'a PackageName,
+        source: &'a DependencySource, freshness: FreshnessSettings)
+        -> BoxFuture<'a, Result<Vec<Box<dyn Version>>>> {
+        match source {
+            DependencySource::AlternateRegistry { index, .. } => match self.alternate_client(index) {
+                Some(client) => client.get_versions_chained(name, freshness),
+                None => /* Err(PackageNotFound { registry: "alternate registry (not registered)" }) */,
+            },
+            _ => self.get_versions_with(name, freshness),
+        }
+    }
+    // get_latest_matching_from mirrors this exactly, delegating to
+    // get_latest_matching_chained.
+
+    fn search<'a>(&'a self, query: &'a str, limit: usize)
+        -> BoxFuture<'a, Result<Vec<Box<dyn Metadata>>>> {
+        if matches!(self.tier, PypiRegistryTier::WorkspaceDeclared) {
+            return Box::pin(async { Ok(Vec::new()) }); // fixes S4
+        }
+        /* unchanged existing implementation */
+    }
+    // warm_search_index and get_package_metadata gain the identical guard
+    // (fixes S4/M3).
+}
+```
+
+```rust
+// crates/deps-pypi/src/formatter.rs (MODIFIED)
+
+impl EcosystemFormatter for PypiFormatter {
+    fn can_resolve_source(&self, source: &deps_core::DependencySource) -> bool {
+        matches!(source,
+            deps_core::DependencySource::Registry
+            | deps_core::DependencySource::AlternateRegistry { .. })
+    }
+    // suppress_package_url: no override needed — the default
+    // `!self.source_is_public_registry_content(source)` (itself defaulted to
+    // `matches!(source, Registry)`) already does the right thing for a
+    // dependency that resolves via an explicit AlternateRegistry chain.
+    // Known cosmetic limitation (M1, not fixed): a plain dependency in an
+    // extras-only file (FR-005b) is classified AlternateRegistry at parse
+    // time, before the winning hop is known — if it actually resolves via
+    // the implicit public fallback, its pypi.org hover link is still
+    // suppressed. Accepted for phase 1; documented in ECOSYSTEM_GUIDE.md.
+}
+```
+
+## 4. API Design
+
+Not a REST/gRPC API — this feature's "API" is outbound HTTP content negotiation
+against a workspace-declared index, reusing the exact pattern `deps-pypi`
+already implements for `pypi.org` (FR-004):
+
+| Step | Request | Success | Fallback |
+|------|---------|---------|----------|
+| 1 | `GET {simple_base}/{normalized_name}/` with `Accept: application/vnd.pypi.simple.v1+json` | PEP 691 JSON body | — |
+| 2 | (if step 1 returns `text/html` or a non-JSON body) | — | Parse as PEP 503 Simple HTML (existing `deps-pypi` HTML parser, unchanged) |
+| 3 | (if step 1/2 return 404, or 200 with an empty listing) | — | FR-005: try next hop in `fallback_chain`, else `PackageNotFound` (terminal) |
+| 4 | (if step 1/2 return any other error — 5xx, timeout, malformed) | — | Terminal, propagated immediately — does **not** try the next hop (§1 Failure Taxonomy) |
+
+## 5. Integration Points
+
+| System | Direction | Protocol | Notes |
+|--------|-----------|----------|-------|
+| Workspace-declared PyPI-protocol index (devpi/Artifactory/Nexus/Azure Artifacts/self-hosted) | outbound | HTTPS, PEP 503/691 Simple API | Gated by `net_policy::classify_host` + `RegistryAccessPolicy` at registration time (shared `registries.workspace_registries`, default `public_only`); fetches routed through `HttpCache::get_cached_workspace_with_headers` (existing, re-classifies every redirect hop) |
+| `pypi.org` (implicit fallback, FR-005(b) only) | outbound | HTTPS, PEP 503/691 | A freshly-constructed `Public`-tier client (same `simple_base`, same ungated transport as the root — not an `Arc::clone` of the root itself, fixes N1's reference-cycle issue) used as the chain's final hop — never validated as a `PypiIndexUrl`, never subject to `workspace_registries` (fixes S6) |
+
+## 6. Security
+
+- **Authentication**: none in phase 1 (Out of Scope). Any index URL with
+  embedded userinfo is rejected at validation time (FR-006/FR-011) — never
+  stripped-and-proceeded. An unauthenticated 401/403 from a real private feed
+  (e.g. Azure Artifacts) is a *terminal* chain error per the Failure Taxonomy,
+  not a silent fallthrough — see SC-002's r2 caveat.
+- **Authorization**: `RegistryAccessPolicy` (shared, cross-ecosystem) gates
+  every *explicitly-declared* resolved index's host classification before any
+  fetch; default `public_only` blocks RFC1918/loopback/link-local/cloud-metadata/
+  etc. hosts unless the user opts into `all`. The implicit public fallback hop
+  is never gated (§1).
+- **Input validation**: `PypiIndexUrl::new` rejects non-`https`, malformed URLs,
+  and userinfo-bearing URLs before any network call. An invalid **explicit
+  primary or named source** routes to `CustomRegistry` (fail-closed); an
+  invalid **extra** is dropped from its chain with a warning (FR-006 r2) —
+  neither path ever falls back to `pypi.org` for an explicitly-configured
+  index.
+- **Outbound name disclosure** (new in r2, closes C3): FR-005(b) mandates
+  declared extras are queried before the implicit `pypi.org` fallback,
+  specifically so a private package's name is never sent to the public index
+  before the user's own declared index has had a chance.
+- **Sensitive data**: `InvalidEntry.raw` and every log line use the raw,
+  as-written value — no expansion step exists for PyPI config (unlike npm's
+  `${VAR}` env-var expansion), so there's no equivalent "log the unexpanded
+  value, not the expanded one" concern; still, no field in `PypiIndexConfig`,
+  `PypiIndexUrl`, or `InvalidEntry` is capable of holding a credential value at
+  all (NFR-001), verified structurally in tests (SC-005).
+
+## 7. Testing Strategy
+
+| Level | Framework | What to Test | Coverage Target |
+|-------|-----------|---------------|-------------------|
+| Unit | `cargo nextest` | `PypiIndexUrl::new` validation matrix (https/http, userinfo present/absent, blocked/allowed host classes, malformed URL) | Every `PypiIndexUrlError` variant |
+| Unit | `cargo nextest` | `PypiIndexConfig::resolve_source_for` / `resolved_chains` — primary-only (case a), extras-only (case b, implicit fallback), primary+extras, named-source (Poetry `explicit` / uv `index=`), unlabeled Poetry source → primary mapping | FR-002/003/005/006/007/013, the corrected decision table above |
+| Unit | `cargo nextest` | `ResolvedChain::key` uniqueness: same primary + different extras → different keys; explicit `[A,B]` vs implicit-fallback-to-`[A,B]` → different keys | Fixes C2, regression test for the aliasing bug |
+| Unit | `cargo nextest` | `requirements.txt` `--index-url`/`--extra-index-url`/`-i` value capture from a two-pass parse, including a fixture with the flag positioned **after** the first dependency line | FR-001, fixes S2 |
+| Unit | `cargo nextest` | `[[tool.poetry.source]]` table parsing (`name`/`url`/`priority`, including no-`priority`-key) and per-dependency `source = "<name>"` resolution | FR-007 |
+| Unit | `cargo nextest` | `[tool.uv.index]` table entry parsing (`name`/`url`/`default`) and `[tool.uv.sources] { index = "<name>" }` per-dependency binding | FR-013 |
+| Integration | `mockito` (Registry Integration Gate) | FR-005(a): package present on both explicit primary and an extra → primary wins. FR-005(b): package present on both a declared extra and the (mocked) public index → extra wins, no public request issued for that name until the extra misses. Package present only on an extra → resolves there in both cases (SC-002/US-002/NFR-006) | SC-001, SC-002, SC-004 |
+| Integration | `mockito` | Failure taxonomy: primary returns 500/timeout → chain terminates with that error, does **not** try extras; primary returns 404 → falls through; primary returns 200+empty listing → falls through identically to 404 | Fixes S5 |
+| Integration | `mockito` | Alternate index returns PEP 503 HTML instead of PEP 691 JSON → parsed via existing fallback path | FR-004 |
+| Integration | `mockito` | `search`/`warm_search_index`/`get_package_metadata` on a `WorkspaceDeclared`-tier client issue **no** HTTP request and return empty | Fixes S4/M3 |
+| Integration | `mockito` | `workspace_registries = off`, two scenarios: (A) explicit valid primary + a blocked extra — the chain still works via the primary hop (fixes S6); (B) extras-only, no primary — the chain zero-hops and every dependency degrades to plain `Registry` (fixes N5) rather than failing closed per-package | Fixes S6, N5 |
+| Regression | existing suite | Every existing `deps-pypi` test unchanged (no index declaration anywhere) | SC-003, NFR-004, NFR-005 |
+| Structural | `cargo nextest` | `PypiIndexConfig`/`PypiIndexUrl`/`InvalidEntry` have no field capable of holding a credential-shaped value | NFR-001, SC-005 |
+| Live (per Registry Integration Gate) | manual, `RUST_LOG=debug` | Hover against a real or `mockito`-mocked devpi/Artifactory-shaped fixture before filing the implementation PR | `.claude/rules/continuous-improvement.md` |
+
+`test-util` feature (fixes S7): `crates/deps-pypi/Cargo.toml` gains
+`test-util = []`, mirroring `crates/deps-npm/Cargo.toml:27` — `PypiIndexUrl`'s
+loopback carve-out is gated on `cfg(any(test, feature = "test-util"))`, and
+the integration tests under `crates/deps-pypi/tests/` (a separate crate from
+the library, where `cfg(test)` does not apply) enable this feature to
+construct a `http://127.0.0.1`-based `mockito` fixture as a valid alternate
+index.
+
+## 8. Performance Considerations
+
+- **Zero-regression path** (NFR-004): a file with no index declaration anywhere
+  never constructs more than an empty `PypiIndexConfig`, never calls
+  `resolved_chains`/`register_chain`, and takes the exact same code path as
+  today.
+- **Chain fetch cost**: a dependency absent from every configured index pays
+  `len(hops)` requests worst-case (mirrors pip's own real-world worst case,
+  since pip's resolver also queries every configured index). `HttpCache`'s
+  existing TTL/conditional-request machinery caches each hop's result, so
+  repeated hovers don't re-pay the full chain cost. A genuine error (5xx/
+  timeout) on an early hop terminates the chain immediately per the Failure
+  Taxonomy, so a broken primary costs exactly one failed request, not a full
+  chain walk.
+- **Leaf allocation**: each `ResolvedChain`'s non-deduplicated leaf clients
+  (§1) are lightweight (`Arc<HttpCache>` clone + empty `IndexCell`, never
+  populated thanks to the S4 tier guard) — not a meaningful memory cost even
+  without cross-chain deduplication.
+
+## 9. Rollout Plan
+
+No feature flag. Ships gated entirely by the existing, already-shipped
+`registries.workspace_registries` setting (default `public_only`) — a workspace
+that has never touched that setting gets `--index-url`/`--extra-index-url`
+resolution against public-classified hosts immediately (safe, no internal-network
+exposure) and internal-host resolution only after the user opts into `all`,
+identical to how Cargo's and npm's equivalents rolled out. `off` continues to
+allow ordinary public-package resolution in every file, including one that
+declares `--extra-index-url` (fixes S6 — see §1).
+
+## 10. Constitution Compliance
+
+No `constitution.md` exists yet for this project (per spec.md's own note) —
+cross-checked against `.claude/rules/*.md` instead:
+
+| Principle (from `.claude/rules/`) | Status | Notes |
+|---|---|---|
+| DRY — reuse existing implementations (`CLAUDE.md`) | Compliant | Zero new `deps-core` types; reuses `DependencySource::AlternateRegistry`/`CustomRegistry`, `Registry` trait defaults, `net_policy`, `HttpCache::get_cached_workspace_with_headers`, `select_latest_matching[_with_context]` as-is |
+| MVP — minimum necessary functionality (`CLAUDE.md`) | Compliant | `pip.conf`/env vars and `[[tool.uv.sources]]`'s git/path/workspace variants explicitly deferred; `-r`/`-c` include propagation explicitly deferred (2026-09-02) |
+| Verify security claims empirically, not from unchecked assumption (project practice) | Compliant (r2) | r1's FR-005/NFR-003 security claims about pip's "documented precedence" and Poetry's default priority were both verified live against current documentation in r2 and corrected where wrong — see Revision History |
+| Registry Integration Gate (`continuous-improvement.md`) | Planned | Live verification against a real/mocked private-index fixture required before filing the implementation PR (§7 above) |
+| Cross-ecosystem consistency (`continuous-improvement.md`) | Compliant | Hover/diagnostics/code-actions behave identically to Cargo's/npm's equivalent alternate-registry dependencies; no PyPI-specific UX divergence introduced beyond the documented M1 cosmetic limitation |
+
+## 11. Risks and Mitigations
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|--------------|------------|
+| Fallback-chain worst-case latency (N indexes probed for a genuinely-missing package) | Low — hover-only, not a blocking install path | Medium (typo'd package names, genuinely removed packages) | `HttpCache` caches negative (404/empty) results per its existing TTL; a genuine error terminates the chain early rather than walking every hop |
+| `MAX_ALTERNATE_REGISTRIES` cap now counts chain identities, not URLs — a monorepo with many differing extras combinations against the same primary could exhaust it faster than Cargo/npm | Low-Medium — degrades to `CustomRegistry`-shaped fail-closed behavior for new registrations past the cap, not a crash | Low (needs many distinct chain shapes in one process) | Documented in §1; revisit the cap if it proves too low in practice |
+| M1 (unfixed): a plain dependency in an extras-only file loses its `pypi.org` hover link even when it actually resolves via the implicit public fallback | Low — cosmetic only, no data-correctness impact | Certain, for every such dependency | Documented in `ECOSYSTEM_GUIDE.md` and §3's formatter note; fixing it would require deferring source classification to fetch time, out of scope for phase 1 |
+| Config is per-file, not per-workspace — a package might resolve differently in two `requirements/*.txt` files with different `--index-url` values, and `-r`/`-c` includes do not propagate config | Low — matches pip's own actual per-invocation behavior for the first case; documented known limitation for the second | Low | Spec's edge-case table documents both as accepted limitations, not bugs |
+| Unauthenticated phase-1 chain cannot actually reach a real auth-gated private feed (e.g. Azure Artifacts) — SC-002 is only provably correct against a fixture | Medium — the feature's flagship motivating scenario (US-002/Dependi #292) is not fully solved end-to-end until the deferred auth spec ships | Certain for any auth-gated feed | Documented in spec SC-002's r2 caveat; the routing/fallback mechanism itself is still correct and immediately useful for any *unauthenticated* private index (devpi with anonymous read, an internal mirror behind network-level access control rather than HTTP auth) |
+
+## See Also
+
+- [[spec]] — feature specification
+- [[tasks]] — implementation tasks (next phase)
+- [[MOC-specs]] — all specifications
+- [[032-npm-npmrc-registry-support/plan|032 npm .npmrc plan]] — structural template, `NpmRegistry`/`NpmConfig` reference implementation this plan mirrors
+- `crates/deps-npm/src/config.rs`, `crates/deps-npm/src/registry.rs` — the executed npm reference implementation (file/line references gathered live this session)
+- `.local/handoff/2026-09-02T21-55-03-critic.md` — the full critic review this r2 revision addresses

--- a/specs/033-pypi-private-index-support/spec.md
+++ b/specs/033-pypi-private-index-support/spec.md
@@ -1,0 +1,502 @@
+---
+aliases:
+  - PyPI Private/Custom Index Support
+  - pip --index-url / --extra-index-url Resolution
+tags:
+  - sdd
+  - spec
+  - research
+  - enhancement
+  - pypi
+  - security
+created: 2026-09-02
+status: draft
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+  - "[[023-cargo-custom-registries/spec|Cargo Custom/Private Registry & Source-Replacement Resolution]]"
+  - "[[032-npm-npmrc-registry-support/spec|npm .npmrc Custom/Private Registry Support]]"
+---
+
+# Feature: PyPI Private/Custom Index Resolution (`--index-url` / `--extra-index-url` / Poetry `source` / uv `index`)
+
+> [!info] Metadata
+> **Author**: k05h31@gmail.com
+> **Issue**: none yet — file after this spec is reviewed
+> **Branch**: (assign at implementation time, e.g. `feat/<issue>-pypi-private-index-support`)
+> **Priority**: P3
+> **Type**: research/enhancement (competitive parity gap)
+> **Revision**: r3 (2026-09-02) — r2 corrected FR-005/FR-006/FR-007/FR-008/FR-013,
+> NFR-003, SC-002/SC-004 and the Edge Cases table after a `rust-critic` design
+> review of `plan.md` found the original FR-005 resolution order backwards
+> (leaked private package names to `pypi.org`, inverted the dependency-confusion
+> protection the spec claims — verified against pip's own docs, which the r1
+> draft cited without checking) and the Poetry unlabeled-priority default
+> backwards (verified against Poetry's own docs). r3 fixes 6 further defects a
+> second critic pass found in r2's own fixes: the uv `default`/`explicit`
+> mapping (verified against uv's own docs, also backwards in r2), an
+> undocumented terminal-on-transport-error trade-off (FR-005(c)/NFR-003(3)), an
+> undefined zero-hop chain case, and `AlternateRegistry.index`'s contract
+> (now documented as an opaque routing key for chain sources, not always a
+> literal URL). See `plan.md`'s Revision History for the full critic findings
+> both revisions address.
+
+## 1. Overview
+
+### Problem Statement
+
+`deps-pypi` has zero support for private/custom package index resolution —
+confirmed live this session by reading the crate directly:
+
+- `crates/deps-pypi/src/registry.rs:21,24` hardcodes
+  `const PYPI_BASE: &str = "https://pypi.org/pypi";` and
+  `const PYPI_SIMPLE_BASE: &str = "https://pypi.org/simple";` with no
+  override mechanism of any kind — every lookup, regardless of any
+  project configuration, goes to the public registry.
+- `crates/deps-pypi/src/parser/requirements.rs:34-35` lists `--index-url`
+  and `--extra-index-url` in `KNOWN_OPTIONS`, but purely so a
+  `requirements.txt` line starting with either token is correctly
+  classified as "a pip option line, not a dependency" during parsing
+  (confirmed by reading the full option-line handling around lines 20-48).
+  The URL value that follows the flag is never captured, stored, or used
+  to resolve a single package.
+- `crates/deps-pypi/src/parser/pyproject.rs` has no handling for Poetry's
+  `[[tool.poetry.source]]` table (which declares additional/private
+  package sources, e.g. `priority = "explicit"` for a company Artifactory
+  feed) or uv's `[tool.uv.index]` / `[[tool.uv.sources]]` tables — grepped
+  for `source`/`extra-index` this session; the only `source` occurrences
+  in the file are an unrelated `PypiDependencySource` enum field (git/path
+  provenance) and byte-span bookkeeping, confirmed by reading the matches.
+- No `pip.conf`/`pip.ini` (pip's own config-file mechanism, analogous to
+  npm's `.npmrc` or Cargo's `.cargo/config.toml`) or
+  `PIP_INDEX_URL`/`PIP_EXTRA_INDEX_URL` environment-variable handling
+  exists anywhere in the crate.
+
+This is the same silent-wrong-data bug class already fixed twice in this
+project: issue #248 (Cargo) and the equivalent regression class closed by
+[[032-npm-npmrc-registry-support/spec|032]] (US-004) for npm. Any
+workspace using a self-hosted PyPI mirror (devpi, Artifactory, Azure
+Artifacts, Nexus, a plain PEP 503 Simple HTML index behind a corporate
+VPN) gets hover/diagnostic/completion data for the *wrong* index with no
+indication anything is off — the LSP happily reports "up to date" or
+"outdated" against `pypi.org` for a package that does not exist there at
+all, or exists there with an unrelated version history.
+
+`deps-cargo` (issues/PRs #431/#440/#441/#447) and `deps-npm`
+(issue #502, PR #510, merged 2026-09-02) already ship a proven reference
+pattern for exactly this class of problem, and the shared infrastructure
+in `deps-core` is generic enough that `deps-pypi` needs no `deps-core`
+change to reuse it:
+
+- `DependencySource::AlternateRegistry { index, mirrors_crates_io }`
+  (`crates/deps-core/src/parser.rs:894`) — a source-agnostic "resolved to
+  a concrete, fetchable index URL" variant. `deps-pypi` would construct
+  it directly (with `mirrors_crates_io: false`, the same choice npm made
+  — no analogous mirror-verification concept exists for a PyPI-protocol
+  index).
+- `DependencySource::CustomRegistry { url }`
+  (`crates/deps-core/src/parser.rs:882`) — the existing "present, but not
+  resolved to a concrete, fetchable index" fail-closed state.
+  `is_version_resolvable()` is already `false` for it
+  (`crates/deps-core/src/parser.rs:920`), so every existing fail-closed
+  gate (hover, diagnostics, code actions) applies with zero new code.
+- `Registry::get_versions_from` / `get_latest_matching_from`
+  (`crates/deps-core/src/registry.rs`) — defaulted trait methods any
+  `Registry` impl can override; `deps-pypi`'s registry client would
+  override these exactly as `CargoRegistry` and `NpmRegistry` do.
+- `EcosystemFormatter::can_resolve_source` (added by #440's FR-016,
+  defaulted to `DependencySource::is_version_resolvable()`) — the single
+  override point gating hover/diagnostics/code-actions; `PypiFormatter`
+  would override it exactly as `CargoFormatter`/`NpmFormatter` do.
+- `deps_core::net_policy` (`HostClass`, `classify_host`,
+  `RegistryAccessPolicy`, `WorkspaceRegistryAccess`) — the SSRF-hardening
+  host classifier already gating Cargo's and npm's workspace-declared
+  registries behind the shared `registries.workspace_registries` setting
+  (`off` / `public_only` / `all`, default `public_only`, renamed from
+  `cargo.workspace_registries` by [[032-npm-npmrc-registry-support/spec|032]]'s
+  FR-008 precisely so later ecosystems would not need a parallel key).
+  `deps-pypi` reuses this same setting.
+
+What `deps-pypi` needs on top of that shared foundation is PyPI-specific:
+parsing `requirements.txt` `--index-url`/`--extra-index-url` flag values
+(currently discarded), Poetry's `[[tool.poetry.source]]` table, uv's
+index-related tables, and — the one piece with no clean Cargo or npm
+analogue — **`--extra-index-url`'s additive, multi-index semantics**: pip
+checks *all* configured indexes for a match (first successful match wins
+by default), unlike Cargo's replace-with (strictly one index per
+dependency) or npm's scope-exclusive routing (one registry per `@scope`
+prefix). See FR-005 and the Open Questions below for how this spec
+proposes to narrow that ambiguity for phase 1 rather than fully solve
+pip's real resolution-order semantics.
+
+**Demand evidence** (verified live via `gh issue view` against
+`filllabs/dependi`, this project's closest tracked competitor, per
+`.local/testing/playbooks/competitive-parity.md`'s "Private/alternative
+registry support" row): of the private/alternate-registry issues tracked
+there as open against Dependi, three are PyPI-specific — the single
+largest concentration for any one ecosystem in that list:
+
+- `` github.com/filllabs/dependi/issues/285 `` — "Python / support
+  private pypi simple html endpoint" (user wants PEP 503 Simple HTML
+  index support for a private PyPI mirror — not even PEP 691 JSON, the
+  plain HTML form).
+- `` github.com/filllabs/dependi/issues/292 `` — "Add support for extra
+  index servers" (user on Azure Artifacts private feed, needs BOTH
+  `pypi.org` AND a private feed simultaneously — i.e. genuine
+  `--extra-index-url` additive semantics, not a replace-only override).
+- `` github.com/filllabs/dependi/issues/293 `` — "Unable to resolve Azure
+  package feed" (same root cause as #292, filed independently as a bug by
+  a different user — corroborating signal, not a single voice).
+
+This is a stronger demand-concentration signal than the npm case that
+justified issue #502/PR #510 (which had no comparable issue-count
+concentration on Dependi's tracker for a single ecosystem).
+
+`gh issue list --search "pypi private index"` and
+`--search "extra-index-url"` against this repository (`bug-ops/deps-lsp`)
+both returned zero hits this session — this is not a duplicate of an
+existing open or closed issue.
+
+> [!warning] Assumptions
+> - Target indexes speak either the PEP 503 Simple HTML format or the
+>   PEP 691 Simple JSON format `deps-pypi` already parses for the public
+>   index (`PYPI_SIMPLE_BASE`/`SIMPLE_API_ACCEPT`,
+>   `crates/deps-pypi/src/registry.rs:24,32`) — devpi, Artifactory PyPI
+>   remote/virtual repos, Nexus, and Azure Artifacts feeds all implement
+>   PEP 503 Simple HTML; PEP 691 JSON support is inconsistent among
+>   self-hosted indexes. A private-index resolver must content-negotiate
+>   the same way the public-index client already does (`Accept:
+>   application/vnd.pypi.simple.v1+json` with a graceful fallback path),
+>   **not** assume JSON-only — this is the PyPI-specific nuance flagged in
+>   the finding and is load-bearing for FR-004.
+> - `requirements.txt`/`constraints.txt` `--index-url`/`--extra-index-url`
+>   flag values, Poetry's `[[tool.poetry.source]]` table, and uv's
+>   `[tool.uv.index]` table are the three in-scope configuration surfaces
+>   for phase 1 (see FR-001 through FR-003). `pip.conf`/`pip.ini` and
+>   `PIP_INDEX_URL`/`PIP_EXTRA_INDEX_URL` environment variables are a
+>   fourth, real configuration surface pip itself supports but this spec
+>   does **not** commit to implementing — see Open Questions.
+> - **Divergent from both Cargo and npm's trust model, and unresolved by
+>   this spec**: an index URL may legitimately embed HTTP basic-auth
+>   userinfo (`https://user:pass@internal.example/simple`) per pip's own
+>   documented convention, or rely on `keyring`/`.netrc` credential
+>   resolution outside the URL entirely. Neither Cargo's nor npm's
+>   phase-1 rule (reject any URL with embedded userinfo, parse no
+>   auth-shaped key at all) has been re-validated against pip's specific
+>   conventions here — see Out of Scope and Open Questions.
+
+### Goal
+
+A PyPI/pip dependency whose applicable index is overridden via
+`requirements.txt` `--index-url`/`--extra-index-url`, Poetry's
+`[[tool.poetry.source]]`, or uv's `[tool.uv.index]` gets the same
+hover/diagnostic/completion value a `pypi.org` dependency gets today —
+with zero regression for projects declaring no custom index, and with no
+credential ever read, stored, or transmitted in this phase (auth wiring
+deferred, see Out of Scope).
+
+### Out of Scope
+
+> [!danger] Explicit Exclusions
+> - **All auth/credential handling** — HTTP basic-auth embedded in an
+>   index URL (`https://user:pass@host/simple`), pip's `keyring` backend
+>   integration, `.netrc` resolution, and any `PIP_INDEX_URL`-embedded
+>   credential form. Phase 1 resolves *which* index a dependency belongs
+>   to and fetches it unauthenticated; any URL with embedded userinfo
+>   fails closed per FR-006/FR-011, matching the Cargo/npm precedent
+>   exactly — it never reads, stores, or transmits a credential. `keyring`
+>   and `.netrc` receive no detection or acknowledgment in phase 1. This
+>   mirrors how [[032-npm-npmrc-registry-support/spec|032]] scoped npm's
+>   `_authToken` family out of its own phase 1. A dedicated follow-up spec
+>   is the right place to revisit pip's broader credential conventions.
+> - **`pip.conf`/`pip.ini`** (pip's own INI-style config-file mechanism —
+>   the closest PyPI analogue to `.npmrc`/`.cargo/config.toml`) and
+>   **`PIP_INDEX_URL`/`PIP_EXTRA_INDEX_URL`-family environment
+>   variables**. Both are real, commonly-used configuration surfaces (in
+>   some CI/enterprise setups, the *primary* one — a `requirements.txt`
+>   may declare no index flags at all and rely entirely on an ambient
+>   `pip.conf`). Deliberately deferred to a separate follow-up spec: file
+>   discovery precedence (per-project / per-user / per-site /
+>   `PIP_CONFIG_FILE`) and env-var-vs-file precedence need to be
+>   re-verified against current pip documentation before committing to an
+>   implementation, which is out of this spec's scope. A workspace
+>   relying solely on `pip.conf`/`PIP_*` env vars sees **no improvement**
+>   from this spec's phase 1 — file the follow-up issue once this phase
+>   ships.
+> - **uv's `[tool.uv.sources]` non-index-routing variants** — uv's
+>   `[tool.uv.sources]` table supports several key shapes; only the
+>   `index = "<name>"` shape (routes a dependency to a named
+>   `[tool.uv.index]` entry — registry routing, in scope per FR-013,
+>   added 2026-09-02 after critic review found named uv indexes were
+>   otherwise unreachable) is in scope. `git =`, `path =`, `workspace =
+>   true`, and any other provenance-pinning shape are a distinct problem
+>   (dependency provenance, not registry routing) and remain excluded — a
+>   separate future spec, if one is ever filed, owns that surface.
+> - **Package-name search/completion** for an index that does not
+>   implement a PEP 503/691-compatible listing endpoint — same choice
+>   [[032-npm-npmrc-registry-support/spec|032]]'s FR-011 made for npm:
+>   unconditional no-op for alternate-index-resolved dependencies rather
+>   than a per-index capability probe.
+> - **A dedicated config-file watcher** — same choice Cargo's FR-013 and
+>   npm's FR-016 made: document staleness (edits take effect on next
+>   reparse of the affected manifest/requirements file) rather than build
+>   a new watcher subsystem.
+> - **Full pip index-priority/resolution-order semantics** — real pip
+>   resolution across multiple `--extra-index-url` entries involves
+>   version-matching across *all* configured indexes with configurable
+>   tie-breaking (and, notoriously, a well-documented security footgun
+>   where a malicious public package can shadow a same-named private one
+>   — "dependency confusion"). This spec's FR-005 defines a deliberately
+>   narrower phase-1 behavior and does not attempt to replicate pip's
+>   full resolver; the dependency-confusion angle itself is flagged as a
+>   Success Criterion (SC-004) rather than solved algorithmically in
+>   phase 1.
+
+## 2. User Stories
+
+### US-001: `--index-url` full-mirror resolution in `requirements.txt`
+
+AS A developer whose company routes all pip traffic through a corporate
+mirror (Artifactory/devpi/Nexus)
+I WANT dependencies in `requirements.txt` to resolve against that mirror
+SO THAT hover/diagnostics reflect what my mirror actually serves (which
+may lag or diverge from the public index)
+
+**Acceptance criteria:**
+```
+GIVEN a requirements.txt starting with
+      --index-url https://pypi.mycorp.example/simple/
+WHEN I hover over any dependency declared later in the file
+THEN the hover reflects pypi.mycorp.example's data, not pypi.org's, and
+     no request is sent to pypi.org for that dependency
+```
+
+### US-002: `--extra-index-url` additive private-package resolution
+
+AS A developer on an Azure Artifacts private feed who also needs public
+PyPI packages in the same project
+I WANT a dependency published only on my private feed to resolve there
+SO THAT hover/diagnostics work for it without breaking public-package
+resolution for everything else in the same file
+
+**Acceptance criteria:**
+```
+GIVEN a requirements.txt containing
+      --extra-index-url https://pkgs.dev.azure.com/myorg/_packaging/myfeed/pypi/simple/
+  AND a dependency name that exists only on that private feed
+WHEN I hover over that dependency
+THEN the hover shows data resolved from the extra index, not "package
+     not found" against pypi.org alone
+```
+
+### US-003: Poetry `[[tool.poetry.source]]` resolution
+
+AS A developer using Poetry with a declared private source
+I WANT dependencies routed to that source (per Poetry's `priority`
+semantics) to resolve against it
+SO THAT hover/diagnostics reflect the correct index for a
+`pyproject.toml`-based project, not only `requirements.txt`
+
+**Acceptance criteria:**
+```
+GIVEN a pyproject.toml with
+      [[tool.poetry.source]]
+      name = "internal"
+      url = "https://pypi.mycorp.example/simple/"
+      priority = "explicit"
+  AND a dependency declared with source = "internal"
+WHEN I hover over that dependency
+THEN the hover reflects pypi.mycorp.example's data
+```
+
+### US-004: No regression for public-only projects
+
+AS A developer with no index override anywhere in my project
+I WANT the LSP to keep behaving exactly as it does today
+SO THAT this feature introduces zero risk for the overwhelming majority
+of PyPI/pip projects
+
+**Acceptance criteria:**
+```
+GIVEN no --index-url/--extra-index-url flag, no [[tool.poetry.source]],
+      and no [tool.uv.index] table anywhere in the project
+WHEN I hover over any dependency
+THEN the hover is byte-identical to pre-feature behavior (pypi.org)
+```
+
+### US-005: Unresolved/misconfigured index fails closed
+
+AS A developer whose `--index-url` or `[[tool.poetry.source]]` entry
+points at an unreachable, invalid, or policy-blocked URL
+I WANT the LSP to show no data for dependencies routed to it rather than
+silently checking the public index
+SO THAT I never mistake a stale/wrong public-index result for my private
+index's actual state — and, symmetrically, so a malicious or
+typo-squatted public package cannot silently supersede a private package
+of the same name (the dependency-confusion risk noted in Out of Scope)
+
+**Acceptance criteria:**
+```
+GIVEN --index-url not-a-valid-url in requirements.txt
+WHEN I hover over any dependency in that file
+THEN no version data is shown, and no request is sent to pypi.org for
+     that dependency (mirrors the regression class issue #248 fixed for
+     Cargo and the equivalent class 032 closed for npm)
+```
+
+## 3. Functional Requirements
+
+Use EARS notation. Prefix with FR-NNN.
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | THE SYSTEM SHALL parse `--index-url <url>` and `--extra-index-url <url>` option lines in `requirements.txt`/`constraints.txt` (both `--flag value` and `--flag=value` spellings, matching the existing `KNOWN_OPTIONS` token-recognition grammar in `crates/deps-pypi/src/parser/requirements.rs`) and capture the URL value, instead of discarding it as today | must |
+| FR-002 | WHEN an `--index-url` value is present and passes URL validation (see FR-006) THE SYSTEM SHALL treat it as the replacement default index for every dependency in that file that has no more specific override — analogous to npm's top-level `registry=` (032 FR-003) and Cargo's `[source]` replace-with | must |
+| FR-003 | WHEN one or more `--extra-index-url` values are present and pass URL validation THE SYSTEM SHALL treat each as an additional index to be checked for dependencies not found (or not yet resolved) via the primary index — see FR-005 for the phase-1 resolution-order rule that narrows pip's full multi-index semantics | must |
+| FR-004 | THE SYSTEM SHALL content-negotiate against a resolved alternate index the same way `deps-pypi` already does for the public Simple API — requesting `SIMPLE_API_ACCEPT` (`application/vnd.pypi.simple.v1+json`, PEP 691) and falling back to parsing the PEP 503 Simple HTML response when the alternate index does not honor the `Accept` header or returns `text/html` — because self-hosted indexes (devpi, Artifactory, Azure Artifacts) do not reliably serve PEP 691 JSON, unlike `pypi.org` | must |
+| FR-005 | Resolution order depends on whether `--index-url` is **explicit** in the file. **(a) Explicit primary**: WHEN a dependency name is present on both the explicit `--index-url` index and one or more `--extra-index-url` indexes THE SYSTEM SHALL resolve it against the explicit primary first, only falling through to `--extra-index-url` indexes (declaration order) if the package is absent there — an explicit `--index-url` is a deliberate, user-stated choice to check that index first, so this direction carries no name-disclosure risk. **(b) No explicit primary**: WHEN a file has one or more `--extra-index-url` values but no explicit `--index-url` THE SYSTEM SHALL check the declared extras (declaration order) **before** the implicit public `pypi.org` fallback — never the reverse. Rule (b) exists specifically so a private-only package name (US-002) is never sent to `pypi.org` before the user's own declared index has had a chance, and so a same-named public package can never silently shadow a private one the user explicitly configured. This is the sole phase-1 resolution-order rule — no configuration escape hatch; revisit only if a concrete workspace need for a different order surfaces after shipping. **Corrected 2026-09-02** (critic review, verified against pip's own docs — see NFR-003): pip itself documents no precedence between `--index-url`/`--extra-index-url` ("there is no priority in the locations that are searched... the best match... is selected") and explicitly warns `--extra-index-url` is unsafe for private packages precisely because of this merge-and-pick-best behavior. This spec deliberately does **not** replicate that unsafe pip default — rule (b) is a phase-1 safety choice, not a claim of pip-behavior parity. **(c) Transport failure on any hop other than the last is terminal, not skipped** (confirmed 2026-09-02, second critic pass): a connection error, timeout, or 5xx from a hop THE SYSTEM SHALL propagate immediately as the chain's result rather than falling through to the next hop — including case (b)'s declared extras. This means an unreachable declared extra (e.g. a developer off the corporate VPN) halts resolution for *every* dependency in that file, including ordinary public ones, rather than silently falling through to `pypi.org` — a deliberate, confirmed trade-off: falling through on transport failure would send every affected package's name to `pypi.org` whenever the private index is merely unreachable, which is the exact disclosure NFR-003(2) exists to prevent. `PackageNotFound` (an explicit 404, or a 200 response with an empty listing) is the only condition that continues to the next hop — see NFR-003(3) for the required distinguishable diagnostic this produces | must — the narrowed rule itself, not a promise of full pip-resolver parity |
+| FR-006 | WHEN an explicit `--index-url`/`[[tool.poetry.source]]` (`primary`/`default` priority)/`[tool.uv.index]` (`default = true`) URL value is present but fails validation (non-https, contains userinfo, or is not well-formed) or is blocked by FR-008's policy THE SYSTEM SHALL represent the affected dependency's source as `DependencySource::CustomRegistry { url: <the raw value as written> }` — the existing `deps-core` variant whose `is_version_resolvable()` is already `false` — logging a `tracing::warn!` naming the raw value, and SHALL NOT fetch that dependency's name against `pypi.org`. WHEN an `--extra-index-url`/supplemental-priority-source value fails the same validation THE SYSTEM SHALL log the same warning but SHALL drop only that entry from the fallback chain (per FR-005) rather than failing the whole dependency closed — an extra is additive/optional by definition, so one misconfigured extra must not block resolution via the primary or the remaining valid extras/implicit public fallback. Userinfo rejection follows the Cargo/npm precedent exactly — resolved, not deferred: pip's URL-embedded-credential and `keyring`/`.netrc` conventions are out of scope for phase 1 (see Out of Scope), so the fail-closed-per-entry rule applies uniformly regardless of pip-specific auth mechanisms | must |
+| FR-007 | THE SYSTEM SHALL parse Poetry's `[[tool.poetry.source]]` table entries (`name`, `url`, and `priority` keys) in `pyproject.toml`, and SHALL resolve a dependency declaring `source = "<name>"` against the matching entry's `url`, subject to the same FR-006 validation and FR-008 policy gate. An entry with no explicit `priority` key SHALL be treated as `priority = "primary"` — this matches current Poetry documentation ("Sources without a priority are considered primary sources, too"), verified live 2026-09-02 (see plan.md for the citation; the original phase-1 draft of this spec had this backwards as `supplemental` and has been corrected). **When at least one `primary`/`default`-priority source is configured, no implicit `pypi.org` hop is appended** — also verified live against current Poetry documentation ("If you configure at least one primary source, the implicit PyPI source is disabled"), added 2026-09-02 after a second critic pass found the original citation incomplete: without this second sentence, FR-005(a)'s "no implicit public hop for an explicit primary" rule reads unmotivated for Poetry specifically and could be mis-"fixed" later into appending one, breaking Poetry parity | must |
+| FR-008 | THE SYSTEM SHALL classify every **explicitly-declared** resolved index URL's host (an explicit `--index-url`, every `--extra-index-url`, every Poetry/uv source) through `deps_core::net_policy::classify_host` and gate the fetch behind the existing shared `registries.workspace_registries` setting (`off` / `public_only` / `all`, default `public_only`) — the same setting Cargo and npm already gate on, reused as-is with no new `pypi.*` key, consistent with why 032's FR-008 renamed it away from a Cargo-specific name in the first place. The **implicit public `pypi.org` fallback** used by FR-005(b) is never subject to this gate — it is the same ungated public-tier client `deps-pypi` already uses for every plain dependency today, so `workspace_registries = off` blocks only the explicitly-declared extras/primary, never ordinary public-package resolution in the same file (this is the fix for a defect the critic review found in the original phase-1 draft: routing every dependency in an extras-carrying file through the gated chain would have made `off` incorrectly break plain public packages too) | must |
+| FR-009 | THE SYSTEM SHALL add `PypiFormatter::can_resolve_source` (overriding the existing defaulted `EcosystemFormatter::can_resolve_source` hook) so hover/diagnostics/code-actions correctly gate on a resolved `AlternateRegistry` source — no `deps-core` trait change required | must |
+| FR-010 | THE SYSTEM SHALL add `Registry::get_versions_from` / `get_latest_matching_from` overrides on `deps-pypi`'s registry client, routing fetches for `AlternateRegistry`-sourced dependencies to the resolved index instead of `PYPI_BASE`/`PYPI_SIMPLE_BASE` — reuses the existing defaulted `deps-core::Registry` trait methods. WHEN a resolved `AlternateRegistry`'s `index` has no registered client THE SYSTEM SHALL return `PackageNotFound` and SHALL NOT fall back to `pypi.org` — the same fail-closed rule 032's FR-010 established for npm, closing the same #248 regression class | must |
+| FR-011 | THE SYSTEM SHALL NOT read, log, or transmit any embedded URL userinfo (`user:pass@`) or any other credential-shaped value from an index URL — parsing SHALL reject (per FR-006) rather than strip-and-proceed, so no code path ever holds a credential value in memory. **Implementation requirement (added 2026-09-02, implementation-review round — the first implementation attempt violated this exact rule by logging and retaining the raw, full URL including userinfo)**: when FR-006's `tracing::warn!` names the rejected entry and when `CustomRegistry { url }` retains it for the document's lifetime, THE SYSTEM SHALL use a **redacted** form of the raw value (userinfo replaced with a fixed marker, e.g. `https://***@host/path`, not the literal `user:pass`) — never the unredacted raw string. This still lets a user identify *which* declared index was rejected without ever holding or displaying the credential itself. `keyring`/`.netrc` mechanisms receive no acknowledgment or detection in phase 1 — entirely out of scope, deferred to a dedicated auth-handling follow-up spec (see Out of Scope) | must — security-blocking |
+| FR-012 | THE SYSTEM SHALL document `requirements.txt`/`pyproject.toml` index-declaration staleness as a known limitation (edits take effect on next reparse of the affected file) rather than add a dedicated file watcher, mirroring Cargo's FR-013 and npm's FR-016 resolution | must — the choice itself, not a specific mechanism, is mandatory |
+| FR-013 | uv's `[tool.uv.index]` table entries (`name`, `url`, `default`, `explicit` keys) SHALL be parsed and resolved using the same FR-006/FR-008 validation and policy gate as Poetry sources and `requirements.txt` flags, mapped per uv's own documented semantics (verified live 2026-09-02 against `docs.astral.sh/uv/concepts/indexes/`, **corrected from an initial draft that had this backwards**): every entry that has neither `default = true` nor `explicit = true` is searched automatically for every dependency (a chain hop, in declaration order — the uv analogue of `--extra-index-url`, not a named-only source); the entry with `default = true` (uv permits at most one) is uv's lowest-priority, last-resort index — checked *after* every non-`explicit` entry, replacing the implicit `pypi.org` fallback in that final slot rather than acting as a checked-first primary; an entry with `explicit = true` is parsed into named sources only, never auto-included in the chain. In addition (added 2026-09-02, critic review — an `explicit` uv index was otherwise undeliverable), a `[tool.uv.sources]` entry of the form `<name> = { index = "<index-name>" }` SHALL be parsed and SHALL resolve that dependency against the matching `[tool.uv.index]` entry's URL (works for both `explicit` and non-`explicit` entries), the direct uv analogue of Poetry's FR-007 `source = "<name>"`. Every other `[tool.uv.sources]` shape (`git =`, `path =`, `workspace = true`, or any combination without an `index =` key — dependency provenance, not registry routing) remains explicitly out of scope | should |
+| FR-014 | Package-name search/completion for a dependency resolved to an alternate index SHALL no-op rather than error or query `pypi.org`, mirroring 032's FR-011 for npm | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Security | No credential-shaped value (URL userinfo, or any future `keyring`/`.netrc`-adjacent field) is ever parsed, held in memory, logged, or transmitted in phase 1 — verified by a structural test asserting the parsed config type has no field capable of holding such a value, matching the pattern Cargo's NFR-001 and npm's NFR-001 established |
+| NFR-002 | Security | Every resolved index URL is validated (https-only, no userinfo, with the same test-only loopback carve-out precedent as Cargo/npm) and normalized (trailing slash handling consistent with PEP 503's `/simple/{name}/` path convention) before any network request |
+| NFR-003 | Security | Three residual risks/costs, all must be stated for security-reviewer sign-off before implementation merges. **(1) Inbound reachability**: an unauthenticated HTTPS GET to a workspace-declared index still occurs, which is reachability into the user's internal network usable for existence probing by a hostile repository — mitigated identically to Cargo/npm by `registries.workspace_registries` defaulting to `public_only`. **(2) Outbound name disclosure** (added 2026-09-02, critic review — absent from the original phase-1 draft): resolving a dependency in a file with only `--extra-index-url` declared (no explicit primary) inherently requires querying *some* index for that package name; FR-005(b) mandates the declared extras are queried before the implicit `pypi.org` fallback specifically so a private package's name is never sent to the public index first, and so a same-named public package can never silently win over an explicitly-configured private one — this is the corrected, safer direction (the original draft had this backwards; verified against pip's own documentation, which explicitly warns `--extra-index-url` is unsafe for private packages for exactly this reason). Sign-off should confirm rule (b)'s ordering, not just its existence. **(3) Availability cost of (2)'s mitigation** (added 2026-09-02, second critic pass): FR-005(c)'s terminal-on-transport-failure rule, which (2) requires, means an unreachable declared extra blocks resolution for every dependency in that file — including ordinary public ones that have nothing to do with the private index — rather than degrading gracefully to `pypi.org`. THE SYSTEM SHALL surface a distinguishable diagnostic for this case **visible to the user through the LSP's normal hover/diagnostic surface** — not merely a `tracing::warn!` log line, which a user running without `RUST_LOG=debug` never sees (fixed 2026-09-02, implementation-review round: the first implementation attempt logged this correctly but never routed it to hover/diagnostics, so every affected dependency showed the same generic "registry lookup failed" message as any other network error, defeating the purpose of distinguishing this case at all). Wording along the lines of "extra index unreachable — resolution halted rather than falling back to pypi.org" so a developer working off-VPN can tell this apart from a genuinely broken/nonexistent package. Sign-off should confirm this availability/confidentiality trade-off is accepted, not merely that it exists |
+| NFR-004 | Performance | No additional filesystem/network activity for a project declaring no index override anywhere (`requirements.txt`, `pyproject.toml` Poetry/uv tables) — zero regression path, verified by existing test suite |
+| NFR-005 | Reliability | Zero behavior change for any project declaring no custom index — verified by the existing `deps-pypi` test suite producing unchanged results |
+| NFR-006 | Maintainability | Both FR-005 orderings are verified by tests: (a) a package present on both an explicit primary and an extra resolves to the primary's data; (b) with no explicit primary, a package present on both a declared extra and `pypi.org` resolves to the extra's data and issues no `pypi.org` request for that name; (c) a package present only on an extra index resolves there without a "not found" false negative in either case |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `DependencySource::AlternateRegistry` | Existing `deps-core` variant, reused as-is — the FR-002/FR-003/FR-007 resolved state | `index: String`, `mirrors_crates_io: bool` (always `false` for PyPI, matching npm's choice). **Note (added 2026-09-02, second critic pass)**: `deps-core`'s doc comment describes `index` as "the resolved index URL" — accurate for Cargo/npm, which always store a literal URL there. PyPI's multi-hop chain sources (FR-005) instead store an **opaque, parser-owned routing key** (not a URL — see plan.md §3's `ResolvedChain::key`) for any dependency whose source is a chain rather than a single index; a single-hop named-source dependency (Poetry/uv `source`/`index =`) still stores that source's literal URL, matching Cargo/npm's convention. No `deps-core` consumer renders or parses this field as a URL today, so this is a documentation-level widening of the field's existing contract, not a type change — permitted by this spec's "Never widen the `deps-core` trait surface" boundary, which does not cover doc comments |
+| `DependencySource::CustomRegistry` | Existing `deps-core` variant, reused as PyPI's FR-006 fail-closed state — no new variant introduced | `url: String` — the raw value as written; `is_version_resolvable()` already `false` |
+| `PypiIndexConfig` | New `deps-pypi` type — resolved index configuration for one manifest/requirements file | `primary: Option<Result<PypiIndexUrl, InvalidEntry>>` (from `--index-url` or a `priority = "primary"`/`"default"`-equivalent Poetry source), `extras: Vec<Result<PypiIndexUrl, InvalidEntry>>` (declaration order preserved, FR-005), `named_sources: HashMap<String, Result<PypiIndexUrl, InvalidEntry>>` (Poetry `[[tool.poetry.source]]` keyed by `name`, consulted when a dependency declares `source = "<name>"`) |
+| `InvalidEntry` | New `deps-pypi` type — a present-but-unusable entry, carrying what FR-006 needs to build `CustomRegistry` and to warn | `raw: String` (as written), `reason` (validation failure kind) |
+| `PypiIndexUrl` | Validated, normalized index URL newtype, new and `deps-pypi`-local (mirrors `NpmRegistryIndex` from 032 rather than promoting a shared type — see Open Questions on whether a third near-identical newtype across Cargo/npm/PyPI is worth consolidating into `deps-core`) | https-only, no userinfo, PEP 503-path-normalized |
+| `PypiRegistry` | Existing `deps-pypi` `Registry` impl, extended into a router mirroring `NpmRegistry`'s `alternates` map | `+ alternates: Arc<DashMap<String, Arc<PypiRegistry>>>` (root-owned only, keyed by chain identity — see plan.md's C2 fix, not by primary URL alone), `+ fallback_chain: Vec<Arc<PypiRegistry>>` (resolved clients, not raw URLs — see plan.md's C1 fix), `+ simple_base: String` (distinct from the existing `index_url` field, which is the package-*search* index only — see plan.md's C4 fix; version-fetch URLs are built from `simple_base`) |
+| `Registry::get_versions_from` / `get_latest_matching_from` | Existing defaulted `deps-core::Registry` trait methods | Overridden by `PypiRegistry`, no signature change |
+| `EcosystemFormatter::can_resolve_source` | Existing defaulted `deps-core` trait method | Overridden by `PypiFormatter`, no signature change |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| No `--index-url`/`--extra-index-url`/Poetry source/uv index anywhere | Byte-identical to today's behavior (US-004) |
+| `--index-url` present (explicit primary), no dependencies reference anything special | Every dependency in the file routes to the new primary index first, then declared extras (FR-002, FR-005a) |
+| Only `--extra-index-url` present, no `--index-url` | Every dependency routes through the declared extras first, implicit public `pypi.org` last (FR-005b) — **not** the reverse |
+| Explicit `--index-url` present, dependency exists on both primary and extra | Primary index's data wins (FR-005a, NFR-006) |
+| Only `--extra-index-url` present, dependency exists on both an extra and `pypi.org` | The extra's data wins — `pypi.org` is never queried for that name until every declared extra misses (FR-005b, NFR-003) |
+| `--extra-index-url` present, dependency exists only on the extra index | Resolved via the extra index, not reported "not found" (US-002, FR-005) |
+| Explicit `--index-url not-a-valid-url` | Source becomes `CustomRegistry { url: "not-a-valid-url" }`; warn logged; no `pypi.org` fallback (FR-006, US-005) |
+| An `--extra-index-url` entry fails validation, primary or other extras are still valid | That one entry is dropped from the chain (warn logged); resolution proceeds via the primary/remaining valid extras/implicit public fallback — does **not** fail the whole dependency closed (FR-006, corrected 2026-09-02) |
+| Index URL contains embedded userinfo (`https://user:pass@host/simple/`) | Rejected per FR-006/FR-011 → fails closed per the entry-specific rule above (Cargo/npm precedent, resolved for phase 1) |
+| `[[tool.poetry.source]]` entry with no `priority` key | Treated as `priority = "primary"` (FR-007, corrected 2026-09-02 — matches current Poetry docs) |
+| `[[tool.poetry.source]]` entry with no matching `source = "<name>"` on any dependency | Parsed but never consulted — no effect |
+| `pyproject.toml` dependency declares `source = "<name>"` with no matching `[[tool.poetry.source]]` entry | Treated as unresolvable per FR-006 (name looked up, not found in `named_sources`) rather than silently falling back to `pypi.org` |
+| Alternate index returns PEP 503 HTML instead of PEP 691 JSON | Parsed via the existing HTML-fallback path (FR-004) — not treated as an error |
+| Alternate index unreachable / times out | No version data shown; no panic; identical shape to public-index-unreachable handling today; a timeout/5xx does **not** trigger fallthrough to the next chain entry the way `PackageNotFound` does (see plan.md's failure-taxonomy fix) |
+| `requirements.txt` `--index-url`/`--extra-index-url` edited after initial resolution | Stale until the affected file is next reparsed (FR-012, documented limitation) |
+| `workspace_registries = off`, file has an **explicit valid `--index-url`** plus a blocked `--extra-index-url` | The extra drops out of the chain (FR-006); the chain still has a working hop (the explicit primary), so every dependency resolves via it exactly as under `public_only`/`all` (FR-008) — corrected 2026-09-02 (this is the S6 fix: a blocked extra never breaks a chain that still has a valid hop) |
+| `workspace_registries = off`, file declares **only** `--extra-index-url` entries (no explicit primary), every extra blocked | Every extra drops out (FR-006); with no explicit primary, the resulting chain has zero hops. THE SYSTEM SHALL resolve every plain dependency in that file as plain `DependencySource::Registry` (byte-identical to a file with no declarations at all) — **not** per-dependency fail-closed and **not** an undefined/empty `AlternateRegistry` chain (fixed 2026-09-02, second critic pass — this case was previously undefined; there is no per-package distinction at parse time, so every plain dependency in an extras-only file necessarily shares this outcome) |
+| A declared `--extra-index-url` is unreachable (connection error/timeout) with no explicit primary in the file (FR-005(b)/(c)) | Resolution halts for every dependency in that file, including ordinary public ones — a distinguishable diagnostic is shown (NFR-003(3)), not a silent/generic failure. Confirmed 2026-09-02 as an intentional availability/confidentiality trade-off, not a defect |
+| Chain resolution reaching the "supplemental"/extras stop condition | Stops at the first hop with *any* non-empty version list — an approximation of Poetry's own "yields a compatible package **distribution**" (version-aware) condition, not a full re-implementation of it. Stated explicitly (added 2026-09-02, second critic pass) as a phase-1 divergence, consistent with this spec's existing disclaimer that it does not replicate pip's/Poetry's full resolver |
+| An index URL resolves to an RFC1918/loopback host under the default `public_only` policy | Blocked by FR-008's policy → that entry drops from the chain (extras) or fails closed (explicit primary); permitted only under `all` |
+| Same package name present with different indexes on two separate requirement lines (rare but possible via multiple `-r` includes) | Out of scope for phase 1's per-file resolution model — documented limitation, not silently merged |
+| `-r base.txt` include declares `--index-url`, the includer file's own dependencies do not | Config does not propagate along the include graph in phase 1 — the includer's dependencies resolve against `pypi.org` unless it declares its own override. Documented known limitation (decided 2026-09-02), not implemented in phase 1 |
+| `pip.conf`/`PIP_INDEX_URL` present, no in-file `--index-url` | No effect in phase 1 (Out of Scope) — dependencies resolve exactly as they do today, against `pypi.org`, which is a known false-negative for that class of project |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Private-index dependency (via `--index-url`) shows live hover/diagnostic/completion data | Pass on a real or mocked devpi/Artifactory-shaped PEP 503 fixture |
+| SC-002 | `--extra-index-url`-only dependency (absent from the public/primary index) resolves correctly | Pass on a fixture mirroring US-002/Dependi issue #292's Azure Artifacts scenario. **Caveat (added 2026-09-02)**: this verifies phase 1's unauthenticated resolution logic against a fixture that returns 200; the real Dependi #292/#293 Azure Artifacts feed requires authentication (401/403 unauthenticated) and is therefore only reachable once the deferred auth follow-up spec ships — SC-002 proves the routing/fallback mechanism works, not that the live Azure scenario is solved end-to-end in phase 1 |
+| SC-003 | Zero regression on projects declaring no index override | Every existing `deps-pypi` test produces unchanged results |
+| SC-004 | Misconfigured/unreachable extra never silently falls back to `pypi.org` ahead of a valid remaining index, and — the corrected direction (2026-09-02) — a private/extra-index match is never silently shadowed by a same-named `pypi.org` result when no explicit primary is declared | Test mirroring the #248/032 regression pattern, adapted for PyPI's FR-005(a)/(b) order: (a) explicit-primary-then-extras for files with `--index-url`; (b) extras-then-implicit-public for files without it. Asserts no `pypi.org` request occurs before the declared extras are exhausted in case (b), and that a `CustomRegistry`-sourced dependency never triggers a `pypi.org` request at all |
+| SC-005 | No credential-shaped value is ever parsed into memory | Structural test per NFR-001/FR-011 |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Run `cargo +nightly fmt --check`, `cargo clippy --all-targets --all-features --workspace -- -D warnings`, `cargo nextest run --workspace --all-features` before considering a task complete.
+- Follow the Registry Integration Gate (`.claude/rules/continuous-improvement.md`) — verify against a real or mocked private PyPI-protocol index before filing the implementation PR.
+- Update `CHANGELOG.md`, `ECOSYSTEM_GUIDE.md`, `.local/testing/coverage.md` (PyPI row), `.local/testing/playbooks/pypi.md` (create if absent), `.local/testing/regressions.md`.
+- Reuse `DependencySource::AlternateRegistry`/`CustomRegistry`, `Registry::get_versions_from`/`get_latest_matching_from`, `EcosystemFormatter::can_resolve_source`, and `deps_core::net_policy` as-is rather than adding parallel `deps-pypi`-only mechanisms.
+
+### Ask First
+- Any decision that touches auth/credential handling (URL userinfo, `keyring`, `.netrc`) — explicitly out of scope for this spec; a dedicated follow-up spec owns pip's broader credential conventions.
+- Implementing `pip.conf`/`PIP_INDEX_URL`/`PIP_EXTRA_INDEX_URL` support — explicitly out of scope, deferred to a separate follow-up spec; do not add ad hoc env-var reading in this feature.
+- Consolidating `PypiIndexUrl` with Cargo's `RegistryIndex`/npm's `NpmRegistryIndex` into a shared `deps-core` type — a cross-crate refactor beyond this spec's own file scope, deferred until a third near-identical implementation makes the duplication concrete, not decided here.
+- Any change to FR-005's phase-1 resolution-order rule (primary-then-extras) — this is a deliberate narrowing of pip's real resolver behavior, decided as the sole phase-1 rule with no configuration escape hatch; any deviation needs explicit sign-off given the dependency-confusion security angle (NFR-003).
+
+### Never
+- Parse, log, or transmit any credential-shaped value (URL userinfo or otherwise) in this phase (FR-011).
+- Fall back to `pypi.org` when an explicit `--index-url`/`--extra-index-url`/Poetry-source/uv-index override is present but fails to resolve (FR-006) — the exact bug class issue #248 fixed for Cargo and 032 fixed for npm.
+- Widen the `deps-core` `Registry`/`EcosystemFormatter` **trait** surface — every hook this spec needs already exists generically from the Cargo/npm work.
+
+## 9. Open Questions
+
+All blocking `[NEEDS CLARIFICATION]` items are resolved as of 2026-09-02:
+
+- **Auth/credential handling**: resolved — reject any index URL with embedded
+  userinfo, matching the Cargo/npm precedent exactly (FR-006/FR-011). No
+  `.netrc` detection or acknowledgment in phase 1; pip's broader credential
+  conventions (`keyring`, `.netrc`, URL-embedded basic-auth) are entirely out
+  of scope, owned by a dedicated future auth-handling spec.
+- **`pip.conf`/`pip.ini` and `PIP_INDEX_URL`/`PIP_EXTRA_INDEX_URL`**:
+  resolved — out of scope for this spec, deferred to a separate follow-up
+  spec/issue filed after this phase ships. File-discovery precedence needs
+  its own research pass rather than blocking this feature.
+- **uv schema scope**: resolved — FR-013 covers `[tool.uv.index]` table
+  entries (`name`, `url`, `default`) plus `[tool.uv.sources]`'s
+  `index = "<name>"` shape (added 2026-09-02, critic review: a named uv
+  index was otherwise unreachable). Every other `[tool.uv.sources]` shape
+  (`git =`, `path =`, `workspace = true`) is excluded outright — dependency
+  provenance, not registry routing, and a distinct problem from this spec's
+  scope.
+- **FR-005 resolution order**: resolved, and **corrected 2026-09-02** after
+  critic review found the original rule backwards. Two sub-rules: (a) an
+  explicit `--index-url` is checked before its file's extras (safe — a
+  deliberate user choice); (b) with no explicit primary, declared extras are
+  checked *before* the implicit `pypi.org` fallback (not after) — verified
+  against pip's own documentation, which states there is no precedence
+  between `--index-url`/`--extra-index-url` and explicitly warns
+  `--extra-index-url` is unsafe for private packages for exactly the reason
+  rule (b) avoids. No configuration escape hatch in either sub-rule.
+
+Non-blocking, deliberately deferred:
+
+- Whether `PypiIndexUrl` should eventually be consolidated with Cargo's
+  `RegistryIndex`/npm's `NpmRegistryIndex` into one `deps-core`-shared
+  newtype is left for a later refactor once three near-identical
+  implementations exist and the actual duplication is visible, rather than
+  speculatively generalizing now (matches this project's stated MVP/
+  no-premature-abstraction principle).
+
+## 10. See Also
+
+- [[constitution]] — project principles (not yet created for this project; cross-check against `.claude/rules/*.md` instead)
+- [[MOC-specs]] — all specifications
+- [[023-cargo-custom-registries/spec|023-cargo-custom-registries]] — the original reference implementation pattern: `DependencySource::AlternateRegistry`, `Registry::get_versions_from`/`get_latest_matching_from`, `EcosystemFormatter::can_resolve_source`, `deps_core::net_policy` host-classifier gating
+- [[032-npm-npmrc-registry-support/spec|032-npm-npmrc-registry-support]] — closest analogue: the most recently shipped instance of this pattern, and the source of the shared `registries.workspace_registries` policy key this spec reuses as-is
+- `.local/testing/playbooks/competitive-parity.md` — "Private/alternative registry support" row naming PyPI, Maven, NuGet, Go, Composer, and Bundler as unfiled follow-ons to the Cargo pattern
+- Dependi private-registry demand evidence (different repository, links intentionally not auto-linked): `` github.com/filllabs/dependi/issues/285 ``, `` github.com/filllabs/dependi/issues/292 ``, `` github.com/filllabs/dependi/issues/293 ``
+- `crates/deps-core/src/parser.rs` — `DependencySource`, `AlternateRegistry`, `CustomRegistry`, `is_version_resolvable`
+- `crates/deps-core/src/registry.rs` — `Registry` trait, `get_versions_from`/`get_latest_matching_from`
+- `crates/deps-core/src/net_policy.rs` — `HostClass`, `classify_host`, `RegistryAccessPolicy`, `WorkspaceRegistryAccess`
+- `crates/deps-pypi/src/registry.rs` — `PYPI_BASE`, `PYPI_SIMPLE_BASE`, `SIMPLE_API_ACCEPT`, the hardcoded constants and content-negotiation pattern this spec extends
+- `crates/deps-pypi/src/parser/requirements.rs` — `KNOWN_OPTIONS`, the existing `--index-url`/`--extra-index-url` token recognition this spec extends to actually capture the URL value
+- `crates/deps-pypi/src/parser/pyproject.rs` — existing PEP 621/Poetry dependency parsing this spec builds `[[tool.poetry.source]]` resolution on top of
+- Issue #248 — the Cargo silent-fallback-to-public-registry bug this spec's FR-006/US-005 explicitly avoid repeating for PyPI

--- a/specs/033-pypi-private-index-support/tasks.md
+++ b/specs/033-pypi-private-index-support/tasks.md
@@ -1,0 +1,692 @@
+---
+aliases:
+  - PyPI Private Index Tasks
+tags:
+  - sdd
+  - tasks
+  - pypi
+  - security
+created: 2026-09-02
+status: draft
+related:
+  - "[[spec]]"
+  - "[[plan]]"
+---
+
+# Implementation Tasks: PyPI Private/Custom Index Resolution
+
+> [!info] References
+> **Spec**: [[spec]]
+> **Plan**: [[plan]]
+> **Issue**: #513
+> **Total tasks**: 15
+
+> [!warning] Revision History
+> **r2 (2026-09-02)** — rewritten after a `rust-critic` review of r1's plan.md
+> found 4 Critical defects encoded directly into r1's T006/T007 acceptance
+> criteria (chain lookup structurally could not resolve; global chain-key
+> aliasing; implicit-primary leaked private package names to `pypi.org` and
+> inverted the dependency-confusion protection; wrong base-URL field reused).
+> T001-T009 below reflect the corrected plan.md r2 design. Two tasks added:
+> T006a (tier guard) and T015/T016 folded from r1's T013/T014 with expanded
+> criteria.
+>
+> **r3 (2026-09-02)** — a second critic pass on r2 (verdict downgraded
+> `critical` → `significant`; all r1 findings confirmed genuinely fixed) found
+> 6 new Significant defects in r2's own fixes, closed here: T002 gains the
+> zero-hop-chain case and the opaque hashed chain-key (not URL-shaped); T005's
+> uv mapping is corrected (was backwards vs uv's own docs — `default = true`
+> is a last-resort hop, not primary; non-`default`/non-`explicit` entries are
+> automatic chain hops, not named-only); T006's `register_chain`/
+> `register_named_source` take `root: &Arc<Self>` (not `&self`) and the
+> implicit-public hop is a fresh `Public`-tier client (not `Arc::clone(&root)`,
+> which would cycle); T006 narrows `simple_base` parameterization to
+> `simple_api_url` only (not `metadata_url`, which would 404 on the wrong
+> root); T007 documents the confirmed terminal-on-transport-error trade-off
+> and its required diagnostic. Do not implement against any r1- or r2-era task
+> description — plan.md's Revision History has the full corrected rationale
+> for every fix in this list.
+
+## Progress
+
+- [ ] T001: `PypiIndexUrl` validation type + `test-util` feature
+- [ ] T002: `PypiIndexConfig`/`ResolvedChain` data model and resolution logic
+- [ ] T003: `requirements.txt` two-pass `--index-url`/`--extra-index-url`/`-i` capture
+- [ ] T004: Poetry `[[tool.poetry.source]]` table + per-dependency `source =` parsing
+- [ ] T005: uv `[tool.uv.index]` + `[tool.uv.sources] { index = "<name>" }` parsing
+- [ ] T006: `PypiRegistry` chain infrastructure (`simple_base`, root-owned `alternates`, resolved `fallback_chain`)
+- [ ] T007: `Registry` trait overrides with chained fallback + failure taxonomy (FR-005)
+- [ ] T008: Tier guard on `search`/`warm_search_index`/`get_package_metadata`
+- [ ] T009: `PypiFormatter::can_resolve_source` override
+- [ ] T010: Ecosystem wiring — thread config into the two-pass parse pipeline
+- [ ] T011: Structural/unit tests — validation, resolution, chain-key uniqueness, credential-safety
+- [ ] T012: Integration tests — FR-005(a)/(b) ordering, failure taxonomy, `workspace_registries = off`
+- [ ] T013: Regression verification — zero change for public-only projects
+- [ ] T014: Documentation — CHANGELOG, ECOSYSTEM_GUIDE, testing knowledge base
+- [ ] T015: Live verification against a real/mocked private-index fixture
+
+---
+
+## Dependency Graph
+
+```mermaid
+graph TD
+    T001[T001: PypiIndexUrl + test-util] --> T002[T002: PypiIndexConfig/ResolvedChain]
+    T001 --> T006[T006: PypiRegistry chain infra]
+    T002 --> T003[T003: requirements.txt two-pass capture]
+    T002 --> T004[T004: Poetry source table]
+    T002 --> T005[T005: uv index + sources]
+    T006 --> T007[T007: Registry trait overrides + failure taxonomy]
+    T006 --> T008[T008: Tier guard search/warm/metadata]
+    T002 --> T009[T009: Formatter can_resolve_source]
+    T003 --> T010[T010: Ecosystem wiring]
+    T004 --> T010
+    T005 --> T010
+    T007 --> T010
+    T008 --> T010
+    T009 --> T010
+    T001 --> T011[T011: Structural/unit tests]
+    T002 --> T011
+    T007 --> T012[T012: Integration tests]
+    T008 --> T012
+    T010 --> T012
+    T010 --> T013[T013: Regression verification]
+    T010 --> T014[T014: Documentation]
+    T012 --> T014
+    T010 --> T015[T015: Live verification]
+    T012 --> T015
+```
+
+---
+
+### T001: `PypiIndexUrl` validation type + `test-util` feature
+
+**Context**: Every other task depends on a validated, normalized index URL type.
+Mirrors `NpmRegistryIndex::new_for_log` exactly (https-only, no userinfo,
+`classify_host`/`RegistryAccessPolicy` gated). Includes the `test-util` feature
+fix (S7) upfront since T012's integration tests need it.
+
+**Spec reference**: [[spec#FR-006]], [[spec#FR-011]], [[spec#NFR-002]]
+**Plan reference**: [[plan#3-data-model]]
+**Acceptance criteria**:
+- [ ] `crates/deps-pypi/src/config.rs` created with `PypiIndexUrlError`,
+      `PypiIndexUrl::new`/`new_for_log`, `PypiIndexUrl::as_str`
+- [ ] Rejects non-`https` URLs (except the test-only loopback carve-out)
+- [ ] Rejects any URL with `username()`/`password()` present
+- [ ] Classifies host via `deps_core::net_policy::classify_host` and gates via
+      `RegistryAccessPolicy::get().allows(class)`
+- [ ] Normalizes by trimming a trailing `/` (PEP 503 `/simple/{name}/` path
+      convention, matching `simple_api_url`'s existing join logic)
+- [ ] `crates/deps-pypi/Cargo.toml` gains `test-util = []`, mirroring
+      `crates/deps-npm/Cargo.toml:27` — the loopback carve-out is gated on
+      `cfg(any(test, feature = "test-util"))`
+- [ ] Unit tests cover every `PypiIndexUrlError` variant
+**Dependencies**: none
+**Files**: `crates/deps-pypi/src/config.rs` (new), `crates/deps-pypi/Cargo.toml`
+**Complexity**: low
+
+---
+
+### T002: `PypiIndexConfig`/`ResolvedChain` data model and resolution logic
+
+**Context**: The per-file resolved-config type every parser populates and every
+dependency consults, plus the `ResolvedChain` type that drives chain
+registration. Implements the corrected FR-005(a)/(b) structure and the
+corrected Poetry-priority mapping.
+
+**Spec reference**: [[spec#FR-002]], [[spec#FR-003]], [[spec#FR-005]],
+[[spec#FR-006]], [[spec#FR-007]], [[spec#FR-013]]
+**Plan reference**: [[plan#3-data-model]], [[plan#1-architecture]] (chain-key
+identity subsection)
+**Acceptance criteria**:
+- [ ] `InvalidEntry { raw, reason }`, `PypiIndexConfig { primary, extras,
+      named_sources }`, and `ResolvedChain { key, hops, implicit_public_fallback }`
+      added to `config.rs`
+- [ ] `resolve_source_for(named_source: Option<&str>) -> DependencySource`:
+      no override anywhere → `Registry`; explicit primary present → routes
+      through the primary+extras chain (case a); no explicit primary but
+      extras present → routes through the extras+implicit-public chain
+      (case b); named source requested → that source's own URL, or
+      `CustomRegistry` if unresolved; an invalid **explicit primary** or
+      **named source** → `CustomRegistry`; an invalid **extra** does **not**
+      produce `CustomRegistry` — it is simply excluded from the chain (see
+      `resolved_chains`)
+- [ ] `resolved_chains() -> Vec<ResolvedChain>` returns one chain for the
+      primary/extras case (if either is present) and one single-hop chain per
+      named source — empty `Vec` when the file declares nothing (US-004)
+      **or when every extra was dropped by FR-006 and no explicit primary
+      exists (the zero-hop case — see below)**
+- [ ] **Zero-hop case (fixes N5)**: when a case-(b) file's extras are all
+      dropped (e.g. `workspace_registries = off`) and no explicit primary was
+      declared, `resolve_source_for(None)` returns plain
+      `DependencySource::Registry` — **not** an `AlternateRegistry` pointing
+      at an empty chain. Test this explicitly; do not leave it to whatever
+      the zero-hop registration code happens to do
+- [ ] `ResolvedChain::key` construction: an opaque, single-line hashed token
+      (`format!("pypi-chain:{:016x}", digest)`, `digest` from
+      `std::collections::hash_map::DefaultHasher` over the ordered hop
+      strings + the `implicit_public_fallback` flag) — **never** a
+      newline-joined or otherwise URL-shaped value (fixes N6 — violates
+      `deps-core`'s documented `AlternateRegistry.index` contract). **Test
+      asserts** an explicit chain `[A, B]` and an implicit chain that
+      resolves to hops `[A, B]` (plus the fallback flag) produce *different*
+      keys (regression test for the C2 aliasing defect)
+- [ ] Poetry priority mapping implemented exactly as plan.md's corrected
+      decision table: `primary`/`default`/**no `priority` key** → primary;
+      `supplemental`/`secondary` → extras; `explicit` → named-source only
+- [ ] Unit tests: primary-only (case a), extras-only with no primary
+      (case b), primary+extras, named-source via `explicit`, unlabeled
+      Poetry source → primary (not supplemental) behavior, an invalid extra
+      dropped from `resolved_chains` without producing `CustomRegistry`
+**Dependencies**: T001
+**Files**: `crates/deps-pypi/src/config.rs`
+**Complexity**: medium
+
+---
+
+### T003: `requirements.txt` two-pass `--index-url`/`--extra-index-url`/`-i` capture
+
+**Context**: Today these tokens are recognized only to correctly classify the
+line as "not a dependency" (`KNOWN_OPTIONS`); the URL value is discarded.
+This task captures the value into a `PypiIndexConfig` under construction for
+the file, using a **two-pass** parse (fixes S2 — pip applies index options
+file-wide regardless of line position; a single top-to-bottom pass would
+leave dependencies declared before a late `--index-url` line unrouted).
+
+**Spec reference**: [[spec#FR-001]], [[spec#US-001]], [[spec#US-002]]
+**Plan reference**: [[plan#1-architecture]] (two-pass parse)
+**Acceptance criteria**:
+- [ ] Pass 1 scans the whole file and collects every `--index-url <url>`,
+      `--index-url=<url>`, `-i <url>`, `--extra-index-url <url>`, and
+      `--extra-index-url=<url>` occurrence into a `PypiIndexConfig`,
+      regardless of position relative to dependency lines
+- [ ] Pass 2 resolves every dependency's source using the fully-collected
+      config via `resolve_source_for(None)`
+- [ ] **Test**: a fixture with `--index-url` positioned *after* the first
+      dependency line — that earlier dependency still resolves against the
+      declared primary, not `pypi.org` (regression test for the S2 defect)
+- [ ] Existing `KNOWN_OPTIONS`/`strong_signal` classification behavior is
+      unchanged for every other option token
+**Dependencies**: T002
+**Files**: `crates/deps-pypi/src/parser/requirements.rs`
+**Complexity**: medium
+
+---
+
+### T004: Poetry `[[tool.poetry.source]]` table + per-dependency `source =` parsing
+
+**Context**: `pyproject.toml`'s Poetry-specific private-source declaration and
+per-dependency source binding — the direct analogue of npm's `@scope:registry=`.
+
+**Spec reference**: [[spec#FR-007]], [[spec#US-003]]
+**Acceptance criteria**:
+- [ ] `[[tool.poetry.source]]` entries (`name`, `url`, `priority`) parsed into
+      `PypiIndexConfig.named_sources` and, per the corrected Poetry-priority
+      mapping (T002), into `primary`/`extras` as applicable — **including**
+      an entry with no `priority` key mapping to primary, not extras
+- [ ] A Poetry dependency declaring `source = "<name>"` resolves via
+      `resolve_source_for(Some("<name>"))`
+- [ ] A `source = "<name>"` with no matching `[[tool.poetry.source]]` entry
+      resolves to `CustomRegistry` (per spec's edge-case table), not a silent
+      `pypi.org` fallback
+- [ ] Existing Poetry `git`/`path`/`url`-derived `PypiDependencySource`
+      handling is unchanged for dependencies that declare none of these
+**Dependencies**: T002
+**Files**: `crates/deps-pypi/src/parser/pyproject.rs`
+**Complexity**: medium
+
+---
+
+### T005: uv `[tool.uv.index]` + `[tool.uv.sources] { index = "<name>" }` parsing
+
+**Context**: uv's index-declaration table plus its per-dependency
+index-routing binding — the direct uv analogue of Poetry's `source = "<name>"`
+(FR-007). Scope expanded 2026-09-02 (critic review): without the `index =`
+binding, a named/`explicit`-equivalent uv index is entirely unreachable. The
+mapping below was itself corrected 2026-09-02 by a second critic pass after
+verification against `docs.astral.sh/uv/concepts/indexes/` found the first
+draft backwards — implement exactly as written here, not per any earlier
+description.
+
+**Spec reference**: [[spec#FR-013]]
+**Plan reference**: [[plan#1-architecture]] ("uv's chain shape is its own
+third case")
+**Acceptance criteria**:
+- [ ] `[tool.uv.index]` array-of-tables entries (`name`, `url`, `default`,
+      `explicit`) parsed using the same `PypiIndexUrl` validation and
+      `RegistryAccessPolicy` gate as T003/T004
+- [ ] An entry with neither `default = true` nor `explicit = true` is
+      appended to `extras` in declaration order — it is searched
+      **automatically** for every dependency (uv's own documented default),
+      the direct analogue of `--extra-index-url`, **not** `named_sources`-only
+- [ ] An entry with `default = true` (uv permits at most one) becomes the
+      **final** hop of the chain — uv's lowest-priority, last-resort index,
+      replacing the implicit public fallback in that slot. It does **not**
+      populate `PypiIndexConfig.primary` and is **not** checked first — a
+      test must assert a package present on both a non-default entry and the
+      `default` entry resolves via the non-default one
+- [ ] An entry with `explicit = true` is registered into `named_sources`
+      only, never auto-included in the chain
+- [ ] `[tool.uv.sources] <dep> = { index = "<name>" }` parsed and resolves
+      that dependency via `resolve_source_for(Some("<name>"))` — works for
+      both `explicit` and non-`explicit` named entries, mirroring FR-007's
+      Poetry handling
+- [ ] A pure-uv `pyproject.toml`'s `PypiIndexConfig.primary` stays `None` —
+      uv never populates the `primary`/FR-005(a) slot; its chain always
+      routes through the FR-005(b) shape (test this explicitly, it is easy to
+      get backwards)
+- [ ] Every other `[tool.uv.sources]` shape (`git =`, `path =`,
+      `workspace = true`, or any combination without an `index =` key) is
+      **not** parsed by this feature — confirmed by a test asserting their
+      presence has no effect
+**Dependencies**: T002
+**Files**: `crates/deps-pypi/src/parser/pyproject.rs`
+**Complexity**: medium
+
+---
+
+### T006: `PypiRegistry` chain infrastructure
+
+**Context**: The routing infrastructure `get_versions_from`/
+`get_latest_matching_from` dispatch through. This is the task whose r1
+acceptance criteria the critic identified as directly encoding two Critical
+defects (C1: chain lookup structurally could not resolve; C4: wrong base-URL
+field reused) — the criteria below are the corrected r2 design and **must**
+be implemented as written here, not per any earlier description.
+
+**Spec reference**: [[spec#FR-002]], [[spec#FR-003]], [[spec#FR-005]],
+[[spec#FR-008]]
+**Plan reference**: [[plan#1-architecture]] (Chain resolution mechanism,
+Chain-key identity), [[plan#3-data-model]]
+**Acceptance criteria**:
+- [ ] `PypiRegistryTier` enum (`Public`/`WorkspaceDeclared`) added to
+      `registry.rs`
+- [ ] `PypiRegistry` gains a **new `simple_base: String` field, distinct
+      from the existing `index_url` field** (which remains the package-name
+      *search*-index base, untouched in meaning) — only `simple_api_url`
+      (PEP 503/691 version fetches, currently built from the module const
+      `PYPI_SIMPLE_BASE`) is parameterized to use `self.simple_base`.
+      **`metadata_url`/`PYPI_BASE` is left untouched** (fixes N3, second
+      critic pass — `PYPI_BASE` and `PYPI_SIMPLE_BASE` are different roots;
+      parameterizing `metadata_url` on `simple_base` too would 404 the
+      public client, and no alternate client ever reaches it anyway once
+      T008's tier guard lands). **This is the fix for C4** — verify with a
+      test that an alternate client's version fetch actually hits the
+      configured private host, not `pypi.org`
+- [ ] `PypiRegistry` gains `tier`, `alternates: Arc<DashMap<String,
+      Arc<Self>>>` (root-owned only), `fallback_chain: Vec<Arc<Self>>`
+      (**resolved concrete clients, not raw URLs — this is the fix for C1**)
+- [ ] `with_base(cache, simple_base: &PypiIndexUrl, fallback_chain: Vec<Arc<Self>>)
+      -> Self` constructs one hop (`WorkspaceDeclared` tier)
+- [ ] `register_chain(root: &Arc<Self>, chain: &ResolvedChain)` — takes the
+      root as a **plain parameter, not `&self`** (fixes N1, second critic
+      pass — `self: &Arc<Self>` receivers are unstable). Builds the full hop
+      tree (hop 0 as the returned client's own `simple_base`/`tier`; hops
+      1..N-1 as freshly-constructed leaf clients with empty `fallback_chain`;
+      when `implicit_public_fallback` is set, the final hop is a **freshly-
+      constructed `Public`-tier client** — same `simple_base`/transport as
+      the root, but **not** `Arc::clone(root)`, which would create a
+      root→alternates→head→fallback_chain→root reference cycle) and inserts
+      the head into `root.alternates` under `chain.key`. Idempotent per key,
+      capped at `MAX_ALTERNATE_REGISTRIES = 256`
+- [ ] `register_named_source(root: &Arc<Self>, index: &PypiIndexUrl)`
+      registers a single-hop leaf under the source's own URL into
+      `root.alternates` — same `root` parameter shape as `register_chain`
+- [ ] `alternate_client(index: &str) -> Option<Arc<Self>>` is a plain map
+      lookup — called **only on the root** (verify: a test constructing a
+      non-root chain client and calling `alternate_client` on it directly
+      returns `None` for everything, documenting the invariant, not
+      asserting it should work — this is intentionally the C1 invariant, not
+      a bug to fix here)
+- [ ] `WorkspaceDeclared`-tier fetches route through
+      `HttpCache::get_cached_workspace_with_headers` (existing, unchanged)
+- [ ] Test: no reference cycle — dropping the `PypiEcosystem`/root after
+      registering at least one implicit-fallback chain actually deallocates
+      (verifies N1's second fix; a naive `Arc::clone(root)` would leak)
+**Dependencies**: T001
+**Files**: `crates/deps-pypi/src/registry.rs`
+**Complexity**: high
+
+---
+
+### T007: `Registry` trait overrides with chained fallback + failure taxonomy (FR-005)
+
+**Context**: The fetch-time logic that makes the FR-005(a)/(b) chain actually
+work, including the corrected failure taxonomy (S5) that distinguishes
+`PackageNotFound`/empty-listing (continue) from a genuine error (terminate).
+
+**Spec reference**: [[spec#FR-005]], [[spec#NFR-006]], [[spec#SC-004]]
+**Plan reference**: [[plan#1-architecture]] (Failure taxonomy subsection)
+**Acceptance criteria**:
+- [ ] `get_versions_from`/`get_latest_matching_from` overridden on
+      `PypiRegistry`, dispatching on `DependencySource::AlternateRegistry`
+      exactly as `NpmRegistry` does for the non-chained case
+- [ ] `get_versions_chained` (private helper): tries `self.get_versions_with`
+      (hop 0, using `self.simple_base`) first, then each `self.fallback_chain`
+      entry's own `get_versions_with` in order — **no further map lookup at
+      any point** (verifies T006's C1 fix actually resolves a hop end to end)
+- [ ] Stop condition implements the plan's three-way taxonomy exactly:
+      `Ok(non-empty)` → terminal, return; `Err(PackageNotFound)` or
+      `Ok(empty)` → continue to next hop; any other `Err` → terminal,
+      propagate immediately, do **not** try the next hop
+- [ ] **Confirmed trade-off (N4, second critic pass)**: this applies to a
+      case-(b) chain exactly as to case (a) — an unreachable hop 0 (a
+      declared extra, when no explicit primary exists) halts resolution for
+      every dependency in that file, public ones included. This is
+      intentional, not a bug to soften. THE SYSTEM SHALL surface a
+      distinguishable diagnostic for this case (spec NFR-003(3) — e.g.
+      "extra index unreachable — resolution halted, not falling back to
+      pypi.org"), not a generic fetch-error message. Test: a case-(b) chain
+      whose sole extra times out produces this distinguishable message, and
+      no request reaches the implicit public fallback
+- [ ] `get_latest_matching_chained` derived from `get_versions_chained` +
+      `select_latest_matching[_with_context]` — **no independent chain walk**
+      (fixes M4); a winning hop with no version matching the requirement is
+      terminal (`Ok(None)`), not a trigger to search further hops
+- [ ] `AlternateRegistry` with no registered `alternate_client` returns
+      `PackageNotFound { registry: "alternate registry (not registered)" }`
+- [ ] Every hop reuses FR-004's existing PEP 691-then-PEP 503 content
+      negotiation unchanged
+**Dependencies**: T006
+**Files**: `crates/deps-pypi/src/registry.rs`
+**Complexity**: high
+
+---
+
+### T008: Tier guard on `search`/`warm_search_index`/`get_package_metadata`
+
+**Context**: New task (2026-09-02, critic review S4/M3) — without this guard,
+an unguarded `search`/`warm_search_index` on a `WorkspaceDeclared`-tier client
+would trigger a full project-listing download from the private host, and the
+existing but currently-unrouted `get_package_metadata` would send a private
+package name to `pypi.org`'s JSON API the moment any future call site reaches
+it.
+
+**Spec reference**: [[spec#FR-014]]
+**Plan reference**: [[plan#1-architecture]] (Tier guard on search endpoints)
+**Acceptance criteria**:
+- [ ] `search` returns `Ok(vec![])` immediately for any `WorkspaceDeclared`-
+      tier client, issuing no HTTP request
+- [ ] `warm_search_index` no-ops immediately for any `WorkspaceDeclared`-tier
+      client, never triggering `trigger_index_build`
+- [ ] `get_package_metadata` gains the identical tier guard, even though it
+      has no in-workspace caller today — closing the latent leak before any
+      future call site can reach it
+- [ ] Test asserts all three issue zero HTTP requests when called on a
+      `WorkspaceDeclared`-tier client (mockito assertion: no matcher hit)
+**Dependencies**: T006
+**Files**: `crates/deps-pypi/src/registry.rs`
+**Complexity**: low
+
+---
+
+### T009: `PypiFormatter::can_resolve_source` override
+
+**Context**: The single override point gating hover/diagnostics/code-actions
+on a resolved `AlternateRegistry` source — without it, `is_version_resolvable()`
+(which is `false` for `AlternateRegistry`) would incorrectly suppress a
+successfully-routed private-index dependency.
+
+**Spec reference**: [[spec#FR-009]]
+**Acceptance criteria**:
+- [ ] `PypiFormatter::can_resolve_source` overridden to accept
+      `Registry | AlternateRegistry { .. }`, mirroring `NpmFormatter` exactly
+- [ ] `CustomRegistry` continues to fall through to the default
+      (`is_version_resolvable() == false`) — no separate override needed
+- [ ] Hover/diagnostics/completion tests confirm an `AlternateRegistry`
+      dependency renders identically in shape to a `Registry` one
+- [ ] Document the M1 cosmetic limitation (a plain dependency in an
+      extras-only file loses its pypi.org hover link even when it actually
+      resolves via the implicit public fallback) as a code comment near the
+      override, per plan.md §3's formatter note — not something to fix here
+**Dependencies**: T002
+**Files**: `crates/deps-pypi/src/formatter.rs`
+**Complexity**: low
+
+---
+
+### T010: Ecosystem wiring — thread config into the two-pass parse pipeline
+
+**Context**: Connects T003/T004/T005's per-file `PypiIndexConfig` to T006/T007's
+registry client, so a parsed manifest's dependencies actually route through the
+new machinery. The integration point mirrors `NpmEcosystem::parse_manifest`'s
+registration call, adapted for `resolved_chains()`'s chain-based (not
+single-URL) registration.
+
+**Spec reference**: [[spec#FR-008]]
+**Plan reference**: [[plan#2-project-structure]]
+**Acceptance criteria**:
+- [ ] `PypiEcosystem::parse_manifest` builds one `PypiIndexConfig` per parsed
+      file (via T003/T004/T005's two-pass parsers) and calls
+      `PypiIndexConfig::resolved_chains()` to `register_chain` every chain,
+      plus `register_named_source` for every named source, with the **root**
+      `PypiRegistry` instance
+- [ ] The existing shared `RegistryAccessPolicy` (`registries.workspace_registries`)
+      is threaded through to `PypiIndexUrl::new` — no new `pypi.*` config key
+      introduced
+- [ ] A file with no index declaration anywhere never constructs more than an
+      empty/default `PypiIndexConfig` and never calls `register_chain`
+- [ ] **Test A (S6, mixed chain)**: `workspace_registries = off` with a file
+      declaring an **explicit valid `--index-url`** plus an
+      `--extra-index-url` — the extra drops out of the chain (FR-006), but
+      the chain still has a working hop (the explicit primary), so every
+      dependency in the file resolves via that primary exactly as it would
+      under `public_only`/`all`. This is the S6 scenario: a blocked extra
+      must not break a chain that still has a valid remaining hop
+- [ ] **Test B (N5, zero-hop, second critic pass)**: `workspace_registries =
+      off` with a file declaring **only** `--extra-index-url` entries (no
+      explicit primary) — every extra is blocked, the chain has zero hops,
+      and per N5's fix every plain dependency in that file resolves as
+      **plain `DependencySource::Registry`** (not `CustomRegistry`, not a
+      structurally-broken empty `AlternateRegistry`) — i.e. it degrades
+      gracefully to ordinary public resolution for the whole file, same as a
+      file with no declarations at all. Do **not** write this test expecting
+      per-package fail-closed behavior — there is no per-package distinction
+      at parse time; every plain dependency in an extras-only file shares one
+      `DependencySource`
+**Dependencies**: T003, T004, T005, T007, T008, T009
+**Files**: `crates/deps-pypi/src/ecosystem.rs`, `crates/deps-pypi/src/lib.rs`
+**Complexity**: medium
+
+---
+
+### T011: Structural/unit tests — validation, resolution, chain-key uniqueness, credential-safety
+
+**Context**: NFR-001/SC-005's structural guarantee that no credential-shaped
+value can ever be held, plus the full validation/resolution/chain-key matrix
+(including the C2 regression test already required inline by T002).
+
+**Spec reference**: [[spec#NFR-001]], [[spec#SC-005]]
+**Plan reference**: [[plan#7-testing-strategy]]
+**Acceptance criteria**:
+- [ ] A structural test asserts `PypiIndexConfig`/`PypiIndexUrl`/`InvalidEntry`
+      have no field capable of holding a credential-shaped value (mirrors
+      Cargo's/npm's NFR-001 test pattern)
+- [ ] Full `PypiIndexUrlError` matrix covered (already partially in T001;
+      this task closes any remaining gaps found during T002-T005)
+- [ ] `PypiIndexConfig::resolve_source_for`/`resolved_chains` matrix:
+      case (a) primary-only, case (a) primary+extras, case (b) extras-only,
+      named-source, unlabeled-Poetry-source-as-primary, invalid-extra-dropped
+      (not `CustomRegistry`)
+- [ ] `ResolvedChain::key` uniqueness test (already required by T002 — confirm
+      it exists and passes, not a duplicate task)
+**Dependencies**: T001, T002
+**Files**: `crates/deps-pypi/src/config.rs` (test module), possibly
+`crates/deps-pypi/tests/`
+**Complexity**: medium
+
+---
+
+### T012: Integration tests — FR-005(a)/(b) ordering, failure taxonomy, `workspace_registries = off`
+
+**Context**: End-to-end verification of both FR-005 sub-cases, the corrected
+failure taxonomy, and the S6 gating fix, per the Registry Integration Gate.
+
+**Spec reference**: [[spec#SC-001]], [[spec#SC-002]], [[spec#SC-004]],
+[[spec#NFR-006]], [[spec#FR-004]]
+**Acceptance criteria**:
+- [ ] **Case (a)**: explicit primary + extra, package on both → primary
+      wins (NFR-006)
+- [ ] **Case (b)**: no explicit primary, extra + implicit public, package on
+      both → **extra wins, no request to the public fixture for that name**
+      until the extra is confirmed to miss (this is the regression test for
+      the C3 security fix — must assert request-count/order via mockito, not
+      just the final result)
+- [ ] Package present only on an extra (either case) → resolves there, not
+      "not found" (US-002/SC-002)
+- [ ] Failure taxonomy: primary returns 500/timeout → chain terminates with
+      that error, extras/public are **not** queried; primary returns 404 →
+      falls through; primary returns 200+empty listing → falls through
+      identically to 404 (S5)
+- [ ] **Case (b) transport failure (N4, second critic pass)**: no explicit
+      primary, sole declared extra times out/errors → chain terminates with
+      a *distinguishable* diagnostic (not a generic fetch error), the
+      implicit public fallback is **not** queried, and — cross-checked
+      against a second dependency in the same file that has no relation to
+      the private feed — that ordinary dependency **also** fails to resolve
+      in this scenario (confirming N4's confirmed trade-off is real, not
+      accidentally scoped to only the affected package)
+- [ ] Alternate index returning PEP 503 HTML (not PEP 691 JSON) parses
+      correctly via the existing HTML-fallback path (FR-004)
+- [ ] `search`/`warm_search_index`/`get_package_metadata` issue zero requests
+      on a `WorkspaceDeclared`-tier client (cross-check with T008's unit test
+      — this is the integration-level confirmation)
+- [ ] `workspace_registries = off`, **Test A** (mixed: valid explicit primary
+      + blocked extra) — chain still resolves via the primary (S6)
+- [ ] `workspace_registries = off`, **Test B** (extras-only, no primary,
+      every extra blocked) — zero-hop chain, every dependency in the file
+      resolves as plain `Registry` (N5), not per-package fail-closed
+**Dependencies**: T007, T008, T010
+**Files**: `crates/deps-pypi/tests/` (new or existing integration test file)
+**Complexity**: high
+
+---
+
+### T013: Regression verification — zero change for public-only projects
+
+**Context**: US-004/NFR-004/NFR-005's non-negotiable zero-regression bar.
+
+**Spec reference**: [[spec#US-004]], [[spec#NFR-004]], [[spec#NFR-005]],
+[[spec#SC-003]]
+**Acceptance criteria**:
+- [ ] Full existing `deps-pypi` test suite passes unchanged
+- [ ] `cargo nextest run -p deps-pypi --all-features` produces identical pass
+      count to the pre-feature baseline
+- [ ] Manual hover check on a `requirements.txt`/`pyproject.toml` with no
+      index declaration confirms byte-identical output to pre-feature
+**Dependencies**: T010
+**Files**: none (verification only)
+**Complexity**: low
+
+---
+
+### T014: Documentation — CHANGELOG, ECOSYSTEM_GUIDE, testing knowledge base
+
+**Context**: Required by this spec's "Always" agent boundary and the project's
+`branching.md`/`continuous-improvement.md` rules. Must document the M1
+cosmetic limitation and the FR-005(b) ordering rationale, since both are
+user-visible/security-relevant behaviors a reader would otherwise not expect.
+
+**Spec reference**: [[spec#8-agent-boundaries]]
+**Acceptance criteria**:
+- [ ] `CHANGELOG.md` `[Unreleased]` entry added (one line, PR link added once
+      known)
+- [ ] `ECOSYSTEM_GUIDE.md` updated to describe PyPI private-index support,
+      including the FR-005(a)/(b) ordering rule in plain language and the M1
+      hover-link limitation
+- [ ] `.local/testing/coverage.md` PyPI row updated
+- [ ] `.local/testing/playbooks/pypi.md` created (if absent) or updated with
+      private-index test positions
+- [ ] `.local/testing/regressions.md` gets the minimal reproduction manifest
+      for the #248-class regression this feature must not reintroduce, plus
+      a manifest reproducing the C3 name-disclosure scenario this revision
+      fixed (extras-only file, package present on both extra and public)
+**Dependencies**: T010, T012
+**Files**: `CHANGELOG.md`, `ECOSYSTEM_GUIDE.md`, `.local/testing/coverage.md`,
+`.local/testing/playbooks/pypi.md`, `.local/testing/regressions.md`
+**Complexity**: low
+
+---
+
+### T015: Live verification against a real/mocked private-index fixture
+
+**Context**: The Registry Integration Gate (`.claude/rules/continuous-improvement.md`)
+requires live verification before filing the implementation PR — unit/mock
+tests alone are insufficient per that rule.
+
+**Spec reference**: [[spec#8-agent-boundaries]] (Always: "Follow the Registry
+Integration Gate")
+**Acceptance criteria**:
+- [ ] `RUST_LOG=debug cargo run -p deps-lsp` launched against a fixture
+      project with (1) a `requirements.txt` containing an explicit
+      `--index-url` + `--extra-index-url` (case a), and (2) a separate
+      fixture with only `--extra-index-url` (case b), both pointed at a real
+      or `mockito`-mocked devpi/Artifactory-shaped index
+- [ ] Hover output inspected and confirmed correct for a dependency resolved
+      via the private index in both cases, and confirmed that case (b) does
+      not issue a request to the real `pypi.org` for a name that resolves on
+      the mocked extra (network trace or log inspection)
+- [ ] Session log reviewed for `WARN`/`ERROR`/panics per
+      `continuous-improvement.md`'s manual-testing checklist
+**Dependencies**: T010, T012
+**Files**: none (verification only)
+**Complexity**: medium
+
+---
+
+## Implementation Notes
+
+### Order of execution
+
+T001 → T002 unlock everything else and should land first. T003/T004/T005 (the
+three parser surfaces) and T006 (registry infra) can proceed in parallel once
+T002 lands. T007 and T008 both depend only on T006 and can proceed together.
+T009 depends only on T002. T010 is the integration point and must wait for
+all of T003/T004/T005/T007/T008/T009. T011 can start as soon as T001/T002
+land. T012-T015 are the closing sequence.
+
+### Common patterns
+
+Follow `crates/deps-npm/src/config.rs` and `crates/deps-npm/src/registry.rs`
+line-for-line where the shape matches (`PypiIndexUrl` ≈ `NpmRegistryIndex`).
+Deviate where plan.md's r2 Architecture section explicitly calls for it — the
+`simple_base` field, the resolved (not string-keyed) `fallback_chain`, and the
+`ResolvedChain`-based registration have no npm equivalent and exist
+specifically because npm never needed a multi-hop fallback chain.
+
+### Gotchas
+
+- **Never** let `CustomRegistry` (explicit primary or named-source failure)
+  fall through to a `pypi.org` fetch anywhere — the exact #248 regression
+  class. An invalid **extra**, by contrast, must NOT produce `CustomRegistry`
+  — it is dropped from its chain, not escalated. Getting this distinction
+  backwards in either direction is a defect.
+- **The implicit public fallback (`ResolvedChain::implicit_public_fallback`)
+  must always be the *last* hop, never the first** — this is the C3 fix and
+  the single most security-relevant invariant in this feature. A test that
+  only checks "the right data eventually comes back" will not catch a
+  reintroduction of the r1 bug; T012's case-(b) test must assert *request
+  order/count*, not just the final result.
+- `alternate_client` must only ever be called on the **root** registry
+  instance. A chain client's own `alternates` map is always empty by
+  construction (T006) — this is intentional, not a bug, and `get_versions_chained`
+  must never call `self.alternate_client(...)` on itself; it walks the
+  already-resolved `fallback_chain: Vec<Arc<Self>>` instead.
+- `simple_base` and `index_url` are **different fields with different
+  meanings** — do not reuse one for the other (the C4 defect). `index_url` is
+  search-only; `simple_base` is the version-fetch base every hop actually
+  uses.
+- `MAX_ALTERNATE_REGISTRIES = 256` now caps distinct chain *identities*, not
+  distinct index URLs — see plan.md §1's risk note.
+- Log every `InvalidEntry` with the **raw, as-written** value only — no
+  expansion step exists for PyPI config (unlike npm's `${VAR}`), so this is
+  simpler than npm's case, but still don't reformat/normalize before logging
+  a rejected value.
+
+## See Also
+
+- [[spec]] — feature specification
+- [[plan]] — technical plan
+- [[MOC-specs]] — all specifications
+- `.local/handoff/2026-09-02T21-55-03-critic.md` — the critic review this
+  revision addresses

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -54,7 +54,7 @@ status: moc
 | 030 | [[030-gitlab-ci-ecosystem/spec\|New ecosystem: GitLab CI/CD include: version pins]] | specify | draft — research/new ecosystem, P4, 8 open `[NEEDS CLARIFICATION]` items, blocked on #208 (issue #466 tracks implementation) |
 | 031 | [[031-github-actions-sha-pin-diagnostic/spec\|GitHub Actions mutable-ref-pin security diagnostic (SHA-pin recommendation)]] | tasks | implemented — research/parity, P2, awaiting merge (PR #477, issue #473) |
 | 032 | [[032-npm-npmrc-registry-support/spec\|npm .npmrc custom/private registry support (scoped registries + top-level registry=)]] | plan | implemented — research/enhancement, P3, awaiting merge (PR #510, issue #502) |
-| 033 | [[033-pypi-private-index-support/spec\|PyPI private/custom index resolution (--index-url / --extra-index-url / Poetry source / uv index)]] | tasks | draft — research/enhancement, P3, r3 (15 tasks), two critic passes clean (critical→significant→addressed), ready for implementation (issue #513) |
+| 033 | [[033-pypi-private-index-support/spec\|PyPI private/custom index resolution (--index-url / --extra-index-url / Poetry source / uv index)]] | tasks | shipped — research/enhancement, P3 (PR #516, issue #513) |
 
 ## Completed Specs
 

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -54,6 +54,7 @@ status: moc
 | 030 | [[030-gitlab-ci-ecosystem/spec\|New ecosystem: GitLab CI/CD include: version pins]] | specify | draft — research/new ecosystem, P4, 8 open `[NEEDS CLARIFICATION]` items, blocked on #208 (issue #466 tracks implementation) |
 | 031 | [[031-github-actions-sha-pin-diagnostic/spec\|GitHub Actions mutable-ref-pin security diagnostic (SHA-pin recommendation)]] | tasks | implemented — research/parity, P2, awaiting merge (PR #477, issue #473) |
 | 032 | [[032-npm-npmrc-registry-support/spec\|npm .npmrc custom/private registry support (scoped registries + top-level registry=)]] | plan | implemented — research/enhancement, P3, awaiting merge (PR #510, issue #502) |
+| 033 | [[033-pypi-private-index-support/spec\|PyPI private/custom index resolution (--index-url / --extra-index-url / Poetry source / uv index)]] | tasks | draft — research/enhancement, P3, r3 (15 tasks), two critic passes clean (critical→significant→addressed), ready for implementation (issue #513) |
 
 ## Completed Specs
 


### PR DESCRIPTION
## Summary

- requirements.txt `--index-url`/`--extra-index-url`, Poetry `[[tool.poetry.source]]`, and uv `[tool.uv.index]`/`[tool.uv.sources]` now resolve dependencies against declared private/custom PyPI indexes instead of only pypi.org, mirroring the existing Cargo (#440/#447) and npm (#510) private-registry pattern.
- `--index-url` replaces the default index; `--extra-index-url` is additive and checked before the implicit pypi.org fallback, never after — this ordering matters for security: checking pypi.org first would leak private package names on every lookup and invert dependency-confusion protection.
- Each declared index resolves once into a fallback chain of registry clients at registration time. A transport failure on any hop halts resolution for that file rather than silently falling through to pypi.org for a package that may not be intended to be public; the halt now reaches hover/diagnostics via a new, purely-additive `DepsError::ChainResolutionHalted` variant instead of only a log line.
- Credential userinfo (`user:pass@`) is redacted before any log or stored diagnostic.
- Reuses `DependencySource::AlternateRegistry`/`CustomRegistry`, `Registry::get_versions_from`/`get_latest_matching_from`, `EcosystemFormatter`'s `SourcePolicy`/`PackageRendering` traits, and `net_policy`'s SSRF gate exactly as already shipped for Cargo/npm — no other `deps-core` trait surface changes.
- Full SDD package (`specs/033-pypi-private-index-support/{spec,plan,tasks}.md`) documents the design, including two adversarial-critic rounds against the pre-implementation design and the resolution-order rationale.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (3728 passed, 49 skipped)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links --deny warnings" cargo doc --no-deps --workspace --all-features`
- [x] Live verification against `test.pypi.org` as a real HTTPS private-index stand-in (all fixtures resolved correctly, zero contact with pypi.org)
- [x] Formal code review (two rounds: initial + re-review after rebasing onto #514/#515), both approved

Closes #513