### PR TITLE
release: v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-09-03
+
 ### Added
 - **deps-core, deps-lsp**: supply-chain trust signal in hover — OpenSSF Scorecard score and SLSA/attestation provenance status via deps.dev, for npm/Cargo/Go/Maven/PyPI/Bundler/NuGet, behind a new `supply_chain.enabled` toggle (resolves #543) (#554)
 
 ### Fixed
-- **deps-core, deps-github-actions, deps-swift**: fixed sequential GitHub tag-pagination fetch exceeding the per-dependency timeout for high-tag-count repos (resolves #553)
+- **deps-core, deps-github-actions, deps-swift**: fixed sequential GitHub tag-pagination fetch exceeding the per-dependency timeout for high-tag-count repos (resolves #553) (#555)
 - **deps-core, deps-lsp, deps-github-actions**: fixed false "Unknown package" diagnostic when a dependency's tags exist but none are full-semver-shaped (e.g. `dtolnay/rust-toolchain`), and a stray hover "Press Cmd+. to update version" footer with an empty "Recent versions" section in the same case (resolves #550) (#552)
 - **deps-github-actions**: mutable-ref-pin diagnostic now fires for literal-named git tags (e.g. `taiki-e/install-action@cargo-deny`) previously misclassified as an undiagnosable branch pin (resolves #551) (#552)
 
@@ -726,7 +728,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TLS enforced via rustls
 - cargo-deny configured for vulnerability scanning
 
-[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/bug-ops/deps-lsp/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/bug-ops/deps-lsp/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/bug-ops/deps-lsp/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/bug-ops/deps-lsp/compare/v0.10.1...v0.11.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "deps-bundler"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "criterion",
  "deps-core",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "deps-cargo"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "bytes",
  "criterion",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "deps-composer"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "deps-core",
  "mockito",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "deps-core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "bytes",
  "criterion",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "deps-dart"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "criterion",
  "deps-core",
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "deps-deno"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "deps-core",
  "deps-npm",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "deps-github-actions"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "dashmap",
  "deps-core",
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "deps-go"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "criterion",
  "deps-core",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "deps-gradle"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "deps-core",
  "deps-maven",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "deps-lsp"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "criterion",
  "dashmap",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "deps-maven"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "bytes",
  "dashmap",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "deps-npm"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "criterion",
  "dashmap",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "deps-nuget"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "criterion",
  "deps-core",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "deps-pypi"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "criterion",
  "dashmap",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "deps-swift"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "bytes",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/deps-zed"]
 resolver = "3"
 
 [workspace.package]
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.91"
 authors = ["Andrei G"]
@@ -15,21 +15,21 @@ repository = "https://github.com/bug-ops/deps-lsp"
 bytes = "1"
 criterion = "0.8"
 dashmap = "6.2"
-deps-bundler = { version = "0.12.0", path ="crates/deps-bundler" }
-deps-cargo = { version = "0.12.0", path ="crates/deps-cargo" }
-deps-composer = { version = "0.12.0", path ="crates/deps-composer" }
-deps-core = { version = "0.12.0", path ="crates/deps-core" }
-deps-dart = { version = "0.12.0", path ="crates/deps-dart" }
-deps-deno = { version = "0.12.0", path ="crates/deps-deno" }
-deps-github-actions = { version = "0.12.0", path ="crates/deps-github-actions" }
-deps-go = { version = "0.12.0", path ="crates/deps-go" }
-deps-gradle = { version = "0.12.0", path ="crates/deps-gradle" }
-deps-lsp = { version = "0.12.0", path ="crates/deps-lsp" }
-deps-maven = { version = "0.12.0", path ="crates/deps-maven" }
-deps-npm = { version = "0.12.0", path ="crates/deps-npm" }
-deps-nuget = { version = "0.12.0", path ="crates/deps-nuget" }
-deps-pypi = { version = "0.12.0", path ="crates/deps-pypi" }
-deps-swift = { version = "0.12.0", path ="crates/deps-swift" }
+deps-bundler = { version = "0.12.1", path ="crates/deps-bundler" }
+deps-cargo = { version = "0.12.1", path ="crates/deps-cargo" }
+deps-composer = { version = "0.12.1", path ="crates/deps-composer" }
+deps-core = { version = "0.12.1", path ="crates/deps-core" }
+deps-dart = { version = "0.12.1", path ="crates/deps-dart" }
+deps-deno = { version = "0.12.1", path ="crates/deps-deno" }
+deps-github-actions = { version = "0.12.1", path ="crates/deps-github-actions" }
+deps-go = { version = "0.12.1", path ="crates/deps-go" }
+deps-gradle = { version = "0.12.1", path ="crates/deps-gradle" }
+deps-lsp = { version = "0.12.1", path ="crates/deps-lsp" }
+deps-maven = { version = "0.12.1", path ="crates/deps-maven" }
+deps-npm = { version = "0.12.1", path ="crates/deps-npm" }
+deps-nuget = { version = "0.12.1", path ="crates/deps-nuget" }
+deps-pypi = { version = "0.12.1", path ="crates/deps-pypi" }
+deps-swift = { version = "0.12.1", path ="crates/deps-swift" }
 dirs = "6"
 futures = "0.3"
 insta = "1.48"

--- a/crates/deps-core/README.md
+++ b/crates/deps-core/README.md
@@ -26,6 +26,7 @@ This crate provides the shared infrastructure used by all ecosystem-specific cra
 - **`check_yaml_nesting_depth`** — single-pass structural guard rejecting pathologically nested YAML (flow bracket depth and block-style indentation/dash-chain nesting) before it reaches the recursive-descent `yaml-rust2` parser
 - **`check_yaml_expansion`** — streaming pre-pass over `yaml-rust2`'s own parser event stream rejecting YAML whose anchor/alias references would expand to an excessive number of allocated bytes (billion-laughs-style), independent of nesting depth
 - **`lockfile::read_lockfile_content`** — shared read-and-error-wrap helper for lock file parsers
+- **`deps_dev::DepsDevClient`** — supply-chain trust signal client for the [deps.dev](https://deps.dev) API, resolving a dependency's linked source repository, OpenSSF Scorecard score, and SLSA/attestation provenance status (`SupplyChainTrustSignal`, `ScorecardSummary`, `ProvenanceStatus`)
 - **Error types** — Unified error handling with `thiserror`
 
 ## Installation

--- a/crates/deps-lsp/README.md
+++ b/crates/deps-lsp/README.md
@@ -17,6 +17,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 - **Hover info** — Package descriptions with resolved version from lock file
 - **Diagnostics** — Warnings for outdated, unknown, yanked, or unsatisfiable-requirement dependencies
 - **Vulnerability scanning** — OSV.dev-backed advisories in diagnostics and hover, across all supported ecosystems
+- **Supply-chain trust signal** — OpenSSF Scorecard score and SLSA/attestation provenance status in hover, via deps.dev, for npm, Cargo, Go, Maven, PyPI, Bundler, and NuGet
 - **Release-freshness signal** — Flags a "latest" version still within a cooldown window in hover and completion, mirroring GitHub Dependabot's default 3-day package cooldown
 - **Code actions** — Quick fixes to update dependencies, resolve unsatisfiable version requirements, and upgrade to a patched version for known vulnerabilities
 - **Code lens** — "Update N outdated dependencies" batch update on every open manifest
@@ -61,6 +62,7 @@ deps-lsp = { version = "0.12", default-features = false, features = ["cargo", "n
 | `composer` | PHP / composer.json | Yes |
 | `nuget` | C# / .csproj, Directory.Packages.props, packages.config | Yes |
 | `deno` | Deno (JSR/npm) / deno.json, deno.jsonc | Yes |
+| `github-actions` | YAML / .github/workflows/*.yml, *.yaml | Yes |
 
 `deno` pulls in `deps-npm` transitively (`DenoRegistry` delegates `npm:` specifiers to it, per its D3 architecture), even when the `npm` feature itself is disabled.
 

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -774,6 +774,10 @@ independently on the same step with distinct codes:
 actions/checkout is pinned to the mutable tag ref `v4`; pin to a full commit SHA to guard against tag mutation
 ```
 
+The diagnostic fires for two kinds of tags:
+- **Semantic-version-shaped tags** (`v1.2.3`, `v4.0`, etc.) — detected by text pattern and confirmed via the registry.
+- **Literal-named tags** (non-version-like names such as `cargo-deny`, `latest-stable`) — these do not look tag-shaped to the parser, but when the registry confirms they are real tags, they become eligible for this diagnostic too (issue #551).
+
 Unlike every other diagnostic in this project, severity alone cannot silence this one —
 `DiagnosticSeverity` has no suppression value. Set `diagnostics.mutable_ref_pin_enabled` to
 `false` in initialization options to turn it off entirely for teams that intentionally accept
@@ -783,12 +787,13 @@ tag pinning.
 `<sha> # <tag>` — the exact same `{sha} # {tag}` shape the outdated-SHA-update quick fix already
 produces for a SHA-pinned step, reusing the tag/SHA cross-reference already populated by the
 existing outdated-version check (zero new network calls). The quick fix is withheld, not offered
-with a wrong or destructive edit, in two cases:
+with a wrong or destructive edit, in three cases:
 
 - The tag's commit SHA is not yet known — e.g. the document was opened before the registry fetch
   completed, or the tag was moved/deleted/is not a full `major.minor.patch` release the registry
   indexes (a moving major-version ref like `v4` itself is frequently in this category — GitHub's
   tags API lists `v4.3.1`, not a synthetic `v4` tag object).
+- **For literal-named tags**, even if the SHA is known, the quick fix is deliberately withheld (safety boundary FR-005) — a literal tag name like `cargo-deny` could in principle be a typo for a branch name, and silently replacing it with an auto-rewritten SHA would lock workflow behavior in place without the author's explicit intent. The diagnostic still fires so you know the tag is mutable, but the fix requires manual intervention to avoid accidental branch/tag confusion.
 - The `uses:` value is a **quoted YAML scalar** (`uses: "actions/checkout@v4"`). The ref text
   sits inside the quotes there, so appending `# <tag>` would place a `#` inside the string rather
   than starting a YAML comment — a `uses:` value GitHub Actions rejects. Re-pin a quoted step by
@@ -798,6 +803,17 @@ with a wrong or destructive edit, in two cases:
 tag-to-SHA-style index exists for branches, and adding one would require a new network call per
 branch; reusable-workflow calls (`owner/repo/.github/workflows/x.yml@ref`) and `./local`/
 `docker://` references are not resolvable refs and get no diagnostic either.
+
+### GitHub Actions: Non-Semver Tag Handling (issue #550)
+
+When a GitHub Action repository has only tags that don't parse as full semantic versions — such as
+`dtolnay/rust-toolchain` with its sole tag `v1`, or literal-named tags like `cargo-deny` — the
+hover and diagnostics now handle these gracefully instead of showing a false "Unknown package"
+diagnostic.
+
+- **Hover**: shows the package as resolvable (not unknown), but with an empty "Recent versions" list since no tag matches the standard semver filter. The mutable-ref-pin diagnostic still fires for the tag ref even though no update-to-latest is available.
+- **Diagnostics**: the package is recognized as resolvable, not reported as "Unknown package" — this is a real action, just not one with a conventional semver release train.
+- **Literal-named tags** (non-version-like names): are now recognized as actual tags (when confirmed by the registry) and qualify for the mutable-ref-pin diagnostic, even though they don't follow the `major.minor.patch` or `v\d+` patterns the parser heuristic would normally detect.
 
 ### Supply-Chain Trust Signal (issue #543)
 

--- a/specs/037-supply-chain-trust-signal/spec.md
+++ b/specs/037-supply-chain-trust-signal/spec.md
@@ -14,7 +14,7 @@ tags:
   - cross-ecosystem
 created: 2026-09-03
 updated: 2026-09-03
-status: draft
+status: shipped
 related:
   - "[[constitution]]"
   - "[[MOC-specs]]"

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -58,7 +58,7 @@ status: moc
 | 034 | [[034-go-goproxy-private-registry/spec\|Go GOPROXY/GOPRIVATE module proxy resolution]] | specify | draft — research/enhancement, P3 |
 | 035 | [[035-nuget-private-feed-support/spec\|NuGet private/custom feed support (NuGet.Config packageSources)]] | specify | research/parity, P3, 3 open `[NEEDS CLARIFICATION]` items (issue #523) |
 | 036 | [[036-composer-uppercase-v-prefix-bug/spec\|Composer requirement matching fails for uppercase-V-prefixed versions]] | specify | shipped — bug, P1 (PR #538, issue #534) |
-| 037 | [[037-supply-chain-trust-signal/spec\|Supply-chain trust signal (OpenSSF Scorecard + SLSA provenance) via deps.dev]] | plan | draft — research/parity, P3, implemented and reviewed, PR open (PR #554, issue #543) |
+| 037 | [[037-supply-chain-trust-signal/spec\|Supply-chain trust signal (OpenSSF Scorecard + SLSA provenance) via deps.dev]] | plan | shipped — research/parity, P3 (PR #554, issue #543) |
 | 038 | [[038-workspace-diagnostics-pull-support/spec\|Workspace Diagnostics Pull Support]] | specify | draft — research/enhancement, P4, 4 open `[NEEDS CLARIFICATION]` items (issue #547) |
 | 039 | [[039-github-rate-limit-actionable-diagnostic/spec\|Actionable rate-limit hint in registry diagnostics]] | specify | shipped — bug, P1 (PR #485, issue #478) |
 | 040 | [[040-github-token-redaction-trusted-origin-pin/spec\|GitHub auth token redaction and trusted-origin pinning]] | specify | shipped — security/hardening, P3 (PR #487, issue #484) |


### PR DESCRIPTION
## Summary

- Bump version from 0.12.0 to 0.12.1
- Update CHANGELOG.md with the 0.12.1 release section
- Update deps-core and deps-lsp crate READMEs for the supply-chain trust signal (deps_dev module, supply_chain feature/config)
- Update docs/ECOSYSTEM_GUIDE.md with the non-semver/literal-named tag handling added in #552
- Mark spec 037 (supply-chain trust signal) as shipped

## Changes since v0.12.0

- feat(deps-core,deps-lsp): supply-chain trust signal via deps.dev (#554)
- fix(deps-core,deps-github-actions): fetch tag pages concurrently to fit per-dependency timeout (#555)
- fix(deps-github-actions): correct tag/version classification for non-semver and literal-named tags (#552)

## Checklist

- [x] Version updated in all manifests
- [x] CHANGELOG.md has release section with date
- [x] READMEs and ECOSYSTEM_GUIDE.md reflect the release
- [x] All CI checks pass locally (fmt, clippy, nextest, rustdoc gate)
- [ ] Ready for tagging after merge