### PR TITLE
fix(deps-github-actions): correct tag/version classification for non-semver and literal-named tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **deps-core, deps-lsp, deps-github-actions**: fixed false "Unknown package" diagnostic when a dependency's tags exist but none are full-semver-shaped (e.g. `dtolnay/rust-toolchain`), and a stray hover "Press Cmd+. to update version" footer with an empty "Recent versions" section in the same case (resolves #550)
+- **deps-github-actions**: mutable-ref-pin diagnostic now fires for literal-named git tags (e.g. `taiki-e/install-action@cargo-deny`) previously misclassified as an undiagnosable branch pin (resolves #551)
+
 ## [0.12.0] - 2026-09-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **deps-core, deps-lsp, deps-github-actions**: fixed false "Unknown package" diagnostic when a dependency's tags exist but none are full-semver-shaped (e.g. `dtolnay/rust-toolchain`), and a stray hover "Press Cmd+. to update version" footer with an empty "Recent versions" section in the same case (resolves #550)
-- **deps-github-actions**: mutable-ref-pin diagnostic now fires for literal-named git tags (e.g. `taiki-e/install-action@cargo-deny`) previously misclassified as an undiagnosable branch pin (resolves #551)
+- **deps-core, deps-lsp, deps-github-actions**: fixed false "Unknown package" diagnostic when a dependency's tags exist but none are full-semver-shaped (e.g. `dtolnay/rust-toolchain`), and a stray hover "Press Cmd+. to update version" footer with an empty "Recent versions" section in the same case (resolves #550) (#552)
+- **deps-github-actions**: mutable-ref-pin diagnostic now fires for literal-named git tags (e.g. `taiki-e/install-action@cargo-deny`) previously misclassified as an undiagnosable branch pin (resolves #551) (#552)
 
 ## [0.12.0] - 2026-09-03
 

--- a/crates/deps-core/src/lsp_helpers/diagnostics.rs
+++ b/crates/deps-core/src/lsp_helpers/diagnostics.rs
@@ -941,8 +941,14 @@ fn apply_in_use_yanked_rule(
 ///    (deferred, collapsed by [`push_collapsed_fetch_failures`] — R8) rather than
 ///    pushed inline, since a fetch failure is a registry-wide condition that can hit
 ///    many dependencies identically.
-/// 4. `Ok(())` + `can_resolve_source` -> R5d `Unknown package '{name}'`.
-/// 5. `Ok(())` -> nothing (#248: unresolvable source, absent cache entry means "never
+/// 4. `Ok(())` + `no_comparable_versions` -> R5e emits nothing (#550): the registry
+///    fetch succeeded and the package demonstrably exists, it just has zero versions
+///    comparable to the declared requirement (e.g. `dtolnay/rust-toolchain`'s only tag
+///    `v1` isn't full semver) — reported by neither R5c ("couldn't be asked") nor R5d
+///    ("no evidence it exists"). Checked before R5d so it takes priority over the
+///    "absent cache entry" heuristic that would otherwise misclassify it.
+/// 5. `Ok(())` + `can_resolve_source` -> R5d `Unknown package '{name}'`.
+/// 6. `Ok(())` -> nothing (#248: unresolvable source, absent cache entry means "never
 ///    fetched").
 fn apply_unknown_package_rule(
     diagnostics: &mut Vec<Diagnostic>,
@@ -956,15 +962,19 @@ fn apply_unknown_package_rule(
         return;
     }
 
-    let fetch_failure: Option<&FetchFailure> = ctx
-        .formatter
-        .can_resolve_source(&dep.source())
+    let can_resolve_source = ctx.formatter.can_resolve_source(&dep.source());
+    let fetch_failure: Option<&FetchFailure> = can_resolve_source
         .then(|| {
             ctx.versions
                 .outcomes
                 .and_then(|o| o.fetch_failure(ctx.normalized_name))
         })
         .flatten();
+    let no_comparable_versions = can_resolve_source
+        && ctx
+            .versions
+            .outcomes
+            .is_some_and(|o| o.no_comparable_versions(ctx.normalized_name));
     match ctx.formatter.validate_package_name(dep.name().as_str()) {
         Err(reason) => {
             diagnostics.push(Diagnostic {
@@ -1000,7 +1010,8 @@ fn apply_unknown_package_rule(
                 failure: fetch_failure.cloned(),
             });
         }
-        Ok(()) if ctx.formatter.can_resolve_source(&dep.source()) => {
+        Ok(()) if no_comparable_versions => {}
+        Ok(()) if can_resolve_source => {
             diagnostics.push(Diagnostic {
                 range: dep.name_range(),
                 severity: Some(ctx.severities.unknown),
@@ -1416,6 +1427,50 @@ mod tests {
         assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::WARNING));
         assert!(diagnostics[0].message.contains("Unknown package"));
         assert!(diagnostics[0].message.contains("unknown-pkg"));
+    }
+
+    /// Regression for #550: a package whose registry fetch succeeded but produced zero
+    /// comparable versions (e.g. `dtolnay/rust-toolchain`, whose only tag `v1` isn't
+    /// full semver, so `GithubActionsRegistry::get_versions` returns `Ok(vec![])`) must
+    /// not be reported "Unknown package" — the package demonstrably exists; there is
+    /// simply nothing derivable from it. No cache entry AND no `no_comparable_versions`
+    /// outcome would still (correctly) produce "Unknown package" — this asserts the
+    /// outcome alone suppresses it.
+    #[test]
+    fn test_generate_diagnostics_from_cache_no_comparable_versions_is_not_unknown_package() {
+        use tower_lsp_server::ls_types::{Position, Range};
+
+        let formatter = MockFormatter;
+
+        let parse_result = MockParseResult {
+            deps: vec![MockDep {
+                name: "dtolnay/rust-toolchain".into(),
+                version_req: "stable".into(),
+                version_range: Range::new(Position::new(0, 10), Position::new(0, 20)),
+                name_range: Range::new(Position::new(0, 0), Position::new(0, 23)),
+            }],
+            uri: crate::test_util::test_uri("/repo/.github/workflows/ci.yml"),
+        };
+
+        let cached_versions = HashMap::new();
+        let resolved_versions = HashMap::new();
+        let outcomes =
+            DependencyOutcomes::new().with_no_comparable_versions("dtolnay/rust-toolchain");
+
+        let diagnostics = generate_diagnostics_from_cache(
+            &parse_result,
+            VersionData::new(&cached_versions, &resolved_versions).with_outcomes(&outcomes),
+            &formatter,
+            parse_result.uri(),
+            crate::freshness::FreshnessSettings::default(),
+            DiagnosticSeverities::default(),
+            PublishTime::now(),
+        );
+
+        assert!(
+            diagnostics.is_empty(),
+            "expected no diagnostic for a package with no comparable versions, got: {diagnostics:?}"
+        );
     }
 
     /// S3 (impl-critic): `generate_diagnostics_from_cache` must actually emit the

--- a/crates/deps-core/src/lsp_helpers/hover.rs
+++ b/crates/deps-core/src/lsp_helpers/hover.rs
@@ -322,7 +322,12 @@ pub async fn generate_hover<R: Registry + ?Sized>(
     push_deprecation_hover_section(&mut markdown, formatter, deprecation);
     push_vulnerability_hover_section(&mut markdown, vuln_outcome);
 
-    if let Some(available_versions) = &available_versions {
+    // `!v.is_empty()`, not just `Some(_)` (#550): a resolvable source's live fetch can
+    // succeed with a genuinely empty list — e.g. a real GitHub repository whose only
+    // tags don't parse as full semver (`dtolnay/rust-toolchain`'s sole tag `v1`) — and
+    // a "**Recent versions**:" header with no entries under it is never useful,
+    // regardless of ecosystem.
+    if let Some(available_versions) = available_versions.as_ref().filter(|v| !v.is_empty()) {
         // Matched by position against `live_latest_idx` (the header's stable-latest pick)
         // rather than raw index 0 or string equality: `available_versions` is sorted purely
         // by version number, so index 0 can be a pre-release the header itself doesn't call
@@ -398,7 +403,21 @@ pub async fn generate_hover<R: Registry + ?Sized>(
         || cached_latest.is_some()
         || matches!(vuln_outcome, Some(ScanOutcome::Vulnerable(_)))
         || deprecation.is_some();
-    if resolvable && (!versions.offline || has_offline_actionable_data) {
+    // #550: a live fetch that genuinely succeeded with zero entries (`Some(&[])`,
+    // distinct from `None` — a fetch that errored or never ran, where an unrelated
+    // Cmd+. action such as an unsatisfiable-fix might still exist per #474's own
+    // reasoning above) is definitive proof there is nothing version-wise to update to.
+    // Combined with no cached/vulnerability/deprecation data either
+    // (`!has_offline_actionable_data`, which already folds in this same emptiness
+    // check), the footer would otherwise advertise an action that provably does not
+    // exist — the "empty Recent versions section plus a stray footer" bug reported
+    // against GHA's `dtolnay/rust-toolchain@stable` but not specific to any one
+    // ecosystem. Every other online case (a non-empty live list, or no live fetch at
+    // all) keeps the pre-#550 unconditional-when-resolvable behavior.
+    let live_fetch_definitively_empty = available_versions.as_ref().is_some_and(Vec::is_empty);
+    let footer_actionable =
+        has_offline_actionable_data || (!live_fetch_definitively_empty && !versions.offline);
+    if resolvable && footer_actionable {
         markdown.push_str(CMD_DOT_FOOTER);
     }
 

--- a/crates/deps-core/src/lsp_helpers/mod.rs
+++ b/crates/deps-core/src/lsp_helpers/mod.rs
@@ -167,13 +167,24 @@ pub struct DependencyOutcome {
     pub deprecation: Option<Deprecation>,
     /// Registry fetch errored, timed out, or was never attempted (#267). See [`FetchFailure`].
     pub fetch_failure: Option<FetchFailure>,
+    /// The registry fetch succeeded (no [`Self::fetch_failure`]) but produced zero
+    /// comparable versions — e.g. a real GitHub repository whose only tags don't parse
+    /// as full `major.minor.patch` semver (`dtolnay/rust-toolchain`'s sole tag `v1`,
+    /// issue #550). Distinct from both an absent [`DependencyOutcome`] entry ("never
+    /// fetched") and [`Self::fetch_failure`] ("couldn't be asked"): this package
+    /// demonstrably exists, so [R5](crate::lsp_helpers::generate_diagnostics_from_cache)
+    /// must not claim it is unknown.
+    pub no_comparable_versions: bool,
 }
 
 impl DependencyOutcome {
-    /// True when none of the three channels are set.
+    /// True when none of the four channels are set.
     #[must_use]
     pub const fn is_empty(&self) -> bool {
-        self.yanked.is_none() && self.deprecation.is_none() && self.fetch_failure.is_none()
+        self.yanked.is_none()
+            && self.deprecation.is_none()
+            && self.fetch_failure.is_none()
+            && !self.no_comparable_versions
     }
 }
 
@@ -218,6 +229,13 @@ impl DependencyOutcomes {
         self.0.get(name)?.fetch_failure.as_ref()
     }
 
+    /// True when the registry fetch for `name` succeeded but produced zero comparable
+    /// versions (#550). See [`DependencyOutcome::no_comparable_versions`].
+    #[must_use]
+    pub fn no_comparable_versions(&self, name: &str) -> bool {
+        self.0.get(name).is_some_and(|o| o.no_comparable_versions)
+    }
+
     /// Records a yanked-version finding for `name`, creating the entry if absent.
     pub fn set_yanked(&mut self, name: String, yanked: (ConcreteVersion, RemovalStatus)) {
         self.0.entry(name).or_default().yanked = Some(yanked);
@@ -241,6 +259,21 @@ impl DependencyOutcomes {
             .or_default()
             .fetch_failure
             .get_or_insert(failure);
+    }
+
+    /// Records that `name`'s registry fetch succeeded but produced zero comparable
+    /// versions (#550), creating the entry if absent.
+    pub fn set_no_comparable_versions(&mut self, name: String) {
+        self.0.entry(name).or_default().no_comparable_versions = true;
+    }
+
+    /// Clears the no-comparable-versions channel for `name`, pruning the entry if it
+    /// becomes empty.
+    pub fn clear_no_comparable_versions(&mut self, name: &str) {
+        if let Some(entry) = self.0.get_mut(name) {
+            entry.no_comparable_versions = false;
+            self.prune(name);
+        }
     }
 
     /// Clears the yanked-version channel for `name`, pruning the entry if it becomes empty.
@@ -334,6 +367,14 @@ impl DependencyOutcomes {
     #[must_use]
     pub fn with_fetch_failure(mut self, name: impl Into<String>, failure: FetchFailure) -> Self {
         self.set_fetch_failure(name.into(), failure);
+        self
+    }
+
+    /// Chainable builder recording a no-comparable-versions finding (#550). Test/fixture
+    /// ergonomics.
+    #[must_use]
+    pub fn with_no_comparable_versions(mut self, name: impl Into<String>) -> Self {
+        self.set_no_comparable_versions(name.into());
         self
     }
 }

--- a/crates/deps-github-actions/src/ecosystem.rs
+++ b/crates/deps-github-actions/src/ecosystem.rs
@@ -1,5 +1,6 @@
 //! GitHub Actions ecosystem implementation for deps-lsp.
 
+use dashmap::DashMap;
 use std::any::Any;
 use std::sync::Arc;
 use tower_lsp_server::ls_types::{
@@ -8,7 +9,7 @@ use tower_lsp_server::ls_types::{
 };
 
 use deps_core::{
-    Ecosystem, ParseResult as ParseResultTrait, Registry, Result,
+    Ecosystem, PackageName, ParseResult as ParseResultTrait, Registry, Result,
     completion::Completions,
     lsp_helpers::{EcosystemFormatter, PackageRendering, markdown_code_span},
 };
@@ -16,8 +17,40 @@ use deps_core::{
 use crate::MUTABLE_REF_PIN_DIAGNOSTIC_CODE;
 
 use crate::formatter::GithubActionsFormatter;
-use crate::registry::GithubActionsRegistry;
+use crate::registry::{GithubActionsRegistry, TagIndex};
 use crate::types::{GithubActionsDependency, PinStyle};
+
+/// Whether `gha_dep`'s ref is diagnosable as a tag — either because
+/// [`crate::parser::classify_uses_value`] already classified it as [`PinStyle::Tag`] from
+/// its text shape, or because `tag_index`'s live `/tags` fetch confirms the ref is a
+/// literal member of the repository's tag list even though it doesn't *look*
+/// tag-shaped (issue #551, e.g. `taiki-e/install-action@cargo-deny`).
+///
+/// [`crate::parser::is_tag_shaped`] is a pure, registry-blind heuristic — it cannot tell
+/// a literal tool-name tag from a genuinely moving branch, since both fail the same
+/// "starts with `v`/a digit" test. Once the registry has actually answered (`tag_index`
+/// carries this repository's entry), the real answer is available and takes priority
+/// over the static guess; before that (`tag_index` cache miss), a [`PinStyle::Branch`]
+/// step stays classified as the "honest unknown" — exactly the pre-#551 behavior — until
+/// a fetch resolves it one way or the other.
+fn is_registry_confirmed_tag(
+    gha_dep: &GithubActionsDependency,
+    tag_index: &DashMap<PackageName, Arc<TagIndex>>,
+) -> bool {
+    match &gha_dep.pin {
+        Some(PinStyle::Tag) => true,
+        Some(PinStyle::Branch) => gha_dep
+            .version_req
+            .as_ref()
+            .map(deps_core::VersionReq::as_str)
+            .is_some_and(|ref_text| {
+                tag_index
+                    .get(&gha_dep.name)
+                    .is_some_and(|index| index.tag_to_sha.contains_key(ref_text))
+            }),
+        Some(PinStyle::Sha { .. }) | None => false,
+    }
+}
 
 /// GitHub Actions ecosystem implementation.
 ///
@@ -153,6 +186,7 @@ impl Ecosystem for GithubActionsEcosystem {
                 diagnostics.extend(mutable_ref_pin_diagnostics(
                     parse_result,
                     severities.mutable_ref_pin,
+                    &self.formatter.tag_index,
                 ));
             }
             diagnostics
@@ -246,21 +280,36 @@ impl Ecosystem for GithubActionsEcosystem {
                 return Some(hover);
             };
 
-            // #501 gap (tester finding): the shared `has_offline_actionable_data` gate in
-            // `deps_core::generate_hover` only sees `VersionData` and cannot see
-            // `formatter.tag_index` — GHA's "Pin to commit SHA" quickfix
-            // (`build_sha_pin_action`, wired into `generate_code_actions` above) is driven
-            // entirely by that separately-populated index, independent of `versions`. So a
-            // `PinStyle::Tag` step with a warm `TagIndex` entry has a real `Cmd+.` action
-            // while offline, even when the shared gate suppressed the footer for lack of any
-            // `VersionData` signal. Restores it post-hoc using the shared `CMD_DOT_FOOTER`
-            // constant (not a hand-copied literal) so the two can never drift apart.
+            // #501 gap (tester finding), widened by critic finding C1 (#550): the shared
+            // `has_offline_actionable_data`/footer gate in `deps_core::generate_hover` only
+            // sees `VersionData` and cannot see `formatter.tag_index` — GHA's "Pin to commit
+            // SHA" quickfix (`build_sha_pin_action`, wired into `generate_code_actions`
+            // above) is driven entirely by that separately-populated index, independent of
+            // `versions`. So a `PinStyle::Tag` step with a warm `TagIndex` entry has a real
+            // `Cmd+.` action even when the shared gate suppressed the footer for lack of any
+            // `VersionData` signal — originally observed offline (#501), but #550's
+            // empty-live-fetch footer gate reintroduced the identical gap *online* too: a
+            // bare-major tag (`@v4`) whose repo tags entirely fail the full-semver filter
+            // (`tags_to_versions`) makes `available_versions == Some([])`, which the shared
+            // gate now (correctly, for the general case) treats as "nothing to update" — but
+            // `populate_tag_index` still indexes bare-major tags (`v4 -> sha`) independent of
+            // that filter, so the quickfix is still genuinely available. Restores the footer
+            // post-hoc in both modes using the shared `CMD_DOT_FOOTER` constant (not a
+            // hand-copied literal) so the two can never drift apart; the
+            // `!content.value.contains(CMD_DOT_FOOTER)` guard below makes this idempotent
+            // when the shared gate already rendered it, so dropping the online/offline split
+            // cannot double-append.
             // `is_plain_scalar` mirrors `build_sha_pin_action`'s own guard (FR-010, spec
             // 031): for a quoted `uses:` scalar, `version_range` sits inside the quotes, so
             // the quickfix withholds itself rather than corrupt the value — the footer must
             // not advertise an action that was never actually offered.
-            if versions.offline
-                && gha_dep.pin == Some(PinStyle::Tag)
+            //
+            // Deliberately keyed on the raw `PinStyle::Tag` check, not
+            // `is_registry_confirmed_tag` (#551 plan): this footer only ever advertises
+            // `build_sha_pin_action`, which itself stays on the stricter, pre-#551 guard
+            // (see that function's doc comment) — the footer must never promise an action
+            // that withholds itself.
+            if gha_dep.pin == Some(PinStyle::Tag)
                 && gha_dep.is_plain_scalar
                 && let Some(tag) = gha_dep
                     .version_req
@@ -356,10 +405,12 @@ fn splice_resolved_line(markdown: &str, resolved_tag: &str, sha: &str) -> String
     format!("{markdown}{line}")
 }
 
-/// Builds one mutable-ref-pin [`Diagnostic`] (issue #473) per `PinStyle::Tag` step in
-/// `parse_result` — `PinStyle::Sha`, `PinStyle::Branch`, and `None` steps produce no
-/// diagnostic (FR-003; `PinStyle::Branch` is out of scope for this iteration, see spec
-/// 031 §"Out of Scope").
+/// Builds one mutable-ref-pin [`Diagnostic`] (issue #473) per diagnosable-as-tag step in
+/// `parse_result` — every `PinStyle::Tag` step, plus a `PinStyle::Branch` step
+/// `tag_index` confirms is actually a real tag (issue #551, e.g.
+/// `taiki-e/install-action@cargo-deny`: see [`is_registry_confirmed_tag`]).
+/// `PinStyle::Sha` and a `PinStyle::Branch` `tag_index` cannot (yet) confirm produce no
+/// diagnostic (FR-003).
 /// Maximum character count of `mutable_ref_pin_diagnostics`' interpolated `name`/`tag`
 /// values before truncation (security audit finding). Mirrors
 /// `deps_core::lsp_helpers::diagnostics`' `MAX_BLOCKED_REGISTRY_MESSAGE_VALUE_CHARS`
@@ -371,13 +422,14 @@ const MAX_MUTABLE_REF_PIN_MESSAGE_VALUE_CHARS: usize = 128;
 fn mutable_ref_pin_diagnostics(
     parse_result: &dyn ParseResultTrait,
     severity: tower_lsp_server::ls_types::DiagnosticSeverity,
+    tag_index: &DashMap<PackageName, Arc<TagIndex>>,
 ) -> Vec<Diagnostic> {
     parse_result
         .dependencies()
         .into_iter()
         .filter_map(|dep| {
             let gha_dep = dep.as_any().downcast_ref::<GithubActionsDependency>()?;
-            if gha_dep.pin != Some(PinStyle::Tag) {
+            if !is_registry_confirmed_tag(gha_dep, tag_index) {
                 return None;
             }
             let range = gha_dep.version_range?;
@@ -393,13 +445,30 @@ fn mutable_ref_pin_diagnostics(
                 tag,
                 MAX_MUTABLE_REF_PIN_MESSAGE_VALUE_CHARS,
             );
+            // Critic finding C2 (#551): `build_sha_pin_action` deliberately stays
+            // restricted to a statically-classified `PinStyle::Tag` (FR-005/plan §11 —
+            // see that function's doc comment on the branch/tag name-collision risk), so
+            // a registry-confirmed-but-`PinStyle::Branch` ref has no automated fix behind
+            // `Cmd+.` here. The message must say so rather than imply one is a keystroke
+            // away, matching every other resolvable-but-unactionable case in this
+            // codebase (e.g. `deps_core`'s own "Registry lookup failed" wording never
+            // promises a quickfix it can't offer).
+            let message = if gha_dep.pin == Some(PinStyle::Tag) {
+                format!(
+                    "{name} is pinned to the mutable tag ref `{tag}`; pin to a full commit \
+                     SHA to guard against tag mutation"
+                )
+            } else {
+                format!(
+                    "{name} is pinned to the mutable tag ref `{tag}`; pin to a full commit \
+                     SHA to guard against tag mutation (manual edit — no automated fix \
+                     available for this ref)"
+                )
+            };
             Some(Diagnostic {
                 range,
                 severity: Some(severity),
-                message: format!(
-                    "{name} is pinned to the mutable tag ref `{tag}`; pin to a full commit \
-                     SHA to guard against tag mutation"
-                ),
+                message,
                 code: Some(NumberOrString::String(
                     MUTABLE_REF_PIN_DIAGNOSTIC_CODE.into(),
                 )),
@@ -417,6 +486,17 @@ fn mutable_ref_pin_diagnostics(
 /// Returns `None` (no destructive/no-op edit, FR-005) when the dependency at `position`
 /// is not `PinStyle::Tag`, has no `version_range`, or the `TagIndex` lookup misses (cache
 /// miss — e.g. the document was opened before the registry fetch completed).
+///
+/// Deliberately **not** widened to [`is_registry_confirmed_tag`]'s `PinStyle::Branch`
+/// case the way [`mutable_ref_pin_diagnostics`] is (#551 plan): FR-005/plan §11 (see
+/// `test_build_sha_pin_action_no_quickfix_for_branch_pin`) already forbids this
+/// quickfix for a `PinStyle::Branch` step even when a same-named `TagIndex` entry
+/// exists, since git permits a branch and a tag to share one name and GitHub's own
+/// `uses:` ref resolution for that collision is undocumented — an *automated edit*
+/// that silently pins to the tag's commit could pin to a different commit than the
+/// ref actually resolves to at run time. A diagnostic's advisory text carries no such
+/// risk (pinning to *some* SHA is safer than a moving ref either way), but this
+/// destructive edit keeps the stricter, pre-#551 guard.
 fn build_sha_pin_action(
     parse_result: &dyn ParseResultTrait,
     position: Position,
@@ -593,6 +673,106 @@ mod tests {
             !diagnostics
                 .iter()
                 .any(|d| d.code == Some(mutable_ref_pin_code()))
+        );
+    }
+
+    /// Regression for #551: `taiki-e/install-action@cargo-deny` is a literal-named ref
+    /// that parses as `PinStyle::Branch` (`is_tag_shaped` requires a leading `v`/digit)
+    /// even though it's a real, resolvable git tag — the registry's own tags fetch is
+    /// the only thing that can tell. Before any fetch has ever populated `TagIndex` for
+    /// this repository (cold cache — the same state a fresh document open starts in),
+    /// the mutable-ref-pin diagnostic must stay withheld: the "honest unknown" state is
+    /// unchanged from before #551, since nothing has confirmed the ref one way or
+    /// another yet.
+    #[tokio::test]
+    async fn test_generate_diagnostics_no_mutable_ref_pin_for_literal_tag_with_cold_tag_index() {
+        let diagnostics =
+            diagnostics_for("steps:\n  - uses: taiki-e/install-action@cargo-deny\n").await;
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.code == Some(mutable_ref_pin_code())),
+            "a literal-named ref with no TagIndex entry yet must stay the honest \
+             unknown, not assumed a tag; got: {diagnostics:?}"
+        );
+    }
+
+    /// Regression for #551: once a fetch has actually populated `TagIndex` for
+    /// `taiki-e/install-action` — tag data mixing a literal tool-selector tag
+    /// (`cargo-deny`, alongside its siblings `nextest`/`cross`/`wasm-pack` in the real
+    /// repository) with a real `vN` release tag (`v2`) — `cargo-deny` must now be
+    /// diagnosable: it's confirmed a real tag, not a moving branch, so the
+    /// mutable-ref-pin hint applies (arguably more relevant here, since these ARE
+    /// mutable reassignable tags). `v2` (statically `PinStyle::Tag` already, unaffected
+    /// by #551) keeps getting its own diagnostic exactly as before.
+    #[tokio::test]
+    async fn test_generate_diagnostics_mutable_ref_pin_for_registry_confirmed_literal_tag() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = GithubActionsEcosystem::new(cache);
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let content = "steps:\n\
+             \x20 - uses: taiki-e/install-action@cargo-deny\n\
+             \x20 - uses: taiki-e/install-action@v2\n";
+        let parse_result = eco.parse_manifest(content, &uri).await.unwrap();
+
+        let mut index = crate::registry::TagIndex::default();
+        index
+            .tag_to_sha
+            .insert("cargo-deny".to_string(), "a".repeat(40));
+        index
+            .tag_to_sha
+            .insert("nextest".to_string(), "b".repeat(40));
+        index.tag_to_sha.insert("v2".to_string(), "c".repeat(40));
+        eco.formatter.tag_index.insert(
+            deps_core::PackageName::new("taiki-e/install-action"),
+            Arc::new(index),
+        );
+
+        let cached = HashMap::new();
+        let resolved = HashMap::new();
+        let diagnostics = eco
+            .generate_diagnostics(
+                parse_result.as_ref(),
+                deps_core::VersionData::new(&cached, &resolved),
+                &uri,
+                deps_core::FreshnessSettings::default(),
+                deps_core::lsp_helpers::DiagnosticSeverities::default(),
+            )
+            .await;
+
+        let mutable_ref_pin_messages: Vec<&str> = diagnostics
+            .iter()
+            .filter(|d| d.code == Some(mutable_ref_pin_code()))
+            .map(|d| d.message.as_str())
+            .collect();
+        assert_eq!(
+            mutable_ref_pin_messages.len(),
+            2,
+            "both the registry-confirmed literal tag and the statically-classified \
+             tag must get the diagnostic; got: {diagnostics:?}"
+        );
+        let cargo_deny_message = *mutable_ref_pin_messages
+            .iter()
+            .find(|m| m.contains("cargo-deny"))
+            .expect("expected a diagnostic naming the confirmed literal tag");
+        let v2_message = *mutable_ref_pin_messages
+            .iter()
+            .find(|m| m.contains("`v2`"))
+            .expect("expected a diagnostic naming the statically-classified tag");
+
+        // Critic finding C2 (#551): `build_sha_pin_action` has no automated fix for the
+        // registry-confirmed-but-`PinStyle::Branch` case (FR-005/plan §11), so its
+        // message must say so — unlike the statically-classified `v2` tag, which does
+        // have the "Pin to commit SHA" quickfix behind `Cmd+.`.
+        assert!(
+            cargo_deny_message.contains("no automated fix available"),
+            "a registry-confirmed literal tag has no SHA-pin quickfix, so the message \
+             must not imply one; got: {cargo_deny_message}"
+        );
+        assert!(
+            !v2_message.contains("no automated fix available"),
+            "a statically-classified tag DOES have the SHA-pin quickfix, so the message \
+             must not claim otherwise; got: {v2_message}"
         );
     }
 
@@ -1003,6 +1183,76 @@ mod tests {
             !content.value.contains("Press `Cmd+.` to update version"),
             "no TagIndex entry exists, so there is no quickfix to restore the footer for; \
              got: {}",
+            content.value
+        );
+    }
+
+    /// Regression for critic finding C1 (#550): a bare-major tag pin (`@v4`, "the most
+    /// common real-world GitHub Actions pinning convention" per `populate_tag_index`'s own
+    /// docs) whose repository's tags are *all* bare-major fails `tags_to_versions`' full
+    /// `major.minor.patch` semver filter entirely, so the live hover fetch genuinely
+    /// succeeds with `available_versions == Some([])` — the #550 hover fix correctly
+    /// suppresses the shared footer for that case in general, but `populate_tag_index`
+    /// indexes bare-major tags independently of that filter, so the SHA-pin quickfix is
+    /// still genuinely available here. Unlike the offline-only sibling test above, this
+    /// drives a real (mocked) network fetch through the actual `GithubActionsRegistry` to
+    /// prove the restore now fires **online** too, not just offline.
+    #[tokio::test]
+    async fn test_generate_hover_restores_footer_online_for_bare_major_tag_with_empty_live_list() {
+        let sha = "a".repeat(40);
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/repos/actions/checkout/tags")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body(format!(
+                r#"[{{"name": "v4", "commit": {{"sha": "{sha}"}}}}]"#
+            ))
+            .create_async()
+            .await;
+
+        let registry = crate::registry::GithubActionsRegistry::for_test(
+            Arc::new(deps_core::HttpCache::new()),
+            server.url(),
+            false,
+        );
+        let formatter = GithubActionsFormatter::new(registry.tag_index());
+        let eco = GithubActionsEcosystem {
+            registry: Arc::new(registry),
+            formatter,
+        };
+
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let content = "steps:\n  - uses: actions/checkout@v4\n";
+        let parse_result = eco.parse_manifest(content, &uri).await.unwrap();
+        let position = parse_result.dependencies()[0].name_range().start;
+        let cached = HashMap::new();
+        let resolved = HashMap::new();
+
+        let hover = eco
+            .generate_hover(
+                parse_result.as_ref(),
+                position,
+                deps_core::VersionData::new(&cached, &resolved),
+                deps_core::FreshnessSettings::default(),
+            )
+            .await
+            .expect("hover should be generated for the dependency on this line");
+
+        let HoverContents::Markup(content) = hover.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(
+            !content.value.contains("**Recent versions**"),
+            "an all-bare-major tag list has zero full-semver entries, so the section \
+             must stay omitted; got: {}",
+            content.value
+        );
+        assert!(
+            content.value.contains("Press `Cmd+.` to update version"),
+            "a Tag-pinned step whose live fetch genuinely succeeded empty still has a \
+             real SHA-pin quickfix via TagIndex, so the footer must be restored online \
+             too, not just offline; got: {}",
             content.value
         );
     }

--- a/crates/deps-github-actions/src/formatter.rs
+++ b/crates/deps-github-actions/src/formatter.rs
@@ -364,9 +364,9 @@ mod tests {
         assert!(!fmt.suppress_package_url(&DependencySource::Registry));
     }
 
-    /// A registry mock whose `get_versions` always succeeds with an empty list — enough
-    /// to drive `generate_hover`'s `resolvable && available_versions.is_some()` footer
-    /// gate (#474) without needing a real `Box<dyn Version>` fixture.
+    /// A registry mock whose `get_versions` always succeeds with an empty list — a real
+    /// GitHub repository whose only tags don't parse as full semver
+    /// (`dtolnay/rust-toolchain`'s sole tag `v1`, issue #550), not a fetch failure.
     struct EmptyRegistry;
 
     impl deps_core::Registry for EmptyRegistry {
@@ -518,8 +518,13 @@ mod tests {
         );
     }
 
+    /// #550: a resolvable Registry source whose live fetch genuinely succeeds with zero
+    /// entries (e.g. `dtolnay/rust-toolchain`, whose only tag `v1` isn't full semver)
+    /// must keep its link but must NOT show the update footer — there's nothing to
+    /// update to, so advertising `Cmd+.` would be misleading. Supersedes this test's
+    /// pre-#550 name and assertion, which locked in exactly that bug.
     #[tokio::test]
-    async fn test_hover_registry_action_keeps_link_and_footer() {
+    async fn test_hover_registry_action_keeps_link_no_footer_when_versions_empty() {
         let markdown = hover_markdown_for("steps:\n  - uses: actions/checkout@v4\n").await;
         assert!(
             markdown.starts_with(&format!(
@@ -529,9 +534,121 @@ mod tests {
             "non-regression: a normal Registry-sourced action keeps its link; got: {markdown}"
         );
         assert!(
-            markdown.contains("Press `Cmd+.`"),
-            "a resolvable Registry source with version data must still show the update \
-             footer; got: {markdown}"
+            !markdown.contains("**Recent versions**"),
+            "an empty live version list must not render an empty section header; got: {markdown}"
+        );
+        assert!(
+            !markdown.contains("Press `Cmd+.`"),
+            "a resolvable Registry source with zero live versions and nothing cached has \
+             no update code action to advertise; got: {markdown}"
+        );
+    }
+
+    /// Non-regression companion to the above (#474's original contract): a resolvable
+    /// Registry source whose live fetch returns real version data must still show the
+    /// update footer.
+    #[tokio::test]
+    async fn test_hover_registry_action_keeps_footer_when_versions_present() {
+        use deps_core::freshness::FreshnessSettings;
+        use deps_core::lsp_helpers::generate_hover;
+        use deps_core::{PublishTime, VersionData};
+        use std::collections::HashMap;
+        use tower_lsp_server::ls_types::HoverContents;
+
+        struct OneVersionRegistry;
+
+        impl deps_core::Registry for OneVersionRegistry {
+            fn get_versions<'a>(
+                &'a self,
+                _name: &'a PackageName,
+            ) -> std::pin::Pin<
+                Box<
+                    dyn std::future::Future<
+                            Output = deps_core::Result<Vec<Box<dyn deps_core::Version>>>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                Box::pin(async move {
+                    Ok(vec![Box::new(crate::types::GithubActionsVersion {
+                        version: "v4.2.0".into(),
+                        sha: "a".repeat(40),
+                        prerelease: false,
+                        published_at: None,
+                    }) as Box<dyn deps_core::Version>])
+                })
+            }
+
+            fn get_latest_matching<'a>(
+                &'a self,
+                _name: &'a PackageName,
+                _req: &'a VersionReq,
+            ) -> std::pin::Pin<
+                Box<
+                    dyn std::future::Future<
+                            Output = deps_core::Result<Option<Box<dyn deps_core::Version>>>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                Box::pin(async move { Ok(None) })
+            }
+
+            fn search<'a>(
+                &'a self,
+                _query: &'a str,
+                _limit: usize,
+            ) -> std::pin::Pin<
+                Box<
+                    dyn std::future::Future<
+                            Output = deps_core::Result<Vec<Box<dyn deps_core::Metadata>>>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                Box::pin(async move { Ok(Vec::new()) })
+            }
+
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+        }
+
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let content = "steps:\n  - uses: actions/checkout@v4\n";
+        let parse_result = crate::parser::parse_workflow_yaml(content, &uri).unwrap();
+        let cached = HashMap::new();
+        let resolved = HashMap::new();
+        let fmt = formatter();
+        let position = deps_core::ParseResult::dependencies(&parse_result)[0]
+            .name_range()
+            .start;
+
+        let hover = generate_hover(
+            &parse_result,
+            position,
+            VersionData::new(&cached, &resolved),
+            &OneVersionRegistry,
+            &fmt,
+            FreshnessSettings::default(),
+            PublishTime::now(),
+        )
+        .await
+        .expect("hover should be generated for the dependency on this line");
+
+        let HoverContents::Markup(content) = hover.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(
+            content.value.contains("**Recent versions**"),
+            "a non-empty live version list must render the section; got: {}",
+            content.value
+        );
+        assert!(
+            content.value.contains("Press `Cmd+.`"),
+            "a resolvable Registry source with real live version data must still show \
+             the update footer; got: {}",
+            content.value
         );
     }
 

--- a/crates/deps-github-actions/src/registry.rs
+++ b/crates/deps-github-actions/src/registry.rs
@@ -174,6 +174,28 @@ impl GithubActionsRegistry {
         }
     }
 
+    /// Creates a registry pointed at a `mockito`-backed URL instead of the real GitHub API
+    /// (critic finding C1 regression coverage, #550) — `pub(crate)`, not module-private, so
+    /// `crate::ecosystem`'s tests can build a [`crate::ecosystem::GithubActionsEcosystem`]
+    /// around a registry whose fetches are fully mocked, letting an end-to-end
+    /// `generate_hover` test reproduce a genuinely empty-but-successful live fetch
+    /// (`available_versions == Some([])`) without a real network call.
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn for_test(
+        cache: Arc<HttpCache>,
+        api_base: impl Into<String>,
+        has_token: bool,
+    ) -> Self {
+        Self {
+            github: GithubTagsClient::for_test(cache, api_base, has_token),
+            tag_index: Arc::new(DashMap::new()),
+            in_flight: Arc::new(DashMap::new()),
+            rate_limit: Arc::new(RateLimitGate::default()),
+            release_dates: Arc::new(ReleaseDatesCache::new()),
+        }
+    }
+
     /// Shares this registry's [`TagIndex`] map with a [`crate::formatter::GithubActionsFormatter`],
     /// so a formatted SHA-pin edit can resolve the new SHA for a given tag.
     ///
@@ -625,13 +647,7 @@ mod tests {
     }
 
     fn mock_registry(base: &str, has_token: bool) -> GithubActionsRegistry {
-        GithubActionsRegistry {
-            github: GithubTagsClient::for_test(Arc::new(HttpCache::new()), base, has_token),
-            tag_index: Arc::new(DashMap::new()),
-            in_flight: Arc::new(DashMap::new()),
-            rate_limit: Arc::new(RateLimitGate::default()),
-            release_dates: Arc::new(ReleaseDatesCache::new()),
-        }
+        GithubActionsRegistry::for_test(Arc::new(HttpCache::new()), base, has_token)
     }
 
     #[tokio::test]

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -247,6 +247,48 @@ fn merge_deprecations_after_fetch(
     }
 }
 
+/// Merges a partial fetch's #550 no-comparable-versions findings into `doc.outcomes`'
+/// corresponding channel (incremental didChange path).
+///
+/// Package-level, like [`merge_deprecations_after_fetch`] (not tied to the declared
+/// version, unlike `yanked`/`fetch_failure` — see the `diff.version_changed` pruning
+/// loop in [`handle_document_change`] for why those two, but not this one, are cleared
+/// on a version-only edit): if a package's registry situation improves between fetches
+/// (a real tag gets published), a stale marker must not survive for the document's
+/// lifetime.
+///
+/// `attempted_names` — every raw package name a fetch was actually attempted for this
+/// round (`dep_sources`' keys, captured before it is consumed) — rather than
+/// [`merge_deprecations_after_fetch`]'s `fetched_names` (`fetch_result.versions`'
+/// keys): a no-comparable-versions package is by definition never a member of
+/// `fetch_result.versions`, so deriving "attempted" from that map's keys would miss
+/// every package this function exists to clear or set.
+fn merge_no_comparable_versions_after_fetch(
+    doc: &mut DocumentState,
+    attempted_names: &[PackageName],
+    mut fetched_no_comparable_versions: HashSet<PackageName>,
+    formatter: &dyn deps_core::lsp_helpers::EcosystemFormatter,
+) {
+    // Same normalized-name dedup rationale as `merge_deprecations_after_fetch` (I2):
+    // decided per normalized name in one pass so two raw names sharing a normalized
+    // key can't flip the outcome based on `attempted_names`' unspecified iteration
+    // order.
+    let mut per_normalized: HashMap<String, bool> = HashMap::new();
+    for name in attempted_names {
+        let normalized = formatter.normalize_package_name(name);
+        let found = fetched_no_comparable_versions.remove(name);
+        let entry = per_normalized.entry(normalized).or_insert(false);
+        *entry = *entry || found;
+    }
+    for (normalized, found) in per_normalized {
+        if found {
+            doc.outcomes.set_no_comparable_versions(normalized);
+        } else {
+            doc.outcomes.clear_no_comparable_versions(&normalized);
+        }
+    }
+}
+
 /// Ceiling on the OSV scan timeout, independent of the configured
 /// `fetch_timeout_secs`: the shared `reqwest` client behind `HttpCache`
 /// already imposes its own client-wide 30s timeout (`cache.rs`), so a
@@ -975,6 +1017,13 @@ struct FetchResult {
     /// package doesn't exist" from "the registry couldn't be asked" instead
     /// of conflating both into a misleading "Unknown package" diagnostic.
     fetch_failed: HashMap<PackageName, FetchFailure>,
+    /// Packages whose registry fetch succeeded but produced zero comparable versions
+    /// (#550), keyed by **raw** package name (same raw/normalized split as
+    /// `yanked_versions` above). Distinct from `fetch_failed`: the registry was
+    /// successfully asked and the package demonstrably exists — it just has nothing a
+    /// version-comparison rule can use — so `generate_diagnostics_from_cache` must
+    /// report neither "Registry lookup failed" nor "Unknown package" for it.
+    no_comparable_versions: HashSet<PackageName>,
     /// Number of packages whose registry fetch did not succeed, counting both a genuine
     /// fetch failure (timeout, error — recorded in `fetch_failed` above) and a not-found
     /// lookup (the registry answered "no such package", never recorded in `fetch_failed`,
@@ -1098,6 +1147,10 @@ async fn fetch_latest_versions_parallel(
                 let mut yanked: Option<(PackageName, ConcreteVersion, RemovalStatus)> = None;
                 let mut failed_name: Option<(PackageName, FetchFailure, String)> = None;
                 let mut deprecation: Option<(PackageName, Deprecation)> = None;
+                // Set only when the fetch (and its `get_latest_matching` fallback) both
+                // genuinely succeeded yet resolved to no version at all (#550) — see the
+                // `Ok(Ok(None))` fallback arm below.
+                let mut no_comparable_versions = false;
                 let version = match result {
                     Ok(Ok(versions)) => {
                         let available: Arc<[ConcreteVersion]> = versions
@@ -1187,6 +1240,15 @@ async fn fetch_latest_versions_parallel(
                                 }
                                 Ok(Ok(None)) => {
                                     tracing::debug!(package = %name, "no version found");
+                                    // Both the list-based pick and this fallback
+                                    // genuinely succeeded and found nothing — the
+                                    // package demonstrably exists (the fetch itself
+                                    // never errored), it just has zero versions this
+                                    // registry can compare against (#550), e.g. a
+                                    // repository whose only tags don't parse as full
+                                    // semver. Distinct from every branch below that
+                                    // sets `failed_name`.
+                                    no_comparable_versions = true;
                                     None
                                 }
                                 Ok(Err(e)) => {
@@ -1356,7 +1418,14 @@ async fn fetch_latest_versions_parallel(
                     sender.send(count);
                 }
 
-                (version, yanked, failed_name, deprecation)
+                let no_comparable_versions_name = no_comparable_versions.then(|| name.clone());
+                (
+                    version,
+                    yanked,
+                    failed_name,
+                    deprecation,
+                    no_comparable_versions_name,
+                )
             }
         })
         .buffer_unordered(max_concurrent)
@@ -1367,11 +1436,12 @@ async fn fetch_latest_versions_parallel(
     let mut yanked_versions = HashMap::new();
     let mut fetch_failed = HashMap::new();
     let mut deprecations = HashMap::new();
+    let mut no_comparable_versions = HashSet::new();
     // First actionable failure in completion order — `results` is collected from
     // `buffer_unordered`, so its order already reflects real finishing order, the same
     // order a shared `Arc<Mutex>` written from inside each task would have observed.
     let mut priority_error: Option<String> = None;
-    for (version, yanked, failed_name, deprecation) in results {
+    for (version, yanked, failed_name, deprecation, no_comparable_versions_name) in results {
         if let Some((name, v)) = version {
             versions.insert(name, v);
         }
@@ -1387,6 +1457,9 @@ async fn fetch_latest_versions_parallel(
         if let Some((name, d)) = deprecation {
             deprecations.insert(name, d);
         }
+        if let Some(name) = no_comparable_versions_name {
+            no_comparable_versions.insert(name);
+        }
     }
 
     // `priority_error` (an actual fetch failure — rate limit, timeout, outage, ...)
@@ -1401,6 +1474,7 @@ async fn fetch_latest_versions_parallel(
         yanked_versions,
         fetch_failed,
         deprecations,
+        no_comparable_versions,
         failed_count: failed.load(std::sync::atomic::Ordering::Relaxed),
         first_error: error_message,
     }
@@ -1660,6 +1734,9 @@ pub async fn handle_document_open(
             }
             for (name, failure) in fetch_result.fetch_failed {
                 outcomes.set_fetch_failure(formatter.normalize_package_name(&name), failure);
+            }
+            for name in fetch_result.no_comparable_versions {
+                outcomes.set_no_comparable_versions(formatter.normalize_package_name(&name));
             }
             // `collided_names` (spec FR-011) are merged in alongside genuine fetch
             // failures so `generate_diagnostics_from_cache` reports "lookup could not
@@ -2037,6 +2114,16 @@ pub async fn handle_document_change(
         };
 
         // Fetch latest versions only for NEW dependencies
+        //
+        // Captured before `dep_sources` is moved into the call below: every raw name a
+        // fetch was actually attempted for this round, used by the #550
+        // no-comparable-versions merge further down to distinguish "attempted and
+        // resolved fine this round" (clear any stale marker) from "not attempted this
+        // round" (leave any existing marker untouched) — unlike `fetched_names` below,
+        // this can't be derived from `fetch_result.versions`'s keys, since a
+        // no-comparable-versions package is by definition never one of them.
+        let attempted_names: Vec<PackageName> =
+            dep_sources.iter().map(|(name, _)| name.clone()).collect();
         let registry = ecosystem_clone.registry();
         let fetch_result = fetch_latest_versions_parallel(
             registry,
@@ -2085,6 +2172,12 @@ pub async fn handle_document_change(
                 &mut doc,
                 &fetched_names,
                 fetch_result.deprecations,
+                formatter,
+            );
+            merge_no_comparable_versions_after_fetch(
+                &mut doc,
+                &attempted_names,
+                fetch_result.no_comparable_versions,
                 formatter,
             );
             if success {
@@ -3977,6 +4070,85 @@ mod tests {
             "a genuine not-found must not be recorded in fetch_failed, or \
              generate_diagnostics_from_cache would report it as a registry \
              error instead of Unknown package"
+        );
+    }
+
+    /// Regression for #550: a registry fetch that genuinely succeeds (no error at
+    /// either the list-based pick or the `get_latest_matching` fallback) but resolves
+    /// to zero versions must be recorded in `no_comparable_versions`, distinct from
+    /// both a normal successful fetch (`versions`) and a real failure
+    /// (`fetch_failed`). Mirrors `GithubActionsRegistry::get_versions("dtolnay/rust-toolchain")`,
+    /// whose sole tag `v1` doesn't parse as full semver, so `tags_to_versions` filters
+    /// it out and returns `Ok(vec![])`.
+    #[tokio::test]
+    async fn test_fetch_success_with_zero_versions_is_recorded_as_no_comparable_versions() {
+        use deps_core::{Metadata, Registry, Version};
+        use std::any::Any;
+
+        struct EmptyButRealRegistry;
+
+        impl Registry for EmptyButRealRegistry {
+            fn get_versions<'a>(
+                &'a self,
+                _name: &'a deps_core::PackageName,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Version>>>>
+            {
+                Box::pin(async move { Ok(vec![]) })
+            }
+
+            fn get_latest_matching<'a>(
+                &'a self,
+                _name: &'a deps_core::PackageName,
+                _req: &'a deps_core::VersionReq,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Option<Box<dyn Version>>>>
+            {
+                Box::pin(async move { Ok(None) })
+            }
+
+            fn search<'a>(
+                &'a self,
+                _query: &'a str,
+                _limit: usize,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Metadata>>>>
+            {
+                Box::pin(async move { Ok(vec![]) })
+            }
+
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        let registry: Arc<dyn Registry> = Arc::new(EmptyButRealRegistry);
+        let packages = vec![PackageName::new("dtolnay/rust-toolchain")];
+
+        let result = fetch_latest_versions_parallel(
+            registry,
+            with_registry_source(packages),
+            &HashMap::new(),
+            None,
+            deps_core::freshness::FreshnessSettings::default(),
+            5,
+            10,
+            None,
+        )
+        .await;
+
+        assert!(result.versions.is_empty());
+        assert!(
+            result.fetch_failed.is_empty(),
+            "a genuine empty-but-successful fetch must not be recorded as a fetch \
+             failure, or generate_diagnostics_from_cache would report a registry \
+             error instead of nothing"
+        );
+        assert!(
+            result
+                .no_comparable_versions
+                .contains(&PackageName::new("dtolnay/rust-toolchain")),
+            "a package whose fetch succeeded with zero comparable versions must be \
+             recorded in no_comparable_versions, or R5 would misreport it as Unknown \
+             package; got: {:?}",
+            result.no_comparable_versions
         );
     }
 
@@ -6138,6 +6310,102 @@ time = "0.1.43"
                      regardless of fetch order: {names:?}"
                 );
             }
+        }
+
+        /// Regression for critic finding C3 (#550): `merge_no_comparable_versions_after_fetch`'s
+        /// `found == true` branch (`set_no_comparable_versions`) had zero coverage — mirrors
+        /// `test_merge_deprecations_after_fetch_retains_finding_for_name_not_refetched`, but
+        /// for the *first-time-set* case: a package attempted this round whose fetch
+        /// genuinely found zero comparable versions must be recorded, and an unrelated
+        /// package not attempted this round must be left untouched either way.
+        #[test]
+        fn test_merge_no_comparable_versions_after_fetch_sets_finding_for_newly_flagged_name() {
+            let state = ServerState::new();
+            let ecosystem = state.ecosystem_registry.get("cargo").unwrap();
+            let formatter = ecosystem.formatter();
+            let mut doc =
+                DocumentState::new_without_parse_result(EcosystemId::Cargo, String::new());
+
+            // "vendor/b" was attempted this round (e.g. a new dependency added by the
+            // edit) and its fetch genuinely succeeded with zero comparable versions;
+            // "vendor/a" was not attempted at all.
+            let mut fetched = HashSet::new();
+            fetched.insert(PackageName::new("vendor/b"));
+            merge_no_comparable_versions_after_fetch(
+                &mut doc,
+                &[PackageName::new("vendor/b")],
+                fetched,
+                formatter,
+            );
+
+            assert!(
+                doc.outcomes.no_comparable_versions("vendor/b"),
+                "a package whose fetch was attempted and found zero comparable versions \
+                 this round must be recorded"
+            );
+            assert!(
+                !doc.outcomes.no_comparable_versions("vendor/a"),
+                "a package never attempted this round must not be flagged"
+            );
+        }
+
+        /// Regression for critic finding C3 (#550): the literal "package no longer has
+        /// zero-comparable-versions on a subsequent fetch" scenario — e.g.
+        /// `dtolnay/rust-toolchain` eventually publishes a real `v1.2.3` tag. Mirrors
+        /// `test_merge_deprecations_after_fetch_clears_finding_when_refetched_clean`.
+        #[test]
+        fn test_merge_no_comparable_versions_after_fetch_clears_finding_when_refetched_with_versions()
+         {
+            let state = ServerState::new();
+            let ecosystem = state.ecosystem_registry.get("cargo").unwrap();
+            let formatter = ecosystem.formatter();
+            let mut doc =
+                DocumentState::new_without_parse_result(EcosystemId::Cargo, String::new());
+            doc.outcomes
+                .set_no_comparable_versions("vendor/a".to_string());
+
+            // "vendor/a" was re-fetched this round and this time resolved a real
+            // version, so it's absent from the fetched-flags set.
+            merge_no_comparable_versions_after_fetch(
+                &mut doc,
+                &[PackageName::new("vendor/a")],
+                HashSet::new(),
+                formatter,
+            );
+
+            assert!(
+                !doc.outcomes.no_comparable_versions("vendor/a"),
+                "a package that was attempted and this time resolved a real version must \
+                 have its stale marker cleared, or R5e would keep suppressing Unknown \
+                 package diagnostics for a name that could now legitimately need one"
+            );
+        }
+
+        /// A finding for a name not attempted this round (e.g. an unrelated dependency
+        /// untouched by a partial didChange fetch) must survive untouched — distinct
+        /// from the clear-on-refetch case above.
+        #[test]
+        fn test_merge_no_comparable_versions_after_fetch_retains_finding_for_name_not_attempted() {
+            let state = ServerState::new();
+            let ecosystem = state.ecosystem_registry.get("cargo").unwrap();
+            let formatter = ecosystem.formatter();
+            let mut doc =
+                DocumentState::new_without_parse_result(EcosystemId::Cargo, String::new());
+            doc.outcomes
+                .set_no_comparable_versions("vendor/a".to_string());
+
+            // Only "vendor/b" was attempted this round; "vendor/a" was untouched.
+            merge_no_comparable_versions_after_fetch(
+                &mut doc,
+                &[PackageName::new("vendor/b")],
+                HashSet::new(),
+                formatter,
+            );
+
+            assert!(
+                doc.outcomes.no_comparable_versions("vendor/a"),
+                "a finding for a name not attempted this round must survive untouched"
+            );
         }
 
         #[tokio::test]


### PR DESCRIPTION
## Summary

Two related GitHub Actions dependency-classification bugs, both rooted in how `deps-github-actions` (and the shared `deps-core`/`deps-lsp` cache/diagnostic layers) handle real-world git tag naming conventions that don't fit a `vX.Y.Z` shape:

- A `PackageVersions`/diagnostic-layer gap conflated "package doesn't exist / fetch failed" with "package exists but its tags are all non-full-semver" into the same "absent from cache" state, producing a false `Unknown package` diagnostic for repos like `dtolnay/rust-toolchain` (its only tag is `v1`).
- A static text-shape heuristic (`is_tag_shaped`) permanently misclassified literal-named tags like `taiki-e/install-action@cargo-deny` as an undiagnosable branch pin, even though the registry's own `/tags` fetch already confirms they're real tags.

## Changes

- New `DependencyOutcome::no_comparable_versions` channel distinguishes a successful-but-empty version fetch from a failed/never-attempted one; wired into `apply_unknown_package_rule` (new R5e arm) to suppress the false diagnostic, and into `hover.rs` to stop rendering an empty "Recent versions" header with a stray `Cmd+.` footer. Lives entirely in ecosystem-agnostic `deps-core`/`deps-lsp` code, so `deps-swift` (identical bug pattern) is fixed too without any Swift-specific change.
- New `is_registry_confirmed_tag` in `deps-github-actions` reclassifies a `PinStyle::Branch` ref as diagnosable once the registry's `TagIndex` confirms it's a real tag, wired into the mutable-ref-pin diagnostic. The automated SHA-pin quickfix (`build_sha_pin_action`) deliberately still refuses this case — an existing safety boundary (FR-005) against branch/tag name-collision ambiguity in GitHub's `uses:` ref resolution — so the diagnostic message now explicitly says the fix is manual.
- Fixed a related online-footer regression surfaced during review: the `Cmd+.` footer was being suppressed for bare-major-tag GitHub Actions (e.g. `actions/checkout@v4`) even when a real SHA-pin quickfix was available, because the footer's gating condition only looked at `VersionData`, not the GHA-specific `TagIndex`.
- Added regression tests reproducing both original scenarios end-to-end via mocks/fixtures (no live network calls), plus dedicated unit tests for the new cache-merge logic.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (3784 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New regression tests for both issues (non-semver-only tag list, literal-named tag alongside a real vN tag)
- [x] Verified `deps-swift` unaffected/fixed by inspection of its shared code path, not just by its test suite passing

Closes #550
Closes #551