### PR TITLE
fix(deps-gradle): allow whitespace before parens in Groovy DSL dependency declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-gradle**: added a dedicated unit test for the parens-no-version dependency pattern (`RE_NO_VERSION_WITH_PARENS`); no behavior change (resolves #517)
 
 ### Fixed
-- **deps-gradle**: a Groovy DSL dependency declaration with whitespace before the opening paren (e.g. `implementation ('junit:junit:4.13.2')`) is no longer silently dropped (resolves #525)
+- **deps-gradle**: a Groovy DSL dependency declaration with whitespace before the opening paren (e.g. `implementation ('junit:junit:4.13.2')`) is no longer silently dropped (resolves #525) (#527)
 - **deps-github-actions**: a tags-API page with one entry missing/malformed `commit.sha` no longer aborts the whole page's parse and silently truncates later pages — only that entry is now skipped (side effect of the #472 GitHub-tags-client extraction) (#476)
 - **deps-core, deps-lsp**: the "requirement satisfiable only by a yanked version" diagnostic no longer lets a co-occurring package-level deprecation finding hide a genuine hard yank (resolves #437) (#438)
 - **deps-deno, deps-npm**: an exact-pin `npm:` dependency in `deno.json` no longer surfaces the yanked-worded diagnostic, matching the equivalent `package.json` dependency's post-#436 behavior; `jsr:` specifiers are unaffected (resolves #448)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-gradle**: added a dedicated unit test for the parens-no-version dependency pattern (`RE_NO_VERSION_WITH_PARENS`); no behavior change (resolves #517)
 
 ### Fixed
+- **deps-gradle**: a Groovy DSL dependency declaration with whitespace before the opening paren (e.g. `implementation ('junit:junit:4.13.2')`) is no longer silently dropped (resolves #525)
 - **deps-github-actions**: a tags-API page with one entry missing/malformed `commit.sha` no longer aborts the whole page's parse and silently truncates later pages — only that entry is now skipped (side effect of the #472 GitHub-tags-client extraction) (#476)
 - **deps-core, deps-lsp**: the "requirement satisfiable only by a yanked version" diagnostic no longer lets a co-occurring package-level deprecation finding hide a genuine hard yank (resolves #437) (#438)
 - **deps-deno, deps-npm**: an exact-pin `npm:` dependency in `deno.json` no longer surfaces the yanked-worded diagnostic, matching the equivalent `package.json` dependency's post-#436 behavior; `jsr:` specifiers are unaffected (resolves #448)

--- a/crates/deps-gradle/src/parser/groovy.rs
+++ b/crates/deps-gradle/src/parser/groovy.rs
@@ -10,8 +10,9 @@ use std::sync::LazyLock;
 use tower_lsp_server::ls_types::Uri;
 
 /// Matches: implementation('group:artifact:version') or implementation("group:artifact:version")
+/// (optional whitespace between the configuration word and the opening paren)
 static RE_WITH_PARENS: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(\w+)\(\s*['"]([^:'"]+):([^:'"]+):([^'"]+)['"]\s*\)"#).expect("RE_WITH_PARENS")
+    Regex::new(r#"(\w+)\s*\(\s*['"]([^:'"]+):([^:'"]+):([^'"]+)['"]\s*\)"#).expect("RE_WITH_PARENS")
 });
 /// Matches: implementation 'group:artifact:version' or implementation "group:artifact:version"
 static RE_WITHOUT_PARENS: LazyLock<Regex> = LazyLock::new(|| {
@@ -22,8 +23,10 @@ static RE_NO_VERSION_WITHOUT_PARENS: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"(\w+)\s+['"]([^:'"]+):([^:'"]+)['"]"#).expect("RE_NO_VERSION_WITHOUT_PARENS")
 });
 /// Matches: implementation('group:artifact') (no version, with parens)
+/// (optional whitespace between the configuration word and the opening paren)
 static RE_NO_VERSION_WITH_PARENS: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(\w+)\(\s*['"]([^:'"]+):([^:'"]+)['"]\s*\)"#).expect("RE_NO_VERSION_WITH_PARENS")
+    Regex::new(r#"(\w+)\s*\(\s*['"]([^:'"]+):([^:'"]+)['"]\s*\)"#)
+        .expect("RE_NO_VERSION_WITH_PARENS")
 });
 
 const CONFIGURATIONS: &[&str] = &[
@@ -301,5 +304,23 @@ mod tests {
         let content = "apply plugin: 'java'\n";
         let result = parse_groovy_dsl(content, &make_uri()).unwrap();
         assert!(result.dependencies.is_empty());
+    }
+
+    #[test]
+    fn test_parse_with_parens_whitespace_no_version() {
+        let content = "dependencies {\n    implementation ('junit:junit')\n}\n";
+        let result = parse_groovy_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].name, "junit:junit");
+        assert!(result.dependencies[0].version_req.is_none());
+    }
+
+    #[test]
+    fn test_parse_with_parens_whitespace_with_version() {
+        let content = "dependencies {\n    implementation ('junit:junit:4.13.2')\n}\n";
+        let result = parse_groovy_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].name, "junit:junit");
+        assert_eq!(result.dependencies[0].version_req, Some("4.13.2".into()));
     }
 }


### PR DESCRIPTION
## Summary
- `RE_WITH_PARENS`/`RE_NO_VERSION_WITH_PARENS` in `crates/deps-gradle/src/parser/groovy.rs` required the opening paren to immediately follow the configuration word, silently dropping declarations such as `implementation ('junit:junit:4.13.2')`.
- Widened both regexes to allow optional whitespace between the configuration word and the opening paren (`(\w+)\(` -> `(\w+)\s*\(`).
- Added regression tests for the no-version and with-version parens forms with a leading space.

Filed `#526` as a follow-up: `crates/deps-gradle/src/parser/kotlin.rs` carries the identical unfixed pattern for the Kotlin DSL parser (`build.gradle.kts`); out of scope for this issue, which is specifically about the Groovy DSL parser.

Closes #525

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (3640 passed)
- [x] New regression tests cover both issue repro cases