### PR TITLE
Consolidate redacted-secret wrapper types into deps-core Redacted<T> with zeroize hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **deps-nuget**: `NuGetSourceChain.hops`/`NuGetRegistry::with_base` now carry per-hop credential/slot data (`ResolvedHop`) instead of a bare feed URL; `deps_lsp::register_ecosystems` now takes an `&EcosystemRuntime` instead of a bare `Arc<RegistryAccessPolicy>` — both breaking, pre-1.0, no alias (#572)
-- **deps-core, deps-cargo, deps-nuget**: consolidated four independently hand-implemented "redact this secret from `Debug`/`Display`" wrapper types into a single `deps_core::secret::Redacted<T>` newtype (#573)
+- **deps-core, deps-cargo, deps-nuget**: consolidated four independently hand-implemented "redact this secret from `Debug`/`Display`" wrapper types into a single `deps_core::secret::Redacted<T>` newtype (resolves #573) (#577)
 
 ### Security
-- **deps-core, deps-nuget**: credential material and its construction intermediates now zeroize on drop (#574)
+- **deps-core, deps-nuget**: credential material and its construction intermediates now zeroize on drop (resolves #574) (#577)
 
 ## [0.12.1] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **deps-nuget**: `NuGetSourceChain.hops`/`NuGetRegistry::with_base` now carry per-hop credential/slot data (`ResolvedHop`) instead of a bare feed URL; `deps_lsp::register_ecosystems` now takes an `&EcosystemRuntime` instead of a bare `Arc<RegistryAccessPolicy>` — both breaking, pre-1.0, no alias (#572)
+- **deps-core, deps-cargo, deps-nuget**: consolidated four independently hand-implemented "redact this secret from `Debug`/`Display`" wrapper types into a single `deps_core::secret::Redacted<T>` newtype (#573)
+
+### Security
+- **deps-core, deps-nuget**: credential material and its construction intermediates now zeroize on drop (#574)
 
 ## [0.12.1] - 2026-09-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,7 @@ dependencies = [
  "url",
  "urlencoding",
  "yaml-rust2",
+ "zeroize",
 ]
 
 [[package]]
@@ -705,6 +706,7 @@ dependencies = [
  "tracing",
  "url",
  "urlencoding",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ url = "2.5"
 urlencoding = "2.1"
 yaml-rust2 = "0.12"
 zed_extension_api = "0.7"
+zeroize = "1.9"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/deps-cargo/src/config.rs
+++ b/crates/deps-cargo/src/config.rs
@@ -49,24 +49,25 @@ use deps_core::{DEFAULT_MAX_CACHED_FILES, MtimeFileCache};
 /// formats it into an `Authorization` header.
 ///
 /// Constructible only from within this module (see the module-level security-model docs) —
-/// no other code path in this crate has the means to produce one. `Debug`/`Display` are
-/// hand-implemented to redact the value so it cannot leak via a log line, a panic message,
-/// or an error's `Display` output.
+/// no other code path in this crate has the means to produce one. A thin wrapper over
+/// [`deps_core::secret::Redacted`] rather than a bare type alias: `Debug` prints
+/// `AuthToken(***)`, not `Redacted(***)`, so a panic message or log line still names which
+/// credential leaked its type.
 #[derive(Clone, PartialEq, Eq)]
-pub struct AuthToken(String);
+pub struct AuthToken(deps_core::secret::Redacted);
 
 impl AuthToken {
     /// Wraps `token`. Kept `pub(crate)` rather than `pub`: the module-level security-model
     /// docs above are the enforcement, and widening this to `pub` would let any other crate
     /// construct one with no [`Provenance`]/[`IndexTrust`] to account for at all.
     pub(crate) fn new(token: String) -> Self {
-        Self(token)
+        Self(deps_core::secret::Redacted::new(token))
     }
 
     /// The raw token value, for building an `Authorization` header. Never logged, printed,
     /// or otherwise surfaced — callers must not pass this to anything but a header value.
     pub(crate) fn as_str(&self) -> &str {
-        &self.0
+        self.0.as_str()
     }
 }
 

--- a/crates/deps-core/Cargo.toml
+++ b/crates/deps-core/Cargo.toml
@@ -47,6 +47,7 @@ tracing-subscriber = { workspace = true, optional = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
 yaml-rust2 = { workspace = true }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["html_reports"] }

--- a/crates/deps-core/src/github.rs
+++ b/crates/deps-core/src/github.rs
@@ -137,17 +137,22 @@ pub fn github_rate_limit_error() -> DepsError {
 /// A `GITHUB_TOKEN` bearer-header value, redacted everywhere except the one call site
 /// ([`GithubTagsClient::headers`]) that hands it to a request as a header value.
 ///
-/// `Debug`/`Display` are hand-implemented to redact the value so it cannot leak via a log
-/// line, a panic message, or a future `#[derive(Debug)]` added to [`GithubTagsClient`] or a
-/// struct embedding it — mirrors `deps_cargo::config::AuthToken`.
+/// A thin wrapper over [`crate::secret::Redacted`] rather than a bare type alias: `Debug`
+/// prints `AuthToken(***)`, not `Redacted(***)`, so a panic message or log line still names
+/// which credential leaked its type — mirrors `deps_cargo::config::AuthToken`.
 #[derive(Clone, PartialEq, Eq)]
-struct AuthToken(String);
+struct AuthToken(crate::secret::Redacted);
 
 impl AuthToken {
+    /// Wraps `value`.
+    fn new(value: String) -> Self {
+        Self(crate::secret::Redacted::new(value))
+    }
+
     /// The raw header value, for attaching to a request. Never logged, printed, or
     /// otherwise surfaced — callers must not pass this to anything but a header value.
     fn as_str(&self) -> &str {
-        &self.0
+        self.0.as_str()
     }
 }
 
@@ -197,12 +202,15 @@ impl GithubTagsClient {
     /// ```
     #[must_use]
     pub fn new(cache: Arc<HttpCache>) -> Self {
-        let token = std::env::var("GITHUB_TOKEN").ok().filter(|t| !t.is_empty());
+        let token = std::env::var("GITHUB_TOKEN")
+            .ok()
+            .map(zeroize::Zeroizing::new)
+            .filter(|t| !t.is_empty());
         let has_token = token.is_some();
         let auth_headers = token
             .map(|token| {
                 tracing::info!("GITHUB_TOKEN detected, using authenticated GitHub API requests");
-                vec![(AUTHORIZATION, AuthToken(format!("Bearer {token}")))]
+                vec![(AUTHORIZATION, AuthToken::new(format!("Bearer {}", *token)))]
             })
             .unwrap_or_default();
 
@@ -225,7 +233,10 @@ impl GithubTagsClient {
     #[must_use]
     pub fn for_test(cache: Arc<HttpCache>, api_base: impl Into<String>, has_token: bool) -> Self {
         let auth_headers = if has_token {
-            vec![(AUTHORIZATION, AuthToken("Bearer test-token".to_string()))]
+            vec![(
+                AUTHORIZATION,
+                AuthToken::new("Bearer test-token".to_string()),
+            )]
         } else {
             Vec::new()
         };
@@ -1123,13 +1134,13 @@ mod tests {
 
     #[test]
     fn test_auth_token_debug_redacts_value() {
-        let token = AuthToken("Bearer super-secret-value".to_string());
+        let token = AuthToken::new("Bearer super-secret-value".to_string());
         assert_eq!(format!("{token:?}"), "AuthToken(***)");
     }
 
     #[test]
     fn test_auth_token_display_redacts_value() {
-        let token = AuthToken("Bearer super-secret-value".to_string());
+        let token = AuthToken::new("Bearer super-secret-value".to_string());
         assert_eq!(format!("{token}"), "***");
     }
 
@@ -1139,7 +1150,7 @@ mod tests {
         // embedding it) accidentally printing a raw `GITHUB_TOKEN` value: exercises the
         // exact shape `GithubTagsClient::auth_headers` stores, `Vec<(HeaderName,
         // AuthToken)>`, not just a bare `AuthToken`.
-        let token = AuthToken("Bearer super-secret-value".to_string());
+        let token = AuthToken::new("Bearer super-secret-value".to_string());
         let headers = vec![(AUTHORIZATION, token)];
         let debug_output = format!("{headers:?}");
         assert!(

--- a/crates/deps-core/src/lib.rs
+++ b/crates/deps-core/src/lib.rs
@@ -28,6 +28,7 @@ pub mod osv;
 pub mod package;
 pub mod parser;
 pub mod registry;
+pub mod secret;
 #[cfg(any(test, feature = "test-util"))]
 pub mod test_util;
 pub mod version_matcher;

--- a/crates/deps-core/src/secret.rs
+++ b/crates/deps-core/src/secret.rs
@@ -1,0 +1,140 @@
+//! Generic "never surfaced via `Debug`/`Display`" wrapper for in-memory secrets.
+//!
+//! `deps_core::github::AuthToken`, `deps_cargo::config::AuthToken`,
+//! `deps_nuget::config::NuGetAuth`, and `deps_nuget::config::RedactedSecret` each
+//! hand-rolled the same single-field tuple struct: a private/crate-visible constructor, an
+//! `as_str()` accessor documented "never logged, printed, or otherwise surfaced", and
+//! hand-written `Debug`/`Display` impls that print `***` (#573). [`Redacted<T>`] is the one
+//! place that pattern is implemented, so the four call sites cannot silently diverge on it
+//! and a fifth ecosystem crate needing the same guarantee does not reinvent it a fifth time.
+//!
+//! Placed beside [`crate::net_policy::redact_userinfo`], which owns the adjacent "a
+//! credential must not leak via a log line" concern for URLs specifically, while this module
+//! owns it for an owned secret value held in memory.
+//!
+//! Beyond redacting `Debug`/`Display`, [`Redacted<T>`] zeroizes its backing memory on drop
+//! (issue #574) — after the value goes out of scope, a core dump or a read of freed/swapped
+//! memory cannot recover the plaintext credential.
+
+use zeroize::{Zeroize, Zeroizing};
+
+/// A secret value whose `Debug`/`Display` output is always `***`, and whose backing memory
+/// is zeroized when it is dropped.
+///
+/// Wrap any credential that must never reach a log line, a panic message, or a future
+/// `#[derive(Debug)]` added to a struct embedding it. `T` defaults to `String`, the shape
+/// every current call site needs; a caller that needs a different backing type must supply
+/// one that implements [`Zeroize`] (e.g. secret bytes as `Vec<u8>`).
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::secret::Redacted;
+///
+/// let token = Redacted::new("super-secret-value".to_string());
+/// assert_eq!(token.as_str(), "super-secret-value");
+/// assert_eq!(format!("{token:?}"), "Redacted(***)");
+/// assert_eq!(format!("{token}"), "***");
+/// ```
+#[derive(Clone)]
+pub struct Redacted<T: Zeroize = String>(Zeroizing<T>);
+
+impl<T: Zeroize> Redacted<T> {
+    /// Wraps `value`. The only way to recover it is [`Self::as_str`] (for `T: AsRef<str>`).
+    pub fn new(value: T) -> Self {
+        Self(Zeroizing::new(value))
+    }
+}
+
+impl<T: Zeroize + AsRef<str>> Redacted<T> {
+    /// The raw secret value. Never pass this to anything but the one call site that needs
+    /// it (e.g. attaching a header value to a request) — never to a log, error message, or
+    /// anything `Debug`/`Display`-formatted downstream.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl<T: Zeroize> std::fmt::Debug for Redacted<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Redacted(***)")
+    }
+}
+
+impl<T: Zeroize> std::fmt::Display for Redacted<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("***")
+    }
+}
+
+impl<T: Zeroize + PartialEq> PartialEq for Redacted<T> {
+    fn eq(&self, other: &Self) -> bool {
+        *self.0 == *other.0
+    }
+}
+
+impl<T: Zeroize + Eq> Eq for Redacted<T> {}
+
+/// Marker confirming [`Redacted<T>`] zeroizes its backing memory on drop — the actual
+/// zeroing is performed by the wrapped [`Zeroizing<T>`] field's own [`Drop`] impl.
+impl<T: Zeroize> zeroize::ZeroizeOnDrop for Redacted<T> {}
+
+#[cfg(test)]
+mod tests {
+    use super::Redacted;
+
+    #[test]
+    fn debug_redacts() {
+        let secret = Redacted::new("hunter2".to_string());
+        assert_eq!(format!("{secret:?}"), "Redacted(***)");
+    }
+
+    #[test]
+    fn display_redacts() {
+        let secret = Redacted::new("hunter2".to_string());
+        assert_eq!(format!("{secret}"), "***");
+    }
+
+    #[test]
+    fn as_str_recovers_the_value() {
+        let secret = Redacted::new("hunter2".to_string());
+        assert_eq!(secret.as_str(), "hunter2");
+    }
+
+    #[test]
+    fn equality_compares_the_wrapped_value() {
+        assert_eq!(
+            Redacted::new("hunter2".to_string()),
+            Redacted::new("hunter2".to_string())
+        );
+        assert_ne!(
+            Redacted::new("hunter2".to_string()),
+            Redacted::new("other".to_string())
+        );
+    }
+
+    #[test]
+    fn embedding_in_a_debug_derive_still_redacts() {
+        #[derive(Debug)]
+        struct Wrapper {
+            token: Redacted,
+        }
+        let wrapper = Wrapper {
+            token: Redacted::new("hunter2".to_string()),
+        };
+        assert_eq!(wrapper.token.as_str(), "hunter2");
+        let debug_output = format!("{wrapper:?}");
+        assert!(debug_output.contains("Redacted(***)"), "{debug_output}");
+        assert!(!debug_output.contains("hunter2"), "{debug_output}");
+    }
+
+    /// Compile-time proof `Redacted<T>` zeroizes on drop — inspecting freed memory
+    /// portably isn't practical in a test, so this asserts the trait bound instead (the
+    /// idiomatic pattern for the `zeroize` ecosystem).
+    #[test]
+    fn implements_zeroize_on_drop() {
+        fn assert_zeroize_on_drop<T: zeroize::ZeroizeOnDrop>() {}
+        assert_zeroize_on_drop::<Redacted<String>>();
+    }
+}

--- a/crates/deps-nuget/Cargo.toml
+++ b/crates/deps-nuget/Cargo.toml
@@ -28,6 +28,7 @@ tower-lsp-server = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["html_reports"] }

--- a/crates/deps-nuget/src/config.rs
+++ b/crates/deps-nuget/src/config.rs
@@ -53,6 +53,7 @@ use deps_core::net_policy::{
 use deps_core::parser::DependencySource;
 use quick_xml::Reader;
 use quick_xml::events::Event;
+use zeroize::Zeroizing;
 
 /// Upper bound on the in-repo `NuGet.Config` ancestor walk, matching `deps-npm`'s/
 /// `deps-cargo`'s identical `MAX_CONFIG_ANCESTOR_DEPTH`.
@@ -196,22 +197,37 @@ pub enum ConfigTier {
 /// module's security-model doc) and deliberately does **not** derive `Hash` — making "a
 /// credential value inside a hash key" a compile error rather than a review item
 /// (NFR-001/FR-016). Never stores the username/password separately once constructed.
+///
+/// A thin wrapper over [`deps_core::secret::Redacted`] rather than a bare type alias:
+/// `Debug` prints `NuGetAuth(***)`, not `Redacted(***)`, so a panic message or log line
+/// still names which credential leaked its type.
 #[derive(Clone, PartialEq, Eq)]
-pub struct NuGetAuth(String);
+pub struct NuGetAuth(deps_core::secret::Redacted);
 
 impl NuGetAuth {
     /// Formats `username`/`password` into a `Basic` header value. `pub(crate)`: only
     /// [`resolve_with_context`]'s final C2 pass, gated on [`ConfigTier::UserProfile`], ever constructs one.
+    ///
+    /// Every intermediate (the raw `user:pass` string, and the base64 encoding of it —
+    /// reversible, not encryption) is held in [`Zeroizing`] from the point of construction,
+    /// not just the final header value, so no un-zeroized plaintext copy is left behind.
     pub(crate) fn new(username: &str, password: &str) -> Self {
-        let encoded =
-            base64::engine::general_purpose::STANDARD.encode(format!("{username}:{password}"));
-        Self(format!("Basic {encoded}"))
+        let mut user_pass =
+            Zeroizing::new(String::with_capacity(username.len() + 1 + password.len()));
+        user_pass.push_str(username);
+        user_pass.push(':');
+        user_pass.push_str(password);
+        let encoded = Zeroizing::new(base64::engine::general_purpose::STANDARD.encode(&*user_pass));
+        Self(deps_core::secret::Redacted::new(format!(
+            "Basic {}",
+            *encoded
+        )))
     }
 
     /// The pre-formatted header value. Never logged, printed, or otherwise surfaced — callers
     /// must not pass this to anything but an `Authorization` header.
     pub(crate) fn header_value(&self) -> &str {
-        &self.0
+        self.0.as_str()
     }
 }
 
@@ -230,12 +246,19 @@ impl std::fmt::Display for NuGetAuth {
 /// A `<packageSourceCredentials>` `Username`/`ClearTextPassword` literal, held **pre-%ENV_VAR%-
 /// expansion** (issue #561, FR-002) — redacted everywhere except [`resolve_with_context`]'s final pass,
 /// which expands and consumes it into a [`NuGetAuth`].
+///
+/// A thin wrapper over [`deps_core::secret::Redacted`] rather than a bare type alias:
+/// `Debug` prints `RedactedSecret(***)`, not `Redacted(***)`.
 #[derive(Clone, PartialEq, Eq)]
-struct RedactedSecret(String);
+struct RedactedSecret(deps_core::secret::Redacted);
 
 impl RedactedSecret {
+    fn new(value: String) -> Self {
+        Self(deps_core::secret::Redacted::new(value))
+    }
+
     fn as_str(&self) -> &str {
-        &self.0
+        self.0.as_str()
     }
 }
 
@@ -885,10 +908,10 @@ fn parse_nuget_config_raw(content: &str) -> RawNuGetConfigFile {
                         if let Some(cred) = out.credentials.last_mut() {
                             match attr_key.as_str() {
                                 "Username" => {
-                                    cred.username = Some(RedactedSecret(attr_value));
+                                    cred.username = Some(RedactedSecret::new(attr_value));
                                 }
                                 "ClearTextPassword" => {
-                                    cred.password = Some(RedactedSecret(attr_value));
+                                    cred.password = Some(RedactedSecret::new(attr_value));
                                 }
                                 "Password" => cred.encrypted = true,
                                 _ => {}
@@ -1486,8 +1509,11 @@ fn expand_credential(credential: &RawCredential) -> Result<NuGetAuth, NuGetFeedU
 /// variable being unset fails the *whole* expansion closed (FR-002) — never a partial
 /// substitution. `%` sequences that don't form a well-formed `%NAME%` reference (empty name, a
 /// non-alphanumeric/underscore character, or an unterminated `%`) are left as literal text.
-fn expand_env_vars(raw: &str) -> Result<String, NuGetFeedUrlError> {
-    expand_env_vars_with(raw, |name| std::env::var(name).ok())
+///
+/// Returns [`Zeroizing`], not a bare `String` — the caller (`expand_credential`) only ever
+/// expands a secret (`RedactedSecret` username/password), never an ordinary value.
+fn expand_env_vars(raw: &str) -> Result<Zeroizing<String>, NuGetFeedUrlError> {
+    expand_env_vars_with(raw, |name| std::env::var(name).ok().map(Zeroizing::new))
 }
 
 /// [`expand_env_vars`], but reading variables through `lookup` instead of [`std::env::var`]
@@ -1495,27 +1521,61 @@ fn expand_env_vars(raw: &str) -> Result<String, NuGetFeedUrlError> {
 /// environment (this workspace forbids `unsafe`, and Rust 2024 made `std::env::set_var` an
 /// `unsafe fn`, so a test cannot do that mutation at all; mirrors
 /// `deps_npm::config::expand_env_vars_with`'s identical rationale).
+///
+/// Scans `raw` (and each looked-up value) by `&str` slice, never collecting the secret into
+/// an intermediate `Vec<char>` copy, and precomputes the exact output length from the
+/// resolved segments before allocating — so the returned [`Zeroizing`] buffer is never grown
+/// past its initial capacity. `zeroize`'s own docs note it cannot guarantee a `Vec`/`String`
+/// reallocation didn't leave a stale copy on the heap; sizing exactly once, up front, is what
+/// avoids that reallocation in the first place, rather than merely zeroizing after the fact.
 fn expand_env_vars_with(
     raw: &str,
-    lookup: impl Fn(&str) -> Option<String>,
-) -> Result<String, NuGetFeedUrlError> {
-    let chars: Vec<char> = raw.chars().collect();
-    let mut out = String::with_capacity(raw.len());
-    let mut i = 0;
-    while i < chars.len() {
-        if chars[i] == '%'
-            && let Some(end) = chars[i + 1..].iter().position(|&c| c == '%')
-        {
-            let name: String = chars[i + 1..i + 1 + end].iter().collect();
+    lookup: impl Fn(&str) -> Option<Zeroizing<String>>,
+) -> Result<Zeroizing<String>, NuGetFeedUrlError> {
+    enum Segment<'a> {
+        Literal(&'a str),
+        Value(Zeroizing<String>),
+    }
+
+    let mut segments = Vec::new();
+    let mut rest = raw;
+    while let Some(pct) = rest.find('%') {
+        let literal = &rest[..pct];
+        let after = &rest[pct + 1..];
+        if let Some(end) = after.find('%') {
+            let name = &after[..end];
             if !name.is_empty() && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
-                let value = lookup(&name).ok_or(NuGetFeedUrlError::HasCredentials)?;
-                out.push_str(&value);
-                i += end + 2;
+                if !literal.is_empty() {
+                    segments.push(Segment::Literal(literal));
+                }
+                let value = lookup(name).ok_or(NuGetFeedUrlError::HasCredentials)?;
+                segments.push(Segment::Value(value));
+                rest = &after[end + 1..];
                 continue;
             }
         }
-        out.push(chars[i]);
-        i += 1;
+        // Not a well-formed `%NAME%` reference: keep everything up to and including this
+        // `%` as literal text, then keep scanning from just past it.
+        segments.push(Segment::Literal(&rest[..=pct]));
+        rest = &rest[pct + 1..];
+    }
+    if !rest.is_empty() {
+        segments.push(Segment::Literal(rest));
+    }
+
+    let total_len: usize = segments
+        .iter()
+        .map(|segment| match segment {
+            Segment::Literal(s) => s.len(),
+            Segment::Value(v) => v.len(),
+        })
+        .sum();
+    let mut out = Zeroizing::new(String::with_capacity(total_len));
+    for segment in &segments {
+        match segment {
+            Segment::Literal(s) => out.push_str(s),
+            Segment::Value(v) => out.push_str(v.as_str()),
+        }
     }
     Ok(out)
 }
@@ -2670,12 +2730,53 @@ mod tests {
     #[test]
     fn test_env_var_expansion_set_and_unset() {
         let set = expand_env_vars_with("%CORP_FEED_PAT%", |name| {
-            (name == "CORP_FEED_PAT").then(|| "secret-pat".to_string())
+            (name == "CORP_FEED_PAT").then(|| Zeroizing::new("secret-pat".to_string()))
         });
-        assert_eq!(set.unwrap(), "secret-pat");
+        assert_eq!(set.unwrap().as_str(), "secret-pat");
 
         let unset = expand_env_vars_with("%CORP_FEED_PAT%", |_| None);
         assert!(matches!(unset, Err(NuGetFeedUrlError::HasCredentials)));
+    }
+
+    /// Regression coverage for the `&str`-slice rewrite of `expand_env_vars_with` (it no
+    /// longer collects `raw` into an intermediate `Vec<char>`): surrounding literal text,
+    /// back-to-back substitutions with no literal between them, a malformed name (non
+    /// alphanumeric/underscore character) left as literal text, and an unterminated `%` at
+    /// end-of-string left as literal text — all must behave exactly as the prior
+    /// char-by-char scan did.
+    #[test]
+    fn test_env_var_expansion_edge_cases() {
+        let lookup = |name: &str| match name {
+            "A" => Some(Zeroizing::new("1".to_string())),
+            "B" => Some(Zeroizing::new("2".to_string())),
+            _ => None,
+        };
+
+        assert_eq!(
+            expand_env_vars_with("pre-%A%-post", lookup)
+                .unwrap()
+                .as_str(),
+            "pre-1-post"
+        );
+        assert_eq!(
+            expand_env_vars_with("%A%%B%", lookup).unwrap().as_str(),
+            "12"
+        );
+        assert_eq!(
+            expand_env_vars_with("abc%1bad!name%def", lookup)
+                .unwrap()
+                .as_str(),
+            "abc%1bad!name%def"
+        );
+        assert_eq!(
+            expand_env_vars_with("abc%A", lookup).unwrap().as_str(),
+            "abc%A"
+        );
+        assert_eq!(expand_env_vars_with("%%", lookup).unwrap().as_str(), "%%");
+        assert!(matches!(
+            expand_env_vars_with("pre-%UNSET%-post", lookup),
+            Err(NuGetFeedUrlError::HasCredentials)
+        ));
     }
 
     /// SC-002 end-to-end: the same expansion wired through `resolve`'s credential-binding
@@ -2686,7 +2787,7 @@ mod tests {
     fn test_expand_credential_missing_password_fails_closed() {
         let credential = RawCredential {
             key: "CorpFeed".to_string(),
-            username: Some(RedactedSecret("user".to_string())),
+            username: Some(RedactedSecret::new("user".to_string())),
             password: None,
             encrypted: false,
         };
@@ -2705,7 +2806,7 @@ mod tests {
         assert!(!format!("{auth:?}").contains("super-secret-pat"));
         assert!(!format!("{auth}").contains("super-secret-pat"));
 
-        let secret = RedactedSecret("super-secret-pat".to_string());
+        let secret = RedactedSecret::new("super-secret-pat".to_string());
         assert!(!format!("{secret:?}").contains("super-secret-pat"));
         assert!(!format!("{secret}").contains("super-secret-pat"));
     }
@@ -2759,7 +2860,7 @@ mod tests {
     fn test_expand_credential_encrypted_password_is_distinct_reason() {
         let credential = RawCredential {
             key: "CorpFeed".to_string(),
-            username: Some(RedactedSecret("user".to_string())),
+            username: Some(RedactedSecret::new("user".to_string())),
             password: None,
             encrypted: true,
         };


### PR DESCRIPTION
## Summary

- Consolidates four independently hand-rolled secret-redaction wrapper types (`deps_core::github::AuthToken`, `deps_cargo::config::AuthToken`, `deps_nuget::config::NuGetAuth`, `deps_nuget::config::RedactedSecret`) into a single `deps_core::secret::Redacted<T>` newtype, so the redaction guarantee is enforced in one place instead of reimplemented per crate.
- Backs `Redacted<T>` with `zeroize::Zeroizing` so credential material — and its construction intermediates along the NuGet Basic-auth and GitHub token paths — is wiped on drop rather than only redacted from `Debug`/`Display`.
- Investigated collapsing duplicate transitive `thiserror`/`unicode-width` versions flagged by `cargo deny check bans`; both are already at their newest crates.io-compatible release, and the older majors are pinned upstream by `node-semver`, `pep508_rs`, and `miette`'s own manifests, so no further collapse is possible without a breaking change to those crates. Documented rather than forced.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4015 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] `cargo test --workspace --doc --all-features` (includes new `secret::Redacted` doctest)
- [x] New regression test covering `%VAR%` expansion edge cases (empty name, unset var with surrounding literals)

Closes #573
Closes #574