### PR TITLE
refactor(deps-core,deps-lsp): decompose generate_hover and lifecycle orchestration functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-cargo, deps-nuget**: renamed the secret-exposing `as_str()` accessor on `Redacted<T>` and its delegating wrapper types (`AuthToken`, `RedactedSecret`) to `expose_secret()`, so it can no longer be confused with an ordinary string conversion in a grep or code review (resolves #581) (#582)
 - **deps-lsp, deps-nuget**: decomposed `handle_document_change` and `resolve_with_context` into named, independently-testable phase helpers — pure refactor, no behavior change (resolves #580) (#583)
 - **deps-core, deps-pypi, deps-nuget, deps-go**: consolidated three independently hand-rolled "hash an ordered routing chain into an opaque identity key" implementations into a single `deps_core::hash_routing_key` helper; resulting chain-key digest values change (process-local cache keys only, never persisted or compared cross-process, so this is not observable); `deps_go::config::ChainSeparator` no longer derives `Hash` (breaking, pre-1.0, no alias) (resolves #579) (#584)
-- **deps-core, deps-lsp**: decomposed `generate_hover` and `fetch_latest_versions_parallel`/`handle_document_open` into named, independently-testable helpers — pure refactor, no behavior change (resolves #586, #585)
+- **deps-core, deps-lsp**: decomposed `generate_hover` and `fetch_latest_versions_parallel`/`handle_document_open` into named, independently-testable helpers — pure refactor, no behavior change (resolves #586, #585) (#588)
 
 ### Security
 - **deps-core, deps-nuget**: credential material and its construction intermediates now zeroize on drop (resolves #574) (#577)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-cargo, deps-nuget**: renamed the secret-exposing `as_str()` accessor on `Redacted<T>` and its delegating wrapper types (`AuthToken`, `RedactedSecret`) to `expose_secret()`, so it can no longer be confused with an ordinary string conversion in a grep or code review (resolves #581) (#582)
 - **deps-lsp, deps-nuget**: decomposed `handle_document_change` and `resolve_with_context` into named, independently-testable phase helpers — pure refactor, no behavior change (resolves #580) (#583)
 - **deps-core, deps-pypi, deps-nuget, deps-go**: consolidated three independently hand-rolled "hash an ordered routing chain into an opaque identity key" implementations into a single `deps_core::hash_routing_key` helper; resulting chain-key digest values change (process-local cache keys only, never persisted or compared cross-process, so this is not observable); `deps_go::config::ChainSeparator` no longer derives `Hash` (breaking, pre-1.0, no alias) (resolves #579) (#584)
+- **deps-core, deps-lsp**: decomposed `generate_hover` and `fetch_latest_versions_parallel`/`handle_document_open` into named, independently-testable helpers — pure refactor, no behavior change (resolves #586, #585)
 
 ### Security
 - **deps-core, deps-nuget**: credential material and its construction intermediates now zeroize on drop (resolves #574) (#577)

--- a/crates/deps-core/src/lsp_helpers/hover.rs
+++ b/crates/deps-core/src/lsp_helpers/hover.rs
@@ -6,8 +6,9 @@ use tower_lsp_server::ls_types::{Hover, HoverContents, MarkupContent, MarkupKind
 use crate::deps_dev::deps_dev_system;
 use crate::osv::ScanOutcome;
 use crate::{
-    ConcreteVersion, Deprecation, ParseResult, ProvenanceStatus, PublishTime, Registry,
-    SupplyChainTrustSignal, Version, VersionReq, format_relative_age, is_within_cooldown,
+    ConcreteVersion, Dependency, DependencySource, Deprecation, ParseResult, ProvenanceStatus,
+    PublishTime, Registry, SupplyChainTrustSignal, Version, VersionReq, format_relative_age,
+    is_within_cooldown,
 };
 
 use super::{
@@ -69,8 +70,6 @@ pub async fn generate_hover<R: Registry + ?Sized>(
     freshness: crate::freshness::FreshnessSettings,
     now: PublishTime,
 ) -> Option<Hover> {
-    use std::fmt::Write;
-
     let dep = parse_result.dependencies().into_iter().find(|d| {
         let on_name = position_in_range(position, d.name_range());
         let on_version = d
@@ -97,58 +96,15 @@ pub async fn generate_hover<R: Registry + ?Sized>(
     // requests overlap instead of stacking (spec 037, plan.md §8 M6).
     let normalized_name = formatter.normalize_package_name(dep.name());
 
-    // Supply-chain trust signal (spec 037): spawned as a detached background task,
-    // concurrently with the registry fetch just below, so a slow or cold-memo
-    // deps.dev never adds its own latency on top of the registry fetch's. Only
-    // `handlers/hover.rs` (deps-lsp) ever sets `versions.trust`, which is what makes
-    // FR-010's hover-only scope structural: every other surface (diagnostics, code
-    // actions, inlay hints, code lenses) is never handed a client and so can never
-    // reach deps.dev.
-    //
-    // Gated on all of: a client was handed in, `network.offline` is not set, the source
-    // resolves against a **public** registry, the ecosystem is one of the seven
-    // `deps_dev_system` maps, and a concrete in-use version exists — the last two
-    // checked with **no** network I/O, so an ecosystem `deps_dev_system` excludes
-    // (Composer, Dart, Swift, ...) spawns nothing at all.
-    //
-    // `formatter.source_is_public_registry_content(&dep_source)`, not the weaker
-    // `resolvable` (`can_resolve_source`): `resolvable` is deliberately widened by some
-    // ecosystems (e.g. `deps-cargo`'s `AlternateRegistry`) to cover *any* configured
-    // registry, private/internal ones included — reusing it here would send a private
-    // package's name and version to deps.dev by default (security audit M2). `source_is_
-    // public_registry_content` is the same, stricter predicate this server's other
-    // third-party lookup (OSV) already gates on (`lifecycle.rs`).
-    //
-    // `!versions.offline`: every other network-gated hover section in this function
-    // checks `versions.offline` (the `Cmd+.` footer, the offline footer itself below) —
-    // without it here, offline mode still spawns a task per hover and writes a 90s
-    // negative memo entry, keeping the signal absent for up to 90s per package after
-    // reconnecting for no reason (critic C4).
-    //
-    // `tokio::spawn` panics outside a Tokio runtime — every caller of `generate_hover`
-    // is `#[tokio::test]`-async or the real LSP server, so this is safe here, but no
-    // doc-test may call this function directly. The spawned future captures only
-    // owned/`'static` data (`Arc<DepsDevClient>`, `&'static str`, owned `String`s) so
-    // it satisfies `Send + 'static` with no borrow from `dep`/`parse_result`.
-    let trust_handle = versions.trust.and_then(|client| {
-        let ecosystem = versions.ecosystem?;
-        let system = deps_dev_system(ecosystem)?;
-        if versions.offline || !formatter.source_is_public_registry_content(&dep_source) {
-            return None;
-        }
-        let version = in_use_version(
-            dep,
-            normalized_name.as_str(),
-            versions.resolved,
-            formatter,
-            ecosystem,
-        )?;
-        let client = Arc::clone(client);
-        let name = dep.name().to_string();
-        Some(tokio::spawn(async move {
-            client.trust_signal(system, &name, &version).await
-        }))
-    });
+    // Spawned concurrently with the registry fetch just below, so a slow or
+    // cold-memo deps.dev never adds its own latency on top of the registry fetch's.
+    let trust_handle = spawn_trust_signal_fetch(
+        dep,
+        &dep_source,
+        &versions,
+        formatter,
+        normalized_name.as_str(),
+    );
 
     // `now` is a caller-supplied parameter (issue #227 M4) rather than computed
     // internally via `PublishTime::now()` — this is what lets tests pin an exact
@@ -187,20 +143,7 @@ pub async fn generate_hover<R: Registry + ?Sized>(
 
     // Pre-allocate with estimated capacity to reduce allocations
     let mut markdown = String::with_capacity(512);
-    match &url {
-        Some(url) => write!(
-            &mut markdown,
-            "# [{}]({})\n\n",
-            escape_markdown(dep.name().as_str()),
-            url
-        ),
-        None => write!(
-            &mut markdown,
-            "# {}\n\n",
-            escape_markdown(dep.name().as_str())
-        ),
-    }
-    .unwrap();
+    push_header_hover_section(&mut markdown, dep, url.as_deref());
 
     let resolved: Option<&str> = if formatter.manifest_requirement_is_resolved_version(dep) {
         dep.version_requirement().map(VersionReq::as_str)
@@ -211,30 +154,9 @@ pub async fn generate_hover<R: Registry + ?Sized>(
             .or_else(|| versions.resolved.get(dep.name()))
             .map(ConcreteVersion::as_str)
     };
-    if let Some(resolved_ver) = resolved {
-        write!(
-            &mut markdown,
-            "**Current**: {}\n\n",
-            markdown_code_span(resolved_ver)
-        )
-        .unwrap();
-    } else if let Some(version_req) = dep.version_requirement() {
-        write!(
-            &mut markdown,
-            "**Requirement**: {}\n\n",
-            markdown_code_span(version_req.as_str())
-        )
-        .unwrap();
-    }
+    push_current_or_requirement_hover_section(&mut markdown, dep, resolved);
 
-    if let Some(marker_expr) = dep.markers() {
-        write!(
-            &mut markdown,
-            "**Active when**: {}\n\n",
-            markdown_code_span(marker_expr)
-        )
-        .unwrap();
-    }
+    push_markers_hover_section(&mut markdown, dep);
 
     // The `**Latest**` line prefers the just-fetched Ch2 list (`available_versions`) over
     // the Ch1 cache (`versions.cached`, populated by the lifecycle's background fetch)
@@ -346,31 +268,7 @@ pub async fn generate_hover<R: Registry + ?Sized>(
             }),
         _ => cached_latest.map(|v| (v.latest.as_str(), v.published_at)),
     };
-    if let Some((latest_ver, raw_published_at)) = latest_line {
-        let published_at = freshness.enabled.then_some(raw_published_at).flatten();
-        let age_secs = published_at.map(|p| p.age_secs_from(now));
-        write!(
-            &mut markdown,
-            "**Latest**: {}",
-            markdown_code_span(latest_ver)
-        )
-        .unwrap();
-        if let Some(age_secs) = age_secs {
-            write!(
-                &mut markdown,
-                " *(published {})*",
-                format_relative_age(age_secs)
-            )
-            .unwrap();
-        }
-        markdown.push_str("\n\n");
-        if age_secs.is_some_and(|age| is_within_cooldown(age, freshness.cooldown_secs)) {
-            markdown.push_str(
-                "> ⏳ **Recently published** — this release is still within the cooldown window.\n\
-                 > It may still be yanked or superseded; consider verifying before upgrading.\n\n",
-            );
-        }
-    }
+    push_latest_hover_section(&mut markdown, latest_line, freshness, now);
 
     // #394 S2: prefer the version-qualified key so a hover on one occurrence
     // of a duplicated name never shows another occurrence's OSV result. See
@@ -416,113 +314,27 @@ pub async fn generate_hover<R: Registry + ?Sized>(
     // a "**Recent versions**:" header with no entries under it is never useful,
     // regardless of ecosystem.
     if let Some(available_versions) = available_versions.as_ref().filter(|v| !v.is_empty()) {
-        // Matched by position against `live_latest_idx` (the header's stable-latest pick)
-        // rather than raw index 0 or string equality: `available_versions` is sorted purely
-        // by version number, so index 0 can be a pre-release the header itself doesn't call
-        // "latest" (issue #313), and matching by version string instead of index could tag
-        // more than one entry if two ever shared a version string. No match in the rendered
-        // top-N slice simply omits the marker.
-        markdown.push_str("**Recent versions**:\n");
-        for (i, version) in available_versions
-            .iter()
-            .take(HOVER_RECENT_VERSIONS)
-            .enumerate()
-        {
-            let version_span = markdown_code_span(version.version_string().as_str());
-            let age_suffix = if freshness.enabled {
-                version_age_suffix(version.as_ref(), now)
-            } else {
-                String::new()
-            };
-            if Some(i) == live_latest_idx {
-                if version.removal_status().is_flagged() {
-                    // The resolved "latest" can itself be flagged (e.g. npm's ranking
-                    // preference falls through to a deprecated version when no clean one
-                    // exists) — the deprecation/yank warning must not silently vanish just
-                    // because this entry also carries the `(latest)` marker (#347/#348 S1).
-                    writeln!(
-                        &mut markdown,
-                        "- {version_span} *(latest)* {}{age_suffix}",
-                        formatter.yanked_label()
-                    )
-                    .unwrap();
-                } else {
-                    writeln!(&mut markdown, "- {version_span} *(latest)*{age_suffix}").unwrap();
-                }
-            } else if version.removal_status().is_flagged() {
-                writeln!(
-                    &mut markdown,
-                    "- {} {}{}",
-                    version_span,
-                    formatter.yanked_label(),
-                    age_suffix
-                )
-                .unwrap();
-            } else {
-                writeln!(&mut markdown, "- {version_span}{age_suffix}").unwrap();
-            }
-        }
+        push_recent_versions_hover_section(
+            &mut markdown,
+            available_versions,
+            live_latest_idx,
+            freshness,
+            now,
+            formatter,
+        );
     }
 
-    // The footer advertises a `Cmd+.` code action — none is ever offered for a source that
-    // is deliberately non-resolvable (e.g. a local composite action or a Docker image ref),
-    // so rendering it unconditionally is misleading there (#474). Gated on `resolvable`
-    // alone, not on `available_versions`/`cached_latest` also being populated: a
-    // vulnerability-fix or unsatisfiable-fix code action (`code_actions.rs`) can exist from
-    // `versions.vulnerabilities` — populated independently of the registry fetch
-    // (`lifecycle.rs`) — even when both of those are empty (e.g. a registry fetch failure),
-    // so requiring them too would silently drop the footer while `Cmd+.` still offers a fix.
-    //
-    // Also gated on offline data availability (#501): `HttpCache` deliberately serves warm
-    // entries while offline (it force-enables caching in that mode), and doc-state fields —
-    // `versions.vulnerabilities`/`cached_latest`/deprecation — survive an online-to-offline
-    // transition via `preserve_cache`, so `Cmd+.` can still produce a real REFACTOR/fix/
-    // replacement action offline as long as *some* version, vulnerability, or deprecation
-    // data was actually rendered above. Only suppress when offline AND none of that data is
-    // present — a cold process with nothing cached yet, where no producer in
-    // `generate_code_actions` has anything to act on.
-    //
-    // `matches!(vuln_outcome, Some(ScanOutcome::Vulnerable(_)))`, not `vuln_outcome.is_some()`
-    // (#501 C5): offline does not skip the OSV scan, it lets it run and fail, which writes
-    // `ScanOutcome::Skipped(_)` for every dependency — `is_some()` would be true in exactly
-    // #501's own cold-start repro and only `Vulnerable` ever backs
-    // `build_vulnerability_fix_action` (`code_actions.rs`).
-    let has_offline_actionable_data = available_versions.as_ref().is_some_and(|v| !v.is_empty())
-        || cached_latest.is_some()
-        || matches!(vuln_outcome, Some(ScanOutcome::Vulnerable(_)))
-        || deprecation.is_some();
-    // #550: a live fetch that genuinely succeeded with zero entries (`Some(&[])`,
-    // distinct from `None` — a fetch that errored or never ran, where an unrelated
-    // Cmd+. action such as an unsatisfiable-fix might still exist per #474's own
-    // reasoning above) is definitive proof there is nothing version-wise to update to.
-    // Combined with no cached/vulnerability/deprecation data either
-    // (`!has_offline_actionable_data`, which already folds in this same emptiness
-    // check), the footer would otherwise advertise an action that provably does not
-    // exist — the "empty Recent versions section plus a stray footer" bug reported
-    // against GHA's `dtolnay/rust-toolchain@stable` but not specific to any one
-    // ecosystem. Every other online case (a non-empty live list, or no live fetch at
-    // all) keeps the pre-#550 unconditional-when-resolvable behavior.
-    let live_fetch_definitively_empty = available_versions.as_ref().is_some_and(Vec::is_empty);
-    let footer_actionable =
-        has_offline_actionable_data || (!live_fetch_definitively_empty && !versions.offline);
-    if resolvable && footer_actionable {
-        markdown.push_str(CMD_DOT_FOOTER);
-    }
+    push_cmd_dot_footer_hover_section(
+        &mut markdown,
+        resolvable,
+        available_versions.as_deref(),
+        cached_latest,
+        vuln_outcome,
+        deprecation,
+        versions.offline,
+    );
 
-    // `versions.offline` (issue #483): the OSV lookup that produced `ScanOutcome::Skipped`
-    // for this dependency renders nothing above (the `Some(ScanOutcome::Skipped(_)) | None`
-    // arm below), which would otherwise be visually indistinguishable from a scanned,
-    // vulnerability-free dependency — this footer must explicitly call out that
-    // vulnerability data specifically was not checked, not just version data (S2).
-    //
-    // Gated on `resolvable` too, matching the `Cmd+.` footer immediately above (#474/#475):
-    // a dependency that is never network-resolved under any setting (a local composite
-    // action, a Docker image ref, a Git/path dependency) must not claim its version or
-    // vulnerability data went unchecked *because of* `network.offline` — nothing there was
-    // ever going to be checked regardless.
-    if versions.offline && resolvable {
-        markdown.push_str("\n---\n📴 *Offline: version and vulnerability data not checked*");
-    }
+    push_offline_footer_hover_section(&mut markdown, resolvable, versions.offline);
 
     Some(Hover {
         contents: HoverContents::Markup(MarkupContent {
@@ -531,6 +343,301 @@ pub async fn generate_hover<R: Registry + ?Sized>(
         }),
         range: Some(dep.name_range()),
     })
+}
+
+/// Spawns the deps.dev supply-chain trust-signal fetch (spec 037) as a detached
+/// background task. Only `handlers/hover.rs` (deps-lsp) ever sets `versions.trust`,
+/// which is what makes FR-010's hover-only scope structural: every other surface
+/// (diagnostics, code actions, inlay hints, code lenses) is never handed a client and
+/// so can never reach deps.dev.
+///
+/// Gated on all of: a client was handed in, `network.offline` is not set, the source
+/// resolves against a **public** registry, the ecosystem is one of the seven
+/// `deps_dev_system` maps, and a concrete in-use version exists — the last two
+/// checked with **no** network I/O, so an ecosystem `deps_dev_system` excludes
+/// (Composer, Dart, Swift, ...) spawns nothing at all.
+///
+/// `formatter.source_is_public_registry_content(dep_source)`, not the weaker
+/// `EcosystemFormatter::can_resolve_source`: that predicate is deliberately widened
+/// by some ecosystems (e.g. `deps-cargo`'s `AlternateRegistry`) to cover *any*
+/// configured registry, private/internal ones included — reusing it here would send
+/// a private package's name and version to deps.dev by default (security audit M2).
+/// `source_is_public_registry_content` is the same, stricter predicate this server's
+/// other third-party lookup (OSV) already gates on (`lifecycle.rs`).
+///
+/// `!versions.offline`: every other network-gated hover section [`generate_hover`]
+/// builds checks `versions.offline` (the `Cmd+.` footer, the offline footer) —
+/// without it here, offline mode still spawns a task per hover and writes a 90s
+/// negative memo entry, keeping the signal absent for up to 90s per package after
+/// reconnecting for no reason (critic C4).
+///
+/// `tokio::spawn` panics outside a Tokio runtime — every caller of [`generate_hover`]
+/// is `#[tokio::test]`-async or the real LSP server, so this is safe here, but no
+/// doc-test may call it directly. The spawned future captures only owned/`'static`
+/// data (`Arc<DepsDevClient>`, `&'static str`, owned `String`s) so it satisfies
+/// `Send + 'static` with no borrow from `dep`.
+fn spawn_trust_signal_fetch(
+    dep: &dyn Dependency,
+    dep_source: &DependencySource,
+    versions: &VersionData<'_>,
+    formatter: &dyn EcosystemFormatter,
+    normalized_name: &str,
+) -> Option<tokio::task::JoinHandle<Option<SupplyChainTrustSignal>>> {
+    versions.trust.and_then(|client| {
+        let ecosystem = versions.ecosystem?;
+        let system = deps_dev_system(ecosystem)?;
+        if versions.offline || !formatter.source_is_public_registry_content(dep_source) {
+            return None;
+        }
+        let version = in_use_version(
+            dep,
+            normalized_name,
+            versions.resolved,
+            formatter,
+            ecosystem,
+        )?;
+        let client = Arc::clone(client);
+        let name = dep.name().to_string();
+        Some(tokio::spawn(async move {
+            client.trust_signal(system, &name, &version).await
+        }))
+    })
+}
+
+/// Appends the hover header: the dependency name, linked to its registry page when
+/// `url` (from [`EcosystemFormatter::package_url`]) is present.
+fn push_header_hover_section(markdown: &mut String, dep: &dyn Dependency, url: Option<&str>) {
+    use std::fmt::Write as _;
+
+    match url {
+        Some(url) => write!(
+            markdown,
+            "# [{}]({})\n\n",
+            escape_markdown(dep.name().as_str()),
+            url
+        ),
+        None => write!(markdown, "# {}\n\n", escape_markdown(dep.name().as_str())),
+    }
+    .unwrap();
+}
+
+/// Appends the hover "Current"/"Requirement" line. `resolved` — already selecting
+/// between an ecosystem's resolved manifest requirement and the lockfile-resolved
+/// version, per [`EcosystemFormatter::manifest_requirement_is_resolved_version`] —
+/// wins over the bare manifest requirement when present.
+fn push_current_or_requirement_hover_section(
+    markdown: &mut String,
+    dep: &dyn Dependency,
+    resolved: Option<&str>,
+) {
+    use std::fmt::Write as _;
+
+    if let Some(resolved_ver) = resolved {
+        write!(
+            markdown,
+            "**Current**: {}\n\n",
+            markdown_code_span(resolved_ver)
+        )
+        .unwrap();
+    } else if let Some(version_req) = dep.version_requirement() {
+        write!(
+            markdown,
+            "**Requirement**: {}\n\n",
+            markdown_code_span(version_req.as_str())
+        )
+        .unwrap();
+    }
+}
+
+/// Appends the hover "Active when" line for an environment-marker-gated dependency
+/// (e.g. PEP 508's `python_version >= '3.8'`). Ecosystem-specific; renders nothing
+/// when [`Dependency::markers`] is `None`.
+fn push_markers_hover_section(markdown: &mut String, dep: &dyn Dependency) {
+    use std::fmt::Write as _;
+
+    if let Some(marker_expr) = dep.markers() {
+        write!(
+            markdown,
+            "**Active when**: {}\n\n",
+            markdown_code_span(marker_expr)
+        )
+        .unwrap();
+    }
+}
+
+/// Appends the hover "Latest" line and, when the version is still within the
+/// configured cooldown window, the "Recently published" callout beneath it.
+///
+/// `latest_line` renders nothing when `None` — no header, matching an empty "Recent
+/// versions" list below. See [`generate_hover`]'s derivation of `latest_line` for the
+/// full Ch1/Ch2/fallback precedence rules (issue #227 F5, #313, #373).
+fn push_latest_hover_section(
+    markdown: &mut String,
+    latest_line: Option<(&str, Option<PublishTime>)>,
+    freshness: crate::freshness::FreshnessSettings,
+    now: PublishTime,
+) {
+    use std::fmt::Write as _;
+
+    let Some((latest_ver, raw_published_at)) = latest_line else {
+        return;
+    };
+    let published_at = freshness.enabled.then_some(raw_published_at).flatten();
+    let age_secs = published_at.map(|p| p.age_secs_from(now));
+    write!(markdown, "**Latest**: {}", markdown_code_span(latest_ver)).unwrap();
+    if let Some(age_secs) = age_secs {
+        write!(markdown, " *(published {})*", format_relative_age(age_secs)).unwrap();
+    }
+    markdown.push_str("\n\n");
+    if age_secs.is_some_and(|age| is_within_cooldown(age, freshness.cooldown_secs)) {
+        markdown.push_str(
+            "> ⏳ **Recently published** — this release is still within the cooldown window.\n\
+             > It may still be yanked or superseded; consider verifying before upgrading.\n\n",
+        );
+    }
+}
+
+/// Appends the "Recent versions" list: the top [`HOVER_RECENT_VERSIONS`] entries of
+/// `available_versions`, each optionally aged (freshness-gated) and marked
+/// `*(latest)*` at `live_latest_idx` — matched by position against the header's
+/// stable-latest pick rather than raw index 0 or string equality: `available_versions`
+/// is sorted purely by version number, so index 0 can be a pre-release the header
+/// itself doesn't call "latest" (issue #313), and matching by version string instead
+/// of index could tag more than one entry if two ever shared a version string. No
+/// match in the rendered top-N slice simply omits the marker.
+///
+/// Renders nothing when `available_versions` is empty (issue #550): an empty
+/// "Recent versions" header with no entries under it is never useful.
+fn push_recent_versions_hover_section(
+    markdown: &mut String,
+    available_versions: &[Box<dyn Version>],
+    live_latest_idx: Option<usize>,
+    freshness: crate::freshness::FreshnessSettings,
+    now: PublishTime,
+    formatter: &dyn EcosystemFormatter,
+) {
+    use std::fmt::Write as _;
+
+    if available_versions.is_empty() {
+        return;
+    }
+
+    markdown.push_str("**Recent versions**:\n");
+    for (i, version) in available_versions
+        .iter()
+        .take(HOVER_RECENT_VERSIONS)
+        .enumerate()
+    {
+        let version_span = markdown_code_span(version.version_string().as_str());
+        let age_suffix = if freshness.enabled {
+            version_age_suffix(version.as_ref(), now)
+        } else {
+            String::new()
+        };
+        if Some(i) == live_latest_idx {
+            if version.removal_status().is_flagged() {
+                // The resolved "latest" can itself be flagged (e.g. npm's ranking
+                // preference falls through to a deprecated version when no clean one
+                // exists) — the deprecation/yank warning must not silently vanish just
+                // because this entry also carries the `(latest)` marker (#347/#348 S1).
+                writeln!(
+                    markdown,
+                    "- {version_span} *(latest)* {}{age_suffix}",
+                    formatter.yanked_label()
+                )
+                .unwrap();
+            } else {
+                writeln!(markdown, "- {version_span} *(latest)*{age_suffix}").unwrap();
+            }
+        } else if version.removal_status().is_flagged() {
+            writeln!(
+                markdown,
+                "- {} {}{}",
+                version_span,
+                formatter.yanked_label(),
+                age_suffix
+            )
+            .unwrap();
+        } else {
+            writeln!(markdown, "- {version_span}{age_suffix}").unwrap();
+        }
+    }
+}
+
+/// Appends the `Cmd+.` code-action footer — advertised only when a fix action could
+/// actually exist for this dependency, since none is ever offered for a source that
+/// is deliberately non-resolvable (e.g. a local composite action or a Docker image
+/// ref), so rendering it unconditionally is misleading there (#474).
+///
+/// Gated on `resolvable` alone, not on `available_versions`/`cached_latest` also
+/// being populated: a vulnerability-fix or unsatisfiable-fix code action
+/// (`code_actions.rs`) can exist from `vuln_outcome` — populated independently of the
+/// registry fetch (`lifecycle.rs`) — even when both of those are empty (e.g. a
+/// registry fetch failure), so requiring them too would silently drop the footer
+/// while `Cmd+.` still offers a fix.
+///
+/// Also gated on offline data availability (#501): `HttpCache` deliberately serves
+/// warm entries while offline (it force-enables caching in that mode), and doc-state
+/// fields — vulnerabilities/cached latest/deprecation — survive an online-to-offline
+/// transition via `preserve_cache`, so `Cmd+.` can still produce a real
+/// REFACTOR/fix/replacement action offline as long as *some* version, vulnerability,
+/// or deprecation data was actually rendered above. Only suppress when offline AND
+/// none of that data is present — a cold process with nothing cached yet, where no
+/// producer in `generate_code_actions` has anything to act on.
+///
+/// `matches!(vuln_outcome, Some(ScanOutcome::Vulnerable(_)))`, not
+/// `vuln_outcome.is_some()` (#501 C5): offline does not skip the OSV scan, it lets it
+/// run and fail, which writes `ScanOutcome::Skipped(_)` for every dependency —
+/// `is_some()` would be true in exactly #501's own cold-start repro and only
+/// `Vulnerable` ever backs `build_vulnerability_fix_action` (`code_actions.rs`).
+///
+/// A live fetch that genuinely succeeded with zero entries (`Some(&[])`, distinct
+/// from `None` — a fetch that errored or never ran, where an unrelated Cmd+. action
+/// such as an unsatisfiable-fix might still exist per the reasoning above) is
+/// definitive proof there is nothing version-wise to update to (#550): combined with
+/// no cached/vulnerability/deprecation data either, the footer would otherwise
+/// advertise an action that provably does not exist — the "empty Recent versions
+/// section plus a stray footer" bug reported against GHA's
+/// `dtolnay/rust-toolchain@stable` but not specific to any one ecosystem. Every other
+/// online case (a non-empty live list, or no live fetch at all) keeps the pre-#550
+/// unconditional-when-resolvable behavior.
+fn push_cmd_dot_footer_hover_section(
+    markdown: &mut String,
+    resolvable: bool,
+    available_versions: Option<&[Box<dyn Version>]>,
+    cached_latest: Option<&super::PackageVersions>,
+    vuln_outcome: Option<&ScanOutcome>,
+    deprecation: Option<&Deprecation>,
+    offline: bool,
+) {
+    let has_offline_actionable_data = available_versions.is_some_and(|v| !v.is_empty())
+        || cached_latest.is_some()
+        || matches!(vuln_outcome, Some(ScanOutcome::Vulnerable(_)))
+        || deprecation.is_some();
+    let live_fetch_definitively_empty = available_versions.is_some_and(<[_]>::is_empty);
+    let footer_actionable =
+        has_offline_actionable_data || (!live_fetch_definitively_empty && !offline);
+    if resolvable && footer_actionable {
+        markdown.push_str(CMD_DOT_FOOTER);
+    }
+}
+
+/// Appends the "Offline: version and vulnerability data not checked" footer (issue
+/// #483) — the OSV lookup that produced `ScanOutcome::Skipped` for this dependency
+/// renders nothing in the vulnerability section, which would otherwise be visually
+/// indistinguishable from a scanned, vulnerability-free dependency; this footer calls
+/// out that vulnerability data specifically was not checked, not just version data
+/// (S2).
+///
+/// Gated on `resolvable` too, matching the `Cmd+.` footer (#474/#475): a dependency
+/// that is never network-resolved under any setting (a local composite action, a
+/// Docker image ref, a Git/path dependency) must not claim its version or
+/// vulnerability data went unchecked *because of* `network.offline` — nothing there
+/// was ever going to be checked regardless.
+fn push_offline_footer_hover_section(markdown: &mut String, resolvable: bool, offline: bool) {
+    if offline && resolvable {
+        markdown.push_str("\n---\n📴 *Offline: version and vulnerability data not checked*");
+    }
 }
 
 /// Lowercase display label for a [`crate::osv::VulnSeverity`], used only in hover text.

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -1128,304 +1128,22 @@ async fn fetch_latest_versions_parallel(
             let wildcard_req = &wildcard_req;
             let in_use_versions = in_use.get(&name).cloned().unwrap_or_default();
             async move {
-                // Single round trip: the full version list is fetched once, and "latest"
-                // is a pure in-memory pick over it (`Registry::select_latest_matching`) —
-                // no second registry call, so the retained full list costs nothing extra
-                // over the network (see `PackageVersions`). `get_versions_from` (source-
-                // aware, spec FR-001) rather than `get_versions`: this populates
-                // `published_at` for registries that support it (#339), matching hover's
-                // existing freshness-aware call, AND routes a resolved
-                // `DependencySource::AlternateRegistry` to its own index instead of the
-                // ecosystem's default registry — registries with no override forward
-                // straight to `get_versions` at zero extra cost either way.
-                let result = tokio::time::timeout(
+                fetch_and_classify_package(
+                    registry.as_ref(),
+                    name,
+                    source,
+                    in_use_versions,
+                    wildcard_req,
+                    freshness,
                     timeout,
-                    registry.get_versions_from(&name, &source, freshness),
+                    minimum_stability,
+                    check_yanked,
+                    &fetched,
+                    &failed,
+                    &first_error,
+                    progress_sender.as_ref(),
                 )
-                .await;
-
-                let mut yanked: Option<(PackageName, ConcreteVersion, RemovalStatus)> = None;
-                let mut failed_name: Option<(PackageName, FetchFailure, String)> = None;
-                let mut deprecation: Option<(PackageName, Deprecation)> = None;
-                // Set only when the fetch (and its `get_latest_matching` fallback) both
-                // genuinely succeeded yet resolved to no version at all (#550) — see the
-                // `Ok(Ok(None))` fallback arm below.
-                let mut no_comparable_versions = false;
-                let version = match result {
-                    Ok(Ok(versions)) => {
-                        let available: Arc<[ConcreteVersion]> = versions
-                            .iter()
-                            .map(|v| v.version_string().clone())
-                            .collect();
-                        // Retained alongside `available` so `generate_diagnostics_from_cache`
-                        // can flag a requirement satisfiable only by a yanked version — see
-                        // `PackageVersions::yanked`. Gated on `check_yanked`: a registry that
-                        // cannot answer `removal_status()` (§#298) must not populate this list
-                        // with an untrustworthy always-`Available` signal. Carries each
-                        // entry's own `RemovalStatus` (#437) so the #247 diagnostic path can
-                        // gate its package-level-deprecation suppression on `AdvisoryDeprecated`
-                        // specifically, never on a genuine `Yanked` finding.
-                        let yanked_list: Arc<[(ConcreteVersion, RemovalStatus)]> = if check_yanked {
-                            versions
-                                .iter()
-                                .filter_map(|v| {
-                                    let status = v.removal_status();
-                                    status
-                                        .is_flagged()
-                                        .then(|| (v.version_string().clone(), status))
-                                })
-                                .collect()
-                        } else {
-                            Arc::from([])
-                        };
-                        // `.get(idx)` rather than `versions[idx]`: `select_latest_matching`
-                        // is a public `Registry` trait method, so an out-of-tree
-                        // implementation returning a stale index must not panic this task.
-                        // `_with_context` (not the plain method) so a registry with
-                        // manifest-level stability state (Composer's `minimum-stability`,
-                        // #424 S1) can apply it — every other registry's default
-                        // implementation just forwards to the plain method unchanged.
-                        let resolved = if let Some(v) = registry
-                            .select_latest_matching_with_context(
-                                &versions,
-                                wildcard_req,
-                                minimum_stability,
-                            )
-                            .and_then(|idx| versions.get(idx))
-                        {
-                            let latest = v.version_string().clone();
-                            tracing::debug!(package = %name, version = %latest, "fetched");
-                            Some((
-                                latest,
-                                v.removal_status(),
-                                v.published_at(),
-                                v.deprecation().cloned(),
-                            ))
-                        } else {
-                            // The pure list-based pick found nothing — for most
-                            // ecosystems this genuinely means "no version found", but
-                            // for a registry whose list endpoint can be incomplete
-                            // (e.g. Go's `/@v/list`, which never enumerates
-                            // pseudo-versions and can be entirely empty for an
-                            // untagged module) it may just mean the list alone isn't
-                            // enough. Fall back to the registry's own
-                            // `get_latest_matching`, which some registries answer from
-                            // a different, more complete source (Go's `/@latest`). This
-                            // costs a second network call, but only in this already-rare
-                            // "list-based pick failed" case, not the common path.
-                            let fallback = tokio::time::timeout(
-                                timeout,
-                                registry.get_latest_matching_from(
-                                    &name,
-                                    &source,
-                                    wildcard_req,
-                                    minimum_stability,
-                                ),
-                            )
-                            .await;
-                            match fallback {
-                                Ok(Ok(Some(v))) => {
-                                    let latest = v.version_string().clone();
-                                    tracing::debug!(
-                                        package = %name,
-                                        version = %latest,
-                                        "fetched via get_latest_matching fallback"
-                                    );
-                                    Some((
-                                        latest,
-                                        v.removal_status(),
-                                        v.published_at(),
-                                        v.deprecation().cloned(),
-                                    ))
-                                }
-                                Ok(Ok(None)) => {
-                                    tracing::debug!(package = %name, "no version found");
-                                    // Both the list-based pick and this fallback
-                                    // genuinely succeeded and found nothing — the
-                                    // package demonstrably exists (the fetch itself
-                                    // never errored), it just has zero versions this
-                                    // registry can compare against (#550), e.g. a
-                                    // repository whose only tags don't parse as full
-                                    // semver. Distinct from every branch below that
-                                    // sets `failed_name`.
-                                    no_comparable_versions = true;
-                                    None
-                                }
-                                Ok(Err(e)) => {
-                                    tracing::warn!(
-                                        package = %name,
-                                        error = %e,
-                                        "fetch fallback failed"
-                                    );
-                                    failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                    let mut fe =
-                                        first_error.lock().unwrap_or_else(|p| p.into_inner());
-                                    if fe.is_none() {
-                                        *fe = Some(e.to_string());
-                                    }
-                                    drop(fe);
-                                    // A genuine not-found (the registry was
-                                    // successfully asked and said "no such
-                                    // package") is not a fetch failure — only
-                                    // an unanswerable request is (#267 C1).
-                                    if !e.is_not_found() {
-                                        failed_name =
-                                            Some((name.clone(), e.fetch_failure(), e.to_string()));
-                                    }
-                                    None
-                                }
-                                Err(_) => {
-                                    tracing::warn!(
-                                        package = %name,
-                                        "fetch fallback timed out ({}s)",
-                                        timeout.as_secs()
-                                    );
-                                    failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                    failed_name = Some((
-                                        name.clone(),
-                                        FetchFailure::Transient,
-                                        format!(
-                                            "{name}: registry request timed out after {}s",
-                                            timeout.as_secs()
-                                        ),
-                                    ));
-                                    None
-                                }
-                            }
-                        };
-
-                        if check_yanked {
-                            // Row 1 (§4.7): the picked "latest" itself yanked —
-                            // zero extra cost, since it's already in hand.
-                            // Unreachable in production for an *enabled*
-                            // registry under today's hardcoded wildcard (one
-                            // never returns a yanked version for `*`), but
-                            // stays correct as a defense-in-depth check.
-                            if let Some((latest, status, _, _)) = &resolved
-                                && status.is_flagged()
-                            {
-                                yanked = Some((name.clone(), latest.clone(), *status));
-                            }
-
-                            // Row 2/3 (§4.7, revised under #206): `versions`
-                            // is the full, already-fetched, unfiltered list —
-                            // no second registry round trip is needed to
-                            // check whether the in-use version was yanked,
-                            // unlike the pre-#206 probe design. Checked for
-                            // every dependency with a known in-use version,
-                            // not just when it differs from `latest`, since
-                            // it's now a free in-memory lookup either way. A
-                            // yanked in-use version wins over an already
-                            // -recorded yanked `latest` — it's the version
-                            // the user actually has.
-                            //
-                            // Multiple occurrences of the same name (#394,
-                            // e.g. under both `[dependencies]` and
-                            // `[target.*.dependencies]`) can carry different
-                            // in-use versions — every one is checked so a
-                            // yanked pin on any occurrence is never missed
-                            // just because another occurrence happens to
-                            // share the registry lookup.
-                            // Filters on `is_flagged()` inside the `find` predicate itself
-                            // (not via a separate `.filter()` on the first version-string
-                            // match) so a registry response with more than one entry sharing
-                            // `iv`'s version string still finds a flagged one if any exists —
-                            // mirroring the pre-#205 `.any(matches && flagged)` scan rather
-                            // than narrowing to "is the *first* same-string entry flagged".
-                            if let Some((iv, status)) = in_use_versions.iter().find_map(|iv| {
-                                versions
-                                    .iter()
-                                    .find(|v| {
-                                        v.version_string() == iv.as_str()
-                                            && v.removal_status().is_flagged()
-                                    })
-                                    .map(|v| (iv, v.removal_status()))
-                            }) {
-                                yanked = Some((name.clone(), iv.as_str().into(), status));
-                            }
-                        }
-
-                        // #205: the package-level deprecation finding is derived from the
-                        // same `Version` `resolved` already picked as "latest" — covering
-                        // the `get_latest_matching_with_context` fallback branch above too,
-                        // whose returned `Version` is not a member of `versions` at all. See
-                        // `FetchResult::deprecations`'s docs for why this must not instead
-                        // scan `versions`.
-                        if let Some((_, _, _, dep_info)) = &resolved
-                            && let Some(dep_info) = dep_info
-                        {
-                            deprecation = Some((name.clone(), dep_info.clone()));
-                        }
-
-                        resolved.map(|(latest, _, published_at, _)| {
-                            (
-                                name.clone(),
-                                PackageVersions {
-                                    latest,
-                                    available,
-                                    yanked: yanked_list,
-                                    published_at,
-                                },
-                            )
-                        })
-                    }
-                    Ok(Err(e)) => {
-                        // Issue #483: while offline, every fetch fails by design — this
-                        // would otherwise log a per-dependency WARNING for every open/edit,
-                        // contradicting the toast suppression two call sites away in this
-                        // same file for being "unusable".
-                        if e.is_offline() {
-                            tracing::debug!(package = %name, "fetch skipped: offline");
-                        } else {
-                            tracing::warn!(package = %name, error = %e, "fetch failed");
-                        }
-                        failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        let mut fe = first_error.lock().unwrap_or_else(|p| p.into_inner());
-                        if fe.is_none() {
-                            *fe = Some(e.to_string());
-                        }
-                        drop(fe);
-                        // A genuine not-found (the registry was successfully
-                        // asked and said "no such package") is not a fetch
-                        // failure — only an unanswerable request is (#267
-                        // C1). Marking it `fetch_failed` here would make
-                        // `generate_diagnostics_from_cache` report "Registry
-                        // lookup failed" for the common typo'd-name case
-                        // instead of "Unknown package", inverting the bug
-                        // this field exists to fix.
-                        if !e.is_not_found() {
-                            failed_name = Some((name.clone(), e.fetch_failure(), e.to_string()));
-                        }
-                        None
-                    }
-                    Err(_) => {
-                        tracing::warn!(package = %name, "fetch timed out ({}s)", timeout.as_secs());
-                        failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        failed_name = Some((
-                            name.clone(),
-                            FetchFailure::Transient,
-                            format!(
-                                "{name}: registry request timed out after {}s",
-                                timeout.as_secs()
-                            ),
-                        ));
-                        None
-                    }
-                };
-
-                let count = fetched.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-                if let Some(ref sender) = progress_sender {
-                    sender.send(count);
-                }
-
-                let no_comparable_versions_name = no_comparable_versions.then(|| name.clone());
-                (
-                    version,
-                    yanked,
-                    failed_name,
-                    deprecation,
-                    no_comparable_versions_name,
-                )
+                .await
             }
         })
         .buffer_unordered(max_concurrent)
@@ -1478,6 +1196,340 @@ async fn fetch_latest_versions_parallel(
         failed_count: failed.load(std::sync::atomic::Ordering::Relaxed),
         first_error: error_message,
     }
+}
+
+/// Per-package outcome returned by [`fetch_and_classify_package`]: the resolved
+/// `(name, PackageVersions)` entry, a yanked finding, a fetch failure, a package-level
+/// deprecation finding, and a name whose fetch succeeded with no comparable versions
+/// (#550) — folded into [`fetch_latest_versions_parallel`]'s aggregate `FetchResult`
+/// once every package in the stream has finished.
+type PackageFetchOutcome = (
+    Option<(PackageName, PackageVersions)>,
+    Option<(PackageName, ConcreteVersion, RemovalStatus)>,
+    Option<(PackageName, FetchFailure, String)>,
+    Option<(PackageName, Deprecation)>,
+    Option<PackageName>,
+);
+
+/// Fetches, classifies, and version-selects a single package within
+/// [`fetch_latest_versions_parallel`]'s concurrent stream: one round trip for the full
+/// version list, an in-memory "latest" pick with a `get_latest_matching_from` fallback
+/// when the list-based pick fails on a non-empty list, yanked/deprecation extraction,
+/// and updates to the shared `fetched`/`failed`/`first_error` counters the stream
+/// aggregates across every package.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "mirrors the per-package async closure this was extracted from — every \
+              parameter is either call-site fetch tuning already threaded through \
+              fetch_latest_versions_parallel or a counter/sender shared across the \
+              whole stream; grouping into a struct would only move, not reduce, churn"
+)]
+async fn fetch_and_classify_package(
+    registry: &dyn Registry,
+    name: PackageName,
+    source: deps_core::parser::DependencySource,
+    in_use_versions: Vec<String>,
+    wildcard_req: &VersionReq,
+    freshness: deps_core::freshness::FreshnessSettings,
+    timeout: Duration,
+    minimum_stability: Option<&str>,
+    check_yanked: bool,
+    fetched: &std::sync::atomic::AtomicUsize,
+    failed: &std::sync::atomic::AtomicUsize,
+    first_error: &std::sync::Mutex<Option<String>>,
+    progress_sender: Option<&ProgressSender>,
+) -> PackageFetchOutcome {
+    // Single round trip: the full version list is fetched once, and "latest"
+    // is a pure in-memory pick over it (`Registry::select_latest_matching`) —
+    // no second registry call, so the retained full list costs nothing extra
+    // over the network (see `PackageVersions`). `get_versions_from` (source-
+    // aware, spec FR-001) rather than `get_versions`: this populates
+    // `published_at` for registries that support it (#339), matching hover's
+    // existing freshness-aware call, AND routes a resolved
+    // `DependencySource::AlternateRegistry` to its own index instead of the
+    // ecosystem's default registry — registries with no override forward
+    // straight to `get_versions` at zero extra cost either way.
+    let result = tokio::time::timeout(
+        timeout,
+        registry.get_versions_from(&name, &source, freshness),
+    )
+    .await;
+
+    let mut yanked: Option<(PackageName, ConcreteVersion, RemovalStatus)> = None;
+    let mut failed_name: Option<(PackageName, FetchFailure, String)> = None;
+    let mut deprecation: Option<(PackageName, Deprecation)> = None;
+    // Set only when the fetch (and its `get_latest_matching` fallback) both
+    // genuinely succeeded yet resolved to no version at all (#550) — see the
+    // `Ok(Ok(None))` fallback arm below.
+    let mut no_comparable_versions = false;
+    let version = match result {
+        Ok(Ok(versions)) => {
+            let available: Arc<[ConcreteVersion]> = versions
+                .iter()
+                .map(|v| v.version_string().clone())
+                .collect();
+            // Retained alongside `available` so `generate_diagnostics_from_cache`
+            // can flag a requirement satisfiable only by a yanked version — see
+            // `PackageVersions::yanked`. Gated on `check_yanked`: a registry that
+            // cannot answer `removal_status()` (§#298) must not populate this list
+            // with an untrustworthy always-`Available` signal. Carries each
+            // entry's own `RemovalStatus` (#437) so the #247 diagnostic path can
+            // gate its package-level-deprecation suppression on `AdvisoryDeprecated`
+            // specifically, never on a genuine `Yanked` finding.
+            let yanked_list: Arc<[(ConcreteVersion, RemovalStatus)]> = if check_yanked {
+                versions
+                    .iter()
+                    .filter_map(|v| {
+                        let status = v.removal_status();
+                        status
+                            .is_flagged()
+                            .then(|| (v.version_string().clone(), status))
+                    })
+                    .collect()
+            } else {
+                Arc::from([])
+            };
+            // `.get(idx)` rather than `versions[idx]`: `select_latest_matching`
+            // is a public `Registry` trait method, so an out-of-tree
+            // implementation returning a stale index must not panic this task.
+            // `_with_context` (not the plain method) so a registry with
+            // manifest-level stability state (Composer's `minimum-stability`,
+            // #424 S1) can apply it — every other registry's default
+            // implementation just forwards to the plain method unchanged.
+            let resolved = if let Some(v) = registry
+                .select_latest_matching_with_context(&versions, wildcard_req, minimum_stability)
+                .and_then(|idx| versions.get(idx))
+            {
+                let latest = v.version_string().clone();
+                tracing::debug!(package = %name, version = %latest, "fetched");
+                Some((
+                    latest,
+                    v.removal_status(),
+                    v.published_at(),
+                    v.deprecation().cloned(),
+                ))
+            } else {
+                // The pure list-based pick found nothing — for most
+                // ecosystems this genuinely means "no version found", but
+                // for a registry whose list endpoint can be incomplete
+                // (e.g. Go's `/@v/list`, which never enumerates
+                // pseudo-versions and can be entirely empty for an
+                // untagged module) it may just mean the list alone isn't
+                // enough. Fall back to the registry's own
+                // `get_latest_matching`, which some registries answer from
+                // a different, more complete source (Go's `/@latest`). This
+                // costs a second network call, but only in this already-rare
+                // "list-based pick failed" case, not the common path.
+                let fallback = tokio::time::timeout(
+                    timeout,
+                    registry.get_latest_matching_from(
+                        &name,
+                        &source,
+                        wildcard_req,
+                        minimum_stability,
+                    ),
+                )
+                .await;
+                match fallback {
+                    Ok(Ok(Some(v))) => {
+                        let latest = v.version_string().clone();
+                        tracing::debug!(
+                            package = %name,
+                            version = %latest,
+                            "fetched via get_latest_matching fallback"
+                        );
+                        Some((
+                            latest,
+                            v.removal_status(),
+                            v.published_at(),
+                            v.deprecation().cloned(),
+                        ))
+                    }
+                    Ok(Ok(None)) => {
+                        tracing::debug!(package = %name, "no version found");
+                        // Both the list-based pick and this fallback
+                        // genuinely succeeded and found nothing — the
+                        // package demonstrably exists (the fetch itself
+                        // never errored), it just has zero versions this
+                        // registry can compare against (#550), e.g. a
+                        // repository whose only tags don't parse as full
+                        // semver. Distinct from every branch below that
+                        // sets `failed_name`.
+                        no_comparable_versions = true;
+                        None
+                    }
+                    Ok(Err(e)) => {
+                        tracing::warn!(
+                            package = %name,
+                            error = %e,
+                            "fetch fallback failed"
+                        );
+                        failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        let mut fe = first_error.lock().unwrap_or_else(|p| p.into_inner());
+                        if fe.is_none() {
+                            *fe = Some(e.to_string());
+                        }
+                        drop(fe);
+                        // A genuine not-found (the registry was
+                        // successfully asked and said "no such
+                        // package") is not a fetch failure — only
+                        // an unanswerable request is (#267 C1).
+                        if !e.is_not_found() {
+                            failed_name = Some((name.clone(), e.fetch_failure(), e.to_string()));
+                        }
+                        None
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            package = %name,
+                            "fetch fallback timed out ({}s)",
+                            timeout.as_secs()
+                        );
+                        failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        failed_name = Some((
+                            name.clone(),
+                            FetchFailure::Transient,
+                            format!(
+                                "{name}: registry request timed out after {}s",
+                                timeout.as_secs()
+                            ),
+                        ));
+                        None
+                    }
+                }
+            };
+
+            if check_yanked {
+                // Row 1 (§4.7): the picked "latest" itself yanked —
+                // zero extra cost, since it's already in hand.
+                // Unreachable in production for an *enabled*
+                // registry under today's hardcoded wildcard (one
+                // never returns a yanked version for `*`), but
+                // stays correct as a defense-in-depth check.
+                if let Some((latest, status, _, _)) = &resolved
+                    && status.is_flagged()
+                {
+                    yanked = Some((name.clone(), latest.clone(), *status));
+                }
+
+                // Row 2/3 (§4.7, revised under #206): `versions`
+                // is the full, already-fetched, unfiltered list —
+                // no second registry round trip is needed to
+                // check whether the in-use version was yanked,
+                // unlike the pre-#206 probe design. Checked for
+                // every dependency with a known in-use version,
+                // not just when it differs from `latest`, since
+                // it's now a free in-memory lookup either way. A
+                // yanked in-use version wins over an already
+                // -recorded yanked `latest` — it's the version
+                // the user actually has.
+                //
+                // Multiple occurrences of the same name (#394,
+                // e.g. under both `[dependencies]` and
+                // `[target.*.dependencies]`) can carry different
+                // in-use versions — every one is checked so a
+                // yanked pin on any occurrence is never missed
+                // just because another occurrence happens to
+                // share the registry lookup.
+                // Filters on `is_flagged()` inside the `find` predicate itself
+                // (not via a separate `.filter()` on the first version-string
+                // match) so a registry response with more than one entry sharing
+                // `iv`'s version string still finds a flagged one if any exists —
+                // mirroring the pre-#205 `.any(matches && flagged)` scan rather
+                // than narrowing to "is the *first* same-string entry flagged".
+                if let Some((iv, status)) = in_use_versions.iter().find_map(|iv| {
+                    versions
+                        .iter()
+                        .find(|v| {
+                            v.version_string() == iv.as_str() && v.removal_status().is_flagged()
+                        })
+                        .map(|v| (iv, v.removal_status()))
+                }) {
+                    yanked = Some((name.clone(), iv.as_str().into(), status));
+                }
+            }
+
+            // #205: the package-level deprecation finding is derived from the
+            // same `Version` `resolved` already picked as "latest" — covering
+            // the `get_latest_matching_with_context` fallback branch above too,
+            // whose returned `Version` is not a member of `versions` at all. See
+            // `FetchResult::deprecations`'s docs for why this must not instead
+            // scan `versions`.
+            if let Some((_, _, _, dep_info)) = &resolved
+                && let Some(dep_info) = dep_info
+            {
+                deprecation = Some((name.clone(), dep_info.clone()));
+            }
+
+            resolved.map(|(latest, _, published_at, _)| {
+                (
+                    name.clone(),
+                    PackageVersions {
+                        latest,
+                        available,
+                        yanked: yanked_list,
+                        published_at,
+                    },
+                )
+            })
+        }
+        Ok(Err(e)) => {
+            // Issue #483: while offline, every fetch fails by design — this
+            // would otherwise log a per-dependency WARNING for every open/edit,
+            // contradicting the toast suppression two call sites away in this
+            // same file for being "unusable".
+            if e.is_offline() {
+                tracing::debug!(package = %name, "fetch skipped: offline");
+            } else {
+                tracing::warn!(package = %name, error = %e, "fetch failed");
+            }
+            failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let mut fe = first_error.lock().unwrap_or_else(|p| p.into_inner());
+            if fe.is_none() {
+                *fe = Some(e.to_string());
+            }
+            drop(fe);
+            // A genuine not-found (the registry was successfully
+            // asked and said "no such package") is not a fetch
+            // failure — only an unanswerable request is (#267
+            // C1). Marking it `fetch_failed` here would make
+            // `generate_diagnostics_from_cache` report "Registry
+            // lookup failed" for the common typo'd-name case
+            // instead of "Unknown package", inverting the bug
+            // this field exists to fix.
+            if !e.is_not_found() {
+                failed_name = Some((name.clone(), e.fetch_failure(), e.to_string()));
+            }
+            None
+        }
+        Err(_) => {
+            tracing::warn!(package = %name, "fetch timed out ({}s)", timeout.as_secs());
+            failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            failed_name = Some((
+                name.clone(),
+                FetchFailure::Transient,
+                format!(
+                    "{name}: registry request timed out after {}s",
+                    timeout.as_secs()
+                ),
+            ));
+            None
+        }
+    };
+
+    let count = fetched.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+    if let Some(sender) = progress_sender {
+        sender.send(count);
+    }
+
+    let no_comparable_versions_name = no_comparable_versions.then(|| name.clone());
+    (
+        version,
+        yanked,
+        failed_name,
+        deprecation,
+        no_comparable_versions_name,
+    )
 }
 
 /// Decides whether a fetch-failure toast should be shown for this fetch cycle, and what
@@ -1570,274 +1622,294 @@ pub async fn handle_document_open(
     };
 
     // Spawn background task to fetch versions
-    let uri_clone = uri.clone();
-    let state_clone = Arc::clone(&state);
-    let ecosystem_clone = Arc::clone(&ecosystem);
-    let client_clone = client.clone();
-
-    let task = tokio::spawn(async move {
-        tracing::debug!("background task started");
-
-        // Load resolved versions from lock file first (instant, no network)
-        let resolved_versions =
-            load_resolved_versions(&uri_clone, &state_clone, ecosystem_clone.as_ref()).await;
-
-        // Update document state with resolved versions immediately
-        if !resolved_versions.is_empty()
-            && let Some(mut doc) = state_clone.documents.get_mut(&uri_clone)
-        {
-            doc.update_resolved_versions(resolved_versions.clone());
-
-            // Use resolved versions as cached versions for instant display,
-            // except for a dependency whose manifest requirement is itself
-            // already the resolved version (Go's `require` lines) — for
-            // those, go.sum can hold a stale, no-longer-selected version
-            // (#235), so seeding it as the "latest" comparison operand would
-            // desync hover/inlay-hint status against the go.mod-accurate
-            // `resolved` value during the cold-open window before the
-            // registry fetch completes (critique S1).
-            let formatter = ecosystem_clone.formatter();
-            let instant_resolved: HashMap<PackageName, ConcreteVersion> = match doc.parse_result() {
-                Some(parse_result) => {
-                    let deps = parse_result.dependencies();
-                    resolved_versions
-                        .iter()
-                        .filter(|(name, _)| {
-                            deps.iter().find(|d| d.name() == *name).is_none_or(|d| {
-                                !formatter.manifest_requirement_is_resolved_version(*d)
-                            })
-                        })
-                        .map(|(name, version)| (name.clone(), version.clone()))
-                        .collect()
-                }
-                None => resolved_versions.clone(),
-            };
-            doc.update_cached_versions(cached_versions_from_lockfile(&instant_resolved));
-        }
-
-        // Phase A OSV scan, spawned so it runs concurrently with the
-        // registry fetch below rather than gating the inlay-hint refresh
-        // that must happen immediately after it (critique S2).
-        let osv_task = vulnerabilities_enabled.then(|| {
-            tokio::spawn(run_osv_scan_phase_a(
-                uri_clone.clone(),
-                Arc::clone(&state_clone),
-                Arc::clone(&ecosystem_clone),
-                cache_config.fetch_timeout_secs,
-            ))
-        });
-
-        // Collect dependency names+sources and the in-use-version map (§4.6) in one
-        // pass while holding the reference (can't hold across await).
-        let (dep_sources, in_use, minimum_stability, collided_names): (
-            DepSources,
-            HashMap<PackageName, Vec<String>>,
-            Option<String>,
-            HashSet<PackageName>,
-        ) = {
-            let doc = match state_clone.get_document(&uri_clone) {
-                Some(d) => d,
-                None => {
-                    tracing::warn!("document not found, aborting fetch");
-                    return;
-                }
-            };
-            let parse_result = match doc.parse_result() {
-                Some(p) => p,
-                None => {
-                    tracing::warn!("no parse result, aborting fetch");
-                    return;
-                }
-            };
-            // Deduped by name (critique M3): a duplicated name shares one
-            // registry fetch across all its occurrences — the result is
-            // name-keyed anyway (`FetchResult::versions`), so fetching it
-            // more than once would only issue wasted extra registry calls
-            // and inflate `RegistryProgress`'s total. A non-resolvable source is
-            // dropped entirely, and two occurrences of the same name resolving to
-            // *different* sources are dropped and recorded as collided instead
-            // (spec FR-011) — see `dedup_dependencies_by_source`.
-            let (sources_map, collided_names) =
-                dedup_dependencies_by_source(parse_result, ecosystem_clone.formatter());
-            let dep_sources: Vec<_> = sources_map.into_iter().collect();
-            let in_use = collect_in_use_versions(
-                parse_result,
-                &resolved_versions,
-                ecosystem_clone.formatter(),
-                resolve_ecosystem_id(ecosystem_clone.as_ref()),
-            );
-            let minimum_stability = composer_minimum_stability(parse_result);
-            (dep_sources, in_use, minimum_stability, collided_names)
-        };
-
-        tracing::debug!(count = dep_sources.len(), "starting registry fetch");
-
-        // Mark as loading and start progress
-        if let Some(mut doc) = state_clone.documents.get_mut(&uri_clone) {
-            doc.set_loading();
-        }
-
-        let (progress, progress_sender) = if state_clone.supports_progress() {
-            match tokio::time::timeout(
-                std::time::Duration::from_secs(2),
-                RegistryProgress::start(
-                    client_clone.clone(),
-                    uri_clone.as_str(),
-                    dep_sources.len(),
-                ),
-            )
-            .await
-            {
-                Ok(Ok((p, s))) => (Some(p), Some(s)),
-                _ => (None, None),
-            }
-        } else {
-            (None, None)
-        };
-
-        tracing::debug!("progress started, fetching versions");
-
-        // Fetch latest versions from registry in parallel (for update hints)
-        let registry = ecosystem_clone.registry();
-        let fetch_result = fetch_latest_versions_parallel(
-            registry,
-            dep_sources,
-            &in_use,
-            progress_sender,
-            freshness_settings,
-            cache_config.fetch_timeout_secs,
-            cache_config.max_concurrent_fetches,
-            minimum_stability.as_deref(),
-        )
-        .await;
-
-        let success = !fetch_result.versions.is_empty();
-        tracing::debug!(
-            fetched = fetch_result.versions.len(),
-            failed = fetch_result.failed_count,
-            yanked = fetch_result.yanked_versions.len(),
-            "registry fetch complete"
-        );
-
-        // Update document state with cached versions (latest from registry)
-        if let Some(mut doc) = state_clone.documents.get_mut(&uri_clone) {
-            doc.update_cached_versions(fetch_result.versions);
-            // Re-key raw -> normalized (§3.1): `FetchResult`'s three fields are
-            // raw-keyed, `DocumentState::outcomes` is normalized.
-            let formatter = ecosystem_clone.formatter();
-            let mut outcomes = DependencyOutcomes::new();
-            for (name, d) in fetch_result.deprecations {
-                outcomes.set_deprecation(formatter.normalize_package_name(&name), d);
-            }
-            for (name, v) in fetch_result.yanked_versions {
-                outcomes.set_yanked(formatter.normalize_package_name(&name), v);
-            }
-            for (name, failure) in fetch_result.fetch_failed {
-                outcomes.set_fetch_failure(formatter.normalize_package_name(&name), failure);
-            }
-            for name in fetch_result.no_comparable_versions {
-                outcomes.set_no_comparable_versions(formatter.normalize_package_name(&name));
-            }
-            // `collided_names` (spec FR-011) are merged in alongside genuine fetch
-            // failures so `generate_diagnostics_from_cache` reports "lookup could not
-            // be determined" rather than a false "Unknown package" for a name that
-            // was deliberately never queried, not one that doesn't exist. Genuine
-            // failures are inserted first and `collided_names` uses
-            // `set_fetch_failure_if_absent` so a collided name that normalizes to the
-            // same key as a genuine `Actionable`/`Transient` failure never clobbers it
-            // (impl-critic M2).
-            for name in collided_names {
-                outcomes.set_fetch_failure_if_absent(
-                    formatter.normalize_package_name(&name),
-                    FetchFailure::NotAttempted,
-                );
-            }
-            doc.replace_outcomes(outcomes);
-            if success {
-                doc.set_loaded();
-            } else {
-                doc.set_failed();
-            }
-        }
-
-        // End progress
-        if let Some(progress) = progress {
-            progress.end(success).await;
-        }
-
-        // Notify user about failed packages — suppressed when offline, see
-        // `fetch_failure_toast`'s docs. `fetch_result.first_error` is always populated
-        // by `fetch_latest_versions_parallel` whenever `failed_count > 0` (#480: every
-        // site that increments `failed_count` also sets either `priority_error` or
-        // `first_error`, and the two are merged into this field before returning).
-        match fetch_failure_toast(
-            fetch_result.failed_count,
-            fetch_result.first_error.as_deref(),
-            state_clone.cache.is_offline(),
-        ) {
-            Some(message) => {
-                client_clone
-                    .show_message(MessageType::WARNING, message)
-                    .await;
-            }
-            None if fetch_result.failed_count > 0 => {
-                tracing::debug!(
-                    failed_count = fetch_result.failed_count,
-                    "suppressing fetch-failure toast: offline"
-                );
-            }
-            None => {}
-        }
-
-        // Kick off inlay hint / code lens refresh as soon as loading completes, so
-        // clients see updated hints as early as possible — typically before
-        // diagnostics, which may take longer due to additional network calls, though
-        // that ordering is scheduler-dependent, not guaranteed, since the requests
-        // are detached (issue #493: nothing downstream depends on their result, and a
-        // client that never declared refresh support, or stops replying, must not
-        // hang this task's critical path — including the OSV commit and diagnostics
-        // publish below — forever).
-        state_clone.spawn_refresh_requests(&client_clone);
-
-        // Join phase A (already running concurrently since it was spawned
-        // above) and, only now that `cached_versions` holds the registry's
-        // actual latest (not the lockfile-seeded placeholder — critique S1),
-        // run phase B and commit before generating diagnostics.
-        if let Some(osv_task) = osv_task {
-            match osv_task.await {
-                Ok(Some(phase_a_result)) => {
-                    let ecosystem_id = resolve_ecosystem_id(ecosystem_clone.as_ref());
-                    run_osv_phase_b_and_commit(
-                        &uri_clone,
-                        &state_clone,
-                        ecosystem_id,
-                        ecosystem_clone.formatter(),
-                        cache_config.fetch_timeout_secs,
-                        phase_a_result,
-                    )
-                    .await;
-                }
-                Ok(None) => {}
-                Err(e) => tracing::warn!("OSV scan task failed: {e}"),
-            }
-        }
-
-        // Publish diagnostics (may be slower, runs after hints are already visible)
-        let diags = diagnostics::generate_diagnostics_internal(
-            Arc::clone(&state_clone),
-            &uri_clone,
-            freshness_settings,
-            diagnostic_severities,
-            offline,
-        )
-        .await;
-
-        client_clone
-            .publish_diagnostics(uri_clone.clone(), diags, None)
-            .await;
-    });
+    let task = tokio::spawn(run_document_open_background_task(
+        uri.clone(),
+        Arc::clone(&state),
+        Arc::clone(&ecosystem),
+        client.clone(),
+        cache_config,
+        vulnerabilities_enabled,
+        freshness_settings,
+        diagnostic_severities,
+        offline,
+    ));
 
     Ok(task)
+}
+
+/// The background task [`handle_document_open`] spawns: loads lockfile-resolved
+/// versions instantly (no network), seeds them as cached versions, kicks off the OSV
+/// Phase A scan concurrently with the registry fetch, runs the registry fetch,
+/// commits its results (cached versions, outcomes, loading state), then refreshes
+/// inlay hints, joins OSV Phase B, and publishes diagnostics.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "mirrors the async move closure this was extracted from — every parameter \
+              is config already read (and thus fixed) before the task was spawned in \
+              handle_document_open, so a config struct here would only relocate, not \
+              reduce, the parameter list"
+)]
+async fn run_document_open_background_task(
+    uri: Uri,
+    state: Arc<ServerState>,
+    ecosystem: Arc<dyn Ecosystem>,
+    client: Client,
+    cache_config: crate::config::CacheConfig,
+    vulnerabilities_enabled: bool,
+    freshness_settings: deps_core::freshness::FreshnessSettings,
+    diagnostic_severities: deps_core::DiagnosticSeverities,
+    offline: bool,
+) {
+    tracing::debug!("background task started");
+
+    // Load resolved versions from lock file first (instant, no network)
+    let resolved_versions = load_resolved_versions(&uri, &state, ecosystem.as_ref()).await;
+
+    // Update document state with resolved versions immediately
+    if !resolved_versions.is_empty()
+        && let Some(mut doc) = state.documents.get_mut(&uri)
+    {
+        doc.update_resolved_versions(resolved_versions.clone());
+
+        // Use resolved versions as cached versions for instant display,
+        // except for a dependency whose manifest requirement is itself
+        // already the resolved version (Go's `require` lines) — for
+        // those, go.sum can hold a stale, no-longer-selected version
+        // (#235), so seeding it as the "latest" comparison operand would
+        // desync hover/inlay-hint status against the go.mod-accurate
+        // `resolved` value during the cold-open window before the
+        // registry fetch completes (critique S1).
+        let formatter = ecosystem.formatter();
+        let instant_resolved: HashMap<PackageName, ConcreteVersion> = match doc.parse_result() {
+            Some(parse_result) => {
+                let deps = parse_result.dependencies();
+                resolved_versions
+                    .iter()
+                    .filter(|(name, _)| {
+                        deps.iter()
+                            .find(|d| d.name() == *name)
+                            .is_none_or(|d| !formatter.manifest_requirement_is_resolved_version(*d))
+                    })
+                    .map(|(name, version)| (name.clone(), version.clone()))
+                    .collect()
+            }
+            None => resolved_versions.clone(),
+        };
+        doc.update_cached_versions(cached_versions_from_lockfile(&instant_resolved));
+    }
+
+    // Phase A OSV scan, spawned so it runs concurrently with the
+    // registry fetch below rather than gating the inlay-hint refresh
+    // that must happen immediately after it (critique S2).
+    let osv_task = vulnerabilities_enabled.then(|| {
+        tokio::spawn(run_osv_scan_phase_a(
+            uri.clone(),
+            Arc::clone(&state),
+            Arc::clone(&ecosystem),
+            cache_config.fetch_timeout_secs,
+        ))
+    });
+
+    // Collect dependency names+sources and the in-use-version map (§4.6) in one
+    // pass while holding the reference (can't hold across await).
+    let (dep_sources, in_use, minimum_stability, collided_names): (
+        DepSources,
+        HashMap<PackageName, Vec<String>>,
+        Option<String>,
+        HashSet<PackageName>,
+    ) = {
+        let doc = match state.get_document(&uri) {
+            Some(d) => d,
+            None => {
+                tracing::warn!("document not found, aborting fetch");
+                return;
+            }
+        };
+        let parse_result = match doc.parse_result() {
+            Some(p) => p,
+            None => {
+                tracing::warn!("no parse result, aborting fetch");
+                return;
+            }
+        };
+        // Deduped by name (critique M3): a duplicated name shares one
+        // registry fetch across all its occurrences — the result is
+        // name-keyed anyway (`FetchResult::versions`), so fetching it
+        // more than once would only issue wasted extra registry calls
+        // and inflate `RegistryProgress`'s total. A non-resolvable source is
+        // dropped entirely, and two occurrences of the same name resolving to
+        // *different* sources are dropped and recorded as collided instead
+        // (spec FR-011) — see `dedup_dependencies_by_source`.
+        let (sources_map, collided_names) =
+            dedup_dependencies_by_source(parse_result, ecosystem.formatter());
+        let dep_sources: Vec<_> = sources_map.into_iter().collect();
+        let in_use = collect_in_use_versions(
+            parse_result,
+            &resolved_versions,
+            ecosystem.formatter(),
+            resolve_ecosystem_id(ecosystem.as_ref()),
+        );
+        let minimum_stability = composer_minimum_stability(parse_result);
+        (dep_sources, in_use, minimum_stability, collided_names)
+    };
+
+    tracing::debug!(count = dep_sources.len(), "starting registry fetch");
+
+    // Mark as loading and start progress
+    if let Some(mut doc) = state.documents.get_mut(&uri) {
+        doc.set_loading();
+    }
+
+    let (progress, progress_sender) = if state.supports_progress() {
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            RegistryProgress::start(client.clone(), uri.as_str(), dep_sources.len()),
+        )
+        .await
+        {
+            Ok(Ok((p, s))) => (Some(p), Some(s)),
+            _ => (None, None),
+        }
+    } else {
+        (None, None)
+    };
+
+    tracing::debug!("progress started, fetching versions");
+
+    // Fetch latest versions from registry in parallel (for update hints)
+    let registry = ecosystem.registry();
+    let fetch_result = fetch_latest_versions_parallel(
+        registry,
+        dep_sources,
+        &in_use,
+        progress_sender,
+        freshness_settings,
+        cache_config.fetch_timeout_secs,
+        cache_config.max_concurrent_fetches,
+        minimum_stability.as_deref(),
+    )
+    .await;
+
+    let success = !fetch_result.versions.is_empty();
+    tracing::debug!(
+        fetched = fetch_result.versions.len(),
+        failed = fetch_result.failed_count,
+        yanked = fetch_result.yanked_versions.len(),
+        "registry fetch complete"
+    );
+
+    // Update document state with cached versions (latest from registry)
+    if let Some(mut doc) = state.documents.get_mut(&uri) {
+        doc.update_cached_versions(fetch_result.versions);
+        // Re-key raw -> normalized (§3.1): `FetchResult`'s three fields are
+        // raw-keyed, `DocumentState::outcomes` is normalized.
+        let formatter = ecosystem.formatter();
+        let mut outcomes = DependencyOutcomes::new();
+        for (name, d) in fetch_result.deprecations {
+            outcomes.set_deprecation(formatter.normalize_package_name(&name), d);
+        }
+        for (name, v) in fetch_result.yanked_versions {
+            outcomes.set_yanked(formatter.normalize_package_name(&name), v);
+        }
+        for (name, failure) in fetch_result.fetch_failed {
+            outcomes.set_fetch_failure(formatter.normalize_package_name(&name), failure);
+        }
+        for name in fetch_result.no_comparable_versions {
+            outcomes.set_no_comparable_versions(formatter.normalize_package_name(&name));
+        }
+        // `collided_names` (spec FR-011) are merged in alongside genuine fetch
+        // failures so `generate_diagnostics_from_cache` reports "lookup could not
+        // be determined" rather than a false "Unknown package" for a name that
+        // was deliberately never queried, not one that doesn't exist. Genuine
+        // failures are inserted first and `collided_names` uses
+        // `set_fetch_failure_if_absent` so a collided name that normalizes to the
+        // same key as a genuine `Actionable`/`Transient` failure never clobbers it
+        // (impl-critic M2).
+        for name in collided_names {
+            outcomes.set_fetch_failure_if_absent(
+                formatter.normalize_package_name(&name),
+                FetchFailure::NotAttempted,
+            );
+        }
+        doc.replace_outcomes(outcomes);
+        if success {
+            doc.set_loaded();
+        } else {
+            doc.set_failed();
+        }
+    }
+
+    // End progress
+    if let Some(progress) = progress {
+        progress.end(success).await;
+    }
+
+    // Notify user about failed packages — suppressed when offline, see
+    // `fetch_failure_toast`'s docs. `fetch_result.first_error` is always populated
+    // by `fetch_latest_versions_parallel` whenever `failed_count > 0` (#480: every
+    // site that increments `failed_count` also sets either `priority_error` or
+    // `first_error`, and the two are merged into this field before returning).
+    match fetch_failure_toast(
+        fetch_result.failed_count,
+        fetch_result.first_error.as_deref(),
+        state.cache.is_offline(),
+    ) {
+        Some(message) => {
+            client.show_message(MessageType::WARNING, message).await;
+        }
+        None if fetch_result.failed_count > 0 => {
+            tracing::debug!(
+                failed_count = fetch_result.failed_count,
+                "suppressing fetch-failure toast: offline"
+            );
+        }
+        None => {}
+    }
+
+    // Kick off inlay hint / code lens refresh as soon as loading completes, so
+    // clients see updated hints as early as possible — typically before
+    // diagnostics, which may take longer due to additional network calls, though
+    // that ordering is scheduler-dependent, not guaranteed, since the requests
+    // are detached (issue #493: nothing downstream depends on their result, and a
+    // client that never declared refresh support, or stops replying, must not
+    // hang this task's critical path — including the OSV commit and diagnostics
+    // publish below — forever).
+    state.spawn_refresh_requests(&client);
+
+    // Join phase A (already running concurrently since it was spawned
+    // above) and, only now that `cached_versions` holds the registry's
+    // actual latest (not the lockfile-seeded placeholder — critique S1),
+    // run phase B and commit before generating diagnostics.
+    if let Some(osv_task) = osv_task {
+        match osv_task.await {
+            Ok(Some(phase_a_result)) => {
+                let ecosystem_id = resolve_ecosystem_id(ecosystem.as_ref());
+                run_osv_phase_b_and_commit(
+                    &uri,
+                    &state,
+                    ecosystem_id,
+                    ecosystem.formatter(),
+                    cache_config.fetch_timeout_secs,
+                    phase_a_result,
+                )
+                .await;
+            }
+            Ok(None) => {}
+            Err(e) => tracing::warn!("OSV scan task failed: {e}"),
+        }
+    }
+
+    // Publish diagnostics (may be slower, runs after hints are already visible)
+    let diags = diagnostics::generate_diagnostics_internal(
+        Arc::clone(&state),
+        &uri,
+        freshness_settings,
+        diagnostic_severities,
+        offline,
+    )
+    .await;
+
+    client.publish_diagnostics(uri.clone(), diags, None).await;
 }
 
 /// Parses the freshly-edited manifest content and diffs its dependencies against the


### PR DESCRIPTION
## Summary

Pure decomposition follow-up to #583 — no behavior change.

- Decompose `generate_hover` (`crates/deps-core/src/lsp_helpers/hover.rs`) into an orchestrator plus named `push_*_hover_section` / `spawn_trust_signal_fetch` helpers, following the file's existing convention (`push_deprecation_hover_section`, `push_vulnerability_hover_section`).
- Decompose `fetch_latest_versions_parallel` and `handle_document_open` (`crates/deps-lsp/src/document/lifecycle.rs`) by extracting the per-package fetch step into `fetch_and_classify_package` and the spawned background-task body into `run_document_open_background_task`.
- Two hardening fixes surfaced during adversarial critique, folded into this PR:
  - Consistent bool-parameter order between `push_cmd_dot_footer_hover_section` and `push_offline_footer_hover_section`.
  - `push_recent_versions_hover_section` now guards on an empty slice internally, so the #550 non-empty invariant holds by construction rather than only by caller convention.

Closes #586
Closes #585

## Test plan

- [x] `cargo nextest run --workspace --all-features --no-fail-fast` — 4026 passed, 0 failed, 49 skipped (unchanged from main)
- [x] `cargo test --workspace --doc --all-features`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo +nightly fmt --all -- --check`
- [x] Rustdoc gate: `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Adversarial critique: token-level normalized diff confirms both extractions are behavior-preserving (ordering, captured state, error handling, async/cancellation semantics, signature drift all checked)
- [x] Independent test-coverage review confirmed extracted code paths are exercised by existing tests, not just compiled