### PR TITLE
fix(deps-core,deps-npm,deps-pypi,deps-cargo): redact userinfo before validation-failure output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-lsp**: a client that never answers `workspace/applyEdit` for `deps-lsp.updateVersion` or `deps-lsp.updateAllOutdated` no longer permanently occupies a `workspace/executeCommand` concurrency slot; the request is now timeout-bounded (5s), same as #493's fix (resolves #496) (#498)
 - **deps-lsp**: `cold_start.rate_limit_ms` now actually rate-limits cold starts instead of being parsed and silently ignored in favor of a hardcoded 100ms interval (resolves #499) (#504)
 - **deps-github-actions**: resolve SHA-pin quickfix never firing for bare-major moving GitHub Actions tags (v3, v4) (resolves #503)
-- **deps-core, deps-npm, deps-pypi, deps-cargo**: a literal userinfo credential in a registry/index config value (e.g. `.npmrc` `registry=https://user:pass@host/`) no longer leaks into `tracing::warn!` logs or `InvalidEntry`/error-surfaced text on validation failure, including when the value also fails to parse as a URL (resolves #522)
+- **deps-core, deps-npm, deps-pypi, deps-cargo**: a literal userinfo credential in a registry/index config value (e.g. `.npmrc` `registry=https://user:pass@host/`) no longer leaks into `tracing::warn!` logs or `InvalidEntry`/error-surfaced text on validation failure, including when the value also fails to parse as a URL (resolves #522) (#529)
 - **deps-core, deps-github-actions**: hover no longer shows the "Press Cmd+. to update version" footer for a dependency with no actual data or code action while `network.offline` is set (resolves #501) (#506)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-lsp**: a client that never answers `workspace/applyEdit` for `deps-lsp.updateVersion` or `deps-lsp.updateAllOutdated` no longer permanently occupies a `workspace/executeCommand` concurrency slot; the request is now timeout-bounded (5s), same as #493's fix (resolves #496) (#498)
 - **deps-lsp**: `cold_start.rate_limit_ms` now actually rate-limits cold starts instead of being parsed and silently ignored in favor of a hardcoded 100ms interval (resolves #499) (#504)
 - **deps-github-actions**: resolve SHA-pin quickfix never firing for bare-major moving GitHub Actions tags (v3, v4) (resolves #503)
+- **deps-core, deps-npm, deps-pypi, deps-cargo**: a literal userinfo credential in a registry/index config value (e.g. `.npmrc` `registry=https://user:pass@host/`) no longer leaks into `tracing::warn!` logs or `InvalidEntry`/error-surfaced text on validation failure, including when the value also fails to parse as a URL (resolves #522)
 - **deps-core, deps-github-actions**: hover no longer shows the "Press Cmd+. to update version" footer for a dependency with no actual data or code action while `network.offline` is set (resolves #501) (#506)
 
 ### Removed

--- a/crates/deps-cargo/src/config.rs
+++ b/crates/deps-cargo/src/config.rs
@@ -1193,6 +1193,25 @@ mod tests {
         ));
     }
 
+    /// S1: a userinfo-bearing `index = "…"` value that also fails `Url::parse` for an
+    /// unrelated reason (an invalid port here) lands in `RegistryIndexError::InvalidUrl`, not
+    /// `UserInfoPresent` — every call site here logs this error via `tracing::warn!(alias,
+    /// %error, …)`, so the credential must never survive into `InvalidUrl`'s payload or its
+    /// `Display`. Fixed once inside `deps_core::net_policy::validate_index_url`, which every
+    /// `RegistryIndex::new` call routes through — no separate redaction needed here.
+    #[test]
+    fn test_registry_index_invalid_url_error_redacts_userinfo() {
+        let policy = all_policy();
+        let err = RegistryIndex::new(
+            "https://user:hunter2@index.mycorp.dev:99999",
+            IndexTrust::Trusted,
+            &policy,
+        )
+        .unwrap_err();
+        assert!(matches!(err, RegistryIndexError::InvalidUrl(_)));
+        assert!(!err.to_string().contains("hunter2"), "Display: {err}");
+    }
+
     #[test]
     fn test_registry_index_accepts_https_without_sparse_prefix() {
         let policy = all_policy();

--- a/crates/deps-core/src/net_policy.rs
+++ b/crates/deps-core/src/net_policy.rs
@@ -436,6 +436,76 @@ pub enum PolicyGate<'a> {
     Enforce(&'a RegistryAccessPolicy),
 }
 
+/// Replaces any embedded `user:pass@`/`user@` userinfo component in `raw` with a fixed
+/// `***@` marker, for a caller to log or retain instead of the raw credential-bearing value.
+///
+/// A userinfo-bearing index URL is always rejected ([`IndexUrlError::UserInfoPresent`]), but
+/// the *raw* value naming what was rejected must never itself carry the credential through to
+/// a `tracing::warn!` line or an `InvalidEntry`-shaped struct's `raw` field a user might see
+/// surfaced as `DependencySource::CustomRegistry`'s `url` in hover/diagnostics text. A fixed
+/// marker (rather than stripping the component outright) keeps the redacted value visibly
+/// distinct from a URL that never carried userinfo at all, so a user can still tell *that* a
+/// credential was present and removed, without ever seeing what it was. Shared by
+/// `deps-npm`'s and `deps-pypi`'s `resolve_entry` (M1 fix).
+///
+/// `raw` failing [`url::Url::parse`] is not proof it carries no userinfo (S1 finding) — an
+/// otherwise-valid `user:pass@host` can still fail to parse for a reason unrelated to the
+/// userinfo component itself (an invalid port, a malformed IPv6 literal, a non-ASCII host), so
+/// this falls back to a parse-independent redaction rather than returning `raw` untouched.
+/// Returns `raw` unchanged only when neither path finds anything shaped like userinfo to
+/// redact — a value with no `://` at all, or one whose authority carries no `@`.
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::net_policy::redact_userinfo;
+///
+/// assert_eq!(
+///     redact_userinfo("https://user:hunter2@registry.example/simple"),
+///     "https://***@registry.example/simple"
+/// );
+/// assert_eq!(
+///     redact_userinfo("https://registry.example/simple"),
+///     "https://registry.example/simple"
+/// );
+/// ```
+#[must_use]
+pub fn redact_userinfo(raw: &str) -> String {
+    let Ok(mut url) = url::Url::parse(raw) else {
+        return redact_userinfo_unparseable(raw);
+    };
+    if url.username().is_empty() && url.password().is_none() {
+        return raw.to_string();
+    }
+    // `set_username`/`set_password` only fail for a cannot-be-a-base URL — never true here,
+    // since a URL with `username()`/`password()` set is always base-having by construction —
+    // but a hardcoded fallback marker is used instead of ever risking the original,
+    // credential-bearing string leaking through an unexpected `Err` path.
+    if url.set_username("***").is_err() || url.set_password(None).is_err() {
+        return "<redacted: index URL contained userinfo>".to_string();
+    }
+    url.as_str().to_string()
+}
+
+/// [`redact_userinfo`]'s fallback for a `raw` that fails `Url::parse` outright (S1 finding):
+/// locates the `://` scheme separator, then the *last* `@` before the next `/`, `?`, or `#`
+/// (matching how a URL parser resolves multiple unescaped `@`s in the authority — everything
+/// up to it is userinfo, never part of the host), and replaces that whole userinfo span with
+/// `***@`. Returns `raw` unchanged when there is no `://` at all, or no `@` in the authority —
+/// nothing looks like a userinfo component to redact.
+fn redact_userinfo_unparseable(raw: &str) -> String {
+    let Some(scheme_end) = raw.find("://") else {
+        return raw.to_string();
+    };
+    let authority_start = scheme_end + 3;
+    let authority = &raw[authority_start..];
+    let host_boundary = authority.find(['/', '?', '#']).unwrap_or(authority.len());
+    let Some(at) = authority[..host_boundary].rfind('@') else {
+        return raw.to_string();
+    };
+    format!("{}***@{}", &raw[..authority_start], &authority[at + 1..])
+}
+
 /// Whether `url`'s host is loopback (`127.0.0.1`, `localhost`, or `::1`) with an `http`
 /// scheme — the shape every `mockito::Server` binds to.
 ///
@@ -461,6 +531,14 @@ fn is_loopback_url(url: &url::Url) -> bool {
 /// load-bearing: userinfo is rejected *before* the policy gate runs, which is what lets a
 /// caller safely log `raw_for_log` unredacted on a [`IndexUrlError::BlockedHost`] warning,
 /// since a userinfo-bearing candidate can never reach that point. Do not reorder.
+///
+/// [`IndexUrlError::InvalidUrl`] is the one variant this invariant can't cover — `candidate`
+/// failed to parse *before* any userinfo check could run, so `raw_for_log` might still carry
+/// one (S1 finding: an otherwise-valid `user:pass@host` URL can fail to parse for an unrelated
+/// reason, e.g. an invalid port). [`redact_userinfo`] is applied to `raw_for_log` before it is
+/// wrapped in [`IndexUrlError::InvalidUrl`], so every caller — `deps-cargo`, `deps-npm`,
+/// `deps-pypi` — gets this for free, whether or not it separately redacts its own `raw` before
+/// logging.
 ///
 /// # Errors
 ///
@@ -494,7 +572,7 @@ pub fn validate_index_url(
     gate: PolicyGate<'_>,
 ) -> Result<url::Url, IndexUrlError> {
     let url = url::Url::parse(candidate)
-        .map_err(|_| IndexUrlError::InvalidUrl(raw_for_log.to_string()))?;
+        .map_err(|_| IndexUrlError::InvalidUrl(redact_userinfo(raw_for_log)))?;
     let is_https = url.scheme() == "https";
     #[cfg(any(test, feature = "test-util"))]
     let is_https = is_https || is_loopback_url(&url);
@@ -793,5 +871,56 @@ mod tests {
             ),
             Err(IndexUrlError::BlockedHost { .. })
         ));
+    }
+
+    #[test]
+    fn test_redact_userinfo_noop_cases() {
+        assert_eq!(
+            redact_userinfo("https://registry.example/simple"),
+            "https://registry.example/simple"
+        );
+        assert_eq!(redact_userinfo("not-a-valid-url"), "not-a-valid-url");
+    }
+
+    #[test]
+    fn test_redact_userinfo_strips_username_and_password() {
+        let redacted = redact_userinfo("https://user:hunter2@registry.example/simple");
+        assert!(!redacted.contains("hunter2"));
+        assert!(!redacted.contains("user:"));
+        assert_eq!(redacted, "https://***@registry.example/simple");
+    }
+
+    /// S1: an otherwise-userinfo-bearing URL that fails `Url::parse` for an unrelated reason
+    /// (an invalid port here) must still be redacted — `redact_userinfo` cannot rely on
+    /// `Url::parse` succeeding to find the userinfo component.
+    #[test]
+    fn test_redact_userinfo_redacts_unparseable_url_with_userinfo() {
+        let redacted = redact_userinfo("https://user:hunter2@registry.example:99999/simple");
+        assert!(!redacted.contains("hunter2"));
+        assert!(!redacted.contains("user:"));
+        assert_eq!(redacted, "https://***@registry.example:99999/simple");
+    }
+
+    #[test]
+    fn test_redact_userinfo_unparseable_no_userinfo_is_noop() {
+        assert_eq!(
+            redact_userinfo("https://registry.example:99999/simple"),
+            "https://registry.example:99999/simple"
+        );
+    }
+
+    /// S1: `IndexUrlError::InvalidUrl`'s payload is where the leak actually surfaced — every
+    /// caller (`deps-cargo`, `deps-npm`, `deps-pypi`) logs/retains this error's `%error`/
+    /// `Display`, so the redaction must happen inside `validate_index_url` itself, not rely on
+    /// each caller to redact separately.
+    #[test]
+    fn test_validate_index_url_redacts_userinfo_in_invalid_url_error() {
+        let raw = "https://user:hunter2@registry.example:99999/simple";
+        let err = validate_index_url(raw, raw, "cargo", PolicyGate::Skip).unwrap_err();
+        let IndexUrlError::InvalidUrl(redacted) = &err else {
+            panic!("expected InvalidUrl, got {err:?}");
+        };
+        assert!(!redacted.contains("hunter2"), "redacted: {redacted}");
+        assert!(!err.to_string().contains("hunter2"), "Display: {err}");
     }
 }

--- a/crates/deps-npm/src/config.rs
+++ b/crates/deps-npm/src/config.rs
@@ -21,6 +21,13 @@
 //!   in this module for an `_authToken`/`_auth`/`_password`/`_authIdent`/`always-auth`/
 //!   `//host/:_*` value to land in even accidentally. This is a structural guarantee, not a
 //!   runtime filter — verified by this module's own NFR-001 test.
+//! - **A literal `user:pass@`/`user@` written directly in a `registry=`/`@scope:registry=`
+//!   value is redacted before it can leak** (M1 fix, mirroring `deps-pypi`'s own M1). No
+//!   `${VAR}` expansion is needed for this case — a hostile `.npmrc` can write the credential
+//!   straight into the raw value — so `resolve_entry` redacts it (see
+//!   [`deps_core::net_policy::redact_userinfo`]) before it ever reaches a `tracing::warn!`
+//!   call or [`InvalidEntry::raw`], which [`NpmConfig::resolve_source_for`] can surface as
+//!   [`DependencySource::CustomRegistry`]'s `url` in hover/diagnostics text.
 //! - **Internal-network reachability (SSRF-adjacent).** [`NpmRegistryIndex::new`] requires a
 //!   [`deps_core::net_policy::RegistryAccessPolicy`] and checks every candidate against it —
 //!   unlike Cargo's `$CARGO_HOME`-is-trusted split, npm's project and user tiers are
@@ -38,7 +45,7 @@ use std::time::SystemTime;
 
 use deps_core::PackageName;
 use deps_core::net_policy::{
-    HostClass, IndexUrlError, PolicyGate, RegistryAccessPolicy, validate_index_url,
+    HostClass, IndexUrlError, PolicyGate, RegistryAccessPolicy, redact_userinfo, validate_index_url,
 };
 use deps_core::parser::DependencySource;
 
@@ -157,13 +164,14 @@ impl std::fmt::Display for NpmRegistryIndex {
 /// A `registry=`/`@scope:registry=` entry that was present in `.npmrc` but unusable.
 ///
 /// Invalid URL, non-https, an undefined `${VAR}`, or policy-blocked. Carries the raw value
-/// as written (never the expanded form) so [`NpmConfig::resolve_source_for`] can build
+/// as written (never the expanded form, and with any literal userinfo redacted — see
+/// [`deps_core::net_policy::redact_userinfo`]) so [`NpmConfig::resolve_source_for`] can build
 /// [`DependencySource::CustomRegistry`] and so a warning can name what the user actually
 /// wrote, never an expanded-but-rejected value that could leak an environment variable's
-/// contents into the log.
+/// contents into the log, and never a literal credential the user wrote directly in `.npmrc`.
 #[derive(Debug, Clone)]
 pub struct InvalidEntry {
-    /// The raw `.npmrc` value, unexpanded.
+    /// The raw `.npmrc` value, unexpanded, with any literal userinfo redacted.
     pub raw: String,
     /// Why it was rejected.
     pub reason: NpmRegistryIndexError,
@@ -336,27 +344,32 @@ fn expand_env_vars_with(
 /// Expands and validates one raw `.npmrc` value, producing the [`NpmConfig`] entry FR-006's
 /// fail-closed state needs on failure — a `tracing::warn!` naming the **raw**, unexpanded
 /// value either way (an expanded-but-rejected value must never leak an environment
-/// variable's contents into the log).
+/// variable's contents into the log), with any literal `user:pass@`/`user@` userinfo written
+/// directly in that raw value redacted first (M1 fix — see
+/// [`deps_core::net_policy::redact_userinfo`]) — a hostile `.npmrc` can write a credential
+/// straight into `registry=`/`@scope:registry=` with no `${VAR}` expansion involved.
 fn resolve_entry(
     raw: &str,
     policy: &RegistryAccessPolicy,
 ) -> Result<NpmRegistryIndex, InvalidEntry> {
     match expand_env_vars(raw) {
         Ok(expanded) => NpmRegistryIndex::new_for_log(&expanded, raw, policy).map_err(|reason| {
-            tracing::warn!(raw, %reason, "npm registry index failed validation");
+            let redacted = redact_userinfo(raw);
+            tracing::warn!(raw = %redacted, %reason, "npm registry index failed validation");
             InvalidEntry {
-                raw: raw.to_string(),
+                raw: redacted,
                 reason,
             }
         }),
         Err(var) => {
+            let redacted = redact_userinfo(raw);
             tracing::warn!(
-                raw,
+                raw = %redacted,
                 var,
                 "npm registry value references an undefined environment variable"
             );
             Err(InvalidEntry {
-                raw: raw.to_string(),
+                raw: redacted,
                 reason: NpmRegistryIndexError::UndefinedEnvVar(var),
             })
         }
@@ -827,6 +840,71 @@ mod tests {
             NpmRegistryIndexError::InvalidUrl(raw_placeholder.to_string())
         );
         assert!(!err.to_string().contains("super-secret-value"));
+    }
+
+    /// #522: a literal `user:pass@` written directly in `.npmrc` (no `${VAR}` expansion
+    /// involved) must never reach `resolve_entry`'s `tracing::warn!` line or
+    /// `InvalidEntry::raw` unredacted — mirrors `deps-pypi`'s M1 fix test.
+    #[test]
+    fn test_resolve_entry_redacts_literal_userinfo_from_raw_and_log() {
+        let policy = all_policy();
+        let log = deps_core::test_util::capture_tracing_output(|| {
+            let invalid = resolve_entry("https://user:hunter2@npm.example/", &policy).unwrap_err();
+            assert!(matches!(
+                invalid.reason,
+                NpmRegistryIndexError::UserInfoPresent
+            ));
+            assert!(
+                !invalid.raw.contains("hunter2"),
+                "InvalidEntry::raw leaked the credential: {}",
+                invalid.raw
+            );
+            assert!(
+                !invalid.raw.contains("user:"),
+                "InvalidEntry::raw leaked the username: {}",
+                invalid.raw
+            );
+            assert!(
+                invalid.raw.contains("npm.example"),
+                "host should survive redaction"
+            );
+        });
+        assert!(
+            !log.contains("hunter2"),
+            "tracing output leaked the credential: {log:?}"
+        );
+    }
+
+    /// S1: a userinfo-bearing `.npmrc` value that also fails `Url::parse` for an unrelated
+    /// reason (an invalid port here) lands in `NpmRegistryIndexError::InvalidUrl`, not
+    /// `UserInfoPresent` — this is the shape `redact_userinfo`'s original parse-gated no-op
+    /// missed, so the credential must be checked in every channel: `InvalidEntry::raw`, the
+    /// `%reason` `Display`, and the captured log.
+    #[test]
+    fn test_resolve_entry_redacts_literal_userinfo_from_unparseable_raw() {
+        let policy = all_policy();
+        let log = deps_core::test_util::capture_tracing_output(|| {
+            let invalid =
+                resolve_entry("https://user:hunter2@npm.example:99999/", &policy).unwrap_err();
+            assert!(matches!(
+                invalid.reason,
+                NpmRegistryIndexError::InvalidUrl(_)
+            ));
+            assert!(
+                !invalid.raw.contains("hunter2"),
+                "InvalidEntry::raw leaked the credential: {}",
+                invalid.raw
+            );
+            assert!(
+                !invalid.reason.to_string().contains("hunter2"),
+                "reason Display leaked the credential: {}",
+                invalid.reason
+            );
+        });
+        assert!(
+            !log.contains("hunter2"),
+            "tracing output leaked the credential: {log:?}"
+        );
     }
 
     #[test]

--- a/crates/deps-pypi/src/config.rs
+++ b/crates/deps-pypi/src/config.rs
@@ -34,7 +34,9 @@
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
-use deps_core::net_policy::{PolicyGate, RegistryAccessPolicy, validate_index_url};
+use deps_core::net_policy::{
+    PolicyGate, RegistryAccessPolicy, redact_userinfo, validate_index_url,
+};
 use deps_core::parser::DependencySource;
 
 /// Why a candidate index URL failed [`PypiIndexUrl::new`]'s validation.
@@ -98,7 +100,7 @@ impl std::fmt::Display for PypiIndexUrl {
 /// well-formed-but-non-https/userinfo-bearing value.
 ///
 /// Carries the raw value as written, **with any embedded userinfo redacted** (M1 fix — see
-/// `redact_userinfo`), so [`PypiIndexConfig::resolve_source_for`] can build
+/// [`deps_core::net_policy::redact_userinfo`]), so [`PypiIndexConfig::resolve_source_for`] can build
 /// [`DependencySource::CustomRegistry`] for an explicit primary/named source, or log a warning
 /// naming what the user wrote for a dropped extra, without ever holding or surfacing the
 /// credential itself: a `CustomRegistry.url` can reach hover/diagnostics text, and a
@@ -113,40 +115,9 @@ pub struct InvalidEntry {
     pub reason: PypiIndexUrlError,
 }
 
-/// Replaces any embedded `user:pass@`/`user@` userinfo component in `raw` with a fixed
-/// `***@` marker before it is ever logged or stored (M1 fix, FR-011/NFR-001, spec's exact
-/// `https://***@host/path` example).
-///
-/// A userinfo-bearing index URL is always rejected ([`PypiIndexUrlError::UserInfoPresent`]),
-/// but the *raw* value naming what was rejected must never itself carry the credential through
-/// to a `tracing::warn!` line or an [`InvalidEntry::raw`] a user might see surfaced as
-/// [`DependencySource::CustomRegistry`]'s `url` in hover/diagnostics text. A fixed marker
-/// (rather than stripping the component outright) keeps the redacted value visibly distinct
-/// from a URL that never carried userinfo at all, so a user can still tell *that* a credential
-/// was present and removed, without ever seeing what it was.
-///
-/// Returns `raw` unchanged when it doesn't parse as a URL, or parses but carries no userinfo —
-/// there is nothing to redact in either case, so every other [`PypiIndexUrlError`] variant's
-/// `raw` value is unaffected by this function.
-fn redact_userinfo(raw: &str) -> String {
-    let Ok(mut url) = url::Url::parse(raw) else {
-        return raw.to_string();
-    };
-    if url.username().is_empty() && url.password().is_none() {
-        return raw.to_string();
-    }
-    // `set_username`/`set_password` only fail for a cannot-be-a-base URL — never true here,
-    // since a URL with `username()`/`password()` set is always base-having by construction —
-    // but a hardcoded fallback marker is used instead of ever risking the original,
-    // credential-bearing string leaking through an unexpected `Err` path.
-    if url.set_username("***").is_err() || url.set_password(None).is_err() {
-        return "<redacted: index URL contained userinfo>".to_string();
-    }
-    url.as_str().to_string()
-}
-
 /// Validates and normalizes one raw index value, logging a `tracing::warn!` naming the raw
-/// value (userinfo redacted — see [`redact_userinfo`]) on failure. `pub(crate)`: every parser
+/// value (userinfo redacted — see [`deps_core::net_policy::redact_userinfo`]) on failure.
+/// `pub(crate)`: every parser
 /// surface (`requirements.rs`, `pyproject.rs`) that discovers a candidate index value calls
 /// this before handing the result to a [`PypiIndexConfig`] setter.
 pub(crate) fn resolve_entry(
@@ -829,7 +800,10 @@ mod tests {
     }
 
     /// [`redact_userinfo`] is a no-op for a value with no userinfo component (the common
-    /// case), and for a value that doesn't even parse as a URL (nothing to redact from).
+    /// case), and for `"not-a-valid-url"` specifically — no `://` at all, so there is no
+    /// authority for even the parse-independent fallback to inspect (see
+    /// `deps_core::net_policy`'s own `test_redact_userinfo_redacts_unparseable_url_with_userinfo`
+    /// for the case where an unparseable value *does* still carry userinfo).
     #[test]
     fn test_redact_userinfo_noop_cases() {
         assert_eq!(
@@ -847,5 +821,33 @@ mod tests {
         // Spec's exact example format: a fixed `***@` marker, not a bare stripped host — this
         // keeps a redacted value visibly distinct from a URL that never carried userinfo.
         assert_eq!(redacted, "https://***@pypi.example/simple");
+    }
+
+    /// S1: a userinfo-bearing index value that also fails `Url::parse` for an unrelated reason
+    /// (an invalid port here) lands in `PypiIndexUrlError::InvalidUrl`, not `UserInfoPresent` —
+    /// the shape `redact_userinfo`'s original parse-gated no-op missed. Checks every channel:
+    /// `InvalidEntry::raw`, the `%reason` `Display`, and the captured log.
+    #[test]
+    fn test_resolve_entry_redacts_literal_userinfo_from_unparseable_raw() {
+        let policy = all_policy();
+        let log = deps_core::test_util::capture_tracing_output(|| {
+            let invalid = resolve_entry("https://user:hunter2@pypi.example:99999/simple", &policy)
+                .unwrap_err();
+            assert!(matches!(invalid.reason, PypiIndexUrlError::InvalidUrl(_)));
+            assert!(
+                !invalid.raw.contains("hunter2"),
+                "InvalidEntry::raw leaked the credential: {}",
+                invalid.raw
+            );
+            assert!(
+                !invalid.reason.to_string().contains("hunter2"),
+                "reason Display leaked the credential: {}",
+                invalid.reason
+            );
+        });
+        assert!(
+            !log.contains("hunter2"),
+            "tracing output leaked the credential: {log:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- deps-npm's `.npmrc` config resolver logged and retained the raw registry index URL, including any literal `user:pass@` credential, when `validate_index_url` rejected it — the module's own security-model doc only covered the `${VAR}`-expansion leak case, not a credential written literally in the raw value
- deps-pypi already redacted this on its happy path via a local `redact_userinfo`, but the fix was never ported to deps-npm; neither crate redacted the `InvalidUrl` (unparseable-URL) error variant, which embeds the raw string in its `Display` regardless of the parseable-case redaction
- Promoted `redact_userinfo` to `deps_core::net_policy` and applied it inside `validate_index_url` itself, at the single shared construction site for both the userinfo-rejected and unparseable-URL error variants — this closes the leak for deps-cargo, deps-npm, and deps-pypi at once with no per-ecosystem call-site duplication
- Added regression tests across all four crates covering both leak channels (the raw field and the reason/error/`Display` channel) for both the parseable-but-rejected and unparseable-URL cases

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (3646 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --workspace --no-deps --all-features` (CI-matching command)
- [x] New regression tests fail against pre-fix code (verified during review) and pass now, in deps-core, deps-npm, deps-pypi, deps-cargo

Closes #522