### PR TITLE
fix(deps-composer): strip uppercase V prefix in requirement satisfaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-gradle**: Groovy DSL's eight dependency-pattern matchers consolidated into one shared extraction helper, fixing a latent dedup-bookkeeping gap that skipped `matched_positions` tracking in two of them (resolves #533) (#537)
 
 ### Fixed
+- **deps-composer**: an uppercase-`V`-prefixed version (e.g. `V3.1.0`) now correctly satisfies its declared requirement instead of always failing, matching the existing lowercase-`v` behavior (resolves #534) (#538)
 - **deps-gradle**: a Groovy DSL dependency declaration with whitespace before the opening paren (e.g. `implementation ('junit:junit:4.13.2')`) is no longer silently dropped (resolves #525) (#527)
 - **deps-gradle**: a Kotlin DSL dependency declaration with whitespace before the opening paren (e.g. `implementation ("junit:junit:4.13.2")`) is no longer silently dropped, matching the Groovy DSL fix (resolves #526)
 - **deps-gradle**: `platform(...)`/`enforcedPlatform(...)`-wrapped BOM dependency coordinates (e.g. `implementation(platform("org.springframework.boot:spring-boot-dependencies:3.2.0"))`) are no longer silently dropped in Groovy and Kotlin DSL parsing (resolves #531) (#532)

--- a/crates/deps-composer/src/formatter.rs
+++ b/crates/deps-composer/src/formatter.rs
@@ -139,17 +139,19 @@ impl RequirementResolution for ComposerFormatter {
     /// - `X || Y` — OR combinator
     fn version_satisfies_requirement(&self, version: &ConcreteVersion, requirement: &str) -> bool {
         let version = version.as_str();
-        let version = version.strip_prefix('v').unwrap_or(version);
+        let version = version.strip_prefix(['v', 'V']).unwrap_or(version);
         let requirement = requirement.trim();
-        // Composer's own version parser strips a leading `v` from every version string it
-        // normalizes, tags and constraints alike. Mirroring that only for `version` above
-        // and not here made an exact/wildcard/caret/tilde requirement pinned with a `v`
-        // prefix (e.g. `"v1.2.3"`, `"^v1.2.0"`) never match, since `version` had already
-        // lost its `v` while `requirement` had not. Only strip when it leaves something
-        // behind — a bare `"v"` requirement is not a valid version prefix and must fall
-        // through to the exact/partial match below (which correctly rejects it), rather
-        // than collapsing to `""` and being swallowed by the empty/wildcard guard next.
-        let requirement = match requirement.strip_prefix('v') {
+        // Composer's own version parser strips a leading `v`/`V` from every version string
+        // it normalizes, tags and constraints alike (case-insensitively, per
+        // `VersionParser::normalize()`'s `#^v#i` regex). Mirroring that only for `version`
+        // above and not here made an exact/wildcard/caret/tilde requirement pinned with a
+        // `v`/`V` prefix (e.g. `"v1.2.3"`, `"^v1.2.0"`) never match, since `version` had
+        // already lost its prefix while `requirement` had not. Only strip when it leaves
+        // something behind — a bare `"v"`/`"V"` requirement is not a valid version prefix
+        // and must fall through to the exact/partial match below (which correctly rejects
+        // it), rather than collapsing to `""` and being swallowed by the empty/wildcard
+        // guard next.
+        let requirement = match requirement.strip_prefix(['v', 'V']) {
             Some(rest) if !rest.is_empty() => rest,
             _ => requirement,
         };
@@ -195,13 +197,13 @@ impl RequirementResolution for ComposerFormatter {
 
         // Caret operator
         if let Some(req) = requirement.strip_prefix('^') {
-            let req = req.strip_prefix('v').unwrap_or(req);
+            let req = req.strip_prefix(['v', 'V']).unwrap_or(req);
             return satisfies_caret(version, req);
         }
 
         // Tilde operator — Composer-specific semantics
         if let Some(req) = requirement.strip_prefix('~') {
-            let req = req.strip_prefix('v').unwrap_or(req);
+            let req = req.strip_prefix(['v', 'V']).unwrap_or(req);
             return satisfies_tilde_composer(version, req);
         }
 
@@ -210,32 +212,32 @@ impl RequirementResolution for ComposerFormatter {
         // `split_composer_core_and_suffix`'s qualifier-suffix branch and compare as core `0`.
         if let Some(req) = requirement.strip_prefix(">=") {
             let req = req.trim();
-            let req = req.strip_prefix('v').unwrap_or(req);
+            let req = req.strip_prefix(['v', 'V']).unwrap_or(req);
             return compare_versions(version, req) >= 0;
         }
         if let Some(req) = requirement.strip_prefix("<=") {
             let req = req.trim();
-            let req = req.strip_prefix('v').unwrap_or(req);
+            let req = req.strip_prefix(['v', 'V']).unwrap_or(req);
             return compare_versions(version, req) <= 0;
         }
         if let Some(req) = requirement.strip_prefix('>') {
             let req = req.trim();
-            let req = req.strip_prefix('v').unwrap_or(req);
+            let req = req.strip_prefix(['v', 'V']).unwrap_or(req);
             return compare_versions(version, req) > 0;
         }
         if let Some(req) = requirement.strip_prefix('<') {
             let req = req.trim();
-            let req = req.strip_prefix('v').unwrap_or(req);
+            let req = req.strip_prefix(['v', 'V']).unwrap_or(req);
             return compare_versions(version, req) < 0;
         }
         if let Some(req) = requirement.strip_prefix('=') {
             let req = req.trim();
-            let req = req.strip_prefix('v').unwrap_or(req);
+            let req = req.strip_prefix(['v', 'V']).unwrap_or(req);
             return compare_versions(version, req) == 0;
         }
         if let Some(req) = requirement.strip_prefix("!=") {
             let req = req.trim();
-            let req = req.strip_prefix('v').unwrap_or(req);
+            let req = req.strip_prefix(['v', 'V']).unwrap_or(req);
             return compare_versions(version, req) != 0;
         }
 
@@ -824,6 +826,70 @@ mod tests {
         assert!(f.version_satisfies_requirement(&ConcreteVersion::new("v1.0.5"), "1.0.*"));
         assert!(f.version_satisfies_requirement(&ConcreteVersion::new("v1.2.3"), "1.2.3"));
         assert!(!f.version_satisfies_requirement(&ConcreteVersion::new("v2.0.0"), "^1.0"));
+    }
+
+    /// #534: an uppercase-`V`-prefixed candidate version (real Packagist tags, e.g.
+    /// `jeremykenedy/laravel2step`'s `V3.1.0`/`V4.0.0`) must be stripped identically to a
+    /// lowercase `v` prefix, across caret, tilde, comparison-operator, wildcard, and
+    /// exact/partial-match branches.
+    #[test]
+    fn test_uppercase_v_prefix_stripped() {
+        let f = ComposerFormatter;
+        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("V3.1.0"), "^3.0"));
+        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("V1.24.1"), "^1.24"));
+        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("V1.2.3"), "~1.2.3"));
+        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("V4.0.0"), ">=3.0"));
+        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("V1.0.5"), "1.0.*"));
+        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("V3.1.0"), "3.1.0"));
+        assert!(!f.version_satisfies_requirement(&ConcreteVersion::new("V2.0.0"), "^1.0"));
+    }
+
+    /// #534: the requirement side may itself carry an uppercase `V` prefix (bare, or right
+    /// after an operator), and either side's case must not affect the result.
+    #[test]
+    fn test_uppercase_v_prefix_symmetric_on_requirement_side() {
+        let f = ComposerFormatter;
+        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("1.2.3"), "V1.2.3"));
+        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("V1.2.3"), "V1.2.3"));
+        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("V1.2.3"), "v1.2.3"));
+        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("v1.2.3"), "V1.2.3"));
+        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("1.5.0"), "^V1.2.0"));
+        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("1.2.9"), "~V1.2.3"));
+        assert!(!f.version_satisfies_requirement(&ConcreteVersion::new("2.0.0"), "^V1.2.0"));
+        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("1.0.5"), "V1.0.*"));
+    }
+
+    /// #534: the wildcard branch with BOTH the candidate version and the requirement
+    /// carrying an uppercase `V` prefix simultaneously — existing coverage only exercised
+    /// one side at a time.
+    #[test]
+    fn test_uppercase_v_prefix_wildcard_both_sides() {
+        let f = ComposerFormatter;
+        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("V1.0.5"), "V1.0.*"));
+    }
+
+    /// #534: uppercase-`V` on the plain comparison-operator branches (`>=`, `<=`, `>`, `<`,
+    /// `=`, `!=`), mirroring `test_v_prefix_on_comparison_operators` for lowercase `v`.
+    #[test]
+    fn test_uppercase_v_prefix_on_comparison_operators() {
+        let f = ComposerFormatter;
+        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("1.5.0"), ">=V1.0.0"));
+        assert!(!f.version_satisfies_requirement(&ConcreteVersion::new("0.9.0"), ">=V1.0.0"));
+        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("1.5.0"), "<=V2.0.0"));
+        assert!(!f.version_satisfies_requirement(&ConcreteVersion::new("2.5.0"), "<V2.0.0"));
+        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("2.0.1"), ">V2.0.0"));
+        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("2.0.0"), "=V2.0.0"));
+        assert!(!f.version_satisfies_requirement(&ConcreteVersion::new("2.0.0"), "!=V2.0.0"));
+    }
+
+    /// #534: a bare uppercase `"V"` requirement must fall through to exact/partial match
+    /// unchanged, not collapse to `""` and be swallowed by the empty/wildcard guard —
+    /// mirrors `test_bare_v_requirement_does_not_match_everything` for the lowercase case.
+    #[test]
+    fn test_bare_uppercase_v_requirement_does_not_match_everything() {
+        let f = ComposerFormatter;
+        assert!(!f.version_satisfies_requirement(&ConcreteVersion::new("1.2.3"), "V"));
+        assert!(!f.version_satisfies_requirement(&ConcreteVersion::new("0.0.0"), "V"));
     }
 
     #[test]

--- a/crates/deps-composer/src/registry.rs
+++ b/crates/deps-composer/src/registry.rs
@@ -1939,6 +1939,36 @@ mod tests {
         assert_eq!(registry.select_latest_matching(&versions, &req), Some(1));
     }
 
+    // --- #534: uppercase-`V`-prefixed version satisfies a concrete requirement, end-to-end ---
+
+    /// #534: reproduces the real end-to-end regression (not just the isolated formatter unit
+    /// test) — before the fix, an uppercase-`V`-prefixed version like `V3.1.0` sent
+    /// `compare_versions` down `split_composer_core_and_suffix`'s qualifier-suffix branch with
+    /// numeric core `0` (only a lowercase `v` was stripped), so `version_satisfies_requirement`
+    /// silently never matched a concrete requirement, and `select_latest_matching` — the layer
+    /// that actually drives Composer's "latest matching version" resolution — returned `None`
+    /// even though the version is a real match.
+    #[test]
+    fn test_select_latest_matching_uppercase_v_prefixed_version_satisfies_requirement() {
+        use deps_core::{Registry, VersionReq};
+
+        let cache = Arc::new(HttpCache::new());
+        let registry = PackagistRegistry::new(cache);
+        let versions: Vec<Box<dyn deps_core::Version>> = vec![Box::new(ComposerVersion {
+            version: "V3.1.0".into(),
+            version_normalized: "3.1.0.0".into(),
+            abandoned: false,
+            deprecation: None,
+            published_at: None,
+        })];
+        let req = VersionReq::new(">=3.0");
+        assert_eq!(
+            registry.select_latest_matching(&versions, &req),
+            Some(0),
+            "V3.1.0 must satisfy >=3.0 through the real select_latest_matching path"
+        );
+    }
+
     // --- #424 S3: separator-less prerelease suffix consistency ---
 
     /// #424 S3: `1.0.0RC1` (no separator before `RC`) must be excluded from "latest" by the

--- a/specs/036-composer-uppercase-v-prefix-bug/spec.md
+++ b/specs/036-composer-uppercase-v-prefix-bug/spec.md
@@ -7,7 +7,7 @@ tags:
   - bug
   - deps-composer
 created: 2026-09-03
-status: draft
+status: ready
 related:
   - "[[constitution]]"
 ---
@@ -52,20 +52,25 @@ unrecognized qualifier suffix — nowhere close to its real value.
 
 Notably, a *different* function in the same crate,
 `composer_version_stability_rank`/its prerelease classifier
-(`crates/deps-composer/src/types.rs`, line 434:
+(`crates/deps-composer/src/formatter.rs`, line 435:
 `version.strip_prefix(['v', 'V']).unwrap_or(version)`), already correctly strips both
 cases. The codebase already has the correct pattern established elsewhere (added for
 issue #424 critique C1, covered by `test_composer_version_stability_rank_strips_v_prefix`)
 — it just was not applied consistently to `version_satisfies_requirement` in
 `formatter.rs`.
 
-**Downstream impact**: `version_satisfies_requirement` is consumed by
-`crates/deps-core/src/lsp_helpers/in_use_version.rs` and
-`crates/deps-core/src/lsp_helpers/inlay_hints.rs` (confirmed via
-`grep -rln version_satisfies_requirement crates/`). It drives whether deps-lsp reports the
-currently-locked/in-use version as satisfying the manifest's declared requirement for
-Composer dependencies — i.e. it feeds inlay hints and outdated/up-to-date diagnostic
-classification.
+**Downstream impact**: `version_satisfies_requirement`'s real production consumers are
+`deps-core/src/lsp_helpers/formatter.rs:237` (`RequirementResolution::is_requirement_up_to_date`'s
+default, called from `requirement_status`), `ComposerMatcher::matches`
+(`crates/deps-composer/src/formatter.rs:39`, backing `compile_requirement`), and
+`crates/deps-composer/src/registry.rs:316` and `:359` (`select_latest_matching`'s and
+`select_latest_matching_for_manifest`'s match predicates). (The earlier references to
+`crates/deps-core/src/lsp_helpers/in_use_version.rs` and `inlay_hints.rs` were test-only —
+`in_use_version.rs:53` is a doc comment and `inlay_hints.rs:483-513` is inside a
+`#[cfg(test)]` block, not a production call site.) Together these drive whether deps-lsp
+reports the currently-locked/in-use version as satisfying the manifest's declared
+requirement, and which registry version is selected as "latest matching" for Composer
+dependencies — i.e. it feeds inlay hints and outdated/up-to-date diagnostic classification.
 
 ### Goal
 
@@ -164,27 +169,23 @@ comparison function. No new entities.
   behavior in `types.rs`
 - Touch other ecosystems' version-comparison logic
 
-## 9. Open Questions
+## 9. Resolved Design Decisions
 
-- [NEEDS CLARIFICATION: Should the fix centralize `v`/`V`-prefix stripping into one shared
-  helper function (e.g. `strip_v_prefix(s: &str) -> &str`) used by both
-  `version_satisfies_requirement` in `formatter.rs` and `composer_version_stability_rank`
-  in `types.rs` — consistent with the project's DRY convention (user CLAUDE.md: "Follow
-  DRY: before creating any functionality, check for existing implementations... and reuse
-  them") — or should each of the ~10 existing `strip_prefix('v')` call sites in
-  `formatter.rs` simply be changed in place to `strip_prefix(['v', 'V'])`, matching the
-  established local idiom with minimal diff? A shared helper reduces duplication across
-  two files but is a slightly larger refactor for what is otherwise a single-character
-  case-sensitivity bug.]
-- [NEEDS CLARIFICATION: Does the bare degenerate-prefix guard at formatter.rs line 152-155
-  (`Some(rest) if !rest.is_empty() => rest`, documented rationale for why a lone `"v"`
-  requirement must not collapse to `""`) need an equivalent guard for a lone `"V"`
-  requirement, or can both cases share one guard once the strip call accepts `['v', 'V']`?]
+- **No shared helper.** Each of the ~10 existing `strip_prefix('v')` call sites in
+  `formatter.rs` is changed in place to `strip_prefix(['v', 'V'])`. This matches the
+  established local idiom already used in `types.rs`, is a one-token-array change per
+  call site, and avoids introducing a new abstraction for what is a single-character
+  case-sensitivity bug (project MVP convention: no premature abstractions before v1.0.0).
+- **One shared guard.** The existing bare degenerate-prefix guard
+  (`Some(rest) if !rest.is_empty() => rest`) is prefix-value-agnostic — it only checks
+  whether the remainder after stripping is empty, regardless of whether `'v'` or `'V'`
+  was the matched prefix. Once the strip call accepts `['v', 'V']`, the same guard
+  correctly covers a bare `"V"` requirement with no separate branch needed.
 
 ## 10. See Also
 
 - [[constitution]] — project principles
 - [[MOC-specs]] — all specifications
 - `crates/deps-composer/src/formatter.rs` — `ComposerFormatter::version_satisfies_requirement` (bug site)
-- `crates/deps-composer/src/types.rs`, line 434 — `composer_version_stability_rank`'s existing correct `strip_prefix(['v', 'V'])` pattern (reference for the fix)
-- `crates/deps-core/src/lsp_helpers/in_use_version.rs`, `crates/deps-core/src/lsp_helpers/inlay_hints.rs` — downstream consumers affected by this bug
+- `crates/deps-composer/src/formatter.rs`, line 435 — `composer_version_stability_rank`'s existing correct `strip_prefix(['v', 'V'])` pattern (reference for the fix)
+- `crates/deps-core/src/lsp_helpers/formatter.rs:237` (`is_requirement_up_to_date`), `ComposerMatcher::matches` (`crates/deps-composer/src/formatter.rs:39`), `crates/deps-composer/src/registry.rs:316`/`:359` — real downstream consumers affected by this bug

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -57,7 +57,7 @@ status: moc
 | 033 | [[033-pypi-private-index-support/spec\|PyPI private/custom index resolution (--index-url / --extra-index-url / Poetry source / uv index)]] | tasks | shipped — research/enhancement, P3 (PR #516, issue #513) |
 | 034 | [[034-go-goproxy-private-registry/spec\|Go GOPROXY/GOPRIVATE module proxy resolution]] | specify | draft — research/enhancement, P3 |
 | 035 | [[035-nuget-private-feed-support/spec\|NuGet private/custom feed support (NuGet.Config packageSources)]] | specify | research/parity, P3, 3 open `[NEEDS CLARIFICATION]` items (issue #523) |
-| 036 | [[036-composer-uppercase-v-prefix-bug/spec\|Composer requirement matching fails for uppercase-V-prefixed versions]] | specify | draft — bug, P1, 2 open `[NEEDS CLARIFICATION]` items |
+| 036 | [[036-composer-uppercase-v-prefix-bug/spec\|Composer requirement matching fails for uppercase-V-prefixed versions]] | specify | implemented — bug, P1, awaiting merge (issue #534) |
 
 ## Completed Specs
 


### PR DESCRIPTION
## Summary

`ComposerFormatter::version_satisfies_requirement` stripped a leading lowercase `v` from both the candidate version and the requirement string before comparing, but never stripped an uppercase `V`. Real Packagist tags (e.g. `jeremykenedy/laravel2step`'s `V3.1.0`/`V4.0.0`) fell through to `compare_versions` with an empty numeric core, so a locked `V`-prefixed version never satisfied its declared requirement.

Fix: change all ~10 `strip_prefix('v')` call sites in `version_satisfies_requirement` to `strip_prefix(['v', 'V'])`, matching the existing correct pattern already used by `composer_version_stability_rank` in the same file. No shared helper introduced — matches the codebase's established local idiom with minimal diff.

## Changes

- `crates/deps-composer/src/formatter.rs`: strip both `v`/`V` at every operator branch (caret, tilde, six comparison operators, wildcard, exact/partial match); 6 new regression tests.
- `crates/deps-composer/src/registry.rs`: end-to-end regression test through `select_latest_matching`, the real production path where the bug manifests.
- `specs/036-composer-uppercase-v-prefix-bug/spec.md`: resolved both open design questions, corrected two file-location citations and the downstream-impact paragraph to name the real production consumers.

## Test plan

- [x] `cargo nextest run -p deps-composer` — 163 passed, 0 failed
- [x] `cargo nextest run --workspace --all-features --lib --bins` — 3673 passed, 0 failed
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` — clean
- [x] Reviewed by adversarial critic and code reviewer in a dev team pass (verdict: approved)

Closes #534