### PR TITLE
chore(workspace): bump MSRV to 1.98, adopt assert_matches! and strip_circumfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-nuget**: a NuGet source that fails closed on credential binding now logs the source key, reason, and specific cause (debounced per config state, debug/warn severity matching the existing convention), instead of silently dropping the dependency with no observability (resolves #576) (#578)
 
 ### Changed
+- **MSRV bumped to 1.98** — unlocks `assert_matches!` (replacing `assert!(matches!(...))` in tests) and `str::strip_circumfix` (replacing chained `strip_prefix`/`strip_suffix` in `deps-core`, `deps-gradle`, `deps-pypi`) (resolves #549)
 - **deps-nuget**: `NuGetSourceChain.hops`/`NuGetRegistry::with_base` now carry per-hop credential/slot data (`ResolvedHop`) instead of a bare feed URL; `deps_lsp::register_ecosystems` now takes an `&EcosystemRuntime` instead of a bare `Arc<RegistryAccessPolicy>` — both breaking, pre-1.0, no alias (#572)
 - **deps-core, deps-cargo, deps-nuget**: consolidated four independently hand-implemented "redact this secret from `Debug`/`Display`" wrapper types into a single `deps_core::secret::Redacted<T>` newtype (resolves #573) (#577)
 - **deps-core, deps-cargo, deps-nuget**: renamed the secret-exposing `as_str()` accessor on `Redacted<T>` and its delegating wrapper types (`AuthToken`, `RedactedSecret`) to `expose_secret()`, so it can no longer be confused with an ordinary string conversion in a grep or code review (resolves #581) (#582)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-nuget**: a NuGet source that fails closed on credential binding now logs the source key, reason, and specific cause (debounced per config state, debug/warn severity matching the existing convention), instead of silently dropping the dependency with no observability (resolves #576) (#578)
 
 ### Changed
-- **MSRV bumped to 1.98** — unlocks `assert_matches!` (replacing `assert!(matches!(...))` in tests) and `str::strip_circumfix` (replacing chained `strip_prefix`/`strip_suffix` in `deps-core`, `deps-gradle`, `deps-pypi`) (resolves #549)
+- **MSRV bumped to 1.98** — unlocks `assert_matches!` (replacing `assert!(matches!(...))` in tests) and `str::strip_circumfix` (replacing chained `strip_prefix`/`strip_suffix` in `deps-core`, `deps-gradle`, `deps-pypi`) (resolves #549) (#594)
 - **deps-nuget**: `NuGetSourceChain.hops`/`NuGetRegistry::with_base` now carry per-hop credential/slot data (`ResolvedHop`) instead of a bare feed URL; `deps_lsp::register_ecosystems` now takes an `&EcosystemRuntime` instead of a bare `Arc<RegistryAccessPolicy>` — both breaking, pre-1.0, no alias (#572)
 - **deps-core, deps-cargo, deps-nuget**: consolidated four independently hand-implemented "redact this secret from `Debug`/`Display`" wrapper types into a single `deps_core::secret::Redacted<T>` newtype (resolves #573) (#577)
 - **deps-core, deps-cargo, deps-nuget**: renamed the secret-exposing `as_str()` accessor on `Redacted<T>` and its delegating wrapper types (`AuthToken`, `RedactedSecret`) to `expose_secret()`, so it can no longer be confused with an ordinary string conversion in a grep or code review (resolves #581) (#582)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "3"
 [workspace.package]
 version = "0.12.1"
 edition = "2024"
-rust-version = "1.91"
+rust-version = "1.98"
 authors = ["Andrei G"]
 license = "MIT"
 repository = "https://github.com/bug-ops/deps-lsp"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/bug-ops/deps-lsp/actions/workflows/ci.yml/badge.svg)](https://github.com/bug-ops/deps-lsp/actions)
 [![codecov](https://codecov.io/gh/bug-ops/deps-lsp/graph/badge.svg?token=S71PTINTGQ)](https://codecov.io/gh/bug-ops/deps-lsp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![MSRV](https://img.shields.io/badge/MSRV-1.91-blue)](https://blog.rust-lang.org/)
+[![MSRV](https://img.shields.io/badge/MSRV-1.98-blue)](https://blog.rust-lang.org/)
 [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 
 A universal Language Server Protocol (LSP) server for dependency management across Cargo, npm, PyPI, Go, Bundler, Dart, Maven, Gradle, Swift, Composer, NuGet, Deno, and GitHub Actions ecosystems.
@@ -374,7 +374,7 @@ deps-lsp is optimized for responsiveness:
 ## Development
 
 > [!IMPORTANT]
-> Requires Rust 1.91+ (Edition 2024).
+> Requires Rust 1.98+ (Edition 2024).
 
 ### Build
 

--- a/crates/deps-bundler/README.md
+++ b/crates/deps-bundler/README.md
@@ -27,7 +27,7 @@ deps-bundler = "0.12"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.91 or later.
+> Requires Rust 1.98 or later.
 
 ## Usage
 

--- a/crates/deps-bundler/src/parser.rs
+++ b/crates/deps-bundler/src/parser.rs
@@ -300,6 +300,8 @@ impl deps_core::ParseResult for BundlerParseResult {
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     fn test_uri() -> Uri {
         #[cfg(windows)]
         let path = "C:/test/Gemfile";
@@ -334,10 +336,7 @@ gem 'rails', '~> 7.0'";
 gem 'rspec', group: :test";
         let result = parse_gemfile(gemfile, &test_uri()).unwrap();
         assert_eq!(result.dependencies.len(), 1);
-        assert!(matches!(
-            result.dependencies[0].group,
-            DependencyGroup::Test
-        ));
+        assert_matches!(result.dependencies[0].group, DependencyGroup::Test);
     }
 
     #[test]
@@ -354,20 +353,11 @@ gem 'rails'";
         assert_eq!(result.dependencies.len(), 3);
 
         // rspec and pry should be in development group (development is checked first)
-        assert!(matches!(
-            result.dependencies[0].group,
-            DependencyGroup::Development
-        ));
-        assert!(matches!(
-            result.dependencies[1].group,
-            DependencyGroup::Development
-        ));
+        assert_matches!(result.dependencies[0].group, DependencyGroup::Development);
+        assert_matches!(result.dependencies[1].group, DependencyGroup::Development);
 
         // rails should be default group
-        assert!(matches!(
-            result.dependencies[2].group,
-            DependencyGroup::Default
-        ));
+        assert_matches!(result.dependencies[2].group, DependencyGroup::Default);
     }
 
     #[test]
@@ -375,10 +365,7 @@ gem 'rails'";
         let gemfile = r"source 'https://rubygems.org'
 gem 'rails', git: 'https://github.com/rails/rails.git'";
         let result = parse_gemfile(gemfile, &test_uri()).unwrap();
-        assert!(matches!(
-            result.dependencies[0].source,
-            DependencySource::Git { .. }
-        ));
+        assert_matches!(result.dependencies[0].source, DependencySource::Git { .. });
     }
 
     #[test]
@@ -399,10 +386,7 @@ gem 'rails', github: 'rails/rails'";
         let gemfile = r"source 'https://rubygems.org'
 gem 'local_gem', path: '../local_gem'";
         let result = parse_gemfile(gemfile, &test_uri()).unwrap();
-        assert!(matches!(
-            result.dependencies[0].source,
-            DependencySource::Path { .. }
-        ));
+        assert_matches!(result.dependencies[0].source, DependencySource::Path { .. });
     }
 
     #[test]
@@ -450,10 +434,7 @@ gem 'internal-gem'";
         let gemfile = r"source 'https://gems.mycorp.com'
 gem 'rails', git: 'https://github.com/rails/rails.git'";
         let result = parse_gemfile(gemfile, &test_uri()).unwrap();
-        assert!(matches!(
-            result.dependencies[0].source,
-            DependencySource::Git { .. }
-        ));
+        assert_matches!(result.dependencies[0].source, DependencySource::Git { .. });
     }
 
     #[test]
@@ -509,10 +490,7 @@ gem 'rails'
         let gemfile = r"source 'https://rubygems.org'
 gem 'unicorn', group: :production";
         let result = parse_gemfile(gemfile, &test_uri()).unwrap();
-        assert!(matches!(
-            result.dependencies[0].group,
-            DependencyGroup::Production
-        ));
+        assert_matches!(result.dependencies[0].group, DependencyGroup::Production);
     }
 
     #[test]
@@ -520,10 +498,7 @@ gem 'unicorn', group: :production";
         let gemfile = r"source 'https://rubygems.org'
 gem 'pry', group: :development";
         let result = parse_gemfile(gemfile, &test_uri()).unwrap();
-        assert!(matches!(
-            result.dependencies[0].group,
-            DependencyGroup::Development
-        ));
+        assert_matches!(result.dependencies[0].group, DependencyGroup::Development);
     }
 
     #[test]
@@ -545,10 +520,7 @@ group :test do
   gem 'minitest'
 end";
         let result = parse_gemfile(gemfile, &test_uri()).unwrap();
-        assert!(matches!(
-            result.dependencies[0].group,
-            DependencyGroup::Test
-        ));
+        assert_matches!(result.dependencies[0].group, DependencyGroup::Test);
     }
 
     #[test]
@@ -558,10 +530,7 @@ group :production do
   gem 'newrelic_rpm'
 end";
         let result = parse_gemfile(gemfile, &test_uri()).unwrap();
-        assert!(matches!(
-            result.dependencies[0].group,
-            DependencyGroup::Production
-        ));
+        assert_matches!(result.dependencies[0].group, DependencyGroup::Production);
     }
 
     #[test]
@@ -608,10 +577,7 @@ gem 'sidekiq', '~> 7.0', require: false, group: :production";
         assert_eq!(result.dependencies[0].name, "sidekiq");
         assert_eq!(result.dependencies[0].version_req, Some("~> 7.0".into()));
         assert_eq!(result.dependencies[0].require, Some("false".into()));
-        assert!(matches!(
-            result.dependencies[0].group,
-            DependencyGroup::Production
-        ));
+        assert_matches!(result.dependencies[0].group, DependencyGroup::Production);
     }
 
     #[test]
@@ -626,18 +592,9 @@ end
 gem 'rails'";
         let result = parse_gemfile(gemfile, &test_uri()).unwrap();
         assert_eq!(result.dependencies.len(), 3);
-        assert!(matches!(
-            result.dependencies[0].group,
-            DependencyGroup::Development
-        ));
-        assert!(matches!(
-            result.dependencies[1].group,
-            DependencyGroup::Test
-        ));
-        assert!(matches!(
-            result.dependencies[2].group,
-            DependencyGroup::Default
-        ));
+        assert_matches!(result.dependencies[0].group, DependencyGroup::Development);
+        assert_matches!(result.dependencies[1].group, DependencyGroup::Test);
+        assert_matches!(result.dependencies[2].group, DependencyGroup::Default);
     }
 
     #[test]
@@ -696,10 +653,7 @@ gem 'rails', '7.0.8'";
 gem 'rspec', group: [:test, :development]";
         let result = parse_gemfile(gemfile, &test_uri()).unwrap();
         // When array contains both :test and :development, development is checked first
-        assert!(matches!(
-            result.dependencies[0].group,
-            DependencyGroup::Development
-        ));
+        assert_matches!(result.dependencies[0].group, DependencyGroup::Development);
     }
 
     #[test]

--- a/crates/deps-bundler/src/types.rs
+++ b/crates/deps-bundler/src/types.rs
@@ -105,6 +105,7 @@ impl deps_core::Dependency for BundlerDependency {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
     use tower_lsp_server::ls_types::Position;
 
     fn create_test_dependency(source: DependencySource) -> BundlerDependency {
@@ -148,17 +149,17 @@ mod tests {
         let prod = DependencyGroup::Production;
         let custom = DependencyGroup::Custom("staging".into());
 
-        assert!(matches!(default, DependencyGroup::Default));
-        assert!(matches!(dev, DependencyGroup::Development));
-        assert!(matches!(test, DependencyGroup::Test));
-        assert!(matches!(prod, DependencyGroup::Production));
-        assert!(matches!(custom, DependencyGroup::Custom(_)));
+        assert_matches!(default, DependencyGroup::Default);
+        assert_matches!(dev, DependencyGroup::Development);
+        assert_matches!(test, DependencyGroup::Test);
+        assert_matches!(prod, DependencyGroup::Production);
+        assert_matches!(custom, DependencyGroup::Custom(_));
     }
 
     #[test]
     fn test_dependency_group_default() {
         let group = DependencyGroup::default();
-        assert!(matches!(group, DependencyGroup::Default));
+        assert_matches!(group, DependencyGroup::Default);
     }
 
     #[test]

--- a/crates/deps-cargo/README.md
+++ b/crates/deps-cargo/README.md
@@ -29,7 +29,7 @@ deps-cargo = "0.12"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.91 or later.
+> Requires Rust 1.98 or later.
 
 ## Usage
 

--- a/crates/deps-cargo/src/config.rs
+++ b/crates/deps-cargo/src/config.rs
@@ -1053,6 +1053,7 @@ pub fn referenced_aliases(dependencies: &[crate::types::ParsedDependency]) -> Ha
 mod tests {
     use super::*;
     use deps_core::net_policy::WorkspaceRegistryAccess;
+    use std::assert_matches;
 
     fn public_only_policy() -> RegistryAccessPolicy {
         RegistryAccessPolicy::new(WorkspaceRegistryAccess::PublicOnly)
@@ -1081,45 +1082,45 @@ mod tests {
     #[test]
     fn test_registry_index_rejects_http() {
         let policy = all_policy();
-        assert!(matches!(
+        assert_matches!(
             RegistryIndex::new("http://index.mycorp.dev", IndexTrust::Trusted, &policy),
             Err(RegistryIndexError::NotHttps(_))
-        ));
+        );
     }
 
     #[test]
     fn test_registry_index_rejects_userinfo() {
         let policy = all_policy();
-        assert!(matches!(
+        assert_matches!(
             RegistryIndex::new(
                 "https://user:pass@index.mycorp.dev",
                 IndexTrust::Trusted,
                 &policy
             ),
             Err(RegistryIndexError::UserInfoPresent)
-        ));
+        );
     }
 
     #[test]
     fn test_registry_index_rejects_bare_username() {
         let policy = all_policy();
-        assert!(matches!(
+        assert_matches!(
             RegistryIndex::new(
                 "https://user@index.mycorp.dev",
                 IndexTrust::Trusted,
                 &policy
             ),
             Err(RegistryIndexError::UserInfoPresent)
-        ));
+        );
     }
 
     #[test]
     fn test_registry_index_rejects_invalid_url() {
         let policy = all_policy();
-        assert!(matches!(
+        assert_matches!(
             RegistryIndex::new("not a url", IndexTrust::Trusted, &policy),
             Err(RegistryIndexError::InvalidUrl(_))
-        ));
+        );
     }
 
     /// S1: a userinfo-bearing `index = "…"` value that also fails `Url::parse` for an
@@ -1137,7 +1138,7 @@ mod tests {
             &policy,
         )
         .unwrap_err();
-        assert!(matches!(err, RegistryIndexError::InvalidUrl(_)));
+        assert_matches!(err, RegistryIndexError::InvalidUrl(_));
         assert!(!err.to_string().contains("hunter2"), "Display: {err}");
     }
 
@@ -1198,14 +1199,14 @@ mod tests {
     #[test]
     fn test_registry_index_workspace_declared_metadata_ip_blocked_under_public_only() {
         let policy = public_only_policy();
-        assert!(matches!(
+        assert_matches!(
             RegistryIndex::new(
                 "https://169.254.169.254/",
                 IndexTrust::WorkspaceDeclared,
                 &policy
             ),
             Err(RegistryIndexError::BlockedHost { .. })
-        ));
+        );
     }
 
     #[test]
@@ -1224,14 +1225,14 @@ mod tests {
     #[test]
     fn test_registry_index_workspace_declared_blocked_under_off() {
         let policy = off_policy();
-        assert!(matches!(
+        assert_matches!(
             RegistryIndex::new(
                 "https://index.mycorp.dev",
                 IndexTrust::WorkspaceDeclared,
                 &policy
             ),
             Err(RegistryIndexError::BlockedHost { .. })
-        ));
+        );
     }
 
     #[test]
@@ -1700,10 +1701,7 @@ token = "secret-token"
         let policy = all_policy();
         let (_, replacement) = resolve(&HashSet::new(), &[path], None, &cache, &policy);
 
-        assert!(matches!(
-            replacement,
-            SourceReplacement::SparseMirror { .. }
-        ));
+        assert_matches!(replacement, SourceReplacement::SparseMirror { .. });
     }
 
     #[test]

--- a/crates/deps-cargo/src/lockfile.rs
+++ b/crates/deps-cargo/src/lockfile.rs
@@ -229,6 +229,8 @@ fn parse_cargo_dependencies_from_table(table: &toml_span::value::Table<'_>) -> V
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     #[test]
     fn test_parse_cargo_source_registry() {
         let source = parse_cargo_source(Some(
@@ -294,10 +296,10 @@ mod tests {
 
         let parser = CargoLockParser;
         let result = parser.parse_lockfile(&lockfile_path).await;
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DepsError::ParseError { file_type, .. }) if file_type == "Cargo.lock"
-        ));
+        );
     }
 
     #[tokio::test]
@@ -322,10 +324,10 @@ mod tests {
 
         let parser = CargoLockParser;
         let result = parser.parse_lockfile(&lockfile_path).await;
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DepsError::ParseError { file_type, .. }) if file_type == "Cargo.lock"
-        ));
+        );
     }
 
     #[tokio::test]
@@ -348,10 +350,10 @@ mod tests {
 
         let parser = CargoLockParser;
         let result = parser.parse_lockfile(&lockfile_path).await;
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DepsError::ParseError { file_type, .. }) if file_type == "Cargo.lock"
-        ));
+        );
     }
 
     #[tokio::test]

--- a/crates/deps-cargo/src/parser.rs
+++ b/crates/deps-cargo/src/parser.rs
@@ -693,6 +693,8 @@ impl deps_core::ParseResult for ParseResult {
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     fn test_url() -> Uri {
         #[cfg(windows)]
         let path = "C:/test/Cargo.toml";
@@ -708,10 +710,10 @@ mod tests {
         // being exercised here, not the crash itself.
         let content = format!("a = {}1{}", "[".repeat(300), "]".repeat(300));
         let result = parse_cargo_toml(&content, &test_url());
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DepsError::ParseError { file_type, .. }) if file_type == "Cargo.toml"
-        ));
+        );
     }
 
     #[test]
@@ -736,10 +738,7 @@ serde = "1.0""#;
         assert_eq!(result.dependencies.len(), 1);
         assert_eq!(result.dependencies[0].name, "serde");
         assert_eq!(result.dependencies[0].version_req, Some("1.0".into()));
-        assert!(matches!(
-            result.dependencies[0].source,
-            DependencySource::Registry
-        ));
+        assert_matches!(result.dependencies[0].source, DependencySource::Registry);
     }
 
     #[test]
@@ -758,10 +757,7 @@ serde = { version = "1.0", features = ["derive"] }"#;
 serde = { workspace = true }";
         let result = parse_cargo_toml(toml, &test_url()).unwrap();
         assert_eq!(result.dependencies.len(), 1);
-        assert!(matches!(
-            result.dependencies[0].source,
-            DependencySource::Workspace
-        ));
+        assert_matches!(result.dependencies[0].source, DependencySource::Workspace);
     }
 
     #[test]
@@ -818,10 +814,7 @@ example = { git = "https://github.com/example/example" }"#;
 local = { path = "../local" }"#;
         let result = parse_cargo_toml(toml, &test_url()).unwrap();
         assert_eq!(result.dependencies.len(), 1);
-        assert!(matches!(
-            result.dependencies[0].source,
-            DependencySource::Path { .. }
-        ));
+        assert_matches!(result.dependencies[0].source, DependencySource::Path { .. });
     }
 
     #[test]
@@ -1163,18 +1156,18 @@ cc = "1.0"
         let result = parse_cargo_toml(toml, &test_url()).unwrap();
         assert_eq!(result.dependencies.len(), 3);
 
-        assert!(matches!(
+        assert_matches!(
             result.dependencies[0].section,
             DependencySection::Dependencies
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             result.dependencies[1].section,
             DependencySection::DevDependencies
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             result.dependencies[2].section,
             DependencySection::BuildDependencies
-        ));
+        );
     }
 
     #[test]
@@ -1187,7 +1180,7 @@ cc = "1.0"
         assert_eq!(dep.name, "libc");
         assert_eq!(dep.version_req, Some("0.2".into()));
         assert_eq!(dep.source, DependencySource::Registry);
-        assert!(matches!(dep.section, DependencySection::Dependencies));
+        assert_matches!(dep.section, DependencySection::Dependencies);
 
         // Position must point into the target table, not the (nonexistent) top-level one.
         assert_eq!(dep.name_range.start.line, 1);
@@ -1204,7 +1197,7 @@ cc = "1.0"
         let dep = &result.dependencies[0];
         assert_eq!(dep.name, "winapi");
         assert_eq!(dep.version_req, Some("0.3".into()));
-        assert!(matches!(dep.section, DependencySection::DevDependencies));
+        assert_matches!(dep.section, DependencySection::DevDependencies);
     }
 
     #[test]
@@ -1216,7 +1209,7 @@ cc = "1.0"
         let dep = &result.dependencies[0];
         assert_eq!(dep.name, "cc");
         assert_eq!(dep.version_req, Some("1.0".into()));
-        assert!(matches!(dep.section, DependencySection::BuildDependencies));
+        assert_matches!(dep.section, DependencySection::BuildDependencies);
     }
 
     #[test]
@@ -1242,7 +1235,7 @@ cc = "1.0"
             .iter()
             .find(|d| d.name == "serde")
             .unwrap();
-        assert!(matches!(serde.section, DependencySection::Dependencies));
+        assert_matches!(serde.section, DependencySection::Dependencies);
 
         let libc = result
             .dependencies
@@ -1251,17 +1244,17 @@ cc = "1.0"
             .unwrap();
         assert_eq!(libc.version_req, Some("0.2".into()));
         assert_eq!(libc.features, vec!["extra_traits"]);
-        assert!(matches!(libc.section, DependencySection::Dependencies));
+        assert_matches!(libc.section, DependencySection::Dependencies);
 
         let winapi = result
             .dependencies
             .iter()
             .find(|d| d.name == "winapi")
             .unwrap();
-        assert!(matches!(winapi.section, DependencySection::DevDependencies));
+        assert_matches!(winapi.section, DependencySection::DevDependencies);
 
         let cc = result.dependencies.iter().find(|d| d.name == "cc").unwrap();
-        assert!(matches!(cc.section, DependencySection::BuildDependencies));
+        assert_matches!(cc.section, DependencySection::BuildDependencies);
     }
 
     #[test]
@@ -1351,10 +1344,7 @@ tokio = { version = "1.0", features = ["full"] }
         assert_eq!(result.dependencies.len(), 2);
 
         for dep in &result.dependencies {
-            assert!(matches!(
-                dep.section,
-                DependencySection::WorkspaceDependencies
-            ));
+            assert_matches!(dep.section, DependencySection::WorkspaceDependencies);
         }
 
         let serde = result.dependencies.iter().find(|d| d.name == "serde");
@@ -1396,17 +1386,14 @@ tokio = "1.0"
 
         let serde = result.dependencies.iter().find(|d| d.name == "serde");
         assert!(serde.is_some());
-        assert!(matches!(
+        assert_matches!(
             serde.unwrap().section,
             DependencySection::WorkspaceDependencies
-        ));
+        );
 
         let tokio = result.dependencies.iter().find(|d| d.name == "tokio");
         assert!(tokio.is_some());
-        assert!(matches!(
-            tokio.unwrap().section,
-            DependencySection::Dependencies
-        ));
+        assert_matches!(tokio.unwrap().section, DependencySection::Dependencies);
     }
 
     #[test]

--- a/crates/deps-cargo/src/registry.rs
+++ b/crates/deps-cargo/src/registry.rs
@@ -647,6 +647,7 @@ mod tests {
     use super::*;
     use crate::config::IndexTrust;
     use deps_core::net_policy::RegistryAccessPolicy;
+    use std::assert_matches;
     use std::collections::HashMap;
 
     /// Wraps `raw` into a [`RegistryIndex`] for test call sites — see `sparse.rs`'s
@@ -892,7 +893,7 @@ mod tests {
                 deps_core::freshness::FreshnessSettings::default(),
             )
             .await;
-        assert!(matches!(result, Err(DepsError::PackageNotFound { .. })));
+        assert_matches!(result.err(), Some(DepsError::PackageNotFound { .. }));
     }
 
     /// Builds a `CargoRegistry` whose `crates_io` field points at `mockito_url` instead of
@@ -991,7 +992,7 @@ mod tests {
         let result = registry
             .get_latest_matching_for_source(&name, &source, &req)
             .await;
-        assert!(matches!(result, Err(DepsError::PackageNotFound { .. })));
+        assert_matches!(result, Err(DepsError::PackageNotFound { .. }));
     }
 
     #[tokio::test]

--- a/crates/deps-cargo/src/sparse.rs
+++ b/crates/deps-cargo/src/sparse.rs
@@ -392,6 +392,7 @@ impl SparseIndexClient {
 mod tests {
     use super::*;
     use deps_core::net_policy::RegistryAccessPolicy;
+    use std::assert_matches;
 
     /// Wraps `raw` into a [`RegistryIndex`] for test call sites, using an all-allow policy
     /// so a test's own choice of URL (including a loopback mockito URL) is never blocked —
@@ -739,7 +740,7 @@ mod tests {
             Arc::new(HttpCache::new()),
         );
         let err = client.get_versions("..").await.unwrap_err();
-        assert!(matches!(err, DepsError::PackageNotFound { .. }));
+        assert_matches!(err, DepsError::PackageNotFound { .. });
     }
 
     #[tokio::test]
@@ -749,7 +750,7 @@ mod tests {
             Arc::new(HttpCache::new()),
         );
         let err = client.get_versions("../../etc/passwd").await.unwrap_err();
-        assert!(matches!(err, DepsError::PackageNotFound { .. }));
+        assert_matches!(err, DepsError::PackageNotFound { .. });
     }
 
     #[tokio::test]
@@ -810,7 +811,7 @@ mod tests {
             "workspace index",
         );
         let err = client.get_versions("serde").await.unwrap_err();
-        assert!(matches!(err, DepsError::CacheError(_)));
+        assert_matches!(err, DepsError::CacheError(_));
         mock.assert_async().await;
     }
 

--- a/crates/deps-cargo/src/types.rs
+++ b/crates/deps-cargo/src/types.rs
@@ -236,27 +236,23 @@ impl deps_core::Metadata for CrateInfo {
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     #[test]
     fn test_dependency_source_variants() {
-        assert!(matches!(
-            DependencySource::Registry,
-            DependencySource::Registry
-        ));
-        assert!(matches!(
+        assert_matches!(DependencySource::Registry, DependencySource::Registry);
+        assert_matches!(
             DependencySource::Git {
                 url: "u".into(),
                 rev: None
             },
             DependencySource::Git { .. }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             DependencySource::Path { path: "p".into() },
             DependencySource::Path { .. }
-        ));
-        assert!(matches!(
-            DependencySource::Workspace,
-            DependencySource::Workspace
-        ));
+        );
+        assert_matches!(DependencySource::Workspace, DependencySource::Workspace);
     }
 
     #[test]
@@ -266,13 +262,10 @@ mod tests {
         let build_deps = DependencySection::BuildDependencies;
         let workspace_deps = DependencySection::WorkspaceDependencies;
 
-        assert!(matches!(deps, DependencySection::Dependencies));
-        assert!(matches!(dev_deps, DependencySection::DevDependencies));
-        assert!(matches!(build_deps, DependencySection::BuildDependencies));
-        assert!(matches!(
-            workspace_deps,
-            DependencySection::WorkspaceDependencies
-        ));
+        assert_matches!(deps, DependencySection::Dependencies);
+        assert_matches!(dev_deps, DependencySection::DevDependencies);
+        assert_matches!(build_deps, DependencySection::BuildDependencies);
+        assert_matches!(workspace_deps, DependencySection::WorkspaceDependencies);
     }
 
     #[test]

--- a/crates/deps-composer/README.md
+++ b/crates/deps-composer/README.md
@@ -32,7 +32,7 @@ deps-composer = "0.12"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.91 or later.
+> Requires Rust 1.98 or later.
 
 ## Usage
 

--- a/crates/deps-composer/src/parser.rs
+++ b/crates/deps-composer/src/parser.rs
@@ -259,6 +259,8 @@ fn find_positions(
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     fn test_uri() -> Uri {
         deps_core::test_util::test_uri("/test/composer.json")
     }
@@ -282,7 +284,7 @@ mod tests {
             .find(|d| d.name == "symfony/console")
             .expect("symfony/console not found");
         assert_eq!(symfony.version_req, Some("^6.0".into()));
-        assert!(matches!(symfony.section, ComposerSection::Require));
+        assert_matches!(symfony.section, ComposerSection::Require);
 
         let monolog = result
             .dependencies
@@ -302,10 +304,7 @@ mod tests {
 
         let result = parse_composer_json(json, &test_uri()).unwrap();
         assert_eq!(result.dependencies.len(), 1);
-        assert!(matches!(
-            result.dependencies[0].section,
-            ComposerSection::RequireDev
-        ));
+        assert_matches!(result.dependencies[0].section, ComposerSection::RequireDev);
     }
 
     #[test]
@@ -443,7 +442,7 @@ mod tests {
     #[test]
     fn test_parse_invalid_json() {
         let result = parse_composer_json("{invalid json}", &test_uri());
-        assert!(matches!(result, Err(deps_core::DepsError::Json(_))));
+        assert_matches!(result, Err(deps_core::DepsError::Json(_)));
     }
 
     #[test]
@@ -455,7 +454,7 @@ mod tests {
         let depth = deps_core::MAX_JSON_NESTING_DEPTH + 1;
         let json = format!("{}1{}", "[".repeat(depth), "]".repeat(depth));
         let result = parse_composer_json(&json, &test_uri());
-        assert!(matches!(result, Err(deps_core::DepsError::Json(_))));
+        assert_matches!(result, Err(deps_core::DepsError::Json(_)));
     }
 
     #[test]

--- a/crates/deps-composer/src/registry.rs
+++ b/crates/deps-composer/src/registry.rs
@@ -663,6 +663,8 @@ impl deps_core::Registry for PackagistRegistry {
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     #[test]
     fn test_package_url_preserves_vendor_package() {
         assert_eq!(
@@ -771,7 +773,7 @@ mod tests {
     async fn test_get_versions_rejects_vendor_dot_dot_as_not_found() {
         let registry = PackagistRegistry::new(Arc::new(HttpCache::new()));
         let err = registry.get_versions("../evil").await.unwrap_err();
-        assert!(matches!(err, DepsError::PackageNotFound { .. }));
+        assert_matches!(err, DepsError::PackageNotFound { .. });
     }
 
     #[test]

--- a/crates/deps-composer/src/types.rs
+++ b/crates/deps-composer/src/types.rs
@@ -260,6 +260,7 @@ deps_core::impl_metadata!(ComposerPackage {
 mod tests {
     use super::*;
     use deps_core::{Metadata, Version};
+    use std::assert_matches;
     use tower_lsp_server::ls_types::Position;
 
     #[test]
@@ -274,16 +275,13 @@ mod tests {
 
         assert_eq!(dep.name, "symfony/console");
         assert_eq!(dep.version_req, Some("^6.0".into()));
-        assert!(matches!(dep.section, ComposerSection::Require));
+        assert_matches!(dep.section, ComposerSection::Require);
     }
 
     #[test]
     fn test_composer_section_variants() {
-        assert!(matches!(ComposerSection::Require, ComposerSection::Require));
-        assert!(matches!(
-            ComposerSection::RequireDev,
-            ComposerSection::RequireDev
-        ));
+        assert_matches!(ComposerSection::Require, ComposerSection::Require);
+        assert_matches!(ComposerSection::RequireDev, ComposerSection::RequireDev);
     }
 
     #[test]

--- a/crates/deps-core/README.md
+++ b/crates/deps-core/README.md
@@ -37,7 +37,7 @@ deps-core = "0.12"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.91 or later.
+> Requires Rust 1.98 or later.
 
 ## Implementing a new ecosystem
 

--- a/crates/deps-core/src/cache.rs
+++ b/crates/deps-core/src/cache.rs
@@ -1822,6 +1822,8 @@ impl Default for HttpCache {
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     // Guards the non-loopback path of `ensure_https`: every other test in this
     // module reaches it only through loopback `mockito` URLs, so without this
     // test the "reject any other HTTP host" branch would never run.
@@ -1891,10 +1893,10 @@ mod tests {
     #[test]
     fn test_validate_resolved_addrs_blocks_cloud_metadata() {
         let addrs = vec!["169.254.169.254:0".parse().unwrap()];
-        assert!(matches!(
+        assert_matches!(
             validate_resolved_addrs("evil.example", addrs, AddrGuard::Baseline),
             Err(ResolveGuardError::Blocked { .. })
-        ));
+        );
     }
 
     // FR-003: an attacker's public A record alongside a blocked one must not keep the probe
@@ -1905,10 +1907,10 @@ mod tests {
             "1.1.1.1:0".parse().unwrap(),
             "169.254.169.254:0".parse().unwrap(),
         ];
-        assert!(matches!(
+        assert_matches!(
             validate_resolved_addrs("evil.example", addrs, AddrGuard::Baseline),
             Err(ResolveGuardError::Blocked { .. })
-        ));
+        );
     }
 
     #[test]
@@ -1924,19 +1926,19 @@ mod tests {
     // resolved" as "nothing to block".
     #[test]
     fn test_validate_resolved_addrs_fails_closed_on_empty() {
-        assert!(matches!(
+        assert_matches!(
             validate_resolved_addrs("evil.example", vec![], AddrGuard::Baseline),
             Err(ResolveGuardError::NoAddresses { .. })
-        ));
+        );
     }
 
     #[test]
     fn test_validate_resolved_addrs_unwraps_mapped_v4() {
         let addrs = vec!["[::ffff:169.254.169.254]:0".parse().unwrap()];
-        assert!(matches!(
+        assert_matches!(
             validate_resolved_addrs("evil.example", addrs, AddrGuard::Baseline),
             Err(ResolveGuardError::Blocked { .. })
-        ));
+        );
     }
 
     // Issue #455, test-plan item 1: under `Baseline`, an RFC1918/CGNAT/unique-local address is
@@ -1985,10 +1987,10 @@ mod tests {
     fn test_validate_resolved_addrs_workspace_off_rejects_global() {
         let guard = AddrGuard::WorkspaceDeclared(WorkspaceRegistryAccess::Off);
         let addrs = vec!["1.1.1.1:0".parse().unwrap()];
-        assert!(matches!(
+        assert_matches!(
             validate_resolved_addrs("index.crates.io", addrs, guard),
             Err(ResolveGuardError::Blocked { .. })
-        ));
+        );
     }
 
     // Test-plan item 3: `build_guarded_client_with_lookup` shares `build_client_inner` with the
@@ -3359,7 +3361,7 @@ mod tests {
 
         let body = serde_json::json!({ "queries": [] });
         let result: Result<Bytes> = cache.post_json(&url, &body).await;
-        assert!(matches!(result, Err(DepsError::Offline { .. })));
+        assert_matches!(result, Err(DepsError::Offline { .. }));
         mock.assert_async().await;
     }
 
@@ -3378,7 +3380,7 @@ mod tests {
         cache.set_offline(true);
 
         let result: Result<Bytes> = cache.get_transport_only(&url).await;
-        assert!(matches!(result, Err(DepsError::Offline { .. })));
+        assert_matches!(result, Err(DepsError::Offline { .. }));
         mock.assert_async().await;
     }
 
@@ -3458,7 +3460,7 @@ mod tests {
         cache.set_offline(true);
 
         let result: Result<Bytes> = cache.get_cached(&url).await;
-        assert!(matches!(result, Err(DepsError::Offline { .. })));
+        assert_matches!(result, Err(DepsError::Offline { .. }));
         mock.assert_async().await;
     }
 

--- a/crates/deps-core/src/completion.rs
+++ b/crates/deps-core/src/completion.rs
@@ -923,6 +923,7 @@ pub async fn complete_versions_generic(
 mod tests {
     use super::*;
     use std::any::Any;
+    use std::assert_matches;
 
     fn pkg(s: &str) -> PackageName {
         PackageName::new(s)
@@ -1765,10 +1766,7 @@ mod tests {
         assert_eq!(item.label, "serde");
         assert_eq!(item.kind, Some(CompletionItemKind::MODULE));
         assert_eq!(item.detail, Some("v1.0.214".to_string()));
-        assert!(matches!(
-            item.documentation,
-            Some(Documentation::MarkupContent(_))
-        ));
+        assert_matches!(item.documentation, Some(Documentation::MarkupContent(_)));
 
         if let Some(Documentation::MarkupContent(content)) = item.documentation {
             assert!(content.value.contains("**serde** v1\\.0\\.214"));

--- a/crates/deps-core/src/ecosystem.rs
+++ b/crates/deps-core/src/ecosystem.rs
@@ -699,6 +699,8 @@ pub trait Ecosystem: Send + Sync + private::Sealed {
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     #[test]
     fn test_ecosystem_id_roundtrip() {
         const ALL: &[EcosystemId] = &[
@@ -754,7 +756,7 @@ mod tests {
     #[test]
     fn test_ecosystem_id_from_str_unknown() {
         let err = "unknown".parse::<EcosystemId>().unwrap_err();
-        assert!(matches!(err, crate::error::DepsError::UnsupportedEcosystem(s) if s == "unknown"));
+        assert_matches!(err, crate::error::DepsError::UnsupportedEcosystem(s) if s == "unknown");
     }
 
     #[test]

--- a/crates/deps-core/src/lsp_helpers/in_use_version.rs
+++ b/crates/deps-core/src/lsp_helpers/in_use_version.rs
@@ -179,8 +179,7 @@ pub fn concrete_pin_version(requirement: &str, ecosystem: EcosystemId) -> Option
         .strip_prefix("==")
         .or_else(|| trimmed.strip_prefix('='));
     let bracket_pinned = trimmed
-        .strip_prefix('[')
-        .and_then(|s| s.strip_suffix(']'))
+        .strip_circumfix('[', ']')
         .filter(|inner| !inner.contains(','));
 
     match pinned.or(bracket_pinned) {

--- a/crates/deps-core/src/net_policy.rs
+++ b/crates/deps-core/src/net_policy.rs
@@ -615,6 +615,8 @@ pub fn validate_index_url(
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     fn host_class(url: &str) -> HostClass {
         classify_host(&url::Url::parse(url).unwrap())
     }
@@ -876,7 +878,7 @@ mod tests {
             )
             .is_ok()
         );
-        assert!(matches!(
+        assert_matches!(
             validate_index_url(
                 "https://169.254.169.254/",
                 "https://169.254.169.254/",
@@ -884,7 +886,7 @@ mod tests {
                 PolicyGate::Enforce(&policy)
             ),
             Err(IndexUrlError::BlockedHost { .. })
-        ));
+        );
     }
 
     #[test]

--- a/crates/deps-core/src/osv/mod.rs
+++ b/crates/deps-core/src/osv/mod.rs
@@ -704,6 +704,7 @@ fn log_scan_summary(outcomes: &HashMap<String, ScanOutcome>) {
 mod tests {
     use super::*;
     use crate::EcosystemId;
+    use std::assert_matches;
 
     fn client() -> OsvClient {
         OsvClient::new(Arc::new(HttpCache::new()))
@@ -768,7 +769,7 @@ mod tests {
         let outcomes = client.scan(EcosystemId::Npm, &targets, TEST_TIMEOUT).await;
 
         assert_eq!(outcomes.len(), 1);
-        assert!(matches!(outcomes.get("left-pad"), Some(ScanOutcome::Clean)));
+        assert_matches!(outcomes.get("left-pad"), Some(ScanOutcome::Clean));
     }
 
     #[tokio::test]
@@ -786,10 +787,10 @@ mod tests {
 
         assert_eq!(outcomes.len(), 2);
         for key in ["a", "b"] {
-            assert!(matches!(
+            assert_matches!(
                 outcomes.get(key),
                 Some(ScanOutcome::Skipped(SkipReason::QueryFailed))
-            ));
+            );
         }
     }
 
@@ -806,10 +807,10 @@ mod tests {
         let targets = vec![target("a", "1.0.0")];
         let outcomes = client.scan(EcosystemId::Npm, &targets, TEST_TIMEOUT).await;
 
-        assert!(matches!(
+        assert_matches!(
             outcomes.get("a"),
             Some(ScanOutcome::Skipped(SkipReason::QueryFailed))
-        ));
+        );
     }
 
     #[tokio::test]
@@ -837,10 +838,10 @@ mod tests {
         let targets = vec![target("pkg", "1.0.0")];
         let outcomes = client.scan(EcosystemId::Npm, &targets, TEST_TIMEOUT).await;
 
-        assert!(matches!(
+        assert_matches!(
             outcomes.get("pkg"),
             Some(ScanOutcome::Skipped(SkipReason::QueryFailed))
-        ));
+        );
     }
 
     #[tokio::test]
@@ -858,10 +859,10 @@ mod tests {
         let outcomes = client.scan(EcosystemId::Npm, &targets, TEST_TIMEOUT).await;
 
         for key in ["a", "b"] {
-            assert!(matches!(
+            assert_matches!(
                 outcomes.get(key),
                 Some(ScanOutcome::Skipped(SkipReason::QueryFailed))
-            ));
+            );
         }
     }
 
@@ -920,10 +921,10 @@ mod tests {
             .await;
 
         for key in ["a", "b"] {
-            assert!(matches!(
+            assert_matches!(
                 outcomes.get(key),
                 Some(ScanOutcome::Skipped(SkipReason::QueryFailed))
-            ));
+            );
         }
     }
 
@@ -1025,10 +1026,10 @@ mod tests {
         let targets = vec![target("linux", "5.10.1")];
         let outcomes = client.scan(EcosystemId::Go, &targets, TEST_TIMEOUT).await;
 
-        assert!(matches!(
+        assert_matches!(
             outcomes.get("linux"),
             Some(ScanOutcome::Skipped(SkipReason::Truncated))
-        ));
+        );
     }
 
     #[tokio::test]
@@ -1152,7 +1153,7 @@ mod tests {
             !matches!(outcome, ScanOutcome::Clean),
             "a truncated batch result must never render as clean"
         );
-        assert!(matches!(outcome, ScanOutcome::Vulnerable(_)));
+        assert_matches!(outcome, ScanOutcome::Vulnerable(_));
     }
 
     #[tokio::test]
@@ -1236,17 +1237,17 @@ mod tests {
             .check_candidates(EcosystemId::Npm, &candidates, TEST_TIMEOUT)
             .await;
 
-        assert!(matches!(
+        assert_matches!(
             statuses.get("clean-pkg"),
             Some(UpgradeStatus::CandidateClean { version }) if version == "2.0.0"
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             statuses.get("bad-pkg"),
             Some(UpgradeStatus::CandidateVulnerable { version, advisory_ids })
                 if version == "2.0.0"
                     && advisory_ids.items() == ["ADV-1".to_string()]
                     && advisory_ids.total() == 1
-        ));
+        );
     }
 
     #[tokio::test]
@@ -1274,10 +1275,10 @@ mod tests {
             .check_candidates(EcosystemId::Go, &[candidate], TEST_TIMEOUT)
             .await;
 
-        assert!(matches!(
+        assert_matches!(
             statuses.get("golang.org/x/text"),
             Some(UpgradeStatus::CandidateClean { version }) if version == "v0.4.0"
-        ));
+        );
     }
 
     #[test]

--- a/crates/deps-core/src/version_matcher.rs
+++ b/crates/deps-core/src/version_matcher.rs
@@ -251,6 +251,8 @@ fn has_spaced_operator(requirement: &str) -> bool {
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     #[test]
     fn test_semver_matcher_exact_match() {
         let matcher = SemverMatcher;
@@ -391,10 +393,10 @@ mod tests {
     #[test]
     fn test_normalize_operator_spacing_borrows_when_no_spaced_operator() {
         let input = ">=1.0 <2.0";
-        assert!(matches!(
+        assert_matches!(
             normalize_operator_spacing(input),
             Cow::Borrowed(s) if s == input
-        ));
+        );
     }
 
     #[test]

--- a/crates/deps-dart/README.md
+++ b/crates/deps-dart/README.md
@@ -27,7 +27,7 @@ deps-dart = "0.12"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.91 or later.
+> Requires Rust 1.98 or later.
 
 ## Usage
 

--- a/crates/deps-dart/src/parser.rs
+++ b/crates/deps-dart/src/parser.rs
@@ -253,6 +253,8 @@ impl deps_core::ParseResult for DartParseResult {
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     fn test_uri() -> Uri {
         #[cfg(windows)]
         let path = "C:/test/pubspec.yaml";
@@ -287,14 +289,11 @@ dev_dependencies:
 ";
         let result = parse_pubspec_yaml(yaml, &test_uri()).unwrap();
         assert_eq!(result.dependencies.len(), 2);
-        assert!(matches!(
+        assert_matches!(
             result.dependencies[0].section,
             DependencySection::DevDependencies
-        ));
-        assert!(matches!(
-            result.dependencies[0].source,
-            DependencySource::Sdk { .. }
-        ));
+        );
+        assert_matches!(result.dependencies[0].source, DependencySource::Sdk { .. });
     }
 
     #[test]
@@ -332,10 +331,7 @@ dependencies:
     path: ../local_pkg
 ";
         let result = parse_pubspec_yaml(yaml, &test_uri()).unwrap();
-        assert!(matches!(
-            result.dependencies[0].source,
-            DependencySource::Path { .. }
-        ));
+        assert_matches!(result.dependencies[0].source, DependencySource::Path { .. });
     }
 
     #[test]
@@ -368,10 +364,10 @@ dependency_overrides:
 ";
         let result = parse_pubspec_yaml(yaml, &test_uri()).unwrap();
         assert_eq!(result.dependencies.len(), 1);
-        assert!(matches!(
+        assert_matches!(
             result.dependencies[0].section,
             DependencySection::DependencyOverrides
-        ));
+        );
     }
 
     #[test]
@@ -490,10 +486,10 @@ dependencies:
     fn test_invalid_yaml() {
         let yaml = "{{invalid yaml";
         let result = parse_pubspec_yaml(yaml, &test_uri());
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DepsError::ParseError { file_type, .. }) if file_type == "pubspec.yaml"
-        ));
+        );
     }
 
     #[test]

--- a/crates/deps-dart/src/registry.rs
+++ b/crates/deps-dart/src/registry.rs
@@ -325,6 +325,8 @@ impl deps_core::Registry for PubDevRegistry {
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     #[test]
     fn test_package_url() {
         assert_eq!(package_url("provider"), "https://pub.dev/packages/provider");
@@ -569,14 +571,14 @@ mod tests {
         // this test.
         let registry = PubDevRegistry::new(Arc::new(HttpCache::new()));
         let err = registry.get_versions("..").await.unwrap_err();
-        assert!(matches!(err, DepsError::PackageNotFound { .. }));
+        assert_matches!(err, DepsError::PackageNotFound { .. });
     }
 
     #[tokio::test]
     async fn test_get_package_info_rejects_bare_dot_as_not_found() {
         let registry = PubDevRegistry::new(Arc::new(HttpCache::new()));
         let err = registry.get_package_info(".").await.unwrap_err();
-        assert!(matches!(err, DepsError::PackageNotFound { .. }));
+        assert_matches!(err, DepsError::PackageNotFound { .. });
     }
 
     // --- S2 (impl-critic): `search`'s inner per-result fetch (`entry.package`) was

--- a/crates/deps-dart/src/types.rs
+++ b/crates/deps-dart/src/types.rs
@@ -84,6 +84,7 @@ impl deps_core::Dependency for DartDependency {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
     use tower_lsp_server::ls_types::Position;
 
     fn test_dep(source: DependencySource) -> DartDependency {
@@ -100,35 +101,32 @@ mod tests {
 
     #[test]
     fn test_dependency_source_variants() {
-        assert!(matches!(
-            DependencySource::Registry,
-            DependencySource::Registry
-        ));
-        assert!(matches!(
+        assert_matches!(DependencySource::Registry, DependencySource::Registry);
+        assert_matches!(
             DependencySource::Git {
                 url: "u".into(),
                 rev: None
             },
             DependencySource::Git { .. }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             DependencySource::Path { path: "p".into() },
             DependencySource::Path { .. }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             DependencySource::Sdk {
                 sdk: "flutter".into()
             },
             DependencySource::Sdk { .. }
-        ));
+        );
     }
 
     #[test]
     fn test_dependency_section_default() {
-        assert!(matches!(
+        assert_matches!(
             DependencySection::default(),
             DependencySection::Dependencies
-        ));
+        );
     }
 
     #[test]
@@ -158,7 +156,7 @@ mod tests {
             sdk: "flutter".into(),
         });
         assert!(!dep.source().is_registry());
-        assert!(matches!(dep.source(), DependencySource::Sdk { sdk } if sdk == "flutter"));
+        assert_matches!(dep.source(), DependencySource::Sdk { sdk } if sdk == "flutter");
     }
 
     #[test]

--- a/crates/deps-deno/README.md
+++ b/crates/deps-deno/README.md
@@ -26,7 +26,7 @@ deps-deno = "0.12"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.91 or later.
+> Requires Rust 1.98 or later.
 
 ## Usage
 

--- a/crates/deps-deno/src/parser.rs
+++ b/crates/deps-deno/src/parser.rs
@@ -231,6 +231,8 @@ fn byte_range_to_lsp(content: &str, table: &LineOffsetTable, start: usize, end: 
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     fn test_uri() -> Uri {
         deps_core::test_util::test_uri("/test/deno.json")
     }
@@ -249,7 +251,7 @@ mod tests {
         let dep = &result.dependencies[0];
         assert_eq!(dep.name, "jsr:@std/fs");
         assert_eq!(dep.version_req, Some("^1.0".into()));
-        assert!(matches!(dep.section, DenoDependencySection::Imports));
+        assert_matches!(dep.section, DenoDependencySection::Imports);
     }
 
     #[test]
@@ -316,10 +318,10 @@ mod tests {
     fn test_parse_invalid_json_errors() {
         let json = "{ imports: not valid json !!!";
         let result = parse_deno_json(json, &test_uri());
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DepsError::ParseError { file_type, .. }) if file_type == "deno.json"
-        ));
+        );
     }
 
     #[test]

--- a/crates/deps-deno/src/registry.rs
+++ b/crates/deps-deno/src/registry.rs
@@ -539,6 +539,7 @@ mod tests {
     use super::*;
 
     use deps_core::test_util::capture_tracing_output_async;
+    use std::assert_matches;
 
     #[test]
     fn test_jsr_package_url() {
@@ -756,11 +757,11 @@ mod tests {
             status: 404,
         };
         let result = not_found_or(err, "@std/fs");
-        assert!(matches!(
+        assert_matches!(
             result,
             DepsError::PackageNotFound { package, registry }
                 if package == "@std/fs" && registry == REGISTRY
-        ));
+        );
     }
 
     #[test]
@@ -770,7 +771,7 @@ mod tests {
             status: 500,
         };
         let result = not_found_or(err, "@std/fs");
-        assert!(matches!(result, DepsError::HttpStatus { status: 500, .. }));
+        assert_matches!(result, DepsError::HttpStatus { status: 500, .. });
     }
 
     // --- M2/#312: "npm:" alone (partial_name_range's in-progress name, #310) must not
@@ -792,13 +793,13 @@ mod tests {
         let Err(err) = Registry::get_versions(&registry, &PackageName::new("npm:")).await else {
             panic!("expected an error for an empty npm: name");
         };
-        assert!(matches!(
+        assert_matches!(
             err,
             DepsError::PackageNotFound {
                 registry: "deno",
                 ..
             }
-        ));
+        );
     }
 
     #[tokio::test]
@@ -816,13 +817,13 @@ mod tests {
         else {
             panic!("expected an error for an empty npm: name");
         };
-        assert!(matches!(
+        assert_matches!(
             err,
             DepsError::PackageNotFound {
                 registry: "deno",
                 ..
             }
-        ));
+        );
     }
 
     #[tokio::test]
@@ -840,13 +841,13 @@ mod tests {
         else {
             panic!("expected an error for an empty npm: name");
         };
-        assert!(matches!(
+        assert_matches!(
             err,
             DepsError::PackageNotFound {
                 registry: "deno",
                 ..
             }
-        ));
+        );
     }
 
     /// #341: the `npm:` arm forwards the bare name straight to `NpmRegistry::get_versions`
@@ -914,22 +915,22 @@ mod tests {
         let registry = unreachable_jsr(Arc::new(HttpCache::new()));
 
         let err = registry.get_versions("std", "..").await.unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             DepsError::PackageNotFound {
                 registry: REGISTRY,
                 ..
             }
-        ));
+        );
 
         let err = registry.get_versions("std", ".").await.unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             DepsError::PackageNotFound {
                 registry: REGISTRY,
                 ..
             }
-        ));
+        );
     }
 
     #[tokio::test]
@@ -940,13 +941,13 @@ mod tests {
         let registry = unreachable_jsr(Arc::new(HttpCache::new()));
 
         let err = registry.get_versions("..", "pkg").await.unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             DepsError::PackageNotFound {
                 registry: REGISTRY,
                 ..
             }
-        ));
+        );
     }
 
     #[tokio::test]
@@ -987,13 +988,13 @@ mod tests {
         else {
             panic!("expected an error for a dot-prefixed jsr: package segment");
         };
-        assert!(matches!(
+        assert_matches!(
             err,
             DepsError::PackageNotFound {
                 registry: REGISTRY,
                 ..
             }
-        ));
+        );
 
         let Err(err) = Registry::get_versions_with(
             &registry,
@@ -1004,13 +1005,13 @@ mod tests {
         else {
             panic!("expected an error for a dot-prefixed jsr: package segment");
         };
-        assert!(matches!(
+        assert_matches!(
             err,
             DepsError::PackageNotFound {
                 registry: REGISTRY,
                 ..
             }
-        ));
+        );
 
         let Err(err) = Registry::get_latest_matching(
             &registry,
@@ -1021,13 +1022,13 @@ mod tests {
         else {
             panic!("expected an error for a dot-prefixed jsr: package segment");
         };
-        assert!(matches!(
+        assert_matches!(
             err,
             DepsError::PackageNotFound {
                 registry: REGISTRY,
                 ..
             }
-        ));
+        );
 
         mock.assert_async().await;
     }
@@ -1280,6 +1281,6 @@ mod tests {
             .get_versions("this-scope-does-not-exist-12345", "nope")
             .await
             .unwrap_err();
-        assert!(matches!(err, DepsError::PackageNotFound { .. }));
+        assert_matches!(err, DepsError::PackageNotFound { .. });
     }
 }

--- a/crates/deps-github-actions/README.md
+++ b/crates/deps-github-actions/README.md
@@ -45,7 +45,7 @@ deps-github-actions = "0.12"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.91 or later.
+> Requires Rust 1.98 or later.
 
 ## Usage
 

--- a/crates/deps-github-actions/src/parser.rs
+++ b/crates/deps-github-actions/src/parser.rs
@@ -616,6 +616,7 @@ pub fn parse_workflow_yaml(content: &str, uri: &Uri) -> Result<GithubActionsPars
 mod tests {
     use super::*;
     use deps_core::Dependency;
+    use std::assert_matches;
 
     fn test_uri() -> Uri {
         deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml")
@@ -838,7 +839,7 @@ mod tests {
         let dep = &result.dependencies[0];
         assert!(dep.version_range().is_none());
         assert!(dep.version_requirement().is_none());
-        assert!(matches!(dep.source(), DependencySource::Path { .. }));
+        assert_matches!(dep.source(), DependencySource::Path { .. });
     }
 
     #[test]
@@ -847,7 +848,7 @@ mod tests {
         let result = parse_workflow_yaml(content, &test_uri()).unwrap();
         let dep = &result.dependencies[0];
         assert!(dep.version_range().is_none());
-        assert!(matches!(dep.source(), DependencySource::Url { .. }));
+        assert_matches!(dep.source(), DependencySource::Url { .. });
     }
 
     #[test]
@@ -870,7 +871,7 @@ mod tests {
             dep.version_requirement().map(deps_core::VersionReq::as_str),
             Some("v3")
         );
-        assert!(matches!(dep.source(), DependencySource::Registry));
+        assert_matches!(dep.source(), DependencySource::Registry);
         // Critic S1 regression: `version_range` must span the ref (`v3`), not a
         // substring of the truncated subpath (`in`, from `codeql-action/**in**it@v3`)
         // — the bug the range assertion here is specifically for.
@@ -901,7 +902,7 @@ mod tests {
         assert_eq!(dep.name(), "octo-org/repo");
         assert!(dep.version_range().is_none());
         assert!(dep.version_requirement().is_none());
-        assert!(matches!(dep.source(), DependencySource::Url { .. }));
+        assert_matches!(dep.source(), DependencySource::Url { .. });
     }
 
     #[test]
@@ -1060,7 +1061,7 @@ mod tests {
         // `deps_core::parser`'s own gate tests.
         let payload = format!("{}1", "- ".repeat(deps_core::MAX_YAML_NESTING_DEPTH + 1));
         let result = parse_workflow_yaml(&payload, &test_uri());
-        assert!(matches!(result, Err(DepsError::ParseError { .. })));
+        assert_matches!(result, Err(DepsError::ParseError { .. }));
     }
 
     // --- classify_uses_value / ref classification unit coverage ---

--- a/crates/deps-github-actions/src/registry.rs
+++ b/crates/deps-github-actions/src/registry.rs
@@ -534,6 +534,8 @@ impl deps_core::Registry for GithubActionsRegistry {
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     #[test]
     fn test_parse_tags_response() {
         let sha1 = "a".repeat(40);
@@ -789,7 +791,7 @@ mod tests {
 
         let registry = mock_registry(&server.url(), false);
         let err = registry.get_versions("owner/missing").await.unwrap_err();
-        assert!(matches!(err, DepsError::PackageNotFound { .. }));
+        assert_matches!(err, DepsError::PackageNotFound { .. });
     }
 
     #[tokio::test]
@@ -829,10 +831,10 @@ mod tests {
         // `generate_diagnostics_from_cache`.
         let fetch_failed: HashMap<String, deps_core::error::FetchFailure> =
             HashMap::from([("owner/repo".to_string(), failure)]);
-        assert!(matches!(
+        assert_matches!(
             fetch_failed.get("owner/repo"),
             Some(deps_core::error::FetchFailure::Actionable(_))
-        ));
+        );
     }
 
     #[tokio::test]
@@ -968,7 +970,7 @@ mod tests {
             .get_versions("owner/private-repo")
             .await
             .unwrap_err();
-        assert!(matches!(err, DepsError::HttpStatus { status: 403, .. }));
+        assert_matches!(err, DepsError::HttpStatus { status: 403, .. });
         assert!(!registry.rate_limit.is_tripped());
     }
 
@@ -976,7 +978,7 @@ mod tests {
     async fn test_get_versions_rejects_invalid_owner_repo_with_zero_requests() {
         let registry = mock_registry("http://127.0.0.1:1", false);
         let err = registry.get_versions("../../etc/passwd").await.unwrap_err();
-        assert!(matches!(err, DepsError::InvalidUri(_)));
+        assert_matches!(err, DepsError::InvalidUri(_));
     }
 
     #[tokio::test]

--- a/crates/deps-go/README.md
+++ b/crates/deps-go/README.md
@@ -29,7 +29,7 @@ deps-go = "0.12"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.91 or later.
+> Requires Rust 1.98 or later.
 
 ## Usage
 

--- a/crates/deps-go/src/config.rs
+++ b/crates/deps-go/src/config.rs
@@ -935,6 +935,7 @@ fn resolve_at(
 mod tests {
     use super::*;
     use deps_core::net_policy::WorkspaceRegistryAccess;
+    use std::assert_matches;
 
     fn all_policy() -> RegistryAccessPolicy {
         RegistryAccessPolicy::new(WorkspaceRegistryAccess::All)
@@ -953,45 +954,45 @@ mod tests {
 
     #[test]
     fn test_proxy_url_rejects_http() {
-        assert!(matches!(
+        assert_matches!(
             GoProxyUrl::new("http://goproxy.mycorp.example", &all_policy()),
             Err(GoProxyUrlError::NotHttps(_))
-        ));
+        );
     }
 
     #[test]
     fn test_proxy_url_rejects_userinfo() {
-        assert!(matches!(
+        assert_matches!(
             GoProxyUrl::new("https://user:pass@goproxy.mycorp.example", &all_policy()),
             Err(GoProxyUrlError::UserInfoPresent)
-        ));
+        );
     }
 
     #[test]
     fn test_proxy_url_rejects_invalid() {
-        assert!(matches!(
+        assert_matches!(
             GoProxyUrl::new("not-a-valid-url", &all_policy()),
             Err(GoProxyUrlError::InvalidUrl(_))
-        ));
+        );
     }
 
     /// F3: a query string breaks the `{base}/{module}/@v/...` path-join convention every
     /// request URL builder relies on — rejected rather than silently mis-joined.
     #[test]
     fn test_proxy_url_rejects_query_string() {
-        assert!(matches!(
+        assert_matches!(
             GoProxyUrl::new("https://goproxy.mycorp.example/?tok=abc", &all_policy()),
             Err(GoProxyUrlError::InvalidUrl(_))
-        ));
+        );
     }
 
     /// F3: a fragment is rejected for the same path-join reason as a query string.
     #[test]
     fn test_proxy_url_rejects_fragment() {
-        assert!(matches!(
+        assert_matches!(
             GoProxyUrl::new("https://goproxy.mycorp.example/#frag", &all_policy()),
             Err(GoProxyUrlError::InvalidUrl(_))
-        ));
+        );
     }
 
     #[test]
@@ -1344,8 +1345,8 @@ mod tests {
         let chain = config.goproxy_chain().unwrap();
         assert_eq!(chain.key, index);
         assert_eq!(chain.hops.len(), 2);
-        assert!(matches!(chain.hops[0], GoProxyHop::Url(_)));
-        assert!(matches!(chain.hops[1], GoProxyHop::Direct));
+        assert_matches!(chain.hops[0], GoProxyHop::Url(_));
+        assert_matches!(chain.hops[1], GoProxyHop::Direct);
     }
 
     /// US-004: `GOPROXY=off` as sole entry.
@@ -1379,17 +1380,17 @@ mod tests {
         );
         let chain = config.goproxy_chain().unwrap();
         assert_eq!(chain.hops.len(), 1);
-        assert!(matches!(chain.hops[0], GoProxyHop::Url(_)));
+        assert_matches!(chain.hops[0], GoProxyHop::Url(_));
     }
 
     /// FR-011: a policy-blocked hop is treated the same as an invalid one.
     #[test]
     fn test_goproxy_policy_blocked_hop_fails_closed() {
         let config = GoEnvConfig::parse("GOPROXY=https://goproxy.mycorp.example", &off_policy());
-        assert!(matches!(
+        assert_matches!(
             config.resolve_source_for("github.com/gin-gonic/gin"),
             DependencySource::CustomRegistry { .. }
-        ));
+        );
     }
 
     /// FR-002: everything declared after a terminal `direct`/`off` hop is unreachable and
@@ -1402,7 +1403,7 @@ mod tests {
         );
         let chain = config.goproxy_chain().unwrap();
         assert_eq!(chain.hops.len(), 2);
-        assert!(matches!(chain.hops[1], GoProxyHop::Direct));
+        assert_matches!(chain.hops[1], GoProxyHop::Direct);
     }
 
     /// FR-002: pipe-separated entries parse the same as comma-separated ones.
@@ -1462,10 +1463,7 @@ mod tests {
         );
 
         let public_source = config.resolve_source_for("github.com/gin-gonic/gin");
-        assert!(matches!(
-            public_source,
-            DependencySource::AlternateRegistry { .. }
-        ));
+        assert_matches!(public_source, DependencySource::AlternateRegistry { .. });
         assert_ne!(private_source, public_source);
         assert!(config.has_goprivate());
     }
@@ -1541,7 +1539,7 @@ mod tests {
         );
         let chain = config.goproxy_chain().unwrap();
         assert_eq!(chain.hops.len(), 3);
-        assert!(matches!(chain.hops[2], GoProxyHop::Direct));
+        assert_matches!(chain.hops[2], GoProxyHop::Direct);
         assert_eq!(
             chain.separators,
             vec![ChainSeparator::AnyError, ChainSeparator::NotFoundOnly]

--- a/crates/deps-go/src/ecosystem.rs
+++ b/crates/deps-go/src/ecosystem.rs
@@ -19,6 +19,7 @@ use crate::registry::GoRegistry;
 
 /// The source(s) a `CompletionContext::Version`'s bare `package_name` joins back to within a
 /// manifest's already-parsed dependencies (spec 034 F1).
+#[derive(Debug)]
 enum CompletionSource {
     /// No dependency in the manifest has this exact name yet — most commonly because the
     /// user is still typing a brand-new dependency line. Callers fall back to the
@@ -269,6 +270,7 @@ mod tests {
     use super::*;
     use crate::types::{GoDependency, GoDirective};
     use deps_core::{Dependency, EcosystemConfig, PackageVersions, VersionData};
+    use std::assert_matches;
     use std::collections::HashMap;
     use tower_lsp_server::ls_types::{InlayHintLabel, Position, Range};
 
@@ -906,10 +908,10 @@ require github.com/gin-gonic/gin v1.9.1
     #[test]
     fn test_resolve_completion_source_not_in_manifest() {
         let parse_result = empty_parse_result();
-        assert!(matches!(
+        assert_matches!(
             resolve_completion_source(&parse_result, &pkg("github.com/gin-gonic/gin")),
             CompletionSource::NotInManifest
-        ));
+        );
     }
 
     #[test]
@@ -921,10 +923,10 @@ require github.com/gin-gonic/gin v1.9.1
             )],
             uri: deps_core::test_util::test_uri("/test/go.mod"),
         };
-        assert!(matches!(
+        assert_matches!(
             resolve_completion_source(&parse_result, &pkg("github.com/gin-gonic/gin")),
             CompletionSource::Resolved(DependencySource::Registry)
-        ));
+        );
     }
 
     /// Two occurrences of the same name resolving to different sources must not pick either
@@ -944,10 +946,10 @@ require github.com/gin-gonic/gin v1.9.1
             ],
             uri: deps_core::test_util::test_uri("/test/go.mod"),
         };
-        assert!(matches!(
+        assert_matches!(
             resolve_completion_source(&parse_result, &pkg("git.mycorp.example/pkg")),
             CompletionSource::Ambiguous
-        ));
+        );
     }
 
     #[tokio::test]

--- a/crates/deps-go/src/registry.rs
+++ b/crates/deps-go/src/registry.rs
@@ -894,6 +894,8 @@ impl deps_core::Registry for GoRegistry {
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     #[test]
     fn test_parse_version_list() {
         let data = b"v1.0.0\nv1.0.1\nv1.1.0\nv2.0.0\n";
@@ -1003,11 +1005,11 @@ mod tests {
             status: 404,
         };
         let result = not_found_or(err, "github.com/x/y");
-        assert!(matches!(
+        assert_matches!(
             result,
             DepsError::PackageNotFound { package, registry }
                 if package == "github.com/x/y" && registry == REGISTRY
-        ));
+        );
     }
 
     #[test]
@@ -1017,7 +1019,7 @@ mod tests {
             status: 500,
         };
         let result = not_found_or(err, "github.com/x/y");
-        assert!(matches!(result, DepsError::HttpStatus { status: 500, .. }));
+        assert_matches!(result, DepsError::HttpStatus { status: 500, .. });
     }
 
     /// C1: a `410 Gone` response (Athens/Artifactory/Nexus/GitLab's not-found status) maps to
@@ -1029,11 +1031,11 @@ mod tests {
             status: 410,
         };
         let result = not_found_or(err, "github.com/x/y");
-        assert!(matches!(
+        assert_matches!(
             result,
             DepsError::PackageNotFound { package, registry }
                 if package == "github.com/x/y" && registry == REGISTRY
-        ));
+        );
     }
 
     #[test]
@@ -1214,7 +1216,7 @@ mod tests {
             .get_versions("github.com/user/..")
             .await
             .unwrap_err();
-        assert!(matches!(err, DepsError::InvalidVersionReq(_)));
+        assert_matches!(err, DepsError::InvalidVersionReq(_));
     }
 
     #[tokio::test]
@@ -1337,7 +1339,7 @@ mod tests {
         let long_path = "a".repeat(MAX_MODULE_PATH_LENGTH + 1);
         let result = validate_module_path(&long_path);
         assert!(result.is_err());
-        assert!(matches!(result, Err(DepsError::InvalidVersionReq(_))));
+        assert_matches!(result, Err(DepsError::InvalidVersionReq(_)));
     }
 
     #[test]
@@ -1350,14 +1352,14 @@ mod tests {
     fn test_validate_module_path_rejects_bare_dot_dot_segment() {
         let result = validate_module_path("github.com/user/..");
         assert!(result.is_err());
-        assert!(matches!(result, Err(DepsError::InvalidVersionReq(_))));
+        assert_matches!(result, Err(DepsError::InvalidVersionReq(_)));
     }
 
     #[test]
     fn test_validate_module_path_rejects_bare_dot_segment() {
         let result = validate_module_path("./evil");
         assert!(result.is_err());
-        assert!(matches!(result, Err(DepsError::InvalidVersionReq(_))));
+        assert_matches!(result, Err(DepsError::InvalidVersionReq(_)));
     }
 
     #[test]
@@ -1407,14 +1409,14 @@ mod tests {
         let long_version = "v".to_string() + &"1".repeat(MAX_VERSION_LENGTH);
         let result = validate_version_string(&long_version);
         assert!(result.is_err());
-        assert!(matches!(result, Err(DepsError::InvalidVersionReq(_))));
+        assert_matches!(result, Err(DepsError::InvalidVersionReq(_)));
     }
 
     #[test]
     fn test_validate_version_string_path_traversal() {
         let result = validate_version_string("v1.0.0/../etc/passwd");
         assert!(result.is_err());
-        assert!(matches!(result, Err(DepsError::InvalidVersionReq(_))));
+        assert_matches!(result, Err(DepsError::InvalidVersionReq(_)));
     }
 
     #[test]
@@ -1756,7 +1758,7 @@ mod tests {
                 FreshnessSettings::default(),
             )
             .await;
-        assert!(matches!(result, Err(DepsError::ChainResolutionHalted)));
+        assert_matches!(result.err(), Some(DepsError::ChainResolutionHalted));
         hop1_mock.assert_async().await;
     }
 
@@ -1889,7 +1891,7 @@ mod tests {
                 FreshnessSettings::default(),
             )
             .await;
-        assert!(matches!(result, Err(DepsError::PackageNotFound { .. })));
+        assert_matches!(result.err(), Some(DepsError::PackageNotFound { .. }));
     }
 
     /// SC-002 (issue #559 follow-up): a `GOPRIVATE`-matched module's resolved source routes
@@ -1938,7 +1940,7 @@ mod tests {
                 FreshnessSettings::default(),
             )
             .await;
-        assert!(matches!(result, Err(DepsError::PackageNotFound { .. })));
+        assert_matches!(result.err(), Some(DepsError::PackageNotFound { .. }));
         public_mock.assert_async().await;
     }
 
@@ -1967,7 +1969,7 @@ mod tests {
                 FreshnessSettings::default(),
             )
             .await;
-        assert!(matches!(result, Err(DepsError::PackageNotFound { .. })));
+        assert_matches!(result.err(), Some(DepsError::PackageNotFound { .. }));
     }
 
     /// An `AlternateRegistry` source whose index has no registered client is
@@ -1990,13 +1992,13 @@ mod tests {
                 FreshnessSettings::default(),
             )
             .await;
-        assert!(matches!(
-            result,
-            Err(DepsError::PackageNotFound {
+        assert_matches!(
+            result.err(),
+            Some(DepsError::PackageNotFound {
                 registry: "alternate registry (not registered)",
                 ..
             })
-        ));
+        );
     }
 
     /// FR-013: `get_latest_matching_from` routes an `AlternateRegistry` source to the

--- a/crates/deps-go/src/types.rs
+++ b/crates/deps-go/src/types.rs
@@ -150,6 +150,7 @@ mod tests {
     use super::*;
     use deps_core::ecosystem::Dependency;
     use deps_core::registry::{Metadata, Version};
+    use std::assert_matches;
     use tower_lsp_server::ls_types::Position;
 
     #[test]
@@ -169,7 +170,7 @@ mod tests {
             dep.version_requirement().map(deps_core::VersionReq::as_str),
             Some("v1.9.1")
         );
-        assert!(matches!(dep.source(), DependencySource::Registry));
+        assert_matches!(dep.source(), DependencySource::Registry);
         assert_eq!(dep.features().len(), 0);
     }
 

--- a/crates/deps-gradle/README.md
+++ b/crates/deps-gradle/README.md
@@ -31,7 +31,7 @@ deps-gradle = "0.12"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.91 or later.
+> Requires Rust 1.98 or later.
 
 ## Usage
 

--- a/crates/deps-gradle/src/parser/catalog.rs
+++ b/crates/deps-gradle/src/parser/catalog.rs
@@ -162,6 +162,8 @@ fn span_to_range(content: &str, line_table: &LineOffsetTable, span: toml_span::S
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     fn make_uri() -> Uri {
         deps_core::test_util::test_uri("/project/gradle/libs.versions.toml")
     }
@@ -173,10 +175,10 @@ mod tests {
         // being exercised here, not the crash itself.
         let content = format!("a = {}1{}", "[".repeat(300), "]".repeat(300));
         let result = parse_version_catalog(&content, &make_uri());
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DepsError::ParseError { file_type, .. }) if file_type == "Gradle"
-        ));
+        );
     }
 
     #[test]

--- a/crates/deps-gradle/src/parser/mod.rs
+++ b/crates/deps-gradle/src/parser/mod.rs
@@ -16,6 +16,7 @@ use tower_lsp_server::ls_types::{Position, Range, Uri};
 
 pub use deps_core::lsp_helpers::LineOffsetTable;
 
+#[derive(Debug)]
 pub struct GradleParseResult {
     pub dependencies: Vec<GradleDependency>,
     pub uri: Uri,
@@ -39,7 +40,7 @@ pub fn resolve_variables(deps: &mut [GradleDependency], properties: &HashMap<Str
 /// Returns the resolved value if `value` is a `$name` or `${name}` reference. Returns `None` otherwise.
 fn resolve_variable_ref(value: &str, properties: &HashMap<String, String>) -> Option<String> {
     let trimmed = value.trim();
-    if let Some(name) = trimmed.strip_prefix("${").and_then(|s| s.strip_suffix('}')) {
+    if let Some(name) = trimmed.strip_circumfix("${", '}') {
         properties.get(name).cloned()
     } else if let Some(name) = trimmed.strip_prefix('$') {
         properties.get(name).cloned()

--- a/crates/deps-gradle/src/types.rs
+++ b/crates/deps-gradle/src/types.rs
@@ -51,6 +51,7 @@ impl deps_core::Dependency for GradleDependency {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
     use tower_lsp_server::ls_types::Position;
 
     fn test_dep() -> GradleDependency {
@@ -77,10 +78,7 @@ mod tests {
         );
         assert!(dep.features().is_empty());
         assert!(dep.as_any().is::<GradleDependency>());
-        assert!(matches!(
-            dep.source(),
-            deps_core::parser::DependencySource::Registry
-        ));
+        assert_matches!(dep.source(), deps_core::parser::DependencySource::Registry);
     }
 
     #[test]
@@ -90,10 +88,7 @@ mod tests {
         let dep = test_dep();
         assert_eq!(dep.name(), "org.springframework.boot:spring-boot-starter");
         assert!(dep.version_range().is_some());
-        assert!(matches!(
-            dep.source(),
-            deps_core::parser::DependencySource::Registry
-        ));
+        assert_matches!(dep.source(), deps_core::parser::DependencySource::Registry);
     }
 
     #[test]

--- a/crates/deps-lsp/README.md
+++ b/crates/deps-lsp/README.md
@@ -31,7 +31,7 @@ cargo install deps-lsp
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.91 or later.
+> Requires Rust 1.98 or later.
 
 ## Usage
 

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -2684,6 +2684,7 @@ pub async fn ensure_document_loaded(
 mod tests {
     use super::*;
     use deps_core::parser::DependencySource;
+    use std::assert_matches;
 
     /// Pairs every name with the plain `Registry` source — the shape every pre-existing
     /// `fetch_latest_versions_parallel` test used before that function became source-aware
@@ -6065,10 +6066,7 @@ time = "0.1.43"
             state.update_document(uri.clone(), doc_state2);
 
             let doc = state.get_document(&uri).unwrap();
-            assert!(matches!(
-                doc.vulnerabilities.get("time"),
-                Some(ScanOutcome::Clean)
-            ));
+            assert_matches!(doc.vulnerabilities.get("time"), Some(ScanOutcome::Clean));
         }
 
         #[tokio::test]
@@ -7546,10 +7544,10 @@ tokio = "1.0"
             let (targets, skipped) =
                 build_scan_targets(&parse_result, &resolved, &MockFormatter, EcosystemId::Cargo);
             assert!(targets.is_empty());
-            assert!(matches!(
+            assert_matches!(
                 skipped.get("time"),
                 Some(ScanOutcome::Skipped(SkipReason::NonRegistrySource))
-            ));
+            );
         }
 
         #[test]
@@ -7791,10 +7789,10 @@ tokio = "1.0"
             let (targets, skipped) =
                 build_scan_targets(&parse_result, &resolved, &MockFormatter, EcosystemId::Cargo);
             assert!(targets.is_empty());
-            assert!(matches!(
+            assert_matches!(
                 skipped.get("serde"),
                 Some(ScanOutcome::Skipped(SkipReason::NoConcreteVersion))
-            ));
+            );
         }
 
         #[test]
@@ -7811,10 +7809,10 @@ tokio = "1.0"
             let (targets, skipped) =
                 build_scan_targets(&parse_result, &resolved, &MockFormatter, EcosystemId::Cargo);
             assert!(targets.is_empty());
-            assert!(matches!(
+            assert_matches!(
                 skipped.get("serde"),
                 Some(ScanOutcome::Skipped(SkipReason::NoConcreteVersion))
-            ));
+            );
         }
 
         #[test]
@@ -7853,10 +7851,10 @@ tokio = "1.0"
                     EcosystemId::Cargo,
                 );
                 assert!(targets.is_empty(), "{source:?} must be skipped (step 0)");
-                assert!(matches!(
+                assert_matches!(
                     skipped.get("pkg"),
                     Some(ScanOutcome::Skipped(SkipReason::NonRegistrySource))
-                ));
+                );
             }
         }
 
@@ -7894,14 +7892,14 @@ tokio = "1.0"
             assert_eq!(targets.len(), 1);
             assert_eq!(targets[0].key, "concrete");
             assert_eq!(skipped.len(), 2);
-            assert!(matches!(
+            assert_matches!(
                 skipped.get("range-only"),
                 Some(ScanOutcome::Skipped(SkipReason::NoConcreteVersion))
-            ));
-            assert!(matches!(
+            );
+            assert_matches!(
                 skipped.get("git-dep"),
                 Some(ScanOutcome::Skipped(SkipReason::NonRegistrySource))
-            ));
+            );
         }
 
         // `collect_in_use_versions` (§4.6) reuses the same `in_use_version`

--- a/crates/deps-lsp/src/document/state.rs
+++ b/crates/deps-lsp/src/document/state.rs
@@ -781,6 +781,8 @@ impl Default for ServerState {
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     // =========================================================================
     // Generic tests (no feature flag required)
     // =========================================================================
@@ -940,13 +942,13 @@ mod tests {
             }
 
             let doc = state.get_document(&uri).unwrap();
-            assert!(matches!(
+            assert_matches!(
                 doc.loading_state,
                 LoadingState::Idle
                     | LoadingState::Loading
                     | LoadingState::Loaded
                     | LoadingState::Failed
-            ));
+            );
         }
 
         #[test]

--- a/crates/deps-lsp/src/server.rs
+++ b/crates/deps-lsp/src/server.rs
@@ -1015,6 +1015,8 @@ fn build_update_all_outdated_edit(
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     #[test]
     fn test_server_capabilities() {
         let caps = Backend::server_capabilities();
@@ -1677,7 +1679,7 @@ mod tests {
                 .create_async()
                 .await;
             let result = backend.state.cache.get_cached(&url).await;
-            assert!(matches!(result, Err(deps_core::DepsError::Offline { .. })));
+            assert_matches!(result, Err(deps_core::DepsError::Offline { .. }));
             blocked_mock.assert_async().await;
 
             backend

--- a/crates/deps-maven/README.md
+++ b/crates/deps-maven/README.md
@@ -28,7 +28,7 @@ deps-maven = "0.12"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.91 or later.
+> Requires Rust 1.98 or later.
 
 ## Usage
 

--- a/crates/deps-maven/src/parser.rs
+++ b/crates/deps-maven/src/parser.rs
@@ -12,6 +12,7 @@ use std::any::Any;
 use std::collections::HashMap;
 use tower_lsp_server::ls_types::{Range, Uri};
 
+#[derive(Debug)]
 pub struct MavenParseResult {
     pub dependencies: Vec<MavenDependency>,
     pub properties: HashMap<String, String>,
@@ -330,6 +331,8 @@ impl deps_core::ParseResult for MavenParseResult {
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     fn test_uri() -> Uri {
         #[cfg(windows)]
         let path = "C:/test/pom.xml";
@@ -358,7 +361,7 @@ mod tests {
         assert_eq!(dep.artifact_id, "commons-lang3");
         assert_eq!(dep.name, "org.apache.commons:commons-lang3");
         assert_eq!(dep.version_req, Some("3.14.0".into()));
-        assert!(matches!(dep.scope, MavenScope::Compile));
+        assert_matches!(dep.scope, MavenScope::Compile);
     }
 
     #[test]
@@ -383,7 +386,7 @@ mod tests {
         assert_eq!(result.dependencies.len(), 2);
         assert_eq!(result.dependencies[0].name, "com.google.guava:guava");
         assert_eq!(result.dependencies[1].name, "junit:junit");
-        assert!(matches!(result.dependencies[1].scope, MavenScope::Test));
+        assert_matches!(result.dependencies[1].scope, MavenScope::Test);
     }
 
     #[test]
@@ -408,7 +411,7 @@ mod tests {
             result.dependencies[0].name,
             "org.springframework.boot:spring-boot-dependencies"
         );
-        assert!(matches!(result.dependencies[0].scope, MavenScope::Import));
+        assert_matches!(result.dependencies[0].scope, MavenScope::Import);
     }
 
     #[test]
@@ -451,8 +454,8 @@ mod tests {
 </project>";
 
         let result = parse_pom_xml(xml, &test_uri()).unwrap();
-        assert!(matches!(result.dependencies[0].scope, MavenScope::Runtime));
-        assert!(matches!(result.dependencies[1].scope, MavenScope::Provided));
+        assert_matches!(result.dependencies[0].scope, MavenScope::Runtime);
+        assert_matches!(result.dependencies[1].scope, MavenScope::Provided);
     }
 
     #[test]
@@ -567,10 +570,10 @@ mod tests {
         // Malformed attribute triggers a hard error
         let xml2 = r#"<project attr="unclosed></project>"#;
         let result2 = parse_pom_xml(xml2, &test_uri());
-        assert!(matches!(
+        assert_matches!(
             result2,
             Err(DepsError::ParseError { file_type, .. }) if file_type == "pom.xml"
-        ));
+        );
     }
 
     #[test]

--- a/crates/deps-maven/src/registry.rs
+++ b/crates/deps-maven/src/registry.rs
@@ -953,6 +953,8 @@ impl deps_core::Registry for MavenCentralRegistry {
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     #[test]
     fn test_repo_base_for_group_central() {
         assert_eq!(repo_base_for_group("org.apache.commons"), MAVEN_REPO_BASE);
@@ -2296,7 +2298,7 @@ mod tests {
             .get_versions_typed("com.example:..")
             .await
             .expect_err("dot-segment artifactId must be rejected");
-        assert!(matches!(err, DepsError::PackageNotFound { .. }));
+        assert_matches!(err, DepsError::PackageNotFound { .. });
         assert!(err.is_not_found());
     }
 

--- a/crates/deps-maven/src/types.rs
+++ b/crates/deps-maven/src/types.rs
@@ -148,6 +148,7 @@ impl deps_core::Metadata for ArtifactInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
     use tower_lsp_server::ls_types::Position;
 
     fn test_dep() -> MavenDependency {
@@ -165,40 +166,31 @@ mod tests {
     #[test]
     fn test_scope_variants() {
         use std::str::FromStr;
-        assert!(matches!(
-            "test".parse::<MavenScope>().unwrap(),
-            MavenScope::Test
-        ));
-        assert!(matches!(
+        assert_matches!("test".parse::<MavenScope>().unwrap(), MavenScope::Test);
+        assert_matches!(
             "runtime".parse::<MavenScope>().unwrap(),
             MavenScope::Runtime
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             "provided".parse::<MavenScope>().unwrap(),
             MavenScope::Provided
-        ));
-        assert!(matches!(
-            "system".parse::<MavenScope>().unwrap(),
-            MavenScope::System
-        ));
-        assert!(matches!(
-            "import".parse::<MavenScope>().unwrap(),
-            MavenScope::Import
-        ));
-        assert!(matches!(
+        );
+        assert_matches!("system".parse::<MavenScope>().unwrap(), MavenScope::System);
+        assert_matches!("import".parse::<MavenScope>().unwrap(), MavenScope::Import);
+        assert_matches!(
             "compile".parse::<MavenScope>().unwrap(),
             MavenScope::Compile
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             "unknown".parse::<MavenScope>().unwrap(),
             MavenScope::Compile
-        ));
+        );
         let _ = MavenScope::from_str; // ensure trait is accessible
     }
 
     #[test]
     fn test_scope_default() {
-        assert!(matches!(MavenScope::default(), MavenScope::Compile));
+        assert_matches!(MavenScope::default(), MavenScope::Compile);
     }
 
     #[test]
@@ -213,10 +205,7 @@ mod tests {
         );
         assert!(dep.features().is_empty());
         assert!(dep.as_any().is::<MavenDependency>());
-        assert!(matches!(
-            dep.source(),
-            deps_core::parser::DependencySource::Registry
-        ));
+        assert_matches!(dep.source(), deps_core::parser::DependencySource::Registry);
     }
 
     #[test]
@@ -226,10 +215,7 @@ mod tests {
         let dep = test_dep();
         assert_eq!(dep.name(), "org.apache.commons:commons-lang3");
         assert!(dep.version_range().is_some());
-        assert!(matches!(
-            dep.source(),
-            deps_core::parser::DependencySource::Registry
-        ));
+        assert_matches!(dep.source(), deps_core::parser::DependencySource::Registry);
     }
 
     #[test]

--- a/crates/deps-maven/tests/integration_tests.rs
+++ b/crates/deps-maven/tests/integration_tests.rs
@@ -1,6 +1,7 @@
 //! Integration tests using fixture files.
 
 use deps_maven::parse_pom_xml;
+use std::assert_matches;
 use tower_lsp_server::ls_types::Uri;
 
 fn fixture_uri(name: &str) -> Uri {
@@ -92,14 +93,11 @@ fn test_fixture_scoped_deps() {
         .map(|d| (d.artifact_id.clone(), &d.scope))
         .collect();
 
-    assert!(matches!(by_scope["commons-lang3"], MavenScope::Compile));
-    assert!(matches!(by_scope["junit"], MavenScope::Test));
-    assert!(matches!(by_scope["logback-classic"], MavenScope::Runtime));
-    assert!(matches!(
-        by_scope["javax.servlet-api"],
-        MavenScope::Provided
-    ));
-    assert!(matches!(by_scope["tools"], MavenScope::System));
+    assert_matches!(by_scope["commons-lang3"], MavenScope::Compile);
+    assert_matches!(by_scope["junit"], MavenScope::Test);
+    assert_matches!(by_scope["logback-classic"], MavenScope::Runtime);
+    assert_matches!(by_scope["javax.servlet-api"], MavenScope::Provided);
+    assert_matches!(by_scope["tools"], MavenScope::System);
 }
 
 #[test]

--- a/crates/deps-npm/README.md
+++ b/crates/deps-npm/README.md
@@ -29,7 +29,7 @@ deps-npm = "0.12"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.91 or later.
+> Requires Rust 1.98 or later.
 
 ## Usage
 

--- a/crates/deps-npm/src/catalog.rs
+++ b/crates/deps-npm/src/catalog.rs
@@ -573,6 +573,7 @@ pub fn apply(deps: &mut [NpmDependency], config: Option<&PnpmWorkspaceConfig>) {
 mod tests {
     use super::*;
     use crate::types::NpmDependencySection;
+    use std::assert_matches;
     use tower_lsp_server::ls_types::Range;
 
     fn dep(name: &str, version_req: &str) -> NpmDependency {
@@ -632,10 +633,10 @@ mod tests {
         apply(&mut deps, config.as_deref());
 
         assert_eq!(deps[0].version_req, Some("^18.3.0".into()));
-        assert!(matches!(
+        assert_matches!(
             deps[0].catalog.as_ref().unwrap().outcome,
             CatalogOutcome::Resolved(ref r) if r == "^18.3.0"
-        ));
+        );
     }
 
     #[test]

--- a/crates/deps-npm/src/config.rs
+++ b/crates/deps-npm/src/config.rs
@@ -530,6 +530,7 @@ fn resolve_with_home(
 mod tests {
     use super::*;
     use deps_core::net_policy::WorkspaceRegistryAccess;
+    use std::assert_matches;
     use std::time::SystemTime;
 
     fn public_only_policy() -> RegistryAccessPolicy {
@@ -559,10 +560,10 @@ mod tests {
     #[test]
     fn test_npm_registry_index_rejects_http_non_loopback() {
         let policy = all_policy();
-        assert!(matches!(
+        assert_matches!(
             NpmRegistryIndex::new("http://registry.example.com", &policy),
             Err(NpmRegistryIndexError::NotHttps(_))
-        ));
+        );
     }
 
     /// N-C1: even under the `cfg(test)`/`test-util` carve-out, a *non-loopback* `http` host
@@ -570,10 +571,10 @@ mod tests {
     #[test]
     fn test_npm_registry_index_rejects_http_near_miss_loopback() {
         let policy = all_policy();
-        assert!(matches!(
+        assert_matches!(
             NpmRegistryIndex::new("http://localhost.evil.com", &policy),
             Err(NpmRegistryIndexError::NotHttps(_))
-        ));
+        );
     }
 
     #[test]
@@ -586,19 +587,19 @@ mod tests {
     #[test]
     fn test_npm_registry_index_rejects_userinfo() {
         let policy = all_policy();
-        assert!(matches!(
+        assert_matches!(
             NpmRegistryIndex::new("https://user:pass@npm.example", &policy),
             Err(NpmRegistryIndexError::UserInfoPresent)
-        ));
+        );
     }
 
     #[test]
     fn test_npm_registry_index_rejects_invalid_url() {
         let policy = all_policy();
-        assert!(matches!(
+        assert_matches!(
             NpmRegistryIndex::new("not-a-valid-url", &policy),
             Err(NpmRegistryIndexError::InvalidUrl(_))
-        ));
+        );
     }
 
     /// S5: `https://x/` and `https://x` normalize to one index, and neither carries a
@@ -618,14 +619,14 @@ mod tests {
     #[test]
     fn test_npm_registry_index_policy_matrix() {
         assert!(NpmRegistryIndex::new("https://127.0.0.1:4873", &all_policy()).is_ok());
-        assert!(matches!(
+        assert_matches!(
             NpmRegistryIndex::new("https://127.0.0.1:4873", &public_only_policy()),
             Err(NpmRegistryIndexError::BlockedHost { .. })
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             NpmRegistryIndex::new("https://127.0.0.1:4873", &off_policy()),
             Err(NpmRegistryIndexError::BlockedHost { .. })
-        ));
+        );
     }
 
     #[test]
@@ -750,13 +751,13 @@ mod tests {
     fn test_resolve_entry_undefined_var_is_invalid() {
         let policy = all_policy();
         let result = resolve_entry("${UNDEFINED_VAR}", &policy);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(InvalidEntry {
                 reason: NpmRegistryIndexError::UndefinedEnvVar(_),
                 ..
             })
-        ));
+        );
         assert_eq!(result.unwrap_err().raw, "${UNDEFINED_VAR}");
     }
 
@@ -782,7 +783,7 @@ mod tests {
         let log = deps_core::test_util::capture_tracing_output(|| {
             let err = NpmRegistryIndex::new_for_log(expanded_secret, raw_placeholder, &policy)
                 .unwrap_err();
-            assert!(matches!(err, NpmRegistryIndexError::BlockedHost { .. }));
+            assert_matches!(err, NpmRegistryIndexError::BlockedHost { .. });
         });
 
         assert!(
@@ -819,10 +820,7 @@ mod tests {
         let policy = all_policy();
         let log = deps_core::test_util::capture_tracing_output(|| {
             let invalid = resolve_entry("https://user:hunter2@npm.example/", &policy).unwrap_err();
-            assert!(matches!(
-                invalid.reason,
-                NpmRegistryIndexError::UserInfoPresent
-            ));
+            assert_matches!(invalid.reason, NpmRegistryIndexError::UserInfoPresent);
             assert!(
                 !invalid.raw.contains("hunter2"),
                 "InvalidEntry::raw leaked the credential: {}",
@@ -855,10 +853,7 @@ mod tests {
         let log = deps_core::test_util::capture_tracing_output(|| {
             let invalid =
                 resolve_entry("https://user:hunter2@npm.example:99999/", &policy).unwrap_err();
-            assert!(matches!(
-                invalid.reason,
-                NpmRegistryIndexError::InvalidUrl(_)
-            ));
+            assert_matches!(invalid.reason, NpmRegistryIndexError::InvalidUrl(_));
             assert!(
                 !invalid.raw.contains("hunter2"),
                 "InvalidEntry::raw leaked the credential: {}",

--- a/crates/deps-npm/src/ecosystem.rs
+++ b/crates/deps-npm/src/ecosystem.rs
@@ -23,6 +23,7 @@ use crate::types::NpmDependency;
 
 /// The source(s) a `CompletionContext::Version`'s bare `package_name` joins back to within a
 /// manifest's already-parsed dependencies (spec FR-017).
+#[derive(Debug)]
 enum CompletionSource {
     /// No dependency in the manifest has this exact name yet — most commonly because the
     /// user is still typing a brand-new dependency line. Callers fall back to the
@@ -391,6 +392,7 @@ fn catalog_diagnostics(
 mod tests {
     use super::*;
     use deps_core::{EcosystemConfig, VersionData};
+    use std::assert_matches;
     use std::collections::HashMap;
 
     fn pkg(s: &str) -> deps_core::PackageName {
@@ -983,10 +985,10 @@ mod tests {
     #[test]
     fn test_resolve_completion_source_not_in_manifest() {
         let parse_result = empty_parse_result();
-        assert!(matches!(
+        assert_matches!(
             resolve_completion_source(&parse_result, &pkg("express")),
             CompletionSource::NotInManifest
-        ));
+        );
     }
 
     #[test]
@@ -994,10 +996,10 @@ mod tests {
         let parse_result = MockParseResult {
             dependencies: vec![dep_with_source("express", DependencySource::Registry)],
         };
-        assert!(matches!(
+        assert_matches!(
             resolve_completion_source(&parse_result, &pkg("express")),
             CompletionSource::Resolved(DependencySource::Registry)
-        ));
+        );
     }
 
     /// Two occurrences of the same name resolving to different sources must not pick either
@@ -1016,10 +1018,10 @@ mod tests {
                 ),
             ],
         };
-        assert!(matches!(
+        assert_matches!(
             resolve_completion_source(&parse_result, &pkg("@myorg/pkg")),
             CompletionSource::Ambiguous
-        ));
+        );
     }
 
     #[tokio::test]

--- a/crates/deps-npm/src/parser.rs
+++ b/crates/deps-npm/src/parser.rs
@@ -300,6 +300,8 @@ fn find_dependency_positions(
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     fn test_uri() -> Uri {
         deps_core::test_util::test_uri("/test/package.json")
     }
@@ -319,10 +321,7 @@ mod tests {
         let express = &result.dependencies[0];
         assert_eq!(express.name, "express");
         assert_eq!(express.version_req, Some("^4.18.2".into()));
-        assert!(matches!(
-            express.section,
-            NpmDependencySection::Dependencies
-        ));
+        assert_matches!(express.section, NpmDependencySection::Dependencies);
 
         let lodash = &result.dependencies[1];
         assert_eq!(lodash.name, "lodash");
@@ -359,10 +358,10 @@ mod tests {
 
         let result = parse_package_json(json, &test_uri()).unwrap();
         assert_eq!(result.dependencies.len(), 1);
-        assert!(matches!(
+        assert_matches!(
             result.dependencies[0].section,
             NpmDependencySection::PeerDependencies
-        ));
+        );
     }
 
     #[test]
@@ -375,10 +374,10 @@ mod tests {
 
         let result = parse_package_json(json, &test_uri()).unwrap();
         assert_eq!(result.dependencies.len(), 1);
-        assert!(matches!(
+        assert_matches!(
             result.dependencies[0].section,
             NpmDependencySection::OptionalDependencies
-        ));
+        );
     }
 
     #[test]
@@ -435,7 +434,7 @@ mod tests {
     fn test_parse_invalid_json() {
         let json = "{ invalid json }";
         let result = parse_package_json(json, &test_uri());
-        assert!(matches!(result, Err(deps_core::DepsError::Json(_))));
+        assert_matches!(result, Err(deps_core::DepsError::Json(_)));
     }
 
     #[test]
@@ -447,7 +446,7 @@ mod tests {
         let depth = deps_core::MAX_JSON_NESTING_DEPTH + 1;
         let json = format!("{}1{}", "[".repeat(depth), "]".repeat(depth));
         let result = parse_package_json(&json, &test_uri());
-        assert!(matches!(result, Err(deps_core::DepsError::Json(_))));
+        assert_matches!(result, Err(deps_core::DepsError::Json(_)));
     }
 
     #[test]
@@ -827,10 +826,10 @@ mod tests {
         let ctx = NpmParseContext::default(); // default policy is `public_only`
         let result = parse_package_json_with_context(json, &uri, &ctx).unwrap();
 
-        assert!(matches!(
+        assert_matches!(
             &result.dependencies[0].source,
             deps_core::parser::DependencySource::CustomRegistry { .. }
-        ));
+        );
     }
 
     // --- pnpm catalogs (spec 046) ---
@@ -858,10 +857,10 @@ mod tests {
 
         let react = &result.dependencies[0];
         assert_eq!(react.version_req, None);
-        assert!(matches!(
+        assert_matches!(
             react.catalog.as_ref().map(|origin| &origin.outcome),
             Some(crate::catalog::CatalogOutcome::NoWorkspaceFile)
-        ));
+        );
     }
 
     /// A companion regression for a virtual-filesystem URI that *does* carry a path
@@ -884,10 +883,10 @@ mod tests {
 
         let react = &result.dependencies[0];
         assert_eq!(react.version_req, None);
-        assert!(matches!(
+        assert_matches!(
             react.catalog.as_ref().map(|origin| &origin.outcome),
             Some(crate::catalog::CatalogOutcome::NoWorkspaceFile)
-        ));
+        );
     }
 
     /// S2 regression: `Uri::to_file_path` does not check scheme, so an `untitled:` URI (VS
@@ -911,10 +910,10 @@ mod tests {
 
         let react = &result.dependencies[0];
         assert_eq!(react.version_req, None);
-        assert!(matches!(
+        assert_matches!(
             react.catalog.as_ref().map(|origin| &origin.outcome),
             Some(crate::catalog::CatalogOutcome::NoWorkspaceFile)
-        ));
+        );
         // The same guard protects `.npmrc` registry resolution, sharing `manifest_dir`.
         assert_eq!(react.source, deps_core::parser::DependencySource::Registry);
     }
@@ -938,10 +937,10 @@ mod tests {
 
         let react = &result.dependencies[0];
         assert_eq!(react.version_req, None);
-        assert!(matches!(
+        assert_matches!(
             react.catalog.as_ref().map(|origin| &origin.outcome),
             Some(crate::catalog::CatalogOutcome::NoWorkspaceFile)
-        ));
+        );
     }
 
     #[test]

--- a/crates/deps-npm/src/registry.rs
+++ b/crates/deps-npm/src/registry.rs
@@ -959,6 +959,8 @@ impl deps_core::Registry for NpmRegistry {
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     #[test]
     fn test_package_url_plain() {
         assert_eq!(package_url("react"), "https://www.npmjs.com/package/react");
@@ -1124,21 +1126,21 @@ mod tests {
         // undetected by this test.
         let registry = NpmRegistry::new(Arc::new(HttpCache::new()));
         let err = registry.get_versions("..").await.unwrap_err();
-        assert!(matches!(err, DepsError::PackageNotFound { .. }));
+        assert_matches!(err, DepsError::PackageNotFound { .. });
     }
 
     #[tokio::test]
     async fn test_get_versions_rejects_scoped_dot_dot_package_as_not_found() {
         let registry = NpmRegistry::new(Arc::new(HttpCache::new()));
         let err = registry.get_versions("@a/..").await.unwrap_err();
-        assert!(matches!(err, DepsError::PackageNotFound { .. }));
+        assert_matches!(err, DepsError::PackageNotFound { .. });
     }
 
     #[tokio::test]
     async fn test_get_versions_rejects_scoped_dot_package_as_not_found() {
         let registry = NpmRegistry::new(Arc::new(HttpCache::new()));
         let err = registry.get_versions("@a/.").await.unwrap_err();
-        assert!(matches!(err, DepsError::PackageNotFound { .. }));
+        assert_matches!(err, DepsError::PackageNotFound { .. });
     }
 
     #[test]
@@ -1393,11 +1395,11 @@ mod tests {
             status: 404,
         };
         let result = not_found_or(err, "left-pad");
-        assert!(matches!(
+        assert_matches!(
             result,
             DepsError::PackageNotFound { package, registry }
                 if package == "left-pad" && registry == REGISTRY
-        ));
+        );
     }
 
     #[test]
@@ -1407,7 +1409,7 @@ mod tests {
             status: 500,
         };
         let result = not_found_or(err, "pkg-404");
-        assert!(matches!(result, DepsError::HttpStatus { status: 500, .. }));
+        assert_matches!(result, DepsError::HttpStatus { status: 500, .. });
     }
 
     #[tokio::test]
@@ -2564,13 +2566,13 @@ mod tests {
         )
         .await;
         match result {
-            Err(err) => assert!(matches!(
+            Err(err) => assert_matches!(
                 err,
                 DepsError::PackageNotFound {
                     registry: "alternate registry (not registered)",
                     ..
                 }
-            )),
+            ),
             Ok(_) => panic!("expected an unregistered alternate to fail closed"),
         }
         public_mock.assert_async().await;
@@ -2605,13 +2607,13 @@ mod tests {
         )
         .await;
         match result {
-            Err(err) => assert!(matches!(
+            Err(err) => assert_matches!(
                 err,
                 DepsError::PackageNotFound {
                     registry: "alternate registry (not registered)",
                     ..
                 }
-            )),
+            ),
             Ok(_) => panic!("expected an unregistered alternate to fail closed"),
         }
         public_mock.assert_async().await;

--- a/crates/deps-npm/src/types.rs
+++ b/crates/deps-npm/src/types.rs
@@ -198,6 +198,7 @@ deps_core::impl_metadata!(NpmPackage {
 mod tests {
     use super::*;
     use deps_core::{Metadata, Version};
+    use std::assert_matches;
     use tower_lsp_server::ls_types::Position;
 
     #[test]
@@ -223,13 +224,10 @@ mod tests {
         let peer_deps = NpmDependencySection::PeerDependencies;
         let opt_deps = NpmDependencySection::OptionalDependencies;
 
-        assert!(matches!(deps, NpmDependencySection::Dependencies));
-        assert!(matches!(dev_deps, NpmDependencySection::DevDependencies));
-        assert!(matches!(peer_deps, NpmDependencySection::PeerDependencies));
-        assert!(matches!(
-            opt_deps,
-            NpmDependencySection::OptionalDependencies
-        ));
+        assert_matches!(deps, NpmDependencySection::Dependencies);
+        assert_matches!(dev_deps, NpmDependencySection::DevDependencies);
+        assert_matches!(peer_deps, NpmDependencySection::PeerDependencies);
+        assert_matches!(opt_deps, NpmDependencySection::OptionalDependencies);
     }
 
     #[test]

--- a/crates/deps-nuget/README.md
+++ b/crates/deps-nuget/README.md
@@ -22,7 +22,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 - **Private/custom feed resolution** — `NuGet.Config` `<packageSources>`/`<clear/>`/`<disabledPackageSources>`/`<packageSourceCredentials>`/`<packageSourceMapping>`, merged across every in-repo ancestor config file, fail closed on a bad/disabled/credentialed entry rather than falling back to `api.nuget.org` (see `ECOSYSTEM_GUIDE.md`)
 
 > [!IMPORTANT]
-> Requires Rust 1.91 or later.
+> Requires Rust 1.98 or later.
 
 ## Installation
 

--- a/crates/deps-nuget/src/config.rs
+++ b/crates/deps-nuget/src/config.rs
@@ -1909,6 +1909,7 @@ fn expand_env_vars_with(
 mod tests {
     use super::*;
     use deps_core::net_policy::WorkspaceRegistryAccess;
+    use std::assert_matches;
 
     fn all_policy() -> RegistryAccessPolicy {
         RegistryAccessPolicy::new(WorkspaceRegistryAccess::All)
@@ -1933,10 +1934,10 @@ mod tests {
     #[test]
     fn test_feed_url_rejects_userinfo() {
         let policy = all_policy();
-        assert!(matches!(
+        assert_matches!(
             NuGetFeedUrl::new("https://user:pass@feed.example/v3/index.json", &policy),
             Err(NuGetFeedUrlError::UserInfoPresent)
-        ));
+        );
     }
 
     #[test]
@@ -2048,7 +2049,7 @@ mod tests {
         let config = resolve(dir.path(), &cache, &policy);
 
         let source = config.resolve_source_for(&pkg("Any.Package"));
-        assert!(matches!(source, DependencySource::AlternateRegistry { .. }));
+        assert_matches!(source, DependencySource::AlternateRegistry { .. });
         let chains = config.resolved_chains();
         assert_eq!(chains.len(), 1);
         assert_eq!(chains[0].hops.len(), 1);
@@ -2335,10 +2336,10 @@ mod tests {
         let policy = all_policy();
         let config = resolve(dir.path(), &cache, &policy);
 
-        assert!(matches!(
+        assert_matches!(
             config.resolve_source_for(&pkg("Newtonsoft.Json")),
             DependencySource::AlternateRegistry { .. }
-        ));
+        );
     }
 
     /// R1 counterexample from the critic review: a root mapping `{CorpFeed: MyCompany.*,
@@ -2634,10 +2635,10 @@ mod tests {
             DependencySource::Registry
         );
         // The private pattern must still route to CorpFeed, unaffected.
-        assert!(matches!(
+        assert_matches!(
             config.resolve_source_for(&pkg("MyCompany.Internal")),
             DependencySource::AlternateRegistry { .. }
-        ));
+        );
     }
 
     #[test]
@@ -2757,10 +2758,10 @@ mod tests {
         let config = resolve(dir.path(), &cache, &policy);
 
         assert!(config.resolved_chains().is_empty());
-        assert!(matches!(
+        assert_matches!(
             config.resolve_source_for(&pkg("Any.Package")),
             DependencySource::CustomRegistry { .. }
-        ));
+        );
     }
 
     // --- M2: plain-chain path treats a public-only hop like the mapping path does ---
@@ -3060,7 +3061,7 @@ mod tests {
         assert_eq!(set.unwrap().as_str(), "secret-pat");
 
         let unset = expand_env_vars_with("%CORP_FEED_PAT%", |_| None);
-        assert!(matches!(unset, Err(NuGetFeedUrlError::HasCredentials)));
+        assert_matches!(unset, Err(NuGetFeedUrlError::HasCredentials));
     }
 
     /// Regression coverage for the `&str`-slice rewrite of `expand_env_vars_with` (it no
@@ -3098,10 +3099,10 @@ mod tests {
             "abc%A"
         );
         assert_eq!(expand_env_vars_with("%%", lookup).unwrap().as_str(), "%%");
-        assert!(matches!(
+        assert_matches!(
             expand_env_vars_with("pre-%UNSET%-post", lookup),
             Err(NuGetFeedUrlError::HasCredentials)
-        ));
+        );
     }
 
     /// SC-002 end-to-end: the same expansion wired through `resolve`'s credential-binding
@@ -3116,10 +3117,10 @@ mod tests {
             password: None,
             encrypted: false,
         };
-        assert!(matches!(
+        assert_matches!(
             expand_credential(&credential),
             Err(NuGetFeedUrlError::HasCredentials)
-        ));
+        );
     }
 
     /// SC-002/NFR-001: `Debug`/`Display` on the credential-holding types never leak the
@@ -3189,10 +3190,10 @@ mod tests {
             password: None,
             encrypted: true,
         };
-        assert!(matches!(
+        assert_matches!(
             expand_credential(&credential),
             Err(NuGetFeedUrlError::EncryptedPasswordUnsupported)
-        ));
+        );
     }
 
     /// FR-004/SC-010: repo-tier `<packageSourceCredentials>` fails closed unconditionally,
@@ -3609,10 +3610,10 @@ mod tests {
         assert!(flag_off.resolved_chains().is_empty());
 
         let flag_on = resolve_ctx(&repo, &cache, &policy, Some(&user_profile), true);
-        assert!(matches!(
+        assert_matches!(
             flag_on.resolve_source_for(&pkg("Any.Package")),
             DependencySource::AlternateRegistry { .. }
-        ));
+        );
     }
 
     /// FR-009: the non-transitive key-aliasing counterexample from the critic review —

--- a/crates/deps-nuget/src/parser.rs
+++ b/crates/deps-nuget/src/parser.rs
@@ -304,6 +304,8 @@ fn decode_text(e: &BytesText<'_>) -> String {
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     fn test_uri() -> Uri {
         deps_core::test_util::test_uri("/test/App.csproj")
     }
@@ -627,20 +629,20 @@ mod tests {
     fn test_invalid_xml_errors() {
         let xml = r#"<Project attr="unclosed></Project>"#;
         let result = parse_project_file(xml, &test_uri());
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DepsError::ParseError { file_type, .. }) if file_type == "NuGet project file"
-        ));
+        );
     }
 
     #[test]
     fn test_packages_config_invalid_xml_errors() {
         let xml = r#"<packages attr="unclosed></packages>"#;
         let result = parse_packages_config(xml, &test_uri());
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DepsError::ParseError { file_type, .. }) if file_type == "NuGet project file"
-        ));
+        );
     }
 
     #[test]

--- a/crates/deps-nuget/src/registry.rs
+++ b/crates/deps-nuget/src/registry.rs
@@ -1335,6 +1335,7 @@ impl deps_core::Registry for NuGetRegistry {
 mod tests {
     use super::*;
     use crate::config::NuGetFeedUrl;
+    use std::assert_matches;
 
     fn service_index_body(package_base_address: &str, search_query_service: &str) -> String {
         format!(
@@ -1828,7 +1829,7 @@ mod tests {
             .get_versions_typed_with("..", false)
             .await
             .unwrap_err();
-        assert!(matches!(err, deps_core::DepsError::PackageNotFound { .. }));
+        assert_matches!(err, deps_core::DepsError::PackageNotFound { .. });
     }
 
     #[test]
@@ -2312,7 +2313,7 @@ mod tests {
             .unlisted_versions_for_hover("..")
             .await
             .unwrap_err();
-        assert!(matches!(err, deps_core::DepsError::PackageNotFound { .. }));
+        assert_matches!(err, deps_core::DepsError::PackageNotFound { .. });
     }
 
     // --- get_versions_typed_with: end-to-end gating and registration-hive walk (mockito) ---

--- a/crates/deps-nuget/src/types.rs
+++ b/crates/deps-nuget/src/types.rs
@@ -131,6 +131,7 @@ deps_core::impl_metadata!(PackageInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
     use tower_lsp_server::ls_types::Position;
 
     fn test_dep() -> NuGetDependency {
@@ -155,10 +156,7 @@ mod tests {
         );
         assert!(dep.features().is_empty());
         assert!(dep.as_any().is::<NuGetDependency>());
-        assert!(matches!(
-            dep.source(),
-            deps_core::parser::DependencySource::Registry
-        ));
+        assert_matches!(dep.source(), deps_core::parser::DependencySource::Registry);
     }
 
     #[test]

--- a/crates/deps-pypi/README.md
+++ b/crates/deps-pypi/README.md
@@ -32,7 +32,7 @@ deps-pypi = "0.12"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.91 or later.
+> Requires Rust 1.98 or later.
 
 ## Usage
 

--- a/crates/deps-pypi/src/config.rs
+++ b/crates/deps-pypi/src/config.rs
@@ -437,6 +437,7 @@ impl PypiIndexConfig {
 mod tests {
     use super::*;
     use deps_core::net_policy::WorkspaceRegistryAccess;
+    use std::assert_matches;
 
     fn all_policy() -> RegistryAccessPolicy {
         RegistryAccessPolicy::new(WorkspaceRegistryAccess::All)
@@ -457,10 +458,10 @@ mod tests {
     #[test]
     fn test_index_url_rejects_http_non_loopback() {
         let policy = all_policy();
-        assert!(matches!(
+        assert_matches!(
             PypiIndexUrl::new("http://pypi.mycorp.example/simple", &policy),
             Err(PypiIndexUrlError::NotHttps(_))
-        ));
+        );
     }
 
     #[test]
@@ -473,28 +474,28 @@ mod tests {
     #[test]
     fn test_index_url_rejects_http_near_miss_loopback() {
         let policy = all_policy();
-        assert!(matches!(
+        assert_matches!(
             PypiIndexUrl::new("http://localhost.evil.com/simple", &policy),
             Err(PypiIndexUrlError::NotHttps(_))
-        ));
+        );
     }
 
     #[test]
     fn test_index_url_rejects_userinfo() {
         let policy = all_policy();
-        assert!(matches!(
+        assert_matches!(
             PypiIndexUrl::new("https://user:pass@pypi.mycorp.example/simple", &policy),
             Err(PypiIndexUrlError::UserInfoPresent)
-        ));
+        );
     }
 
     #[test]
     fn test_index_url_rejects_invalid_url() {
         let policy = all_policy();
-        assert!(matches!(
+        assert_matches!(
             PypiIndexUrl::new("not-a-valid-url", &policy),
             Err(PypiIndexUrlError::InvalidUrl(_))
-        ));
+        );
     }
 
     #[test]
@@ -510,10 +511,10 @@ mod tests {
     #[test]
     fn test_index_url_policy_matrix() {
         assert!(PypiIndexUrl::new("https://127.0.0.1:9999/simple", &all_policy()).is_ok());
-        assert!(matches!(
+        assert_matches!(
             PypiIndexUrl::new("https://127.0.0.1:9999/simple", &off_policy()),
             Err(PypiIndexUrlError::BlockedHost { .. })
-        ));
+        );
     }
 
     // --- PypiIndexConfig::resolve_source_for / resolved_chains ---
@@ -591,7 +592,7 @@ mod tests {
         config.add_extra("https://extra.example/simple", &policy);
 
         let source = config.resolve_source_for(None);
-        assert!(matches!(source, DependencySource::AlternateRegistry { .. }));
+        assert_matches!(source, DependencySource::AlternateRegistry { .. });
 
         let chains = config.resolved_chains();
         assert_eq!(chains.len(), 1);
@@ -781,7 +782,7 @@ mod tests {
         let log = deps_core::test_util::capture_tracing_output(|| {
             let invalid =
                 resolve_entry("https://user:hunter2@pypi.example/simple", &policy).unwrap_err();
-            assert!(matches!(invalid.reason, PypiIndexUrlError::UserInfoPresent));
+            assert_matches!(invalid.reason, PypiIndexUrlError::UserInfoPresent);
             assert!(
                 !invalid.raw.contains("hunter2"),
                 "InvalidEntry::raw leaked the credential: {}",
@@ -837,7 +838,7 @@ mod tests {
         let log = deps_core::test_util::capture_tracing_output(|| {
             let invalid = resolve_entry("https://user:hunter2@pypi.example:99999/simple", &policy)
                 .unwrap_err();
-            assert!(matches!(invalid.reason, PypiIndexUrlError::InvalidUrl(_)));
+            assert_matches!(invalid.reason, PypiIndexUrlError::InvalidUrl(_));
             assert!(
                 !invalid.raw.contains("hunter2"),
                 "InvalidEntry::raw leaked the credential: {}",

--- a/crates/deps-pypi/src/ecosystem.rs
+++ b/crates/deps-pypi/src/ecosystem.rs
@@ -21,6 +21,7 @@ use crate::registry::PypiRegistry;
 /// The source(s) a `CompletionContext::Version`'s bare `package_name` joins back to within a
 /// manifest's already-parsed dependencies (validator finding #1 — mirrors
 /// `deps_npm::ecosystem`'s identical type).
+#[derive(Debug)]
 enum CompletionSource {
     /// No dependency in the manifest has this exact name yet — most commonly because the
     /// user is still typing a brand-new dependency line. Callers fall back to the
@@ -485,6 +486,7 @@ fn is_safe_document_link_target(target: &str) -> bool {
 mod tests {
     use super::*;
     use deps_core::{EcosystemConfig, VersionData};
+    use std::assert_matches;
     use std::collections::HashMap;
 
     fn pkg(s: &str) -> deps_core::PackageName {
@@ -691,10 +693,10 @@ mod tests {
         let Err(err) = result else {
             panic!("expected a parse error");
         };
-        assert!(matches!(
+        assert_matches!(
             err,
             deps_core::DepsError::ParseError { file_type, .. } if file_type == "pyproject.toml"
-        ));
+        );
     }
 
     #[test]
@@ -1178,16 +1180,16 @@ mod tests {
     #[test]
     fn test_resolve_completion_source_classification() {
         let not_in_manifest = empty_parse_result();
-        assert!(matches!(
+        assert_matches!(
             resolve_completion_source(&not_in_manifest, &pkg("mypkg")),
             CompletionSource::NotInManifest
-        ));
+        );
 
         let resolved = parse_result_with_dependency("mypkg", DependencySource::Registry);
-        assert!(matches!(
+        assert_matches!(
             resolve_completion_source(&resolved, &pkg("mypkg")),
             CompletionSource::Resolved(DependencySource::Registry)
-        ));
+        );
 
         let ambiguous = crate::parser::ParseResult {
             dependencies: vec![
@@ -1208,10 +1210,10 @@ mod tests {
             document_links: Vec::new(),
             resolved_chains: Vec::new(),
         };
-        assert!(matches!(
+        assert_matches!(
             resolve_completion_source(&ambiguous, &pkg("mypkg")),
             CompletionSource::Ambiguous
-        ));
+        );
     }
 
     #[tokio::test]

--- a/crates/deps-pypi/src/formatter.rs
+++ b/crates/deps-pypi/src/formatter.rs
@@ -76,7 +76,7 @@ impl PackageRendering for PypiFormatter {
         }
 
         if let Some(term) = terms.iter().find(|t| t.starts_with("==")) {
-            return match term.strip_prefix("==").and_then(|r| r.strip_suffix(".*")) {
+            return match term.strip_circumfix("==", ".*") {
                 Some(base) => {
                     let candidate = truncate_release_to_match(base, version)
                         .map(|truncated| format!("=={truncated}.*"))

--- a/crates/deps-pypi/src/lockfile.rs
+++ b/crates/deps-pypi/src/lockfile.rs
@@ -323,6 +323,8 @@ fn parse_pypi_dependencies(table: &Table<'_>) -> Vec<String> {
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     #[tokio::test]
     async fn test_parse_lockfile_rejects_excessive_nesting() {
         // Well past MAX_TOML_NESTING_DEPTH (64) but far below the depth
@@ -336,10 +338,10 @@ mod tests {
 
         let parser = PypiLockParser;
         let result = parser.parse_lockfile(&lockfile_path).await;
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DepsError::ParseError { file_type, .. }) if file_type == "Python lock file"
-        ));
+        );
     }
 
     #[tokio::test]

--- a/crates/deps-pypi/src/parser/pyproject.rs
+++ b/crates/deps-pypi/src/parser/pyproject.rs
@@ -772,6 +772,7 @@ mod tests {
     use super::super::{MAX_MARKER_LEN, marker_too_deep};
     use super::*;
     use crate::error::PypiError;
+    use std::assert_matches;
     use tower_lsp_server::ls_types::{Position, Range};
 
     fn test_uri() -> Uri {
@@ -786,7 +787,7 @@ mod tests {
         let content = format!("a = {}1{}", "[".repeat(300), "]".repeat(300));
         let parser = PypiParser::new();
         let result = parser.parse_content(&content, &test_uri());
-        assert!(matches!(result, Err(PypiError::TomlParseError { .. })));
+        assert_matches!(result, Err(PypiError::TomlParseError { .. }));
     }
 
     #[test]
@@ -812,10 +813,7 @@ dependencies = [
                 .map(deps_core::VersionReq::as_str),
             Some(">=2.28.0")
         );
-        assert!(matches!(
-            deps[0].section,
-            PypiDependencySection::Dependencies
-        ));
+        assert_matches!(deps[0].section, PypiDependencySection::Dependencies);
 
         assert_eq!(deps[1].name, "flask");
         assert_eq!(deps[1].extras, vec!["async"]);
@@ -861,10 +859,7 @@ requests = "^2.28.0"
         // Should skip "python"
         assert_eq!(deps.len(), 1);
         assert_eq!(deps[0].name, "requests");
-        assert!(matches!(
-            deps[0].section,
-            PypiDependencySection::PoetryDependencies
-        ));
+        assert_matches!(deps[0].section, PypiDependencySection::PoetryDependencies);
     }
 
     #[test]
@@ -1030,10 +1025,7 @@ flask = "^3.0"
         let result = parser.parse_content(content, &test_uri());
 
         assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            PypiError::TomlParseError { .. }
-        ));
+        assert_matches!(result.unwrap_err(), PypiError::TomlParseError { .. });
     }
 
     #[test]
@@ -1249,7 +1241,7 @@ dependencies = [
         let deps = &result.dependencies;
         assert_eq!(deps.len(), 2);
         assert_eq!(deps[0].name, "mylib");
-        assert!(matches!(deps[0].source, PypiDependencySource::Git { .. }));
+        assert_matches!(deps[0].source, PypiDependencySource::Git { .. });
         assert_eq!(deps[1].name, "django");
     }
 
@@ -2391,10 +2383,7 @@ requests = "^2.28.0"
             .iter()
             .find(|d| d.name == "requests")
             .unwrap();
-        assert!(matches!(
-            dep.source,
-            PypiDependencySource::AlternateRegistry { .. }
-        ));
+        assert_matches!(dep.source, PypiDependencySource::AlternateRegistry { .. });
     }
 
     /// Validator finding S3: two primary-priority Poetry sources must not silently pick an
@@ -2499,10 +2488,10 @@ requests = "^2.28.0"
         let result = parse_with_all_policy(content);
         // No primary declared, but a supplemental source exists -> case (b): still routes
         // through an AlternateRegistry chain (extras + implicit public), not plain Registry.
-        assert!(matches!(
+        assert_matches!(
             result.dependencies[0].source,
             PypiDependencySource::AlternateRegistry { .. }
-        ));
+        );
     }
 
     // --- T005: uv [tool.uv.index] + [tool.uv.sources] (FR-013) ---
@@ -2518,10 +2507,10 @@ url = "https://extra.example/simple"
 dependencies = ["requests>=2.28.0"]
 "#;
         let result = parse_with_all_policy(content);
-        assert!(matches!(
+        assert_matches!(
             result.dependencies[0].source,
             PypiDependencySource::AlternateRegistry { .. }
-        ));
+        );
     }
 
     /// FR-013's corrected mapping: `default = true` is uv's lowest-priority, last-resort
@@ -2549,10 +2538,10 @@ dependencies = ["requests>=2.28.0"]
         // Both entries route through the same case-(b)-shaped chain (AlternateRegistry, not
         // CustomRegistry) — proving `default = true` did not populate `primary` (which would
         // make an invalid primary fail closed instead, a structurally different source).
-        assert!(matches!(
+        assert_matches!(
             result.dependencies[0].source,
             PypiDependencySource::AlternateRegistry { .. }
-        ));
+        );
     }
 
     #[test]

--- a/crates/deps-pypi/src/parser/requirements.rs
+++ b/crates/deps-pypi/src/parser/requirements.rs
@@ -474,6 +474,8 @@ fn is_nameless_requirement(text: &str) -> bool {
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     fn test_uri() -> Uri {
         deps_core::test_util::test_uri("/test/requirements.txt")
     }
@@ -1093,10 +1095,10 @@ mod tests {
         let result = parse(content);
         assert_eq!(result.dependencies.len(), 1);
         assert_eq!(result.dependencies[0].name, "mylib");
-        assert!(matches!(
+        assert_matches!(
             result.dependencies[0].source,
             PypiDependencySource::Url { .. }
-        ));
+        );
         assert_eq!(result.dependencies[0].version_req, None);
     }
 
@@ -1251,10 +1253,10 @@ mod tests {
         let content = "--index-url https://pypi.mycorp.example/simple\nrequests==2.31.0\n";
         let result = parse_with_policy(content, &all_policy());
         assert_eq!(result.dependencies.len(), 1);
-        assert!(matches!(
+        assert_matches!(
             result.dependencies[0].source,
             PypiDependencySource::AlternateRegistry { .. }
-        ));
+        );
     }
 
     /// `--index-url=<url>` (equals spelling) is captured identically to the space-separated
@@ -1263,10 +1265,10 @@ mod tests {
     fn test_index_url_equals_spelling() {
         let content = "--index-url=https://pypi.mycorp.example/simple\nrequests==2.31.0\n";
         let result = parse_with_policy(content, &all_policy());
-        assert!(matches!(
+        assert_matches!(
             result.dependencies[0].source,
             PypiDependencySource::AlternateRegistry { .. }
-        ));
+        );
     }
 
     /// `-i` is pip's short alias for `--index-url`.
@@ -1274,10 +1276,10 @@ mod tests {
     fn test_short_dash_i_alias() {
         let content = "-i https://pypi.mycorp.example/simple\nrequests==2.31.0\n";
         let result = parse_with_policy(content, &all_policy());
-        assert!(matches!(
+        assert_matches!(
             result.dependencies[0].source,
             PypiDependencySource::AlternateRegistry { .. }
-        ));
+        );
     }
 
     /// S2 regression: a dependency declared *before* a late `--index-url` line still routes
@@ -1304,10 +1306,10 @@ mod tests {
     fn test_extra_index_url_alone_routes_through_chain() {
         let content = "--extra-index-url https://extra.example/simple\nrequests==2.31.0\n";
         let result = parse_with_policy(content, &all_policy());
-        assert!(matches!(
+        assert_matches!(
             result.dependencies[0].source,
             PypiDependencySource::AlternateRegistry { .. }
-        ));
+        );
     }
 
     /// FR-006: an explicit `--index-url` that fails validation fails closed
@@ -1356,10 +1358,10 @@ mod tests {
         let content = "--index-url https://pypi.mycorp.example/simple\nname @ https://example.com/name.tar.gz\n";
         let result = parse_with_policy(content, &all_policy());
         assert_eq!(result.dependencies.len(), 1);
-        assert!(matches!(
+        assert_matches!(
             result.dependencies[0].source,
             PypiDependencySource::Url { .. }
-        ));
+        );
     }
 
     /// Validator finding S1: a UTF-8 BOM on the first physical line must not defeat
@@ -1430,10 +1432,10 @@ mod tests {
         let content = "--extra-index-url=https://extra.example/simple --trusted-host extra.example\nrequests==2.31.0\n";
         let result = parse_with_policy(content, &all_policy());
         assert_eq!(result.dependencies.len(), 1);
-        assert!(matches!(
+        assert_matches!(
             result.dependencies[0].source,
             PypiDependencySource::AlternateRegistry { .. }
-        ));
+        );
     }
 
     /// T012 test gap #12: `--extra-index-url=<url>` equals-spelling is captured identically
@@ -1442,9 +1444,9 @@ mod tests {
     fn test_extra_index_url_equals_spelling() {
         let content = "--extra-index-url=https://extra.example/simple\nrequests==2.31.0\n";
         let result = parse_with_policy(content, &all_policy());
-        assert!(matches!(
+        assert_matches!(
             result.dependencies[0].source,
             PypiDependencySource::AlternateRegistry { .. }
-        ));
+        );
     }
 }

--- a/crates/deps-pypi/src/registry.rs
+++ b/crates/deps-pypi/src/registry.rs
@@ -1130,6 +1130,7 @@ mod tests {
     use super::*;
 
     use deps_core::test_util::{capture_tracing_output, capture_tracing_output_async};
+    use std::assert_matches;
 
     #[test]
     fn test_package_url() {
@@ -1735,11 +1736,11 @@ mod tests {
             status: 404,
         };
         let result = not_found_or(err, "flask");
-        assert!(matches!(
+        assert_matches!(
             result,
             DepsError::PackageNotFound { package, registry }
                 if package == "flask" && registry == REGISTRY
-        ));
+        );
     }
 
     #[test]
@@ -1753,7 +1754,7 @@ mod tests {
             status: 500,
         };
         let result = not_found_or(err, "pytest-404");
-        assert!(matches!(result, DepsError::HttpStatus { status: 500, .. }));
+        assert_matches!(result, DepsError::HttpStatus { status: 500, .. });
     }
 
     #[test]
@@ -1787,11 +1788,11 @@ mod tests {
         let cache = std::sync::Arc::new(deps_core::HttpCache::new());
         let registry = PypiRegistry::new(cache);
         let err = registry.get_versions("---").await.unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             DepsError::PackageNotFound { package, registry }
                 if package == "---" && registry == REGISTRY
-        ));
+        );
     }
 
     #[tokio::test]
@@ -1799,7 +1800,7 @@ mod tests {
         let cache = std::sync::Arc::new(deps_core::HttpCache::new());
         let registry = PypiRegistry::new(cache);
         let err = registry.get_package_metadata("...").await.unwrap_err();
-        assert!(matches!(err, DepsError::PackageNotFound { .. }));
+        assert_matches!(err, DepsError::PackageNotFound { .. });
     }
 
     #[tokio::test]
@@ -2722,7 +2723,7 @@ mod tests {
             deps_core::FreshnessSettings::default(),
         )
         .await;
-        assert!(matches!(result, Err(DepsError::PackageNotFound { .. })));
+        assert_matches!(result.err(), Some(DepsError::PackageNotFound { .. }));
 
         let result = deps_core::Registry::get_latest_matching_from(
             &registry,
@@ -2732,7 +2733,7 @@ mod tests {
             None,
         )
         .await;
-        assert!(matches!(result, Err(DepsError::PackageNotFound { .. })));
+        assert_matches!(result.err(), Some(DepsError::PackageNotFound { .. }));
     }
 
     // --- T008: tier guard on search/warm_search_index/get_package_metadata ---
@@ -2789,7 +2790,7 @@ mod tests {
         let client = PypiRegistry::with_base(Arc::clone(&cache), &base, Vec::new());
 
         let err = client.get_package_metadata("flask").await.unwrap_err();
-        assert!(matches!(err, DepsError::PackageNotFound { .. }));
+        assert_matches!(err, DepsError::PackageNotFound { .. });
         mock.assert_async().await;
     }
 }

--- a/crates/deps-pypi/src/types.rs
+++ b/crates/deps-pypi/src/types.rs
@@ -311,6 +311,7 @@ impl deps_core::Metadata for PypiPackage {
 mod tests {
     use super::*;
     use deps_core::{Metadata, Version};
+    use std::assert_matches;
     use tower_lsp_server::ls_types::Position;
 
     #[test]
@@ -370,23 +371,11 @@ mod tests {
             group: "test".into(),
         };
 
-        assert!(matches!(deps, PypiDependencySection::Dependencies));
-        assert!(matches!(
-            opt_deps,
-            PypiDependencySection::OptionalDependencies { .. }
-        ));
-        assert!(matches!(
-            dep_group,
-            PypiDependencySection::DependencyGroup { .. }
-        ));
-        assert!(matches!(
-            poetry_deps,
-            PypiDependencySection::PoetryDependencies
-        ));
-        assert!(matches!(
-            poetry_group,
-            PypiDependencySection::PoetryGroup { .. }
-        ));
+        assert_matches!(deps, PypiDependencySection::Dependencies);
+        assert_matches!(opt_deps, PypiDependencySection::OptionalDependencies { .. });
+        assert_matches!(dep_group, PypiDependencySection::DependencyGroup { .. });
+        assert_matches!(poetry_deps, PypiDependencySection::PoetryDependencies);
+        assert_matches!(poetry_group, PypiDependencySection::PoetryGroup { .. });
     }
 
     #[test]
@@ -404,8 +393,8 @@ mod tests {
         };
 
         assert!(registry.is_registry());
-        assert!(matches!(git, PypiDependencySource::Git { .. }));
-        assert!(matches!(path, PypiDependencySource::Path { .. }));
+        assert_matches!(git, PypiDependencySource::Git { .. });
+        assert_matches!(path, PypiDependencySource::Path { .. });
         assert!(!url.is_registry());
     }
 

--- a/crates/deps-swift/README.md
+++ b/crates/deps-swift/README.md
@@ -30,7 +30,7 @@ deps-swift = "0.12"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.91 or later.
+> Requires Rust 1.98 or later.
 
 ## Usage
 

--- a/crates/deps-swift/src/lockfile.rs
+++ b/crates/deps-swift/src/lockfile.rs
@@ -168,6 +168,7 @@ impl LockFileProvider for SwiftLockParser {
 mod tests {
     use super::*;
     use deps_core::lockfile::LockFileProvider;
+    use std::assert_matches;
 
     #[tokio::test]
     async fn test_parse_v1() {
@@ -273,7 +274,7 @@ mod tests {
         let resolved = parser.parse_lockfile(&path).await.unwrap();
         assert_eq!(resolved.len(), 1);
         let pkg = resolved.get("local-pkg").unwrap();
-        assert!(matches!(pkg.source, ResolvedSource::Path { .. }));
+        assert_matches!(pkg.source, ResolvedSource::Path { .. });
     }
 
     #[tokio::test]

--- a/crates/deps-swift/src/parser.rs
+++ b/crates/deps-swift/src/parser.rs
@@ -509,6 +509,7 @@ pub fn parse_package_swift(content: &str, uri: &Uri) -> Result<SwiftParseResult>
 mod tests {
     use super::*;
     use deps_core::Dependency;
+    use std::assert_matches;
 
     fn test_uri() -> Uri {
         deps_core::test_util::test_uri("/test/Package.swift")
@@ -633,7 +634,7 @@ let package = Package(
         assert_eq!(result.dependencies.len(), 1);
         let dep = &result.dependencies[0];
         assert_eq!(dep.version_requirement(), None);
-        assert!(matches!(dep.source(), DependencySource::Git { .. }));
+        assert_matches!(dep.source(), DependencySource::Git { .. });
     }
 
     #[test]
@@ -641,10 +642,10 @@ let package = Package(
         let content = r#".package(url: "https://github.com/dev/debug", .revision("abc123"))"#;
         let result = parse_package_swift(content, &test_uri()).unwrap();
         assert_eq!(result.dependencies.len(), 1);
-        assert!(matches!(
+        assert_matches!(
             result.dependencies[0].source(),
             DependencySource::Git { .. }
-        ));
+        );
     }
 
     #[test]
@@ -652,10 +653,10 @@ let package = Package(
         let content = r#".package(path: "../LocalPackage")"#;
         let result = parse_package_swift(content, &test_uri()).unwrap();
         assert_eq!(result.dependencies.len(), 1);
-        assert!(matches!(
+        assert_matches!(
             result.dependencies[0].source(),
             DependencySource::Path { .. }
-        ));
+        );
         assert_eq!(result.dependencies[0].name(), "LocalPackage");
     }
 

--- a/crates/deps-swift/src/types.rs
+++ b/crates/deps-swift/src/types.rs
@@ -143,6 +143,7 @@ impl deps_core::ParseResult for SwiftParseResult {
 mod tests {
     use super::*;
     use deps_core::{Dependency, Metadata, Version};
+    use std::assert_matches;
     use tower_lsp_server::ls_types::Position;
 
     #[test]
@@ -162,7 +163,7 @@ mod tests {
             dep.version_requirement().map(deps_core::VersionReq::as_str),
             Some(">=2.0.0, <3.0.0")
         );
-        assert!(matches!(dep.source(), DependencySource::Registry));
+        assert_matches!(dep.source(), DependencySource::Registry);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Re-evaluates and closes #549: re-ran the `rust-modern-apis` scan and found the opportunity counts had grown substantially enough since the issue was originally filed to justify the MSRV bump on their own.

| Candidate API | Needs MSRV | At issue filing | Now |
| --- | --- | --- | --- |
| `assert_matches!` | 1.96 | 53 | 301 (new `deps-deno` #309, `deps-github-actions` #471 crates) |
| `str::strip_circumfix` | 1.98 | 2 | 3 |

## Changes

- `rust-version` 1.91 -> 1.98 in root `Cargo.toml`
- `assert!(matches!(...))` -> `assert_matches!(...)` across test code: 293 conversions; 8 left as `assert!(matches!(...))` in doctests to keep those examples focused on demonstrating the API rather than the assertion macro
- `str::strip_circumfix` applied at the 3 known `.strip_prefix(X).and_then(|s| s.strip_suffix(Y))` chain sites: `deps-core/src/lsp_helpers/in_use_version.rs` (PEP 440 bracket pin), `deps-gradle/src/parser/mod.rs` (Gradle `${name}` reference), `deps-pypi/src/formatter.rs` (PEP 440 wildcard pin)
- `#[derive(Debug)]` added to `CompletionSource` (deps-go/deps-npm/deps-pypi), `GradleParseResult`, `MavenParseResult` — needed for `assert_matches!` to compile at their use sites; additive, semver-minor public API widening
- README MSRV references updated to 1.98 (root + all crate READMEs)
- `CHANGELOG.md` `[Unreleased]` entry added

The `Version` trait itself was intentionally NOT given a `Debug` supertrait — 8 sites matching `Result<_, DepsError>` where the `Ok` type holds `Box<dyn Version>` were converted by matching on `.err()` instead (`Option<DepsError>` is `Debug` since `DepsError` already derives it), keeping this a purely mechanical, non-breaking change.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (3972 passed, 0 failed, 48 skipped)
- [x] `cargo test --doc --workspace --all-features`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Independently verified conversion count against `origin/main` baseline (301/301 accounted for, no regressions)
- [x] Independently verified `strip_circumfix` semantic equivalence against a differential harness (120 edge-case inputs across all 3 call sites, 0 divergences)

Resolves #549