### PR TITLE
test(deps-gradle): cover parens-no-version dependency pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-gradle**: simplified regex caching from `OnceLock` + wrapper functions to `LazyLock<Regex>`, matching the `deps-swift`/`deps-bundler`/`deps-go` idiom; no behavior change (resolves #511) (#514)
 - **Breaking (pre-1.0, public API)**: **deps-core**: split `EcosystemFormatter` into seven concern-scoped supertraits kept behind the same object-safe bound; downstream code can no longer `impl EcosystemFormatter for X` directly (implement the owning concern trait(s) instead), and calling a method through `&dyn EcosystemFormatter` now requires importing the specific trait that declares it (resolves #512) (#515)
 - **Breaking (pre-1.0, public API)**: **deps-core, deps-cargo, deps-npm, deps-pypi**: deduplicated the three ecosystems' near-identical index-URL validation into a shared `deps_core::net_policy::validate_index_url`; `deps_cargo::config::RegistryIndexError` and `deps_pypi::config::PypiIndexUrlError` are now aliases of the new `deps_core::net_policy::IndexUrlError` (resolves #518) (#520)
+- **deps-gradle**: added a dedicated unit test for the parens-no-version dependency pattern (`RE_NO_VERSION_WITH_PARENS`); no behavior change (resolves #517)
 
 ### Fixed
 - **deps-github-actions**: a tags-API page with one entry missing/malformed `commit.sha` no longer aborts the whole page's parse and silently truncates later pages — only that entry is now skipped (side effect of the #472 GitHub-tags-client extraction) (#476)

--- a/crates/deps-gradle/src/parser/groovy.rs
+++ b/crates/deps-gradle/src/parser/groovy.rs
@@ -267,6 +267,19 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_no_version_with_parens() {
+        let content = "dependencies {\n    implementation('com.example:lib')\n}\n";
+        let result = parse_groovy_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name, "com.example:lib");
+        assert!(dep.version_req.is_none());
+        assert!(dep.version_range.is_none());
+        assert_eq!(dep.name_range.start.line, 1);
+        assert_eq!(dep.name_range.start.character, 20);
+    }
+
+    #[test]
     fn test_empty_block() {
         let content = "dependencies {\n}\n";
         let result = parse_groovy_dsl(content, &make_uri()).unwrap();


### PR DESCRIPTION
## Summary
- Adds `test_parse_no_version_with_parens` to `crates/deps-gradle/src/parser/groovy.rs`, covering the "Pattern 3: with parens, no version" branch (`RE_NO_VERSION_WITH_PARENS`)
- The existing `test_parse_with_parens` only covered the 3-part `group:artifact:version` parens form (Pattern 2); the 2-part `group:artifact` parens form was untested
- Asserts `name`, `name_range`, `version_req: None`, and `version_range: None` for `implementation('com.example:lib')`, using an asymmetric group/artifact pair so a transposition bug would be caught, and pinning `name_range` since it's the field whose value actually shifts between the parens and non-parens forms

No behavior change — test-only.

Closes #517

## Test plan
- [x] `cargo nextest run -p deps-gradle --all-features` (141 passed)
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`