### PR TITLE
refactor(deps-core,deps-cargo,deps-nuget): rename secret accessor as_str() to expose_secret()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **deps-nuget**: `NuGetSourceChain.hops`/`NuGetRegistry::with_base` now carry per-hop credential/slot data (`ResolvedHop`) instead of a bare feed URL; `deps_lsp::register_ecosystems` now takes an `&EcosystemRuntime` instead of a bare `Arc<RegistryAccessPolicy>` — both breaking, pre-1.0, no alias (#572)
 - **deps-core, deps-cargo, deps-nuget**: consolidated four independently hand-implemented "redact this secret from `Debug`/`Display`" wrapper types into a single `deps_core::secret::Redacted<T>` newtype (resolves #573) (#577)
-- **deps-core, deps-cargo, deps-nuget**: renamed the secret-exposing `as_str()` accessor on `Redacted<T>` and its delegating wrapper types (`AuthToken`, `RedactedSecret`) to `expose_secret()`, so it can no longer be confused with an ordinary string conversion in a grep or code review (resolves #581)
+- **deps-core, deps-cargo, deps-nuget**: renamed the secret-exposing `as_str()` accessor on `Redacted<T>` and its delegating wrapper types (`AuthToken`, `RedactedSecret`) to `expose_secret()`, so it can no longer be confused with an ordinary string conversion in a grep or code review (resolves #581) (#582)
 
 ### Security
 - **deps-core, deps-nuget**: credential material and its construction intermediates now zeroize on drop (resolves #574) (#577)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **deps-nuget**: `NuGetSourceChain.hops`/`NuGetRegistry::with_base` now carry per-hop credential/slot data (`ResolvedHop`) instead of a bare feed URL; `deps_lsp::register_ecosystems` now takes an `&EcosystemRuntime` instead of a bare `Arc<RegistryAccessPolicy>` — both breaking, pre-1.0, no alias (#572)
 - **deps-core, deps-cargo, deps-nuget**: consolidated four independently hand-implemented "redact this secret from `Debug`/`Display`" wrapper types into a single `deps_core::secret::Redacted<T>` newtype (resolves #573) (#577)
+- **deps-core, deps-cargo, deps-nuget**: renamed the secret-exposing `as_str()` accessor on `Redacted<T>` and its delegating wrapper types (`AuthToken`, `RedactedSecret`) to `expose_secret()`, so it can no longer be confused with an ordinary string conversion in a grep or code review (resolves #581)
 
 ### Security
 - **deps-core, deps-nuget**: credential material and its construction intermediates now zeroize on drop (resolves #574) (#577)

--- a/crates/deps-cargo/src/config.rs
+++ b/crates/deps-cargo/src/config.rs
@@ -66,8 +66,8 @@ impl AuthToken {
 
     /// The raw token value, for building an `Authorization` header. Never logged, printed,
     /// or otherwise surfaced — callers must not pass this to anything but a header value.
-    pub(crate) fn as_str(&self) -> &str {
-        self.0.as_str()
+    pub(crate) fn expose_secret(&self) -> &str {
+        self.0.expose_secret()
     }
 }
 
@@ -1276,7 +1276,7 @@ token = "secret-token"
         let result = parse_cargo_home_registries_raw(content);
         let (raw_index, token) = result.get("my-corp").unwrap();
         assert_eq!(raw_index, "sparse+https://index.mycorp.dev");
-        assert_eq!(token.as_ref().unwrap().as_str(), "secret-token");
+        assert_eq!(token.as_ref().unwrap().expose_secret(), "secret-token");
     }
 
     #[test]
@@ -1379,7 +1379,7 @@ token = "secret-token"
         assert_eq!(entry.index.as_str(), "https://real.example/");
         assert_eq!(entry.provenance, Provenance::CargoHome);
         assert_eq!(
-            entry.auth.as_ref().map(AuthToken::as_str),
+            entry.auth.as_ref().map(AuthToken::expose_secret),
             Some("real-token"),
             "the CARGO_HOME token must not be lost just because the project lives \
              under $HOME"
@@ -1408,7 +1408,7 @@ token = "secret-token"
 
         let entry = config.get("my-corp").unwrap();
         assert_eq!(entry.index.as_str(), "https://real.example/");
-        assert_eq!(entry.auth.as_ref().unwrap().as_str(), "real-token");
+        assert_eq!(entry.auth.as_ref().unwrap().expose_secret(), "real-token");
         assert_eq!(entry.provenance, Provenance::CargoHome);
     }
 
@@ -1437,7 +1437,7 @@ token = "secret-token"
         let (config, _) = resolve_with_env(&aliases, &[], None, &cache, &policy, &env);
         let entry = config.get("env-only-corp").unwrap();
         assert_eq!(entry.index.as_str(), "https://env.example/");
-        assert_eq!(entry.auth.as_ref().unwrap().as_str(), "env-token");
+        assert_eq!(entry.auth.as_ref().unwrap().expose_secret(), "env-token");
         assert_eq!(entry.provenance, Provenance::CargoHome);
     }
 
@@ -1972,7 +1972,10 @@ token = "secret-token"
 
         match replacement {
             SourceReplacement::SparseMirror { auth, .. } => {
-                assert_eq!(auth.as_ref().map(AuthToken::as_str), Some("real-token"));
+                assert_eq!(
+                    auth.as_ref().map(AuthToken::expose_secret),
+                    Some("real-token")
+                );
             }
             SourceReplacement::None => panic!("expected the fully-trusted chain to resolve"),
         }

--- a/crates/deps-cargo/src/sparse.rs
+++ b/crates/deps-cargo/src/sparse.rs
@@ -363,7 +363,7 @@ impl SparseIndexClient {
     async fn fetch(&self, url: &str) -> Result<bytes::Bytes> {
         match (&self.auth, self.trust) {
             (Some(token), IndexTrust::Trusted) => {
-                let header_value = format!("Bearer {}", token.as_str());
+                let header_value = format!("Bearer {}", token.expose_secret());
                 self.cache
                     .get_cached_trusted_origin_with_headers(
                         url,

--- a/crates/deps-core/src/github.rs
+++ b/crates/deps-core/src/github.rs
@@ -151,8 +151,8 @@ impl AuthToken {
 
     /// The raw header value, for attaching to a request. Never logged, printed, or
     /// otherwise surfaced — callers must not pass this to anything but a header value.
-    fn as_str(&self) -> &str {
-        self.0.as_str()
+    fn expose_secret(&self) -> &str {
+        self.0.expose_secret()
     }
 }
 
@@ -273,7 +273,7 @@ impl GithubTagsClient {
     pub(crate) fn headers(&self) -> Vec<(HeaderName, &str)> {
         self.auth_headers
             .iter()
-            .map(|(k, v)| (k.clone(), v.as_str()))
+            .map(|(k, v)| (k.clone(), v.expose_secret()))
             .collect()
     }
 

--- a/crates/deps-core/src/secret.rs
+++ b/crates/deps-core/src/secret.rs
@@ -32,7 +32,7 @@ use zeroize::{Zeroize, Zeroizing};
 /// use deps_core::secret::Redacted;
 ///
 /// let token = Redacted::new("super-secret-value".to_string());
-/// assert_eq!(token.as_str(), "super-secret-value");
+/// assert_eq!(token.expose_secret(), "super-secret-value");
 /// assert_eq!(format!("{token:?}"), "Redacted(***)");
 /// assert_eq!(format!("{token}"), "***");
 /// ```
@@ -40,7 +40,7 @@ use zeroize::{Zeroize, Zeroizing};
 pub struct Redacted<T: Zeroize = String>(Zeroizing<T>);
 
 impl<T: Zeroize> Redacted<T> {
-    /// Wraps `value`. The only way to recover it is [`Self::as_str`] (for `T: AsRef<str>`).
+    /// Wraps `value`. The only way to recover it is [`Self::expose_secret`] (for `T: AsRef<str>`).
     pub fn new(value: T) -> Self {
         Self(Zeroizing::new(value))
     }
@@ -50,8 +50,14 @@ impl<T: Zeroize + AsRef<str>> Redacted<T> {
     /// The raw secret value. Never pass this to anything but the one call site that needs
     /// it (e.g. attaching a header value to a request) — never to a log, error message, or
     /// anything `Debug`/`Display`-formatted downstream.
+    ///
+    /// Named `expose_secret()` rather than `as_str()` deliberately, mirroring the `secrecy`
+    /// crate's `ExposeSecret::expose_secret()` convention: a name shared with hundreds of
+    /// ordinary string-conversion methods across the workspace cannot be grepped for in
+    /// isolation, while a distinctive name lets a reviewer or a future automated lint find
+    /// every place a secret's plaintext crosses its wrapper boundary with a single search.
     #[must_use]
-    pub fn as_str(&self) -> &str {
+    pub fn expose_secret(&self) -> &str {
         self.0.as_ref()
     }
 }
@@ -108,9 +114,9 @@ mod tests {
     }
 
     #[test]
-    fn as_str_recovers_the_value() {
+    fn expose_secret_recovers_the_value() {
         let secret = Redacted::new("hunter2".to_string());
-        assert_eq!(secret.as_str(), "hunter2");
+        assert_eq!(secret.expose_secret(), "hunter2");
     }
 
     #[test]
@@ -134,7 +140,7 @@ mod tests {
         let wrapper = Wrapper {
             token: Redacted::new("hunter2".to_string()),
         };
-        assert_eq!(wrapper.token.as_str(), "hunter2");
+        assert_eq!(wrapper.token.expose_secret(), "hunter2");
         let debug_output = format!("{wrapper:?}");
         assert!(debug_output.contains("Redacted(***)"), "{debug_output}");
         assert!(!debug_output.contains("hunter2"), "{debug_output}");

--- a/crates/deps-nuget/src/config.rs
+++ b/crates/deps-nuget/src/config.rs
@@ -231,7 +231,7 @@ impl NuGetAuth {
     /// The pre-formatted header value. Never logged, printed, or otherwise surfaced — callers
     /// must not pass this to anything but an `Authorization` header.
     pub(crate) fn header_value(&self) -> &str {
-        self.0.as_str()
+        self.0.expose_secret()
     }
 }
 
@@ -272,8 +272,8 @@ impl RedactedSecret {
         Self(deps_core::secret::Redacted::new(value))
     }
 
-    fn as_str(&self) -> &str {
-        self.0.as_str()
+    fn expose_secret(&self) -> &str {
+        self.0.expose_secret()
     }
 }
 
@@ -1710,10 +1710,10 @@ fn expand_credential(credential: &RawCredential) -> Result<NuGetAuth, NuGetFeedU
     let username = credential
         .username
         .as_ref()
-        .map(RedactedSecret::as_str)
+        .map(RedactedSecret::expose_secret)
         .unwrap_or("");
     let username = expand_env_vars(username)?;
-    let password = expand_env_vars(password.as_str())?;
+    let password = expand_env_vars(password.expose_secret())?;
     Ok(NuGetAuth::new(&username, &password))
 }
 


### PR DESCRIPTION
## Summary

- Renames `deps_core::secret::Redacted::as_str()` and its three delegating wrapper accessors (`deps_core::github::AuthToken`, `deps_cargo::config::AuthToken`, `deps_nuget::config::RedactedSecret`) to `expose_secret()`, mirroring the `secrecy` crate's `ExposeSecret::expose_secret()` naming convention.
- Goal: a single workspace-wide grep for the new name finds every place a secret's plaintext crosses its wrapper boundary, distinct from the ~500 unrelated `.as_str()` calls elsewhere in the workspace.
- `deps_nuget::config::NuGetAuth::header_value()` is left unchanged (already distinctly named, out of the naming-collision problem) — only its internal delegation call was updated.
- `deps_cargo::config::RegistryIndex::as_str` and `deps_nuget::config::NuGetFeedUrl::as_str` are untouched (non-secret string conversions, out of scope).
- Pure rename: no change to `Redacted<T>`'s `Debug`/`Display`/`PartialEq`/`Eq`/`Hash`/`ZeroizeOnDrop` behavior.

Full spec: `specs/045-secret-accessor-auditable-naming/spec.md`.

## Test plan

- [x] `cargo build --workspace --all-features`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` — 4020 passed, 0 failed
- [x] `cargo test --workspace --doc --all-features` — `secret.rs` doctest uses `expose_secret()`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] `grep -rn "fn as_str" crates/deps-core/src/secret.rs crates/deps-core/src/github.rs crates/deps-cargo/src/config.rs crates/deps-nuget/src/config.rs` — zero hits (the two out-of-scope non-secret methods remain)

Closes #581