### PR TITLE
refactor(deps-lsp,deps-nuget): decompose oversized orchestration functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **deps-nuget**: `NuGetSourceChain.hops`/`NuGetRegistry::with_base` now carry per-hop credential/slot data (`ResolvedHop`) instead of a bare feed URL; `deps_lsp::register_ecosystems` now takes an `&EcosystemRuntime` instead of a bare `Arc<RegistryAccessPolicy>` — both breaking, pre-1.0, no alias (#572)
 - **deps-core, deps-cargo, deps-nuget**: consolidated four independently hand-implemented "redact this secret from `Debug`/`Display`" wrapper types into a single `deps_core::secret::Redacted<T>` newtype (resolves #573) (#577)
-- **deps-lsp, deps-nuget**: decomposed `handle_document_change` and `resolve_with_context` into named, independently-testable phase helpers — pure refactor, no behavior change (resolves #580)
+- **deps-lsp, deps-nuget**: decomposed `handle_document_change` and `resolve_with_context` into named, independently-testable phase helpers — pure refactor, no behavior change (resolves #580) (#583)
 
 ### Security
 - **deps-core, deps-nuget**: credential material and its construction intermediates now zeroize on drop (resolves #574) (#577)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **deps-nuget**: `NuGetSourceChain.hops`/`NuGetRegistry::with_base` now carry per-hop credential/slot data (`ResolvedHop`) instead of a bare feed URL; `deps_lsp::register_ecosystems` now takes an `&EcosystemRuntime` instead of a bare `Arc<RegistryAccessPolicy>` — both breaking, pre-1.0, no alias (#572)
 - **deps-core, deps-cargo, deps-nuget**: consolidated four independently hand-implemented "redact this secret from `Debug`/`Display`" wrapper types into a single `deps_core::secret::Redacted<T>` newtype (resolves #573) (#577)
+- **deps-lsp, deps-nuget**: decomposed `handle_document_change` and `resolve_with_context` into named, independently-testable phase helpers — pure refactor, no behavior change (resolves #580)
 
 ### Security
 - **deps-core, deps-nuget**: credential material and its construction intermediates now zeroize on drop (resolves #574) (#577)

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -1840,6 +1840,111 @@ pub async fn handle_document_open(
     Ok(task)
 }
 
+/// Parses the freshly-edited manifest content and diffs its dependencies against the
+/// document's previously stored parse result, so the caller can react to what actually
+/// changed (added/removed/version-changed) instead of unconditionally re-fetching and
+/// re-scanning everything on every keystroke.
+async fn parse_and_diff_manifest(
+    uri: &Uri,
+    content: &str,
+    state: &ServerState,
+    ecosystem: &dyn Ecosystem,
+) -> (Option<Box<dyn deps_core::ParseResult>>, DependencyDiff) {
+    // Extract old dependency name -> version_requirement map before parsing
+    // (for diff computation)
+    let old_deps: HashMap<PackageName, Vec<Option<VersionReq>>> =
+        state.get_document(uri).map_or_else(HashMap::new, |doc| {
+            doc.parse_result()
+                .map(dependency_version_map)
+                .unwrap_or_default()
+        });
+
+    // Try to parse manifest (may fail for incomplete syntax)
+    let parse_result = ecosystem.parse_manifest(content, uri).await.ok();
+
+    // Extract new dependency name -> version_requirement map for diff
+    let new_deps: HashMap<PackageName, Vec<Option<VersionReq>>> = parse_result
+        .as_ref()
+        .map(|pr| dependency_version_map(pr.as_ref()))
+        .unwrap_or_default();
+
+    // Compute dependency diff
+    let diff = DependencyDiff::compute(&old_deps, &new_deps);
+    tracing::debug!(
+        added = diff.added.len(),
+        removed = diff.removed.len(),
+        version_changed = diff.version_changed.len(),
+        "dependency diff"
+    );
+
+    (parse_result, diff)
+}
+
+/// Builds the new `DocumentState` from the parsed manifest (or a parse-result-less
+/// placeholder when parsing failed), carries over cache entries the previous state already
+/// held, prunes/invalidates entries the diff says are now stale, and commits the result
+/// into `state`.
+fn commit_parsed_document(
+    uri: &Uri,
+    ecosystem: &dyn Ecosystem,
+    content: String,
+    parse_result: Option<Box<dyn deps_core::ParseResult>>,
+    version: Option<i32>,
+    diff: &DependencyDiff,
+    state: &ServerState,
+) {
+    let mut doc_state = if let Some(pr) = parse_result {
+        DocumentState::new_from_parse_result(resolve_ecosystem_id(ecosystem), content, pr)
+    } else {
+        tracing::debug!("Failed to parse manifest, storing document without parse result");
+        DocumentState::new_without_parse_result(resolve_ecosystem_id(ecosystem), content)
+    };
+    doc_state.set_version(version);
+
+    if let Some(old_doc) = state.get_document(uri) {
+        preserve_cache(&mut doc_state, &old_doc);
+    }
+
+    // Prune stale cache entries for removed dependencies. `vulnerabilities`
+    // is keyed by the *normalized* name (unlike `cached_versions`/
+    // `resolved_versions`, which are raw-`dep.name()`-keyed), so pruning it
+    // with the raw name would silently no-op for Composer/Swift/NuGet-style
+    // ecosystems where normalization changes the string (critique M4).
+    let formatter = ecosystem.formatter();
+    for removed_dep in &diff.removed {
+        doc_state.cached_versions.remove(removed_dep);
+        doc_state.resolved_versions.remove(removed_dep);
+        doc_state
+            .vulnerabilities
+            .remove(&formatter.normalize_package_name(removed_dep));
+        doc_state
+            .outcomes
+            .remove(&formatter.normalize_package_name(removed_dep));
+    }
+
+    // A version-only edit (name unchanged, requirement changed) invalidates
+    // any yanked finding recorded against the dependency's *old* version —
+    // e.g. editing a yanked pin to a safe one must not leave a stale
+    // diagnostic anchored on the new range (security F1 / impl-critic S1).
+    // Drop rather than try to refresh in place; the registry re-fetch that
+    // follows in the caller (`deps_to_fetch` includes `version_changed`)
+    // repopulates the entry if the *new* version also turns out to be
+    // yanked. Same for `fetch_failed` (#267): a stale fetch-error marker
+    // must not survive an edit that gets re-fetched below.
+    //
+    // Deliberately NOT mirrored for `deprecations`: #205's finding is
+    // package-level, derived from `latest`, not the dependency's declared
+    // version — editing which version is pinned does not make the package
+    // any less (or more) deprecated, so there is nothing stale to drop here.
+    for changed_dep in &diff.version_changed {
+        let normalized = formatter.normalize_package_name(changed_dep);
+        doc_state.outcomes.clear_yanked(&normalized);
+        doc_state.outcomes.clear_fetch_failure(&normalized);
+    }
+
+    state.update_document(uri.clone(), doc_state);
+}
+
 /// Generic document change handler using ecosystem registry.
 ///
 /// Re-parses manifest when document content changes and spawns a debounced
@@ -1865,83 +1970,18 @@ pub async fn handle_document_change(
 
     check_content_size(&content, &uri)?;
 
-    // Extract old dependency name -> version_requirement map before parsing
-    // (for diff computation)
-    let old_deps: HashMap<PackageName, Vec<Option<VersionReq>>> =
-        state.get_document(&uri).map_or_else(HashMap::new, |doc| {
-            doc.parse_result()
-                .map(dependency_version_map)
-                .unwrap_or_default()
-        });
+    let (parse_result, diff) =
+        parse_and_diff_manifest(&uri, &content, &state, ecosystem.as_ref()).await;
 
-    // Try to parse manifest (may fail for incomplete syntax)
-    let parse_result = ecosystem.parse_manifest(&content, &uri).await.ok();
-
-    // Extract new dependency name -> version_requirement map for diff
-    let new_deps: HashMap<PackageName, Vec<Option<VersionReq>>> = parse_result
-        .as_ref()
-        .map(|pr| dependency_version_map(pr.as_ref()))
-        .unwrap_or_default();
-
-    // Compute dependency diff
-    let diff = DependencyDiff::compute(&old_deps, &new_deps);
-    tracing::debug!(
-        added = diff.added.len(),
-        removed = diff.removed.len(),
-        version_changed = diff.version_changed.len(),
-        "dependency diff"
+    commit_parsed_document(
+        &uri,
+        ecosystem.as_ref(),
+        content,
+        parse_result,
+        version,
+        &diff,
+        &state,
     );
-
-    let mut doc_state = if let Some(pr) = parse_result {
-        DocumentState::new_from_parse_result(resolve_ecosystem_id(&*ecosystem), content, pr)
-    } else {
-        tracing::debug!("Failed to parse manifest, storing document without parse result");
-        DocumentState::new_without_parse_result(resolve_ecosystem_id(&*ecosystem), content)
-    };
-    doc_state.set_version(version);
-
-    if let Some(old_doc) = state.get_document(&uri) {
-        preserve_cache(&mut doc_state, &old_doc);
-    }
-
-    // Prune stale cache entries for removed dependencies. `vulnerabilities`
-    // is keyed by the *normalized* name (unlike `cached_versions`/
-    // `resolved_versions`, which are raw-`dep.name()`-keyed), so pruning it
-    // with the raw name would silently no-op for Composer/Swift/NuGet-style
-    // ecosystems where normalization changes the string (critique M4).
-    let formatter = ecosystem.formatter();
-    for removed_dep in &diff.removed {
-        doc_state.cached_versions.remove(removed_dep);
-        doc_state.resolved_versions.remove(removed_dep);
-        doc_state
-            .vulnerabilities
-            .remove(&formatter.normalize_package_name(removed_dep));
-        doc_state
-            .outcomes
-            .remove(&formatter.normalize_package_name(removed_dep));
-    }
-
-    // A version-only edit (name unchanged, requirement changed) invalidates
-    // any yanked finding recorded against the dependency's *old* version —
-    // e.g. editing a yanked pin to a safe one must not leave a stale
-    // diagnostic anchored on the new range (security F1 / impl-critic S1).
-    // Drop rather than try to refresh in place; the registry re-fetch below
-    // (`deps_to_fetch` includes `version_changed`) repopulates the entry if
-    // the *new* version also turns out to be yanked. Same for `fetch_failed`
-    // (#267): a stale fetch-error marker must not survive an edit that gets
-    // re-fetched below.
-    //
-    // Deliberately NOT mirrored for `deprecations`: #205's finding is
-    // package-level, derived from `latest`, not the dependency's declared
-    // version — editing which version is pinned does not make the package
-    // any less (or more) deprecated, so there is nothing stale to drop here.
-    for changed_dep in &diff.version_changed {
-        let normalized = formatter.normalize_package_name(changed_dep);
-        doc_state.outcomes.clear_yanked(&normalized);
-        doc_state.outcomes.clear_fetch_failure(&normalized);
-    }
-
-    state.update_document(uri.clone(), doc_state);
 
     // Clone cache, diagnostics, and freshness config before spawning background task
     // (all read here, before any OSV request is built — FR-011).
@@ -1956,11 +1996,6 @@ pub async fn handle_document_change(
         )
     };
 
-    // Spawn background task to update diagnostics
-    let uri_clone = uri.clone();
-    let state_clone = Arc::clone(&state);
-    let ecosystem_clone = Arc::clone(&ecosystem);
-    let client_clone = client.clone();
     let needs_osv_rescan = diff.needs_osv_rescan();
     // The yanked probe must also re-run for a version-only edit, not just a
     // newly added dependency — otherwise editing a dependency's pin from a
@@ -1969,290 +2004,419 @@ pub async fn handle_document_change(
     let mut deps_to_fetch = diff.added;
     deps_to_fetch.extend(diff.version_changed);
 
-    let task = tokio::spawn(async move {
-        // Small debounce delay
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    // Spawn background task to update diagnostics
+    let task = tokio::spawn(run_document_change_task(
+        uri,
+        state,
+        ecosystem,
+        client,
+        ChangeTaskConfig {
+            cache: cache_config,
+            vulnerabilities_enabled,
+            freshness: freshness_settings,
+            diagnostic_severities,
+            offline,
+        },
+        needs_osv_rescan,
+        deps_to_fetch,
+    ));
 
-        // Load resolved versions from lock file first (instant, no network)
-        let resolved_versions =
-            load_resolved_versions(&uri_clone, &state_clone, ecosystem_clone.as_ref()).await;
+    Ok(task)
+}
 
-        // Update document state with resolved versions only
-        // Do NOT touch cached_versions - they contain latest registry versions
-        if !resolved_versions.is_empty()
-            && let Some(mut doc) = state_clone.documents.get_mut(&uri_clone)
-        {
-            doc.update_resolved_versions(resolved_versions.clone());
-        }
+/// Config values snapshotted from `DepsConfig` before spawning [`run_document_change_task`]
+/// (FR-011: all read before any OSV request is built), so the task never needs to hold the
+/// config lock itself. Bundled into one struct rather than five parameters since every field
+/// is captured together by the same snapshot in [`handle_document_change`].
+struct ChangeTaskConfig {
+    cache: crate::config::CacheConfig,
+    vulnerabilities_enabled: bool,
+    freshness: deps_core::FreshnessSettings,
+    diagnostic_severities: deps_core::DiagnosticSeverities,
+    offline: bool,
+}
 
-        // Phase A OSV scan (only when a dependency was added or an existing
-        // one's version changed — critique S1), spawned so it runs
-        // concurrently with the registry fetch below.
-        let osv_task = (vulnerabilities_enabled && needs_osv_rescan).then(|| {
-            tokio::spawn(run_osv_scan_phase_a(
-                uri_clone.clone(),
-                Arc::clone(&state_clone),
-                Arc::clone(&ecosystem_clone),
-                cache_config.fetch_timeout_secs,
-            ))
-        });
+/// Background task spawned by [`handle_document_change`] once the new document state has
+/// been committed: reloads lock-file-resolved versions, then runs the OSV rescan
+/// concurrently with any registry fetch the diff calls for, and finally publishes the
+/// resulting diagnostics.
+async fn run_document_change_task(
+    uri: Uri,
+    state: Arc<ServerState>,
+    ecosystem: Arc<dyn Ecosystem>,
+    client: Client,
+    config: ChangeTaskConfig,
+    needs_osv_rescan: bool,
+    deps_to_fetch: Vec<PackageName>,
+) {
+    // Small debounce delay
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
-        // Skip registry fetch if nothing new was added and no existing
-        // dependency's version changed.
-        //
-        // Known limitation (#424 N2): editing composer.json's `minimum-stability` field alone
-        // adds no dependency and changes no requirement string, so `deps_to_fetch` stays empty
-        // and this early-return skips the fetch — existing dependencies keep their
-        // `cached_versions` computed under the *previous* stability floor until the document
-        // is closed and reopened. Not fixed here: doing so would mean treating a
-        // `minimum_stability` change as its own full-refetch trigger in the diff above, a
-        // separate concern from #424's parse+thread scope.
-        if deps_to_fetch.is_empty() {
-            tracing::debug!("no added or version-changed dependencies, skipping registry fetch");
+    // Load resolved versions from lock file first (instant, no network)
+    let resolved_versions = load_resolved_versions(&uri, &state, ecosystem.as_ref()).await;
 
-            if let Some(mut doc) = state_clone.documents.get_mut(&uri_clone) {
-                doc.set_loaded();
-            }
+    // Update document state with resolved versions only
+    // Do NOT touch cached_versions - they contain latest registry versions
+    if !resolved_versions.is_empty()
+        && let Some(mut doc) = state.documents.get_mut(&uri)
+    {
+        doc.update_resolved_versions(resolved_versions.clone());
+    }
 
-            // Detached, capability-gated, timeout-bounded (issue #493): see
-            // `ServerState::spawn_refresh_requests` for rationale.
-            state_clone.spawn_refresh_requests(&client_clone);
+    // Phase A OSV scan (only when a dependency was added or an existing
+    // one's version changed — critique S1), spawned so it runs
+    // concurrently with the registry fetch below.
+    let osv_task = (config.vulnerabilities_enabled && needs_osv_rescan).then(|| {
+        tokio::spawn(run_osv_scan_phase_a(
+            uri.clone(),
+            Arc::clone(&state),
+            Arc::clone(&ecosystem),
+            config.cache.fetch_timeout_secs,
+        ))
+    });
 
-            if let Some(osv_task) = osv_task {
-                match osv_task.await {
-                    Ok(Some(phase_a_result)) => {
-                        let ecosystem_id = resolve_ecosystem_id(ecosystem_clone.as_ref());
-                        run_osv_phase_b_and_commit(
-                            &uri_clone,
-                            &state_clone,
-                            ecosystem_id,
-                            ecosystem_clone.formatter(),
-                            cache_config.fetch_timeout_secs,
-                            phase_a_result,
-                        )
-                        .await;
-                    }
-                    Ok(None) => {}
-                    Err(e) => tracing::warn!("OSV scan task failed: {e}"),
-                }
-            }
+    // Skip registry fetch if nothing new was added and no existing
+    // dependency's version changed.
+    //
+    // Known limitation (#424 N2): editing composer.json's `minimum-stability` field alone
+    // adds no dependency and changes no requirement string, so `deps_to_fetch` stays empty
+    // and this early-return skips the fetch — existing dependencies keep their
+    // `cached_versions` computed under the *previous* stability floor until the document
+    // is closed and reopened. Not fixed here: doing so would mean treating a
+    // `minimum_stability` change as its own full-refetch trigger in the diff above, a
+    // separate concern from #424's parse+thread scope.
+    if deps_to_fetch.is_empty() {
+        tracing::debug!("no added or version-changed dependencies, skipping registry fetch");
 
-            let diags = diagnostics::generate_diagnostics_internal(
-                Arc::clone(&state_clone),
-                &uri_clone,
-                freshness_settings,
-                diagnostic_severities,
-                offline,
-            )
-            .await;
-            client_clone
-                .publish_diagnostics(uri_clone.clone(), diags, None)
-                .await;
-            return;
-        }
-
-        tracing::info!(
-            count = deps_to_fetch.len(),
-            "fetching versions for added/version-changed dependencies"
-        );
-
-        // Mark as loading and start progress
-        if let Some(mut doc) = state_clone.documents.get_mut(&uri_clone) {
-            doc.set_loading();
-        }
-
-        let (progress, progress_sender) = if state_clone.supports_progress() {
-            match tokio::time::timeout(
-                std::time::Duration::from_secs(2),
-                RegistryProgress::start(
-                    client_clone.clone(),
-                    uri_clone.as_str(),
-                    deps_to_fetch.len(),
-                ),
-            )
-            .await
-            {
-                Ok(Ok((p, s))) => (Some(p), Some(s)),
-                _ => (None, None),
-            }
-        } else {
-            (None, None)
-        };
-
-        // Build the in-use-version map (§4.6) and the added/changed dependencies' resolved
-        // sources (spec FR-001/FR-011) from the freshly-committed parse result and the
-        // resolved versions just loaded above.
-        let (in_use, minimum_stability, dep_sources, collided_names): (
-            HashMap<PackageName, Vec<String>>,
-            Option<String>,
-            DepSources,
-            HashSet<PackageName>,
-        ) = match state_clone.get_document(&uri_clone) {
-            Some(doc) => match doc.parse_result() {
-                Some(pr) => {
-                    let (sources, collided_names) =
-                        dedup_dependencies_by_source(pr, ecosystem_clone.formatter());
-                    let dep_sources = deps_to_fetch
-                        .iter()
-                        .filter_map(|name| sources.get(name).map(|s| (name.clone(), s.clone())))
-                        .collect();
-                    (
-                        collect_in_use_versions(
-                            pr,
-                            &resolved_versions,
-                            ecosystem_clone.formatter(),
-                            resolve_ecosystem_id(ecosystem_clone.as_ref()),
-                        ),
-                        composer_minimum_stability(pr),
-                        dep_sources,
-                        collided_names,
-                    )
-                }
-                None => (HashMap::new(), None, Vec::new(), HashSet::new()),
-            },
-            None => (HashMap::new(), None, Vec::new(), HashSet::new()),
-        };
-
-        // Fetch latest versions only for NEW dependencies
-        //
-        // Captured before `dep_sources` is moved into the call below: every raw name a
-        // fetch was actually attempted for this round, used by the #550
-        // no-comparable-versions merge further down to distinguish "attempted and
-        // resolved fine this round" (clear any stale marker) from "not attempted this
-        // round" (leave any existing marker untouched) — unlike `fetched_names` below,
-        // this can't be derived from `fetch_result.versions`'s keys, since a
-        // no-comparable-versions package is by definition never one of them.
-        let attempted_names: Vec<PackageName> =
-            dep_sources.iter().map(|(name, _)| name.clone()).collect();
-        let registry = ecosystem_clone.registry();
-        let fetch_result = fetch_latest_versions_parallel(
-            registry,
-            dep_sources,
-            &in_use,
-            progress_sender,
-            freshness_settings,
-            cache_config.fetch_timeout_secs,
-            cache_config.max_concurrent_fetches,
-            minimum_stability.as_deref(),
-        )
-        .await;
-
-        let success = !fetch_result.versions.is_empty();
-
-        // Merge new versions into existing cache
-        if let Some(mut doc) = state_clone.documents.get_mut(&uri_clone) {
-            // Captured before `fetch_result.versions` is consumed below: every name
-            // successfully fetched this round, used by the S1 deprecation-clearing
-            // loop further down to distinguish "fetched and clean" from "not fetched
-            // this round" — only the former may clear a stale finding.
-            let fetched_names: Vec<PackageName> = fetch_result.versions.keys().cloned().collect();
-            for (name, version) in fetch_result.versions {
-                doc.cached_versions.insert(name, version);
-            }
-            // Re-key raw -> normalized (§3.1), same as the didOpen path.
-            let formatter = ecosystem_clone.formatter();
-            for (name, version) in fetch_result.yanked_versions {
-                doc.outcomes
-                    .set_yanked(formatter.normalize_package_name(&name), version);
-            }
-            for (name, failure) in fetch_result.fetch_failed {
-                doc.outcomes
-                    .set_fetch_failure(formatter.normalize_package_name(&name), failure);
-            }
-            // `set_fetch_failure_if_absent` (not `set_fetch_failure`): a collided name
-            // normalizing to the same key as a genuine failure just recorded above must
-            // not clobber it (impl-critic M2).
-            for name in collided_names {
-                doc.outcomes.set_fetch_failure_if_absent(
-                    formatter.normalize_package_name(&name),
-                    FetchFailure::NotAttempted,
-                );
-            }
-            merge_deprecations_after_fetch(
-                &mut doc,
-                &fetched_names,
-                fetch_result.deprecations,
-                formatter,
-            );
-            merge_no_comparable_versions_after_fetch(
-                &mut doc,
-                &attempted_names,
-                fetch_result.no_comparable_versions,
-                formatter,
-            );
-            if success {
-                doc.set_loaded();
-            } else {
-                doc.set_failed();
-            }
-        }
-
-        if let Some(progress) = progress {
-            progress.end(success).await;
-        }
-
-        // Notify user about failed packages — suppressed when offline, see
-        // `fetch_failure_toast`'s docs. `fetch_result.first_error` is always populated
-        // by `fetch_latest_versions_parallel` whenever `failed_count > 0` (#480: every
-        // site that increments `failed_count` also sets either `priority_error` or
-        // `first_error`, and the two are merged into this field before returning).
-        match fetch_failure_toast(
-            fetch_result.failed_count,
-            fetch_result.first_error.as_deref(),
-            state_clone.cache.is_offline(),
-        ) {
-            Some(message) => {
-                client_clone
-                    .show_message(MessageType::WARNING, message)
-                    .await;
-            }
-            None if fetch_result.failed_count > 0 => {
-                tracing::debug!(
-                    failed_count = fetch_result.failed_count,
-                    "suppressing fetch-failure toast: offline"
-                );
-            }
-            None => {}
+        if let Some(mut doc) = state.documents.get_mut(&uri) {
+            doc.set_loaded();
         }
 
         // Detached, capability-gated, timeout-bounded (issue #493): see
         // `ServerState::spawn_refresh_requests` for rationale.
-        state_clone.spawn_refresh_requests(&client_clone);
+        state.spawn_refresh_requests(&client);
 
-        if let Some(osv_task) = osv_task {
-            match osv_task.await {
-                Ok(Some(phase_a_result)) => {
-                    let ecosystem_id = resolve_ecosystem_id(ecosystem_clone.as_ref());
-                    run_osv_phase_b_and_commit(
-                        &uri_clone,
-                        &state_clone,
-                        ecosystem_id,
-                        ecosystem_clone.formatter(),
-                        cache_config.fetch_timeout_secs,
-                        phase_a_result,
-                    )
-                    .await;
-                }
-                Ok(None) => {}
-                Err(e) => tracing::warn!("OSV scan task failed: {e}"),
-            }
-        }
-
-        let diags = diagnostics::generate_diagnostics_internal(
-            Arc::clone(&state_clone),
-            &uri_clone,
-            freshness_settings,
-            diagnostic_severities,
-            offline,
+        await_and_commit_osv_phase_b(
+            osv_task,
+            &uri,
+            &state,
+            ecosystem.as_ref(),
+            config.cache.fetch_timeout_secs,
         )
         .await;
 
-        client_clone
-            .publish_diagnostics(uri_clone.clone(), diags, None)
-            .await;
-    });
+        generate_and_publish_diagnostics(
+            &state,
+            &uri,
+            &client,
+            config.freshness,
+            config.diagnostic_severities,
+            config.offline,
+        )
+        .await;
+        return;
+    }
 
-    Ok(task)
+    let (progress, fetch_result, attempted_names, collided_names) =
+        fetch_registry_versions_for_change(
+            &uri,
+            &state,
+            &client,
+            ecosystem.as_ref(),
+            &resolved_versions,
+            deps_to_fetch,
+            config.freshness,
+            config.cache.fetch_timeout_secs,
+            config.cache.max_concurrent_fetches,
+        )
+        .await;
+
+    let success = !fetch_result.versions.is_empty();
+
+    // Merge new versions into existing cache
+    let (failed_count, first_error) = merge_registry_fetch_result(
+        &state,
+        &uri,
+        ecosystem.formatter(),
+        fetch_result,
+        &attempted_names,
+        collided_names,
+        success,
+    );
+
+    if let Some(progress) = progress {
+        progress.end(success).await;
+    }
+
+    // Notify user about failed packages — suppressed when offline, see
+    // `fetch_failure_toast`'s docs. `fetch_result.first_error` is always populated
+    // by `fetch_latest_versions_parallel` whenever `failed_count > 0` (#480: every
+    // site that increments `failed_count` also sets either `priority_error` or
+    // `first_error`, and the two are merged into this field before returning).
+    match fetch_failure_toast(
+        failed_count,
+        first_error.as_deref(),
+        state.cache.is_offline(),
+    ) {
+        Some(message) => {
+            client.show_message(MessageType::WARNING, message).await;
+        }
+        None if failed_count > 0 => {
+            tracing::debug!(failed_count, "suppressing fetch-failure toast: offline");
+        }
+        None => {}
+    }
+
+    // Detached, capability-gated, timeout-bounded (issue #493): see
+    // `ServerState::spawn_refresh_requests` for rationale.
+    state.spawn_refresh_requests(&client);
+
+    await_and_commit_osv_phase_b(
+        osv_task,
+        &uri,
+        &state,
+        ecosystem.as_ref(),
+        config.cache.fetch_timeout_secs,
+    )
+    .await;
+
+    generate_and_publish_diagnostics(
+        &state,
+        &uri,
+        &client,
+        config.freshness,
+        config.diagnostic_severities,
+        config.offline,
+    )
+    .await;
+}
+
+/// Awaits the concurrently-spawned OSV phase-A scan, if one was started, and — when it
+/// produced a result — runs phase B against the now-resolved registry versions and commits
+/// the outcome. Shared by both branches of [`run_document_change_task`] (nothing to fetch
+/// vs. a full registry fetch), which otherwise diverge before OSV handling but must treat
+/// it identically.
+async fn await_and_commit_osv_phase_b(
+    osv_task: Option<JoinHandle<Option<OsvScanResult>>>,
+    uri: &Uri,
+    state: &Arc<ServerState>,
+    ecosystem: &dyn Ecosystem,
+    fetch_timeout_secs: u64,
+) {
+    let Some(osv_task) = osv_task else {
+        return;
+    };
+    match osv_task.await {
+        Ok(Some(phase_a_result)) => {
+            let ecosystem_id = resolve_ecosystem_id(ecosystem);
+            run_osv_phase_b_and_commit(
+                uri,
+                state,
+                ecosystem_id,
+                ecosystem.formatter(),
+                fetch_timeout_secs,
+                phase_a_result,
+            )
+            .await;
+        }
+        Ok(None) => {}
+        Err(e) => tracing::warn!("OSV scan task failed: {e}"),
+    }
+}
+
+/// Generates diagnostics from the current document/cache state and publishes them to the
+/// client. Shared by both branches of [`run_document_change_task`], each of which must end
+/// with an up-to-date publish regardless of whether a registry fetch actually ran.
+async fn generate_and_publish_diagnostics(
+    state: &Arc<ServerState>,
+    uri: &Uri,
+    client: &Client,
+    freshness_settings: deps_core::FreshnessSettings,
+    diagnostic_severities: deps_core::DiagnosticSeverities,
+    offline: bool,
+) {
+    let diags = diagnostics::generate_diagnostics_internal(
+        Arc::clone(state),
+        uri,
+        freshness_settings,
+        diagnostic_severities,
+        offline,
+    )
+    .await;
+    client.publish_diagnostics(uri.clone(), diags, None).await;
+}
+
+/// Fans the registry fetch out for the added/version-changed dependencies determined by the
+/// caller's diff: marks the document loading, opens an LSP progress notification when the
+/// client supports it, resolves each dependency occurrence to a fetchable source (deduping
+/// same-name collisions across different resolved sources), and fetches latest versions in
+/// parallel. Returns everything the caller needs to merge the result and end the progress
+/// notification, without exposing the intermediate `in_use`/`dep_sources` bookkeeping.
+#[allow(clippy::too_many_arguments)]
+async fn fetch_registry_versions_for_change(
+    uri: &Uri,
+    state: &ServerState,
+    client: &Client,
+    ecosystem: &dyn Ecosystem,
+    resolved_versions: &HashMap<PackageName, ConcreteVersion>,
+    deps_to_fetch: Vec<PackageName>,
+    freshness_settings: deps_core::FreshnessSettings,
+    fetch_timeout_secs: u64,
+    max_concurrent_fetches: usize,
+) -> (
+    Option<RegistryProgress>,
+    FetchResult,
+    Vec<PackageName>,
+    HashSet<PackageName>,
+) {
+    tracing::info!(
+        count = deps_to_fetch.len(),
+        "fetching versions for added/version-changed dependencies"
+    );
+
+    // Mark as loading and start progress
+    if let Some(mut doc) = state.documents.get_mut(uri) {
+        doc.set_loading();
+    }
+
+    let (progress, progress_sender) = if state.supports_progress() {
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            RegistryProgress::start(client.clone(), uri.as_str(), deps_to_fetch.len()),
+        )
+        .await
+        {
+            Ok(Ok((p, s))) => (Some(p), Some(s)),
+            _ => (None, None),
+        }
+    } else {
+        (None, None)
+    };
+
+    // Build the in-use-version map (§4.6) and the added/changed dependencies' resolved
+    // sources (spec FR-001/FR-011) from the freshly-committed parse result and the
+    // resolved versions just loaded above.
+    let (in_use, minimum_stability, dep_sources, collided_names): (
+        HashMap<PackageName, Vec<String>>,
+        Option<String>,
+        DepSources,
+        HashSet<PackageName>,
+    ) = match state.get_document(uri) {
+        Some(doc) => match doc.parse_result() {
+            Some(pr) => {
+                let (sources, collided_names) =
+                    dedup_dependencies_by_source(pr, ecosystem.formatter());
+                let dep_sources = deps_to_fetch
+                    .iter()
+                    .filter_map(|name| sources.get(name).map(|s| (name.clone(), s.clone())))
+                    .collect();
+                (
+                    collect_in_use_versions(
+                        pr,
+                        resolved_versions,
+                        ecosystem.formatter(),
+                        resolve_ecosystem_id(ecosystem),
+                    ),
+                    composer_minimum_stability(pr),
+                    dep_sources,
+                    collided_names,
+                )
+            }
+            None => (HashMap::new(), None, Vec::new(), HashSet::new()),
+        },
+        None => (HashMap::new(), None, Vec::new(), HashSet::new()),
+    };
+
+    // Fetch latest versions only for NEW dependencies
+    //
+    // Captured before `dep_sources` is moved into the call below: every raw name a
+    // fetch was actually attempted for this round, used by the #550
+    // no-comparable-versions merge further down to distinguish "attempted and
+    // resolved fine this round" (clear any stale marker) from "not attempted this
+    // round" (leave any existing marker untouched) — unlike `fetched_names` in the
+    // merge step, this can't be derived from `fetch_result.versions`'s keys, since a
+    // no-comparable-versions package is by definition never one of them.
+    let attempted_names: Vec<PackageName> =
+        dep_sources.iter().map(|(name, _)| name.clone()).collect();
+    let registry = ecosystem.registry();
+    let fetch_result = fetch_latest_versions_parallel(
+        registry,
+        dep_sources,
+        &in_use,
+        progress_sender,
+        freshness_settings,
+        fetch_timeout_secs,
+        max_concurrent_fetches,
+        minimum_stability.as_deref(),
+    )
+    .await;
+
+    (progress, fetch_result, attempted_names, collided_names)
+}
+
+/// Merges a completed registry fetch into the document's cache and outcome maps —
+/// newly fetched versions, yanked/fetch-failure markers (re-keyed raw -> normalized),
+/// collided names recorded as not-attempted, and deprecation / no-comparable-versions
+/// bookkeeping — then marks the document loaded or failed depending on `success`. Returns
+/// `(failed_count, first_error)`, the two `FetchResult` fields this function does not
+/// consume, so the caller can still raise the fetch-failure toast after `fetch_result`
+/// itself has been moved in here.
+fn merge_registry_fetch_result(
+    state: &ServerState,
+    uri: &Uri,
+    formatter: &dyn deps_core::lsp_helpers::EcosystemFormatter,
+    fetch_result: FetchResult,
+    attempted_names: &[PackageName],
+    collided_names: HashSet<PackageName>,
+    success: bool,
+) -> (usize, Option<String>) {
+    if let Some(mut doc) = state.documents.get_mut(uri) {
+        // Captured before `fetch_result.versions` is consumed below: every name
+        // successfully fetched this round, used by the S1 deprecation-clearing
+        // loop further down to distinguish "fetched and clean" from "not fetched
+        // this round" — only the former may clear a stale finding.
+        let fetched_names: Vec<PackageName> = fetch_result.versions.keys().cloned().collect();
+        for (name, version) in fetch_result.versions {
+            doc.cached_versions.insert(name, version);
+        }
+        // Re-key raw -> normalized (§3.1), same as the didOpen path.
+        for (name, version) in fetch_result.yanked_versions {
+            doc.outcomes
+                .set_yanked(formatter.normalize_package_name(&name), version);
+        }
+        for (name, failure) in fetch_result.fetch_failed {
+            doc.outcomes
+                .set_fetch_failure(formatter.normalize_package_name(&name), failure);
+        }
+        // `set_fetch_failure_if_absent` (not `set_fetch_failure`): a collided name
+        // normalizing to the same key as a genuine failure just recorded above must
+        // not clobber it (impl-critic M2).
+        for name in collided_names {
+            doc.outcomes.set_fetch_failure_if_absent(
+                formatter.normalize_package_name(&name),
+                FetchFailure::NotAttempted,
+            );
+        }
+        merge_deprecations_after_fetch(
+            &mut doc,
+            &fetched_names,
+            fetch_result.deprecations,
+            formatter,
+        );
+        merge_no_comparable_versions_after_fetch(
+            &mut doc,
+            attempted_names,
+            fetch_result.no_comparable_versions,
+            formatter,
+        );
+        if success {
+            doc.set_loaded();
+        } else {
+            doc.set_failed();
+        }
+    }
+
+    (fetch_result.failed_count, fetch_result.first_error)
 }
 
 /// Builds a `cached_versions` map from lock-file-resolved versions, ahead of any registry

--- a/crates/deps-nuget/src/config.rs
+++ b/crates/deps-nuget/src/config.rs
@@ -1269,7 +1269,8 @@ pub(crate) fn resolve(
 ///
 /// # Credential binding (§3.2, FR-007)
 ///
-/// The final pass below binds a user-profile credential to a resolved entry `E` iff all of:
+/// The final pass, in `bind_credentials_and_finalize`, binds a user-profile credential to a
+/// resolved entry `E` iff all of:
 /// (0) `E.key` does not overlap the credential-suppression set (union, exclusion); (1) exactly
 /// one user-profile credential's key-candidates overlap `E.key`; (2) exactly one
 /// `user_profile_add` entry's key-candidates overlap that credential's own key; (3) `E`'s URL
@@ -1286,6 +1287,37 @@ pub fn resolve_with_context(
     user_profile_config: Option<&Path>,
     user_profile_sources: &AtomicBool,
 ) -> NuGetConfig {
+    let ancestors = collect_config_ancestors(manifest_dir, config_cache, user_profile_config);
+
+    let user_profile_sources_enabled =
+        user_profile_sources.load(std::sync::atomic::Ordering::Relaxed);
+
+    // S2 fix (impl-critic, issue #576 follow-up): identity of the exact config state this
+    // resolve is built from — see `config_ancestors_fingerprint`'s doc. Computed before the
+    // tier-accumulation walk so `bind_credentials_and_finalize` can debounce its fail-closed
+    // warnings against it below.
+    let config_fingerprint = config_ancestors_fingerprint(&ancestors);
+
+    let accumulated = accumulate_config_tiers(&ancestors, policy, user_profile_sources_enabled);
+
+    bind_credentials_and_finalize(accumulated, config_cache, config_fingerprint)
+}
+
+/// Walks `manifest_dir`'s ancestor directories collecting each `NuGet.Config` found (FR-001),
+/// then resolves the user-profile-tier file, if any, dropping it when it is the same file
+/// (by canonicalized path) as one already found in the repo walk — a user-profile candidate
+/// reachable at both tiers is treated as `Repo` (lower trust wins) rather than loaded a
+/// second time under the higher-trust tier. A `canonicalize` failure on the user-profile
+/// candidate itself drops it entirely (fail closed).
+///
+/// Returns the merged chain in leaf-to-root discovery order with the user-profile file
+/// appended last, so reversing it (as [`accumulate_config_tiers`] does) processes the
+/// user-profile tier first and lets any repo-tier file override it (§3.8).
+fn collect_config_ancestors(
+    manifest_dir: &Path,
+    config_cache: &NuGetConfigCache,
+    user_profile_config: Option<&Path>,
+) -> Vec<(ConfigTier, Arc<RawNuGetConfigFile>)> {
     let mut repo_ancestors: Vec<Arc<RawNuGetConfigFile>> = Vec::new();
     let mut repo_paths: Vec<PathBuf> = Vec::new();
     let mut current: Option<&Path> = Some(manifest_dir);
@@ -1310,10 +1342,6 @@ pub fn resolve_with_context(
         current = dir.parent();
     }
 
-    // FR-001: a user-profile candidate reachable at both tiers (canonicalized) is treated as
-    // Repo (lower trust wins) — dropped here rather than loaded a second time under the
-    // higher-trust tier. A `canonicalize` failure on the user-profile candidate itself drops
-    // it entirely (fail closed).
     let user_profile_file: Option<Arc<RawNuGetConfigFile>> = user_profile_config.and_then(|upc| {
         let canon = std::fs::canonicalize(upc).ok()?;
         let is_repo_dup = repo_paths
@@ -1325,9 +1353,6 @@ pub fn resolve_with_context(
         config_cache.get_or_parse(&canon)
     });
 
-    // Leaf-to-root discovery order (matching `repo_ancestors`'s own order), with the
-    // user-profile file appended last — so after `.rev()` below it is processed *first*,
-    // giving any repo-tier file the ability to override it (§3.8).
     let mut ancestors: Vec<(ConfigTier, Arc<RawNuGetConfigFile>)> = repo_ancestors
         .into_iter()
         .map(|f| (ConfigTier::Repo, f))
@@ -1335,29 +1360,65 @@ pub fn resolve_with_context(
     if let Some(user_file) = user_profile_file {
         ancestors.push((ConfigTier::UserProfile, user_file));
     }
+    ancestors
+}
 
-    let user_profile_sources_enabled =
-        user_profile_sources.load(std::sync::atomic::Ordering::Relaxed);
+/// Content-derived identity of `ancestors`' exact config state (S2 fix, impl-critic, issue
+/// #576 follow-up), derived from *content* rather than `Arc` pointer address (C1 fix,
+/// impl-critic follow-up — pointer identity collides once an old `Arc` is dropped and a
+/// later, differently-content `Arc` is allocated at the same freed address; see
+/// `RawNuGetConfigFile`'s doc). `Arc<T>`'s own `Hash` impl already forwards to `T`'s `Hash`
+/// rather than hashing the pointer, so this is stable across repeat calls that hit
+/// `config_cache` for every ancestor (same content, same hash) and changes the instant any
+/// ancestor's parsed content actually differs. Lets [`fail_closed`] debounce its warning to
+/// once per distinct config state instead of once per resolve call (this pass isn't itself
+/// cached, unlike the per-file raw parse).
+fn config_ancestors_fingerprint(ancestors: &[(ConfigTier, Arc<RawNuGetConfigFile>)]) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for (tier, file) in ancestors {
+        tier.hash(&mut hasher);
+        file.hash(&mut hasher);
+    }
+    hasher.finish()
+}
 
-    // S2 fix (impl-critic, issue #576 follow-up): identity of the exact config state this
-    // resolve is built from, derived from *content* rather than `Arc` pointer address (C1 fix,
-    // impl-critic follow-up — pointer identity collides once an old `Arc` is dropped and a
-    // later, differently-content `Arc` is allocated at the same freed address; see
-    // `RawNuGetConfigFile`'s doc). `Arc<T>`'s own `Hash` impl already forwards to `T`'s `Hash`
-    // rather than hashing the pointer, so this is stable across repeat calls that hit
-    // `config_cache` for every ancestor (same content, same hash) and changes the instant any
-    // ancestor's parsed content actually differs. Lets `fail_closed` below debounce its warning
-    // to once per distinct config state instead of once per resolve call (this pass isn't
-    // itself cached, unlike the per-file raw parse).
-    let config_fingerprint = {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        for (tier, file) in &ancestors {
-            tier.hash(&mut hasher);
-            file.hash(&mut hasher);
-        }
-        hasher.finish()
-    };
+/// State [`accumulate_config_tiers`] builds while walking the merged ancestor chain root-to-
+/// leaf (C1), threaded into [`bind_credentials_and_finalize`] for the credential-binding pass
+/// and the final [`NuGetConfig`] assembly. Kept as one struct rather than a long parameter
+/// list since every field is produced together by the same walk and consumed together by the
+/// same pass.
+struct AccumulatedConfig {
+    sources: Vec<PackageSourceEntry>,
+    cleared: bool,
+    nuget_org_removed: bool,
+    disabled_raw: Vec<(String, String)>,
+    repo_credentialed_raw: Vec<String>,
+    user_credentialed_raw: Vec<String>,
+    mapping: PackageSourceMapping,
+    /// Credential-half accumulators (§3.8) — populated identically regardless of
+    /// `user_profile_sources`.
+    user_credentials: Vec<RawCredential>,
+    user_profile_add: Vec<PackageSourceEntry>,
+    user_profile_credential_suppressed: HashSet<String>,
+}
 
+/// C1: applies each ancestor's contribution root -> leaf (reverse of `ancestors`' leaf-to-root
+/// discovery order), accumulating package sources, `<clear/>`/`<remove>` state, disabled/
+/// credentialed key sets, and `<packageSourceMapping>` into one [`AccumulatedConfig`].
+///
+/// A [`ConfigTier::UserProfile`] file's contribution splits into two halves (§3.8, FR-005/
+/// FR-006): its credential half (`credentialed_keys`, the §3.4 suppression set, raw
+/// `<packageSourceCredentials>` values, and its own `<clear/>`/`<add>`/`<remove>` batch
+/// tracked separately as `user_profile_add`) always applies; its routing half (`sources`,
+/// `sources_cleared`, `removed`/`nuget_org_removed`, `disabled`, `mapping`) is skipped
+/// entirely when `user_profile_sources_enabled` is false (NFR-005). A repo-tier file's
+/// contribution is unaffected by the flag and always applies in full. `cleared` is sticky for
+/// the rest of the walk once set — see this module's doc.
+fn accumulate_config_tiers(
+    ancestors: &[(ConfigTier, Arc<RawNuGetConfigFile>)],
+    policy: &RegistryAccessPolicy,
+    user_profile_sources_enabled: bool,
+) -> AccumulatedConfig {
     let mut sources: Vec<PackageSourceEntry> = Vec::new();
     let mut cleared = false;
     let mut nuget_org_removed = false;
@@ -1371,8 +1432,6 @@ pub fn resolve_with_context(
     let mut user_profile_add: Vec<PackageSourceEntry> = Vec::new();
     let mut user_profile_credential_suppressed: HashSet<String> = HashSet::new();
 
-    // C1: apply root -> leaf (reverse of the leaf-to-root discovery order above). `cleared`
-    // is sticky for the rest of the walk once set — see this module's doc.
     for (tier, file) in ancestors.iter().rev() {
         let tier = *tier;
 
@@ -1432,22 +1491,50 @@ pub fn resolve_with_context(
         }
     }
 
+    AccumulatedConfig {
+        sources,
+        cleared,
+        nuget_org_removed,
+        disabled_raw,
+        repo_credentialed_raw,
+        user_credentialed_raw,
+        mapping,
+        user_credentials,
+        user_profile_add,
+        user_profile_credential_suppressed,
+    }
+}
+
+/// Final pass (§3.2, FR-007): binds a user-profile credential to each resolved source entry
+/// where all of conditions (0)-(3) hold (see [`resolve_with_context`]'s doc for the full
+/// condition list), applying the FR-004 repo-tier-credentialed check and the FR-008 public-
+/// index carve-out first, and fails an entry closed via [`fail_closed`] whenever a credential
+/// match cannot be bound cleanly. Consumes `accumulated` and returns the finished
+/// [`NuGetConfig`], since nothing else in [`resolve_with_context`] needs the intermediate
+/// accumulator state after this point.
+fn bind_credentials_and_finalize(
+    mut accumulated: AccumulatedConfig,
+    config_cache: &NuGetConfigCache,
+    config_fingerprint: u64,
+) -> NuGetConfig {
     let mut disabled_keys: HashSet<String> = HashSet::new();
-    for (key, value) in &disabled_raw {
+    for (key, value) in &accumulated.disabled_raw {
         if value.eq_ignore_ascii_case("true") {
             disabled_keys.extend(key_candidates(key));
         }
     }
-    let repo_credentialed_keys: HashSet<String> = repo_credentialed_raw
+    let repo_credentialed_keys: HashSet<String> = accumulated
+        .repo_credentialed_raw
         .iter()
         .flat_map(|k| key_candidates(k))
         .collect();
-    let user_credentialed_keys: HashSet<String> = user_credentialed_raw
+    let user_credentialed_keys: HashSet<String> = accumulated
+        .user_credentialed_raw
         .iter()
         .flat_map(|k| key_candidates(k))
         .collect();
 
-    for entry in &mut sources {
+    for entry in &mut accumulated.sources {
         let Ok(url) = entry.value.as_ref() else {
             continue;
         };
@@ -1495,9 +1582,9 @@ pub fn resolve_with_context(
 
         match bind_user_profile_credential(
             entry,
-            &user_credentials,
-            &user_profile_add,
-            &user_profile_credential_suppressed,
+            &accumulated.user_credentials,
+            &accumulated.user_profile_add,
+            &accumulated.user_profile_credential_suppressed,
             &resolved_url,
         ) {
             Some(Ok(auth)) => entry.auth = Some(auth),
@@ -1518,10 +1605,10 @@ pub fn resolve_with_context(
     }
 
     NuGetConfig {
-        sources,
-        cleared,
-        nuget_org_removed,
-        mapping,
+        sources: accumulated.sources,
+        cleared: accumulated.cleared,
+        nuget_org_removed: accumulated.nuget_org_removed,
+        mapping: accumulated.mapping,
     }
 }
 


### PR DESCRIPTION
## Summary
- Splits `handle_document_change` (`crates/deps-lsp/src/document/lifecycle.rs`, was ~420 lines) into `parse_and_diff_manifest`, `commit_parsed_document`, and a spawned `run_document_change_task` (delegating to `fetch_registry_versions_for_change`, `merge_registry_fetch_result`, `await_and_commit_osv_phase_b`, `generate_and_publish_diagnostics`), also deduplicating two blocks that were byte-identical in the original.
- Splits `resolve_with_context` (`crates/deps-nuget/src/config.rs`, was ~311 lines) into `collect_config_ancestors`, `config_ancestors_fingerprint`, `accumulate_config_tiers`, and `bind_credentials_and_finalize`.
- Pure decomposition, no intended behavior change — ordering (including credential binding relative to `<clear/>` processing), error propagation, and the async spawn boundary are all preserved exactly.

## Verification
- Independent adversarial critique traced call-site multisets across both diffs and found zero operations added or dropped.
- Full workspace test suite: 4020 passed, 0 failed, 49 skipped (re-verified independently, diffed against the correct base commit — no test deleted or weakened).
- `cargo +nightly fmt --check`, `cargo clippy --all-targets --all-features --workspace -- -D warnings`, and the rustdoc gate with CI's actual flags (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links"`) all clean.
- Independent code review: approved, no naming collisions among the 13 new helpers/structs workspace-wide, all `pub` items carry doc comments.

## Test plan
- [x] `cargo nextest run --workspace --all-features --no-fail-fast`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo +nightly fmt --check`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`

Closes #580