### PR TITLE
fix(deps-gradle): allow whitespace before parens in Kotlin DSL dependency declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **deps-gradle**: a Groovy DSL dependency declaration with whitespace before the opening paren (e.g. `implementation ('junit:junit:4.13.2')`) is no longer silently dropped (resolves #525) (#527)
+- **deps-gradle**: a Kotlin DSL dependency declaration with whitespace before the opening paren (e.g. `implementation ("junit:junit:4.13.2")`) is no longer silently dropped, matching the Groovy DSL fix (resolves #526)
 - **deps-github-actions**: a tags-API page with one entry missing/malformed `commit.sha` no longer aborts the whole page's parse and silently truncates later pages — only that entry is now skipped (side effect of the #472 GitHub-tags-client extraction) (#476)
 - **deps-core, deps-lsp**: the "requirement satisfiable only by a yanked version" diagnostic no longer lets a co-occurring package-level deprecation finding hide a genuine hard yank (resolves #437) (#438)
 - **deps-deno, deps-npm**: an exact-pin `npm:` dependency in `deno.json` no longer surfaces the yanked-worded diagnostic, matching the equivalent `package.json` dependency's post-#436 behavior; `jsr:` specifiers are unaffected (resolves #448)

--- a/crates/deps-gradle/src/parser/kotlin.rs
+++ b/crates/deps-gradle/src/parser/kotlin.rs
@@ -10,12 +10,14 @@ use std::sync::LazyLock;
 use tower_lsp_server::ls_types::Uri;
 
 /// Matches: implementation("group:artifact:version")
+/// (optional whitespace between the configuration word and the opening paren)
 static RE_WITH_VERSION: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(\w+)\(\s*"([^:"\s]+):([^:"\s]+):([^"]+)"\s*\)"#).expect("RE_WITH_VERSION")
+    Regex::new(r#"(\w+)\s*\(\s*"([^:"\s]+):([^:"\s]+):([^"]+)"\s*\)"#).expect("RE_WITH_VERSION")
 });
 /// Matches: implementation("group:artifact") — no version
+/// (optional whitespace between the configuration word and the opening paren)
 static RE_NO_VERSION: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(\w+)\(\s*"([^:"\s]+):([^:"\s"]+)"\s*\)"#).expect("RE_NO_VERSION")
+    Regex::new(r#"(\w+)\s*\(\s*"([^:"\s]+):([^:"\s]+)"\s*\)"#).expect("RE_NO_VERSION")
 });
 
 const CONFIGURATIONS: &[&str] = &[
@@ -222,6 +224,57 @@ mod tests {
     #[test]
     fn test_no_dependencies_block() {
         let content = "plugins {\n    id(\"java\")\n}\n";
+        let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
+        assert!(result.dependencies.is_empty());
+    }
+
+    #[test]
+    fn test_parse_with_parens_whitespace_no_version() {
+        let content = "dependencies {\n    implementation (\"junit:junit\")\n}\n";
+        let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].name, "junit:junit");
+        assert!(result.dependencies[0].version_req.is_none());
+    }
+
+    #[test]
+    fn test_parse_with_parens_whitespace_with_version() {
+        let content = "dependencies {\n    implementation (\"junit:junit:4.13.2\")\n}\n";
+        let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].name, "junit:junit");
+        assert_eq!(result.dependencies[0].version_req, Some("4.13.2".into()));
+    }
+
+    #[test]
+    fn test_parse_with_parens_multiple_spaces_and_tab() {
+        let content = "dependencies {\n    implementation   (\"junit:junit:4.13.2\")\n    api\t(\"a:b:1.0\")\n}\n";
+        let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 2);
+        assert_eq!(result.dependencies[0].name, "junit:junit");
+        assert_eq!(result.dependencies[1].name, "a:b");
+    }
+
+    #[test]
+    fn test_parse_test_implementation_with_parens_whitespace() {
+        let content = "dependencies {\n    testImplementation (\"junit:junit:4.13.2\")\n}\n";
+        let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].configuration, "testImplementation");
+    }
+
+    #[test]
+    fn test_parens_whitespace_no_false_positive_on_nested_calls() {
+        // Nested-call forms (BOM platform imports, project/module refs, catalog
+        // accessors) are not plain "group:artifact[:version]" string literals,
+        // so they must stay unparsed even with whitespace before the parens.
+        let content = r#"dependencies {
+    implementation (platform("org.springframework.boot:spring-boot-dependencies:3.2.0"))
+    implementation (project(":core"))
+    implementation (libs.junit)
+    implementation (kotlin("stdlib"))
+}
+"#;
         let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
         assert!(result.dependencies.is_empty());
     }


### PR DESCRIPTION
## Summary
- `RE_WITH_VERSION` and `RE_NO_VERSION` in the Kotlin DSL parser required the opening paren to immediately follow the configuration word, silently dropping declarations like `implementation ("junit:junit:4.13.2")`.
- Widens both regexes from `(\w+)\(` to `(\w+)\s*\(`, mirroring the Groovy DSL fix in #527 (same bug class, same root cause).
- Drive-by: fixes a duplicated quote in `RE_NO_VERSION`'s character class (`[^:"\s"]` -> `[^:"\s]`); behavior-neutral (duplicate member in a negated class).

## Testing
- Added regression tests for whitespace before parens (no-version and with-version forms), plus coverage for multi-space/tab before the paren, `testImplementation` with whitespace, and false-positive guards against nested calls (`platform(...)`, `project(":core")`, `libs.junit`, `kotlin("stdlib")`).
- `cargo nextest run --workspace --all-features --no-fail-fast`: 3738 passed, 0 failed.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- `cargo +nightly fmt --all -- --check`: clean.
- Rustdoc gate (`RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`) fails on a pre-existing unrelated broken intra-doc link in `deps-npm` (from #510, `crates/deps-npm/src/registry.rs`), confirmed via `git blame` — not introduced by this change.

Closes #526