### PR TITLE
fix(deps-gradle): surface platform()/enforcedPlatform() BOM dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **deps-gradle**: a Groovy DSL dependency declaration with whitespace before the opening paren (e.g. `implementation ('junit:junit:4.13.2')`) is no longer silently dropped (resolves #525) (#527)
 - **deps-gradle**: a Kotlin DSL dependency declaration with whitespace before the opening paren (e.g. `implementation ("junit:junit:4.13.2")`) is no longer silently dropped, matching the Groovy DSL fix (resolves #526)
+- **deps-gradle**: `platform(...)`/`enforcedPlatform(...)`-wrapped BOM dependency coordinates (e.g. `implementation(platform("org.springframework.boot:spring-boot-dependencies:3.2.0"))`) are no longer silently dropped in Groovy and Kotlin DSL parsing (resolves #531)
 - **deps-github-actions**: a tags-API page with one entry missing/malformed `commit.sha` no longer aborts the whole page's parse and silently truncates later pages — only that entry is now skipped (side effect of the #472 GitHub-tags-client extraction) (#476)
 - **deps-core, deps-lsp**: the "requirement satisfiable only by a yanked version" diagnostic no longer lets a co-occurring package-level deprecation finding hide a genuine hard yank (resolves #437) (#438)
 - **deps-deno, deps-npm**: an exact-pin `npm:` dependency in `deno.json` no longer surfaces the yanked-worded diagnostic, matching the equivalent `package.json` dependency's post-#436 behavior; `jsr:` specifiers are unaffected (resolves #448)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **deps-gradle**: a Groovy DSL dependency declaration with whitespace before the opening paren (e.g. `implementation ('junit:junit:4.13.2')`) is no longer silently dropped (resolves #525) (#527)
 - **deps-gradle**: a Kotlin DSL dependency declaration with whitespace before the opening paren (e.g. `implementation ("junit:junit:4.13.2")`) is no longer silently dropped, matching the Groovy DSL fix (resolves #526)
-- **deps-gradle**: `platform(...)`/`enforcedPlatform(...)`-wrapped BOM dependency coordinates (e.g. `implementation(platform("org.springframework.boot:spring-boot-dependencies:3.2.0"))`) are no longer silently dropped in Groovy and Kotlin DSL parsing (resolves #531)
+- **deps-gradle**: `platform(...)`/`enforcedPlatform(...)`-wrapped BOM dependency coordinates (e.g. `implementation(platform("org.springframework.boot:spring-boot-dependencies:3.2.0"))`) are no longer silently dropped in Groovy and Kotlin DSL parsing (resolves #531) (#532)
 - **deps-github-actions**: a tags-API page with one entry missing/malformed `commit.sha` no longer aborts the whole page's parse and silently truncates later pages — only that entry is now skipped (side effect of the #472 GitHub-tags-client extraction) (#476)
 - **deps-core, deps-lsp**: the "requirement satisfiable only by a yanked version" diagnostic no longer lets a co-occurring package-level deprecation finding hide a genuine hard yank (resolves #437) (#438)
 - **deps-deno, deps-npm**: an exact-pin `npm:` dependency in `deno.json` no longer surfaces the yanked-worded diagnostic, matching the equivalent `package.json` dependency's post-#436 behavior; `jsr:` specifiers are unaffected (resolves #448)

--- a/crates/deps-gradle/src/parser/groovy.rs
+++ b/crates/deps-gradle/src/parser/groovy.rs
@@ -28,6 +28,30 @@ static RE_NO_VERSION_WITH_PARENS: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"(\w+)\s*\(\s*['"]([^:'"]+):([^:'"]+)['"]\s*\)"#)
         .expect("RE_NO_VERSION_WITH_PARENS")
 });
+/// Matches: implementation(platform('group:artifact:version')) / enforcedPlatform(...)
+static RE_PLATFORM_WITH_PARENS: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(\w+)\s*\(\s*(?:platform|enforcedPlatform)\s*\(\s*['"]([^:'"]+):([^:'"]+):([^'"]+)['"]\s*\)\s*\)"#,
+    )
+    .expect("RE_PLATFORM_WITH_PARENS")
+});
+/// Matches: implementation platform('group:artifact:version') (no parens around the configuration call)
+static RE_PLATFORM_WITHOUT_PARENS: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(\w+)\s+(?:platform|enforcedPlatform)\s*\(\s*['"]([^:'"]+):([^:'"]+):([^'"]+)['"]\s*\)"#,
+    )
+    .expect("RE_PLATFORM_WITHOUT_PARENS")
+});
+/// Same as RE_PLATFORM_WITH_PARENS, no version
+static RE_PLATFORM_NO_VERSION_WITH_PARENS: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(\w+)\s*\(\s*(?:platform|enforcedPlatform)\s*\(\s*['"]([^:'"]+):([^:'"]+)['"]\s*\)\s*\)"#)
+        .expect("RE_PLATFORM_NO_VERSION_WITH_PARENS")
+});
+/// Same as RE_PLATFORM_WITHOUT_PARENS, no version
+static RE_PLATFORM_NO_VERSION_WITHOUT_PARENS: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(\w+)\s+(?:platform|enforcedPlatform)\s*\(\s*['"]([^:'"]+):([^:'"]+)['"]\s*\)"#)
+        .expect("RE_PLATFORM_NO_VERSION_WITHOUT_PARENS")
+});
 
 const CONFIGURATIONS: &[&str] = &[
     "implementation",
@@ -196,6 +220,120 @@ pub fn parse_groovy_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
                 configuration: config.to_string(),
             });
         }
+
+        // Pattern 5: platform()/enforcedPlatform()-wrapped BOM coordinate, with parens, with version
+        for caps in RE_PLATFORM_WITH_PARENS.captures_iter(line) {
+            let config = caps.get(1).map_or("", |m| m.as_str());
+            if !CONFIGURATIONS.contains(&config) {
+                continue;
+            }
+            let start = caps.get(0).map_or(0, |m| m.start());
+            matched_positions.push(start);
+
+            let group_id = caps.get(2).map_or("", |m| m.as_str()).to_string();
+            let artifact_id = caps.get(3).map_or("", |m| m.as_str()).to_string();
+            let version = caps.get(4).map_or("", |m| m.as_str()).trim().to_string();
+            let name = format!("{group_id}:{artifact_id}");
+
+            let name_range = find_name_range(line, line_u32, &group_id, &artifact_id);
+            let version_range = find_version_range(line, line_u32, &version);
+
+            dependencies.push(GradleDependency {
+                group_id,
+                artifact_id,
+                name: name.into(),
+                name_range,
+                version_req: Some(version.into()),
+                version_range: Some(version_range),
+                configuration: config.to_string(),
+            });
+        }
+
+        // Pattern 6: same, without parens around the configuration call
+        for caps in RE_PLATFORM_WITHOUT_PARENS.captures_iter(line) {
+            let config = caps.get(1).map_or("", |m| m.as_str());
+            if !CONFIGURATIONS.contains(&config) {
+                continue;
+            }
+            let start = caps.get(0).map_or(0, |m| m.start());
+            if matched_positions.contains(&start) {
+                continue;
+            }
+            matched_positions.push(start);
+
+            let group_id = caps.get(2).map_or("", |m| m.as_str()).to_string();
+            let artifact_id = caps.get(3).map_or("", |m| m.as_str()).to_string();
+            let version = caps.get(4).map_or("", |m| m.as_str()).trim().to_string();
+            let name = format!("{group_id}:{artifact_id}");
+
+            let name_range = find_name_range(line, line_u32, &group_id, &artifact_id);
+            let version_range = find_version_range(line, line_u32, &version);
+
+            dependencies.push(GradleDependency {
+                group_id,
+                artifact_id,
+                name: name.into(),
+                name_range,
+                version_req: Some(version.into()),
+                version_range: Some(version_range),
+                configuration: config.to_string(),
+            });
+        }
+
+        // Pattern 7: platform()/enforcedPlatform()-wrapped BOM coordinate, with parens, no version
+        for caps in RE_PLATFORM_NO_VERSION_WITH_PARENS.captures_iter(line) {
+            let config = caps.get(1).map_or("", |m| m.as_str());
+            if !CONFIGURATIONS.contains(&config) {
+                continue;
+            }
+            let start = caps.get(0).map_or(0, |m| m.start());
+            if matched_positions.contains(&start) {
+                continue;
+            }
+            matched_positions.push(start);
+
+            let group_id = caps.get(2).map_or("", |m| m.as_str()).to_string();
+            let artifact_id = caps.get(3).map_or("", |m| m.as_str()).to_string();
+            let name = format!("{group_id}:{artifact_id}");
+            let name_range = find_name_range(line, line_u32, &group_id, &artifact_id);
+
+            dependencies.push(GradleDependency {
+                group_id,
+                artifact_id,
+                name: name.into(),
+                name_range,
+                version_req: None,
+                version_range: None,
+                configuration: config.to_string(),
+            });
+        }
+
+        // Pattern 8: same, without parens around the configuration call
+        for caps in RE_PLATFORM_NO_VERSION_WITHOUT_PARENS.captures_iter(line) {
+            let config = caps.get(1).map_or("", |m| m.as_str());
+            if !CONFIGURATIONS.contains(&config) {
+                continue;
+            }
+            let start = caps.get(0).map_or(0, |m| m.start());
+            if matched_positions.contains(&start) {
+                continue;
+            }
+
+            let group_id = caps.get(2).map_or("", |m| m.as_str()).to_string();
+            let artifact_id = caps.get(3).map_or("", |m| m.as_str()).to_string();
+            let name = format!("{group_id}:{artifact_id}");
+            let name_range = find_name_range(line, line_u32, &group_id, &artifact_id);
+
+            dependencies.push(GradleDependency {
+                group_id,
+                artifact_id,
+                name: name.into(),
+                name_range,
+                version_req: None,
+                version_range: None,
+                configuration: config.to_string(),
+            });
+        }
     }
 
     Ok(GradleParseResult {
@@ -322,5 +460,78 @@ mod tests {
         assert_eq!(result.dependencies.len(), 1);
         assert_eq!(result.dependencies[0].name, "junit:junit");
         assert_eq!(result.dependencies[0].version_req, Some("4.13.2".into()));
+    }
+
+    #[test]
+    fn test_platform_bare_call_with_version() {
+        let content = "dependencies {\n    implementation platform('org.springframework.boot:spring-boot-dependencies:3.2.0')\n}\n";
+        let result = parse_groovy_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(
+            result.dependencies[0].name,
+            "org.springframework.boot:spring-boot-dependencies"
+        );
+        assert_eq!(result.dependencies[0].version_req, Some("3.2.0".into()));
+        assert_eq!(result.dependencies[0].configuration, "implementation");
+    }
+
+    #[test]
+    fn test_platform_with_parens_with_version() {
+        let content = "dependencies {\n    implementation(platform('org.springframework.boot:spring-boot-dependencies:3.2.0'))\n}\n";
+        let result = parse_groovy_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(
+            result.dependencies[0].name,
+            "org.springframework.boot:spring-boot-dependencies"
+        );
+        assert_eq!(result.dependencies[0].version_req, Some("3.2.0".into()));
+    }
+
+    #[test]
+    fn test_enforced_platform_bare_call() {
+        let content = "dependencies {\n    implementation enforcedPlatform('org.springframework.boot:spring-boot-dependencies:3.2.0')\n}\n";
+        let result = parse_groovy_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(
+            result.dependencies[0].name,
+            "org.springframework.boot:spring-boot-dependencies"
+        );
+        assert_eq!(result.dependencies[0].version_req, Some("3.2.0".into()));
+    }
+
+    #[test]
+    fn test_platform_no_version_with_parens() {
+        let content = "dependencies {\n    implementation(platform('org.springframework.boot:spring-boot-dependencies'))\n}\n";
+        let result = parse_groovy_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(
+            result.dependencies[0].name,
+            "org.springframework.boot:spring-boot-dependencies"
+        );
+        assert!(result.dependencies[0].version_req.is_none());
+    }
+
+    #[test]
+    fn test_platform_no_version_bare_call() {
+        let content = "dependencies {\n    implementation platform('org.springframework.boot:spring-boot-dependencies')\n}\n";
+        let result = parse_groovy_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(
+            result.dependencies[0].name,
+            "org.springframework.boot:spring-boot-dependencies"
+        );
+        assert!(result.dependencies[0].version_req.is_none());
+    }
+
+    #[test]
+    fn test_platform_double_quotes() {
+        let content = "dependencies {\n    implementation platform(\"org.springframework.boot:spring-boot-dependencies:3.2.0\")\n}\n";
+        let result = parse_groovy_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(
+            result.dependencies[0].name,
+            "org.springframework.boot:spring-boot-dependencies"
+        );
+        assert_eq!(result.dependencies[0].version_req, Some("3.2.0".into()));
     }
 }

--- a/crates/deps-gradle/src/parser/kotlin.rs
+++ b/crates/deps-gradle/src/parser/kotlin.rs
@@ -19,6 +19,18 @@ static RE_WITH_VERSION: LazyLock<Regex> = LazyLock::new(|| {
 static RE_NO_VERSION: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"(\w+)\s*\(\s*"([^:"\s]+):([^:"\s]+)"\s*\)"#).expect("RE_NO_VERSION")
 });
+/// Matches: implementation(platform("group:artifact:version")) / enforcedPlatform(...)
+static RE_PLATFORM_WITH_VERSION: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(\w+)\s*\(\s*(?:platform|enforcedPlatform)\s*\(\s*"([^:"\s]+):([^:"\s]+):([^"]+)"\s*\)\s*\)"#)
+        .expect("RE_PLATFORM_WITH_VERSION")
+});
+/// Matches: implementation(platform("group:artifact")) — no version
+static RE_PLATFORM_NO_VERSION: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(\w+)\s*\(\s*(?:platform|enforcedPlatform)\s*\(\s*"([^:"\s]+):([^:"\s]+)"\s*\)\s*\)"#,
+    )
+    .expect("RE_PLATFORM_NO_VERSION")
+});
 
 const CONFIGURATIONS: &[&str] = &[
     "implementation",
@@ -120,6 +132,68 @@ pub fn parse_kotlin_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
             // Skip if this match overlaps with a versioned match
             let match_start = caps.get(0).map_or(0, |m| m.start());
             if already_matched.contains(&match_start) {
+                continue;
+            }
+
+            let group_id = caps.get(2).map_or("", |m| m.as_str()).to_string();
+            let artifact_id = caps.get(3).map_or("", |m| m.as_str()).to_string();
+            let name = format!("{group_id}:{artifact_id}");
+            let name_range = find_name_range(line, line_u32, &group_id, &artifact_id);
+
+            dependencies.push(GradleDependency {
+                group_id,
+                artifact_id,
+                name: name.into(),
+                name_range,
+                version_req: None,
+                version_range: None,
+                configuration: config.to_string(),
+            });
+        }
+
+        // Same as above, for platform()/enforcedPlatform()-wrapped BOM coordinates
+        let already_matched_platform: Vec<_> = RE_PLATFORM_WITH_VERSION
+            .captures_iter(line)
+            .filter_map(|c| {
+                let config = c.get(1)?.as_str();
+                CONFIGURATIONS
+                    .contains(&config)
+                    .then_some(c.get(0)?.start())
+            })
+            .collect();
+
+        for caps in RE_PLATFORM_WITH_VERSION.captures_iter(line) {
+            let config = caps.get(1).map_or("", |m| m.as_str());
+            if !CONFIGURATIONS.contains(&config) {
+                continue;
+            }
+
+            let group_id = caps.get(2).map_or("", |m| m.as_str()).to_string();
+            let artifact_id = caps.get(3).map_or("", |m| m.as_str()).to_string();
+            let version = caps.get(4).map_or("", |m| m.as_str()).trim().to_string();
+            let name = format!("{group_id}:{artifact_id}");
+
+            let name_range = find_name_range(line, line_u32, &group_id, &artifact_id);
+            let version_range = find_version_range(line, line_u32, &version);
+
+            dependencies.push(GradleDependency {
+                group_id,
+                artifact_id,
+                name: name.into(),
+                name_range,
+                version_req: Some(version.into()),
+                version_range: Some(version_range),
+                configuration: config.to_string(),
+            });
+        }
+
+        for caps in RE_PLATFORM_NO_VERSION.captures_iter(line) {
+            let config = caps.get(1).map_or("", |m| m.as_str());
+            if !CONFIGURATIONS.contains(&config) {
+                continue;
+            }
+            let match_start = caps.get(0).map_or(0, |m| m.start());
+            if already_matched_platform.contains(&match_start) {
                 continue;
             }
 
@@ -265,9 +339,10 @@ mod tests {
 
     #[test]
     fn test_parens_whitespace_no_false_positive_on_nested_calls() {
-        // Nested-call forms (BOM platform imports, project/module refs, catalog
-        // accessors) are not plain "group:artifact[:version]" string literals,
-        // so they must stay unparsed even with whitespace before the parens.
+        // platform()/enforcedPlatform() BOM wrappers are surfaced as dependencies.
+        // Other nested-call forms (project/module refs, catalog accessors) are not
+        // plain "group:artifact[:version]" string literals, so they must stay
+        // unparsed even with whitespace before the parens.
         let content = r#"dependencies {
     implementation (platform("org.springframework.boot:spring-boot-dependencies:3.2.0"))
     implementation (project(":core"))
@@ -276,7 +351,68 @@ mod tests {
 }
 "#;
         let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
-        assert!(result.dependencies.is_empty());
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(
+            result.dependencies[0].name,
+            "org.springframework.boot:spring-boot-dependencies"
+        );
+        assert_eq!(result.dependencies[0].version_req, Some("3.2.0".into()));
+    }
+
+    #[test]
+    fn test_platform_with_version() {
+        let content = r#"dependencies {
+    implementation(platform("org.springframework.boot:spring-boot-dependencies:3.2.0"))
+}
+"#;
+        let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(
+            result.dependencies[0].name,
+            "org.springframework.boot:spring-boot-dependencies"
+        );
+        assert_eq!(result.dependencies[0].version_req, Some("3.2.0".into()));
+        assert_eq!(result.dependencies[0].configuration, "implementation");
+    }
+
+    #[test]
+    fn test_platform_no_version() {
+        let content = r#"dependencies {
+    implementation(platform("org.springframework.boot:spring-boot-dependencies"))
+}
+"#;
+        let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(
+            result.dependencies[0].name,
+            "org.springframework.boot:spring-boot-dependencies"
+        );
+        assert!(result.dependencies[0].version_req.is_none());
+    }
+
+    #[test]
+    fn test_enforced_platform_with_version() {
+        let content = r#"dependencies {
+    implementation(enforcedPlatform("org.springframework.boot:spring-boot-dependencies:3.2.0"))
+}
+"#;
+        let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(
+            result.dependencies[0].name,
+            "org.springframework.boot:spring-boot-dependencies"
+        );
+        assert_eq!(result.dependencies[0].version_req, Some("3.2.0".into()));
+    }
+
+    #[test]
+    fn test_platform_whitespace_before_parens() {
+        let content =
+            "dependencies {\n    implementation (platform(\"junit:junit-bom:5.10.0\"))\n}\n";
+        let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].name, "junit:junit-bom");
+        assert_eq!(result.dependencies[0].version_req, Some("5.10.0".into()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Both the Groovy and Kotlin DSL parsers used a `(\w+)\(...\)` regex family that matched the wrapping `platform(...)`/`enforcedPlatform(...)` call itself instead of the outer configuration word (e.g. `implementation`), silently dropping the BOM coordinate inside a call like `implementation(platform("org.springframework.boot:spring-boot-dependencies:3.2.0"))`.
- Added platform/enforcedPlatform-aware regex variants alongside the existing patterns in both `crates/deps-gradle/src/parser/kotlin.rs` and `crates/deps-gradle/src/parser/groovy.rs` so these BOM dependencies are surfaced consistently with any other declaration (same `DependencySource`, name/version ranges, hover/diagnostics/inlay-hints behavior).
- Composes correctly with the existing whitespace-before-parens fix (#525/#526/#530).

Closes #531

## Test plan

- [x] `cargo +nightly fmt -p deps-gradle -- --check`
- [x] `cargo clippy -p deps-gradle --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run -p deps-gradle --all-features` — 158/158 passed (10 new regression tests added covering versioned/unversioned, parenthesized/bare-call, whitespace, single/double quotes, `enforcedPlatform`)
- [x] Adversarial critique pass: 12 regex patterns + `CONFIGURATIONS` filter + dedup mechanisms verified duplicate-free across 37 probed lines; confirmed no double-emit risk
- [x] `CHANGELOG.md` updated under `[Unreleased] > Fixed`