### PR TITLE
fix(deps-go): harden GOPROXY/GOPRIVATE follow-up items from #558

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **deps-go, deps-core, deps-lsp**: `$GOENV` `GOPROXY`/`GOPRIVATE` support — a `GOPROXY` proxy chain (with `direct`/`off` sentinels) or a `GOPRIVATE`-matched module path now resolves to live hover/diagnostic/completion data from the configured private proxy (or fails closed with no data for `direct`/`off`) instead of always querying `proxy.golang.org`, failing closed on a bad hop rather than falling back to the public proxy (#558)
 - **deps-nuget, deps-lsp**: NuGet private/custom feed support — in-repo `NuGet.Config` `<packageSources>`/`<clear/>`/`<disabledPackageSources>`/`<packageSourceCredentials>`/`<packageSourceMapping>` are now resolved to live hover/diagnostic/completion data instead of always querying `api.nuget.org`, failing closed on a bad/disabled/credentialed entry rather than falling back to the public feed (resolves #523) (#560)
+- **deps-go**: `$GOENV` `GOPROXY`/`GOPRIVATE` follow-up hardening — test-injectable `$GOENV` path, oversized-`GOPRIVATE`-pattern warning, expanded edge-case/integration test coverage, and `GOPROXY` `,`/`|` separator docs (resolves #559)
 
 ## [0.12.1] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **deps-go, deps-core, deps-lsp**: `$GOENV` `GOPROXY`/`GOPRIVATE` support — a `GOPROXY` proxy chain (with `direct`/`off` sentinels) or a `GOPRIVATE`-matched module path now resolves to live hover/diagnostic/completion data from the configured private proxy (or fails closed with no data for `direct`/`off`) instead of always querying `proxy.golang.org`, failing closed on a bad hop rather than falling back to the public proxy (#558)
 - **deps-nuget, deps-lsp**: NuGet private/custom feed support — in-repo `NuGet.Config` `<packageSources>`/`<clear/>`/`<disabledPackageSources>`/`<packageSourceCredentials>`/`<packageSourceMapping>` are now resolved to live hover/diagnostic/completion data instead of always querying `api.nuget.org`, failing closed on a bad/disabled/credentialed entry rather than falling back to the public feed (resolves #523) (#560)
-- **deps-go**: `$GOENV` `GOPROXY`/`GOPRIVATE` follow-up hardening — test-injectable `$GOENV` path, oversized-`GOPRIVATE`-pattern warning, expanded edge-case/integration test coverage, and `GOPROXY` `,`/`|` separator docs (resolves #559)
+- **deps-go**: `$GOENV` `GOPROXY`/`GOPRIVATE` follow-up hardening — test-injectable `$GOENV` path, oversized-`GOPRIVATE`-pattern warning, expanded edge-case/integration test coverage, and `GOPROXY` `,`/`|` separator docs (#563)
 
 ## [0.12.1] - 2026-09-03
 

--- a/crates/deps-go/src/config.rs
+++ b/crates/deps-go/src/config.rs
@@ -236,6 +236,15 @@ pub const GOPRIVATE_CHAIN_KEY: &str = "go-private:direct";
 /// Tracks which separator (`,`/`|`) preceded each entry (spec 034 S2) so the resulting
 /// [`GoProxyChain::separators`] preserves Go's own distinction between the two — a manual
 /// scan rather than `str::split([',', '|'])`, which would discard exactly that information.
+///
+/// **Known limitation** (spec 034 follow-up C1, issue #559 — documented, not fixed here; see
+/// `docs/ECOSYSTEM_GUIDE.md`'s GOPROXY section): when one or more invalid entries (FR-009)
+/// are dropped between two surviving hops, only the separator immediately preceding the
+/// *surviving* hop is kept — a separator that preceded a *dropped* entry is discarded, not
+/// merged. E.g. `a|invalid,c` records `,` (the separator after the dropped entry), not `|`
+/// (the separator the user actually wrote before it). Pre-existing since PR #558; the
+/// underlying carry-over behavior is out of scope for this PR (tracked as a separate
+/// follow-up) — only the doc/test gap around it is closed here.
 fn parse_goproxy(raw: &str, policy: &RegistryAccessPolicy) -> Result<GoProxyChain, InvalidEntry> {
     let mut hops: Vec<GoProxyHop> = Vec::new();
     let mut separators: Vec<ChainSeparator> = Vec::new();
@@ -374,10 +383,20 @@ pub struct GlobPattern {
 impl GlobPattern {
     /// Wraps and compiles `raw` — no validation surfaced to the caller, matching
     /// `path.Match`'s own behavior (a malformed or oversized pattern simply never matches, per
-    /// `Self::tokens`'s doc).
+    /// `Self::tokens`'s doc). An oversized pattern also logs a `tracing::warn!` (spec 034
+    /// follow-up F6, issue #559): unlike a malformed `GOPROXY` hop, a `GOPRIVATE` pattern that
+    /// never matches fails **open** on confidentiality (the module it should have hidden from
+    /// the public proxy routes there instead), so this failure must be visible rather than
+    /// silent.
     #[must_use]
     pub fn new(raw: &str) -> Self {
         let tokens = if raw.len() > MAX_GLOB_PATTERN_LENGTH {
+            tracing::warn!(
+                pattern_length = raw.len(),
+                max_length = MAX_GLOB_PATTERN_LENGTH,
+                "GOPRIVATE pattern exceeds max length; it will never match, so affected modules \
+                 route to the public proxy instead of being treated as private"
+            );
             None
         } else {
             compile_glob(raw)
@@ -632,6 +651,12 @@ impl GoEnvConfig {
 /// [`parse_goenv_raw`]'s doc for exactly which keys this can ever contain.
 #[derive(Debug, Default)]
 struct RawGoEnv {
+    /// Raw, unvalidated `GOPROXY` value, which may carry embedded userinfo until
+    /// [`GoProxyUrl::new`] rejects it per-hop. Retained for the process lifetime by
+    /// [`GoEnvCache`]'s memoization, mirroring `deps_npm::config::NpmConfigCache`'s identical
+    /// shape exactly — precedent-consistent, not a regression to fix (spec 034 security
+    /// review, F4). Never logged or transmitted as-is (FR-014); only [`redact_userinfo`]'d
+    /// output ever leaves this module.
     goproxy: Option<String>,
     goprivate: Option<String>,
 }
@@ -699,6 +724,13 @@ pub struct GoParseContext {
     pub policy: Arc<RegistryAccessPolicy>,
     /// Memoizes `$GOENV`'s raw, unvalidated contents across every parse that reads it.
     pub config_cache: Arc<GoEnvCache>,
+    /// The resolved `$GOENV` path to consult, if any — resolved once by the caller rather
+    /// than looked up internally, so nothing in this crate reads the live host environment
+    /// implicitly (spec 034 follow-up C3/C4, issue #559). Production callers
+    /// (`crate::lib::register_ecosystems`) pass [`goenv_path`]'s result; tests pass a fixture
+    /// path. `None` — the [`Default`] value — means "no `$GOENV` file", the same hermetic,
+    /// zero-host-read behavior [`crate::parser::parse_go_mod`]'s doc already promises.
+    pub goenv_path: Option<PathBuf>,
 }
 
 /// Resolves `$GOENV`'s path (FR-001).
@@ -744,6 +776,17 @@ fn goenv_path_with_env(env_value: Option<String>) -> Option<PathBuf> {
 #[must_use]
 pub fn resolve(cache: &GoEnvCache, policy: &RegistryAccessPolicy) -> GoEnvConfig {
     resolve_at(cache, policy, goenv_path())
+}
+
+/// Resolves `$GOENV` into a [`GoEnvConfig`], reading the already-resolved
+/// [`GoParseContext::goenv_path`] instead of calling [`goenv_path`] itself.
+///
+/// This is the seam `crate::parser::parse_go_mod_with_context` calls in production, and the
+/// way tests exercise the full parse -> resolve -> `register_chain` -> `get_versions_from`
+/// path without depending on the real host `$GOENV`.
+#[must_use]
+pub fn resolve_with_context(ctx: &GoParseContext) -> GoEnvConfig {
+    resolve_at(&ctx.config_cache, &ctx.policy, ctx.goenv_path.clone())
 }
 
 /// [`resolve`], but taking the `$GOENV` path explicitly instead of [`goenv_path`] — lets tests
@@ -936,6 +979,20 @@ mod tests {
         assert!(!pattern.matches(&"a".repeat(100)));
     }
 
+    /// F6 (spec 034 follow-up, issue #559 C2): an oversized `GOPRIVATE` pattern's silent
+    /// fail-open must actually log a `tracing::warn!`, not just be non-matching.
+    #[test]
+    fn test_glob_pattern_oversized_pattern_logs_warning() {
+        let long_pattern = "*".repeat(MAX_GLOB_PATTERN_LENGTH + 1);
+        let log = deps_core::test_util::capture_tracing_output(|| {
+            let _ = GlobPattern::new(&long_pattern);
+        });
+        assert!(
+            log.contains("GOPRIVATE pattern exceeds max length"),
+            "expected oversized-pattern warning in log: {log:?}"
+        );
+    }
+
     // --- GoEnvConfig::parse / resolve_source_for (FR-001-FR-009) ---
 
     #[test]
@@ -1118,6 +1175,84 @@ mod tests {
             config.resolve_source_for("github.com/other/repo"),
             DependencySource::Registry
         );
+    }
+
+    /// Edge case (issue #559): `GOPROXY=`/`GOPRIVATE=` with nothing after the `=` parse
+    /// successfully but resolve exactly as if the key were absent — no phantom empty-string
+    /// hop/pattern, no panic.
+    #[test]
+    fn test_goenv_empty_goproxy_and_goprivate_values_are_absent() {
+        let config = GoEnvConfig::parse("GOPROXY=\nGOPRIVATE=\n", &all_policy());
+        assert!(config.goproxy_chain().is_none());
+        assert!(!config.has_goprivate());
+        assert_eq!(
+            config.resolve_source_for("github.com/gin-gonic/gin"),
+            DependencySource::Registry
+        );
+    }
+
+    /// Edge case (issue #559): a `$GOENV` line with no `=` at all (not a comment, not blank)
+    /// is silently ignored rather than panicking or corrupting the previous/next key.
+    #[test]
+    fn test_goenv_malformed_line_without_equals_is_ignored() {
+        let content = "GARBAGE LINE WITH NO EQUALS\nGOPROXY=https://goproxy.mycorp.example\n";
+        let config = GoEnvConfig::parse(content, &all_policy());
+        assert!(config.goproxy_chain().is_some());
+    }
+
+    /// Edge case (issue #559): the same `GOPRIVATE` glob pattern declared twice still matches
+    /// (no dedup requirement, no panic) — duplicates are just redundant, not invalid.
+    #[test]
+    fn test_goenv_duplicate_goprivate_patterns_still_match() {
+        let config = GoEnvConfig::parse(
+            "GOPRIVATE=git.mycorp.example/*,git.mycorp.example/*",
+            &all_policy(),
+        );
+        assert!(config.has_goprivate());
+        assert_eq!(
+            config.resolve_source_for("git.mycorp.example/internal/auth"),
+            DependencySource::AlternateRegistry {
+                index: GOPRIVATE_CHAIN_KEY.to_string(),
+                mirrors_crates_io: false,
+            }
+        );
+    }
+
+    /// Edge case (issue #559): a chain mixing `|` before `,` (rather than the `,`-then-`|`
+    /// order `test_goproxy_separators_recorded_distinctly` already covers) still records each
+    /// transition with its own real semantics, not the first separator seen in the value.
+    #[test]
+    fn test_goproxy_mixed_pipe_then_comma_separators() {
+        let config = GoEnvConfig::parse(
+            "GOPROXY=https://a.example|https://b.example,direct",
+            &all_policy(),
+        );
+        let chain = config.goproxy_chain().unwrap();
+        assert_eq!(chain.hops.len(), 3);
+        assert!(matches!(chain.hops[2], GoProxyHop::Direct));
+        assert_eq!(
+            chain.separators,
+            vec![ChainSeparator::AnyError, ChainSeparator::NotFoundOnly]
+        );
+    }
+
+    /// C1 (spec 034 follow-up, issue #559) — **known limitation, pinned deliberately, not a
+    /// desired behavior**: a separator preceding a *dropped* invalid hop is discarded rather
+    /// than carried onto the merged transition between the two surviving hops. Here the
+    /// user's `|` (fall through on any error) before the invalid entry is lost, and the `,`
+    /// (fall through on not-found only) that happened to follow the dropped entry wins
+    /// instead — see `parse_goproxy`'s doc and `docs/ECOSYSTEM_GUIDE.md`'s GOPROXY section.
+    /// Pre-existing since PR #558; fixing the underlying carry-over behavior is out of scope
+    /// for this PR and tracked as a separate follow-up.
+    #[test]
+    fn test_goproxy_separator_before_dropped_hop_is_not_carried_over() {
+        let config = GoEnvConfig::parse(
+            "GOPROXY=https://a.example|not-a-valid-url,https://c.example",
+            &all_policy(),
+        );
+        let chain = config.goproxy_chain().unwrap();
+        assert_eq!(chain.hops.len(), 2);
+        assert_eq!(chain.separators, vec![ChainSeparator::NotFoundOnly]);
     }
 
     // --- redaction (FR-014/NFR-001) ---

--- a/crates/deps-go/src/parser.rs
+++ b/crates/deps-go/src/parser.rs
@@ -148,7 +148,7 @@ pub fn parse_go_mod_with_context(
         "Parsed go.mod successfully"
     );
 
-    let go_config = crate::config::resolve(&ctx.config_cache, &ctx.policy);
+    let go_config = crate::config::resolve_with_context(ctx);
     for dep in &mut dependencies {
         dep.source = go_config.resolve_source_for(dep.module_path.as_str());
     }
@@ -560,5 +560,60 @@ exclude github.com/bad/module v0.1.0
             stripped,
             "replace github.com/old => https://github.com/new "
         );
+    }
+
+    /// Integration test (issue #559 follow-up): the full parse -> resolve -> `register_chain`
+    /// -> `get_versions_from` path, exercised end-to-end against a real fixture `$GOENV` file
+    /// via [`GoParseContext::goenv_path`] rather than the real host environment.
+    #[tokio::test]
+    async fn test_integration_parse_resolve_register_chain_get_versions() {
+        use crate::registry::GoRegistry;
+        use deps_core::net_policy::{RegistryAccessPolicy, WorkspaceRegistryAccess};
+        use deps_core::{FreshnessSettings, HttpCache, Registry};
+        use std::sync::Arc;
+
+        let mut alt_server = mockito::Server::new_async().await;
+        alt_server
+            .mock("GET", "/github.com/gin-gonic/gin/@v/list")
+            .with_status(200)
+            .with_body("v1.9.1\n")
+            .create_async()
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let goenv_path = dir.path().join("env");
+        std::fs::write(
+            &goenv_path,
+            format!("GOPROXY={},direct\n", alt_server.url()),
+        )
+        .unwrap();
+
+        let cache = Arc::new(HttpCache::new());
+        cache.set_registry_policy(WorkspaceRegistryAccess::All);
+        let ctx = GoParseContext {
+            policy: Arc::new(RegistryAccessPolicy::new(WorkspaceRegistryAccess::All)),
+            goenv_path: Some(goenv_path),
+            ..Default::default()
+        };
+
+        let content = "module example.com/myapp\n\nrequire github.com/gin-gonic/gin v1.9.0\n";
+        let result = parse_go_mod_with_context(content, &test_uri(), &ctx).unwrap();
+        assert_eq!(result.resolved_chains.len(), 1);
+
+        let registry = Arc::new(GoRegistry::new(Arc::clone(&cache)));
+        for chain in &result.resolved_chains {
+            GoRegistry::register_chain(&registry, chain);
+        }
+
+        let source = result.dependencies[0].source.clone();
+        let versions = registry
+            .get_versions_from(
+                &deps_core::PackageName::new("github.com/gin-gonic/gin"),
+                &source,
+                FreshnessSettings::default(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(versions.len(), 1);
     }
 }

--- a/crates/deps-go/src/registry.rs
+++ b/crates/deps-go/src/registry.rs
@@ -1892,6 +1892,56 @@ mod tests {
         assert!(matches!(result, Err(DepsError::PackageNotFound { .. })));
     }
 
+    /// SC-002 (issue #559 follow-up): a `GOPRIVATE`-matched module's resolved source routes
+    /// to the bypass chain *and* the registered `GOPROXY` chain never receives a request for
+    /// it — combined into one resolution call, where previously each half was proven by a
+    /// separate unit test.
+    #[tokio::test]
+    async fn test_goprivate_bypass_sends_zero_requests_to_goproxy() {
+        use deps_core::{FreshnessSettings, Registry};
+
+        let mut public_proxy = mockito::Server::new_async().await;
+        let public_mock = public_proxy
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(200)
+            .with_body("v1.9.1\n")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let content = format!(
+            "GOPROXY={},direct\nGOPRIVATE=git.mycorp.example/*\n",
+            public_proxy.url()
+        );
+        let policy = all_policy();
+        let go_config = crate::config::GoEnvConfig::parse(&content, &policy);
+        let source = go_config.resolve_source_for("git.mycorp.example/internal/auth");
+        assert_eq!(
+            source,
+            DependencySource::AlternateRegistry {
+                index: crate::config::GOPRIVATE_CHAIN_KEY.to_string(),
+                mirrors_crates_io: false,
+            }
+        );
+
+        let cache = Arc::new(HttpCache::new());
+        cache.set_registry_policy(WorkspaceRegistryAccess::All);
+        let root = Arc::new(GoRegistry::new(Arc::clone(&cache)));
+        for chain in go_config.resolved_chains() {
+            GoRegistry::register_chain(&root, &chain);
+        }
+
+        let result = root
+            .get_versions_from(
+                &deps_core::PackageName::new("git.mycorp.example/internal/auth"),
+                &source,
+                FreshnessSettings::default(),
+            )
+            .await;
+        assert!(matches!(result, Err(DepsError::PackageNotFound { .. })));
+        public_mock.assert_async().await;
+    }
+
     /// US-004: `GOPROXY=off` shows no data and issues zero requests.
     #[tokio::test]
     async fn test_off_hop_zero_requests() {

--- a/crates/deps-lsp/src/lib.rs
+++ b/crates/deps-lsp/src/lib.rs
@@ -323,6 +323,7 @@ pub fn register_ecosystems(
         let go_context = deps_go::config::GoParseContext {
             policy: Arc::clone(&policy),
             config_cache: Arc::new(deps_go::config::GoEnvCache::new()),
+            goenv_path: deps_go::config::goenv_path(),
         };
         registry.register(Arc::new(GoEcosystem::with_context(
             Arc::new(GoRegistry::new(Arc::clone(&cache))),

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -331,6 +331,34 @@ falling through to the next hop, mirroring PyPI's identical trade-off (see
 above) for the same reason: falling through would risk resolving a private
 module through a fallback the reachability state does not actually support.
 
+**`,` vs `|` separator semantics**: the two `GOPROXY` separators are not
+interchangeable — each governs a different fallback trigger for the hop
+transition it precedes, matching `go help goproxy`/`modfetch/proxy.go`:
+- `,` falls through to the next hop **only on an explicit not-found
+  response** (`404`/`410`) — a transport failure (timeout, 5xx, connection
+  refused) on that hop halts resolution for the dependency instead (see
+  above).
+- `|` falls through to the next hop on **any** error from that hop,
+  including a transport failure.
+
+A single `GOPROXY` value may mix both (e.g.
+`GOPROXY=https://a.example|https://b.example,direct`); each transition
+between two consecutive, *valid* hops keeps the separator that preceded
+it, so a chain can combine "skip on any failure" and "skip only when
+genuinely absent" hop-to-hop as needed.
+
+**Known limitation**: when an invalid hop is dropped (per the fail-closed
+rule above) between two surviving hops, only the separator immediately
+preceding the surviving hop is kept — a separator that preceded the
+*dropped* entry is discarded rather than carried over. For example,
+`GOPROXY=https://a.example|not-a-valid-url,https://c.example` records the
+`,` after the dropped entry, not the `|` the user actually wrote before
+it, so a "skip on any failure" the user intended for the `a` -> `c`
+fallback can be silently narrowed to "skip only when not found" whenever
+the hop in between happens to be invalid. Pinned by a test rather than
+fixed here — see issue #559's follow-up tracking for the underlying
+separator-carryover fix.
+
 **Reachability policy**: governed by the same `registries.workspace_registries`
 setting documented above for Cargo/npm/PyPI. The default public chain
 (`https://proxy.golang.org,direct`) used when `$GOENV` declares no


### PR DESCRIPTION
## Summary

- Adds a test-injectable `$GOENV` path to `GoParseContext` (`goenv_path`, resolved once by the caller; production behavior unchanged), closing the test-hermeticity and untestable-integration-seam gaps.
- Adds 6 tests: a combined GOPRIVATE-bypass "zero GOPROXY requests" test (mockito `.expect(0)`), 4 edge cases (empty `GOPROXY=`/`GOPRIVATE=` value, malformed `$GOENV` line with no `=`, duplicate `GOPRIVATE` patterns, mixed comma/pipe separators), and a full `parse -> resolve -> register_chain -> get_versions_from` integration test.
- Logs a `tracing::warn!` when an oversized `GOPRIVATE` pattern (> 256 chars) is rejected — previously a silent fail-open on the confidentiality control that routed the module to the public proxy with no signal.
- Documents `RawGoEnv.goproxy`'s credential retention in memory as precedent-consistent with `NpmConfigCache`'s identical shape, not a regression — no code change for this item.
- Documents `GOPROXY`'s comma-vs-pipe fallthrough semantics in `docs/ECOSYSTEM_GUIDE.md`, including a known limitation: a separator preceding a *dropped* invalid hop is not carried over onto the merged transition (pre-existing since #558, pinned by a regression test, tracked separately for a future fix rather than changed here to keep this PR scoped to #559's own item list).
- Deliberately does not add a GOPROXY chain hop-count cap — out of scope per the issue (low severity, `$GOENV` is user-owned, not workspace-controlled).

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (3905 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Multi-agent review pipeline: implementation, test-coverage validation, security validation (live E2E against the real LSP server), adversarial critique, code review — all passed

Closes #559