### PR TITLE
fix(deps-core,deps-npm,deps-lsp): cap MtimeFileCache file size and watch pnpm-workspace.yaml/.npmrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **deps-npm, deps-lsp**: watch `pnpm-workspace.yaml`/`.npmrc` for external changes and reparse already-open `package.json` documents so catalog/registry-resolved diagnostics stay current (resolves #590)
+- **deps-npm, deps-lsp**: watch `pnpm-workspace.yaml`/`.npmrc` for external changes and reparse already-open `package.json` documents so catalog/registry-resolved diagnostics stay current (resolves #590) (#595)
 - **deps-npm**: pnpm workspace catalog (`pnpm-workspace.yaml` `catalog:`/`catalog:<name>`) resolution for `package.json` — hover/diagnostics/completion/inlay hints now treat a resolved catalog entry like a literal semver range, while an unresolved one (missing entry, unknown catalog, no workspace file, malformed YAML, duplicate default catalog) never gets silently rewritten by the "Update all outdated dependencies" quick-fix (resolves #587) (#589)
 - **deps-nuget, deps-core, deps-lsp**: NuGet credentialed private feed authentication — a user-profile `NuGet.Config` `<packageSourceCredentials>` (`ClearTextPassword`, with `%ENV_VAR%` expansion) now attaches as a `Basic` `Authorization` header when it binds to a repo-declared source at the exact same URL, over a new origin-pinned, connect-address-guarded transport; a revoked credential's cached response is evicted on the next 401/403 (resolves #561) (#572)
 - **deps-nuget, deps-core**: origin-pinned transport and registration-hive enrichment (publish-time freshness, hover-only unlisted marker) for workspace-declared/alternate NuGet feeds — closes spec 035's NFR-003(3) residual risk (resolves #562) (#572)
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-go**: `$GOENV` `GOPROXY`/`GOPRIVATE` follow-up hardening — test-injectable `$GOENV` path, oversized-`GOPRIVATE`-pattern warning, expanded edge-case/integration test coverage, and `GOPROXY` `,`/`|` separator docs (#563)
 
 ### Fixed
-- **deps-core**: `MtimeFileCache` enforces an 8 MiB size cap (checked via `fs::metadata`) before reading a config file's content, instead of always reading the full file before any safety guard runs (resolves #591)
+- **deps-core**: `MtimeFileCache` enforces an 8 MiB size cap (checked via `fs::metadata`) before reading a config file's content, instead of always reading the full file before any safety guard runs (resolves #591) (#595)
 - **deps-go**: oversized-`GOPRIVATE`-pattern warning now logs once per distinct `$GOENV` file content instead of once per LSP re-parse (resolves #565) (#567)
 - **deps-go**: a `GOPROXY` separator preceding a dropped invalid hop is now merged onto the surviving transition with most-permissive-wins, instead of being silently discarded (resolves #564) (#567)
 - **deps-go**: `has_goprivate()` now reflects whether a usable (compiled) `GOPRIVATE` matcher exists, instead of true whenever any raw pattern was declared — even a rejected one (resolves #566) (#567)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **deps-npm, deps-lsp**: watch `pnpm-workspace.yaml`/`.npmrc` for external changes and reparse already-open `package.json` documents so catalog/registry-resolved diagnostics stay current (resolves #590)
 - **deps-npm**: pnpm workspace catalog (`pnpm-workspace.yaml` `catalog:`/`catalog:<name>`) resolution for `package.json` — hover/diagnostics/completion/inlay hints now treat a resolved catalog entry like a literal semver range, while an unresolved one (missing entry, unknown catalog, no workspace file, malformed YAML, duplicate default catalog) never gets silently rewritten by the "Update all outdated dependencies" quick-fix (resolves #587) (#589)
 - **deps-nuget, deps-core, deps-lsp**: NuGet credentialed private feed authentication — a user-profile `NuGet.Config` `<packageSourceCredentials>` (`ClearTextPassword`, with `%ENV_VAR%` expansion) now attaches as a `Basic` `Authorization` header when it binds to a repo-declared source at the exact same URL, over a new origin-pinned, connect-address-guarded transport; a revoked credential's cached response is evicted on the next 401/403 (resolves #561) (#572)
 - **deps-nuget, deps-core**: origin-pinned transport and registration-hive enrichment (publish-time freshness, hover-only unlisted marker) for workspace-declared/alternate NuGet feeds — closes spec 035's NFR-003(3) residual risk (resolves #562) (#572)
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-go**: `$GOENV` `GOPROXY`/`GOPRIVATE` follow-up hardening — test-injectable `$GOENV` path, oversized-`GOPRIVATE`-pattern warning, expanded edge-case/integration test coverage, and `GOPROXY` `,`/`|` separator docs (#563)
 
 ### Fixed
+- **deps-core**: `MtimeFileCache` enforces an 8 MiB size cap (checked via `fs::metadata`) before reading a config file's content, instead of always reading the full file before any safety guard runs (resolves #591)
 - **deps-go**: oversized-`GOPRIVATE`-pattern warning now logs once per distinct `$GOENV` file content instead of once per LSP re-parse (resolves #565) (#567)
 - **deps-go**: a `GOPROXY` separator preceding a dropped invalid hop is now merged onto the surviving transition with most-permissive-wins, instead of being silently discarded (resolves #564) (#567)
 - **deps-go**: `has_goprivate()` now reflects whether a usable (compiled) `GOPRIVATE` matcher exists, instead of true whenever any raw pattern was declared — even a rejected one (resolves #566) (#567)

--- a/crates/deps-core/src/ecosystem.rs
+++ b/crates/deps-core/src/ecosystem.rs
@@ -460,6 +460,19 @@ pub trait Ecosystem: Send + Sync + private::Sealed {
         &[]
     }
 
+    /// Non-lockfile config filenames this ecosystem resolves *during* [`Self::parse_manifest`]
+    /// (e.g. `["pnpm-workspace.yaml", ".npmrc"]` for npm's catalog and registry resolution),
+    /// whose values end up baked into a manifest's `ParseResult` rather than looked up
+    /// separately the way a [`Self::lockfile_provider`] is.
+    ///
+    /// Used for file watching alongside [`Self::lockfile_filenames`] — LSP monitors changes
+    /// to these files too, but reacts by fully re-parsing every open document of this
+    /// ecosystem (not merely refreshing cached resolved versions, since the value isn't kept
+    /// separately from the parse result to refresh in place). Returns empty slice by default.
+    fn watched_config_filenames(&self) -> &[&'static str] {
+        &[]
+    }
+
     /// Parse a manifest file and return parsed result
     ///
     /// # Arguments

--- a/crates/deps-core/src/ecosystem_registry.rs
+++ b/crates/deps-core/src/ecosystem_registry.rs
@@ -419,6 +419,63 @@ impl EcosystemRegistry {
         }
         patterns
     }
+
+    /// Get ecosystem for a [`Ecosystem::watched_config_filenames`] entry — mirrors
+    /// [`Self::get_for_lockfile`] exactly, reusing the same exact/single-`*`-wildcard
+    /// matching, but scanning the *config* list instead of the lockfile one.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use deps_core::EcosystemRegistry;
+    ///
+    /// let registry = EcosystemRegistry::new();
+    /// // registry.register(npm_ecosystem);
+    ///
+    /// if let Some(ecosystem) = registry.get_for_watched_config("pnpm-workspace.yaml") {
+    ///     println!("pnpm-workspace.yaml handled by: {}", ecosystem.display_name());
+    /// }
+    /// ```
+    pub fn get_for_watched_config(&self, filename: &str) -> Option<Arc<dyn Ecosystem>> {
+        for entry in self.ecosystems.iter() {
+            let ecosystem = entry.value();
+            let matches = ecosystem
+                .watched_config_filenames()
+                .iter()
+                .any(|pattern| lockfile_pattern_matches(pattern, filename));
+            if matches {
+                return Some(Arc::clone(ecosystem));
+            }
+        }
+        None
+    }
+
+    /// Get all [`Ecosystem::watched_config_filenames`] glob patterns for file watching —
+    /// mirrors [`Self::all_lockfile_patterns`], scanning the *config* list instead.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use deps_core::EcosystemRegistry;
+    ///
+    /// let registry = EcosystemRegistry::new();
+    /// // registry.register(npm_ecosystem);
+    ///
+    /// let patterns = registry.all_watched_config_patterns();
+    /// for pattern in patterns {
+    ///     println!("Watching pattern: {}", pattern);
+    /// }
+    /// ```
+    pub fn all_watched_config_patterns(&self) -> Vec<String> {
+        let mut patterns = Vec::new();
+        for entry in self.ecosystems.iter() {
+            let ecosystem = entry.value();
+            for filename in ecosystem.watched_config_filenames() {
+                patterns.push(format!("**/{}", filename));
+            }
+        }
+        patterns
+    }
 }
 
 impl Default for EcosystemRegistry {
@@ -556,6 +613,7 @@ mod tests {
         display_name: &'static str,
         filenames: &'static [&'static str],
         lockfiles: &'static [&'static str],
+        watched_configs: &'static [&'static str],
     }
 
     impl crate::ecosystem::private::Sealed for MockEcosystem {}
@@ -575,6 +633,10 @@ mod tests {
 
         fn lockfile_filenames(&self) -> &[&'static str] {
             self.lockfiles
+        }
+
+        fn watched_config_filenames(&self) -> &[&'static str] {
+            self.watched_configs
         }
 
         fn parse_manifest<'a>(
@@ -851,6 +913,7 @@ mod tests {
             display_name: "Exact",
             filenames: &["requirements.txt"],
             lockfiles: &[],
+            watched_configs: &[],
         }));
         registry.register(Arc::new(MockPatternEcosystem {
             id: "pattern",
@@ -912,6 +975,7 @@ mod tests {
             display_name: "Test Ecosystem",
             filenames: &["test.toml"],
             lockfiles: &[],
+            watched_configs: &[],
         });
 
         registry.register(ecosystem);
@@ -928,6 +992,7 @@ mod tests {
             display_name: "Test Ecosystem",
             filenames: &["test.toml"],
             lockfiles: &[],
+            watched_configs: &[],
         });
 
         registry.register(ecosystem);
@@ -945,6 +1010,7 @@ mod tests {
             display_name: "Test Ecosystem",
             filenames: &["test.toml", "test.json"],
             lockfiles: &[],
+            watched_configs: &[],
         });
 
         registry.register(ecosystem);
@@ -966,6 +1032,7 @@ mod tests {
             display_name: "Test Ecosystem",
             filenames: &["test.toml"],
             lockfiles: &[],
+            watched_configs: &[],
         });
 
         registry.register(ecosystem);
@@ -1060,6 +1127,7 @@ mod tests {
             display_name: "Cargo",
             filenames: &["Cargo.toml"],
             lockfiles: &["Cargo.lock"],
+            watched_configs: &[],
         });
 
         let eco2 = Arc::new(MockEcosystem {
@@ -1067,6 +1135,7 @@ mod tests {
             display_name: "npm",
             filenames: &["package.json"],
             lockfiles: &["package-lock.json"],
+            watched_configs: &[],
         });
 
         registry.register(eco1);
@@ -1092,6 +1161,7 @@ mod tests {
             display_name: "Cargo",
             filenames: &["Cargo.toml"],
             lockfiles: &["Cargo.lock"],
+            watched_configs: &[],
         });
 
         registry.register(ecosystem);
@@ -1112,6 +1182,7 @@ mod tests {
             display_name: "PyPI",
             filenames: &["pyproject.toml"],
             lockfiles: &["poetry.lock", "uv.lock"],
+            watched_configs: &[],
         });
 
         registry.register(ecosystem);
@@ -1136,6 +1207,7 @@ mod tests {
             display_name: "NuGet",
             filenames: &["Directory.Packages.props"],
             lockfiles: &["packages.lock.json", "packages.*.lock.json"],
+            watched_configs: &[],
         });
 
         registry.register(ecosystem);
@@ -1171,6 +1243,7 @@ mod tests {
             display_name: "Cargo",
             filenames: &["Cargo.toml"],
             lockfiles: &["Cargo.lock"],
+            watched_configs: &[],
         });
 
         registry.register(ecosystem);
@@ -1189,6 +1262,7 @@ mod tests {
             display_name: "Cargo",
             filenames: &["Cargo.toml"],
             lockfiles: &["Cargo.lock"],
+            watched_configs: &[],
         });
 
         let eco2 = Arc::new(MockEcosystem {
@@ -1196,6 +1270,7 @@ mod tests {
             display_name: "npm",
             filenames: &["package.json"],
             lockfiles: &["package-lock.json"],
+            watched_configs: &[],
         });
 
         let eco3 = Arc::new(MockEcosystem {
@@ -1203,6 +1278,7 @@ mod tests {
             display_name: "PyPI",
             filenames: &["pyproject.toml"],
             lockfiles: &["poetry.lock", "uv.lock"],
+            watched_configs: &[],
         });
 
         registry.register(eco1);
@@ -1225,12 +1301,73 @@ mod tests {
             display_name: "Test",
             filenames: &["test.toml"],
             lockfiles: &[],
+            watched_configs: &[],
         });
 
         registry.register(ecosystem);
 
         let patterns = registry.all_lockfile_patterns();
         assert!(patterns.is_empty());
+    }
+
+    #[test]
+    fn test_get_for_watched_config() {
+        let registry = EcosystemRegistry::new();
+        let ecosystem = Arc::new(MockEcosystem {
+            id: "npm",
+            display_name: "npm",
+            filenames: &["package.json"],
+            lockfiles: &["package-lock.json"],
+            watched_configs: &["pnpm-workspace.yaml", ".npmrc"],
+        });
+
+        registry.register(ecosystem);
+
+        let retrieved = registry
+            .get_for_watched_config("pnpm-workspace.yaml")
+            .unwrap();
+        assert_eq!(retrieved.id(), "npm");
+        let retrieved = registry.get_for_watched_config(".npmrc").unwrap();
+        assert_eq!(retrieved.id(), "npm");
+
+        // A lockfile is not a watched config, and vice versa.
+        assert!(
+            registry
+                .get_for_watched_config("package-lock.json")
+                .is_none()
+        );
+        assert!(registry.get_for_watched_config("unknown.yaml").is_none());
+    }
+
+    #[test]
+    fn test_all_watched_config_patterns() {
+        let registry = EcosystemRegistry::new();
+        let ecosystem = Arc::new(MockEcosystem {
+            id: "npm",
+            display_name: "npm",
+            filenames: &["package.json"],
+            lockfiles: &["package-lock.json"],
+            watched_configs: &["pnpm-workspace.yaml", ".npmrc"],
+        });
+
+        registry.register(ecosystem);
+
+        let patterns = registry.all_watched_config_patterns();
+        assert_eq!(patterns.len(), 2);
+        assert!(patterns.contains(&"**/pnpm-workspace.yaml".to_string()));
+        assert!(patterns.contains(&"**/.npmrc".to_string()));
+
+        // Lockfile patterns are a disjoint set, unaffected by watched-config registration.
+        assert_eq!(
+            registry.all_lockfile_patterns(),
+            vec!["**/package-lock.json"]
+        );
+    }
+
+    #[test]
+    fn test_all_watched_config_patterns_empty() {
+        let registry = EcosystemRegistry::new();
+        assert!(registry.all_watched_config_patterns().is_empty());
     }
 
     #[test]

--- a/crates/deps-core/src/lib.rs
+++ b/crates/deps-core/src/lib.rs
@@ -57,7 +57,7 @@ pub use lsp_helpers::{
     is_safe_version_string, is_same_major_minor, position_in_range, requirement_is_unsatisfiable,
     warn_rejected_value,
 };
-pub use mtime_cache::{DEFAULT_MAX_CACHED_FILES, MtimeFileCache};
+pub use mtime_cache::{DEFAULT_MAX_CACHED_FILES, MAX_CACHED_FILE_BYTES, MtimeFileCache};
 pub use package::{ConcreteVersion, InvalidPackageName, PackageName, VersionReq};
 pub use parser::{
     DependencySource, LoadingState, MAX_JSON_NESTING_DEPTH, MAX_TOML_NESTING_DEPTH,

--- a/crates/deps-core/src/mtime_cache.rs
+++ b/crates/deps-core/src/mtime_cache.rs
@@ -21,6 +21,18 @@ use crate::fs_probe;
 /// them.
 pub const DEFAULT_MAX_CACHED_FILES: usize = 256;
 
+/// Maximum file size [`MtimeFileCache::get_or_parse`] reads before parsing.
+///
+/// Checked against [`std::fs::Metadata::len`] *before* `read_to_string`, so an oversized file
+/// (e.g. a crafted `pnpm-workspace.yaml` in a cloned repository) never reaches
+/// `read_to_string`, `YamlLoader`, or any content-based guard like
+/// [`crate::check_yaml_nesting_depth`]/[`crate::check_yaml_expansion`] — those guards run on
+/// content already read into memory, so they cannot bound the read itself. 8 MiB matches
+/// [`crate::cache`]'s `MAX_CACHEABLE_ENTRY_BYTES` order of magnitude and is generous for a
+/// real config file (`.cargo/config.toml`, `.npmrc`, `pnpm-workspace.yaml`), which are
+/// typically a few KB.
+pub const MAX_CACHED_FILE_BYTES: u64 = 8 * 1024 * 1024;
+
 /// One cached file's mtime plus its parsed value. The mtime lives here, not on `T`, so `T`
 /// stays exactly the caller's existing parsed-value type with no cache-specific field to
 /// strip at every call site.
@@ -38,6 +50,13 @@ struct CacheEntry<T> {
 /// very next call with no extra bookkeeping.
 pub struct MtimeFileCache<T> {
     files: dashmap::DashMap<PathBuf, CacheEntry<T>>,
+    /// Last mtime an oversized path was warned about, so [`Self::get_or_parse`] logs at most
+    /// once per distinct file version rather than once per call — an oversized file is never
+    /// cached in `files`, so without this every hover/completion/diagnostic pass touching it
+    /// would otherwise re-emit the same warning (impl-critic S2). Bounded by `capacity`, same
+    /// as `files`: once full, a repeat warning is simply not deduped rather than growing this
+    /// map without limit.
+    oversize_warned: dashmap::DashMap<PathBuf, SystemTime>,
     capacity: usize,
     label: &'static str,
 }
@@ -48,7 +67,7 @@ impl<T> std::fmt::Debug for MtimeFileCache<T> {
             .field("label", &self.label)
             .field("capacity", &self.capacity)
             .field("len", &self.files.len())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -59,6 +78,7 @@ impl<T> MtimeFileCache<T> {
     pub fn new(capacity: usize, label: &'static str) -> Self {
         Self {
             files: dashmap::DashMap::new(),
+            oversize_warned: dashmap::DashMap::new(),
             capacity,
             label,
         }
@@ -66,12 +86,17 @@ impl<T> MtimeFileCache<T> {
 
     /// Returns `path`'s parsed contents, from cache if `path`'s mtime is unchanged, else
     /// re-reading and re-parsing with `parse`. `None` if `path` does not exist, is not a
-    /// regular file, or cannot be read.
+    /// regular file, exceeds [`MAX_CACHED_FILE_BYTES`], or cannot be read.
     ///
     /// Rejects anything but a regular file (a FIFO, socket, character device, or directory)
     /// before ever attempting to read it — reading one of those can block the calling thread
     /// indefinitely, and [`std::fs::metadata`] follows symlinks, so a symlinked regular file
     /// still resolves.
+    ///
+    /// Also rejects a file over [`MAX_CACHED_FILE_BYTES`] via the same `stat` result, before
+    /// `read_to_string` ever runs — every content-based safety guard (nesting-depth,
+    /// expansion) only sees content already read into memory, so it cannot bound the read
+    /// itself; this check is what does.
     ///
     /// Always performs one `stat` (the mtime check) — that cost is unavoidable and paid on
     /// every call, cache hit or not — but reads and parses the file's *content* only on a
@@ -96,6 +121,29 @@ impl<T> MtimeFileCache<T> {
     pub fn get_or_parse(&self, path: &Path, parse: impl FnOnce(&str) -> T) -> Option<Arc<T>> {
         let metadata = fs_probe::metadata(path).ok()?;
         if !metadata.is_file() {
+            return None;
+        }
+        if metadata.len() > MAX_CACHED_FILE_BYTES {
+            let mtime = metadata.modified().ok();
+            let already_warned = mtime.is_some_and(|mtime| {
+                self.oversize_warned
+                    .get(path)
+                    .is_some_and(|warned| *warned == mtime)
+            });
+            if !already_warned {
+                tracing::warn!(
+                    path = %path.display(),
+                    label = self.label,
+                    len = metadata.len(),
+                    cap = MAX_CACHED_FILE_BYTES,
+                    "file exceeds mtime file cache size cap; not reading"
+                );
+                if let Some(mtime) = mtime
+                    && self.oversize_warned.len() < self.capacity
+                {
+                    self.oversize_warned.insert(path.to_path_buf(), mtime);
+                }
+            }
             return None;
         }
         let mtime = metadata.modified().ok()?;
@@ -263,6 +311,91 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let cache: MtimeFileCache<Parsed> = MtimeFileCache::new(DEFAULT_MAX_CACHED_FILES, "test");
         assert!(cache.get_or_parse(dir.path(), parse_upper).is_none());
+    }
+
+    /// A file over [`MAX_CACHED_FILE_BYTES`] must never reach `read_to_string`/`parse` at
+    /// all — the size check happens on the `stat` result alone, before any content read.
+    #[test]
+    fn oversized_file_returns_none_without_reading_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("huge.txt");
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(MAX_CACHED_FILE_BYTES + 1).unwrap();
+        drop(file);
+
+        let cache: MtimeFileCache<Parsed> = MtimeFileCache::new(DEFAULT_MAX_CACHED_FILES, "test");
+        let parse_calls = std::cell::Cell::new(0);
+        let result = cache.get_or_parse(&path, |content| {
+            parse_calls.set(parse_calls.get() + 1);
+            parse_upper(content)
+        });
+
+        assert!(result.is_none());
+        assert_eq!(
+            parse_calls.get(),
+            0,
+            "parse must not run on an oversized file"
+        );
+    }
+
+    /// Impl-critic S2 regression: an oversized file must warn at most once per distinct
+    /// mtime, not once per call — an oversized file is never memoized in `files`, so without
+    /// this every hover/completion/diagnostic pass touching it would re-emit the warning.
+    #[test]
+    fn oversized_file_warns_once_per_mtime_not_once_per_call() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("huge.txt");
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(MAX_CACHED_FILE_BYTES + 1).unwrap();
+        drop(file);
+
+        let cache: MtimeFileCache<Parsed> = MtimeFileCache::new(DEFAULT_MAX_CACHED_FILES, "test");
+
+        let log = crate::test_util::capture_tracing_output(|| {
+            assert!(cache.get_or_parse(&path, parse_upper).is_none());
+            assert!(cache.get_or_parse(&path, parse_upper).is_none());
+            assert!(cache.get_or_parse(&path, parse_upper).is_none());
+        });
+
+        assert_eq!(
+            log.matches("file exceeds mtime file cache size cap")
+                .count(),
+            1,
+            "expected exactly one warning across three calls with an unchanged mtime: {log}"
+        );
+    }
+
+    /// A file that changes (still oversized) after already being warned about must warn
+    /// again — the dedup is per file *version*, not a one-time-ever suppression.
+    #[test]
+    fn oversized_file_warns_again_after_mtime_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("huge.txt");
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(MAX_CACHED_FILE_BYTES + 1).unwrap();
+        drop(file);
+
+        let cache: MtimeFileCache<Parsed> = MtimeFileCache::new(DEFAULT_MAX_CACHED_FILES, "test");
+
+        let log = crate::test_util::capture_tracing_output(|| {
+            assert!(cache.get_or_parse(&path, parse_upper).is_none());
+
+            // Ensure a distinguishable mtime on filesystems with coarse timestamp resolution.
+            let future = SystemTime::now() + std::time::Duration::from_secs(2);
+            let file = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
+            file.set_len(MAX_CACHED_FILE_BYTES + 2).unwrap();
+            file.set_modified(future).unwrap();
+            drop(file);
+
+            assert!(cache.get_or_parse(&path, parse_upper).is_none());
+        });
+
+        assert_eq!(
+            log.matches("file exceeds mtime file cache size cap")
+                .count(),
+            2,
+            "expected a fresh warning after the file's mtime changed: {log}"
+        );
     }
 
     /// At capacity, a freshly parsed value is still returned to the caller but not inserted

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -1952,19 +1952,62 @@ async fn parse_and_diff_manifest(
     (parse_result, diff)
 }
 
+/// Whether [`commit_parsed_document`] should verify the document's current version before
+/// committing — see that function's doc for why this exists.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum CommitGuard {
+    /// Always commit — a real edit's own version is authoritative, nothing to guard against.
+    Unconditional,
+    /// Commit only if the document's *current* version in `state` still equals this value;
+    /// otherwise skip the commit entirely (impl-critic S1).
+    ExpectVersion(Option<i32>),
+}
+
+/// Bundles [`commit_parsed_document`]'s two commit-behavior parameters — kept as one struct
+/// (rather than two more positional parameters) to stay under `clippy::too_many_arguments`.
+struct CommitOptions<'a> {
+    diff: &'a DependencyDiff,
+    guard: CommitGuard,
+}
+
 /// Builds the new `DocumentState` from the parsed manifest (or a parse-result-less
 /// placeholder when parsing failed), carries over cache entries the previous state already
-/// held, prunes/invalidates entries the diff says are now stale, and commits the result
-/// into `state`.
+/// held, prunes/invalidates entries `options.diff` says are now stale, and commits the result
+/// into `state` — unless `options.guard` is [`CommitGuard::ExpectVersion`] and the document's
+/// *current* version in `state` no longer matches, in which case the commit is skipped
+/// entirely and `false` is returned.
+///
+/// The guard exists for a reparse whose trigger is *not* the document's own edit stream —
+/// e.g. [`crate::server::Backend::handle_watched_config_change`] (issue #590), which reparses
+/// every open document of an ecosystem using content it snapshotted before the (awaited)
+/// re-parse ran. Without this check, a `did_change` notification landing while that reparse
+/// is in flight gets silently reverted: this function would otherwise commit unconditionally,
+/// overwriting the newer edit with the older, watched-config-triggered content (impl-critic
+/// S1). [`handle_document_change`] passes [`CommitGuard::Unconditional`] — a real edit's own
+/// version is authoritative, there is nothing to guard against.
 fn commit_parsed_document(
     uri: &Uri,
     ecosystem: &dyn Ecosystem,
     content: String,
     parse_result: Option<Box<dyn deps_core::ParseResult>>,
     version: Option<i32>,
-    diff: &DependencyDiff,
     state: &ServerState,
-) {
+    options: CommitOptions<'_>,
+) -> bool {
+    let diff = options.diff;
+    if let CommitGuard::ExpectVersion(expected) = options.guard {
+        let current = state.with_document(uri, |doc| doc.version);
+        if current != Some(expected) {
+            tracing::debug!(
+                ?uri,
+                ?expected,
+                ?current,
+                "skipping stale reparse commit: document version changed since this reparse started"
+            );
+            return false;
+        }
+    }
+
     let mut doc_state = if let Some(pr) = parse_result {
         DocumentState::new_from_parse_result(resolve_ecosystem_id(ecosystem), content, pr)
     } else {
@@ -2015,6 +2058,7 @@ fn commit_parsed_document(
     }
 
     state.update_document(uri.clone(), doc_state);
+    true
 }
 
 /// Generic document change handler using ecosystem registry.
@@ -2029,6 +2073,47 @@ pub async fn handle_document_change(
     client: Client,
     config: Arc<RwLock<DepsConfig>>,
 ) -> Result<JoinHandle<()>> {
+    let task = handle_document_change_guarded(
+        uri,
+        content,
+        version,
+        CommitGuard::Unconditional,
+        state,
+        client,
+        config,
+    )
+    .await?;
+    Ok(task.expect("CommitGuard::Unconditional never skips the commit"))
+}
+
+/// Like [`handle_document_change`], but skips committing the reparse — and spawning its
+/// diagnostics-refresh background task — if `guard` is [`CommitGuard::ExpectVersion`] and the
+/// document's version in `state` no longer matches by the time this reparse finishes; see
+/// [`commit_parsed_document`]'s doc for why.
+///
+/// Returns `Ok(None)` on a skip, never a sentinel/no-op `JoinHandle` (impl-critic S3): the
+/// caller ([`crate::server::Backend::handle_watched_config_change`]) feeds the returned handle
+/// straight into [`ServerState::spawn_background_task`], which unconditionally **aborts** any
+/// existing task registered for the URI before installing the new one. A sentinel handle for
+/// a skipped, superseded reparse would therefore abort the concurrent edit's *real* background
+/// task (registry fetch, OSV rescan, `publish_diagnostics`) that a matching-version commit
+/// already installed — silently dropping that newer edit's diagnostics until the next
+/// keystroke. The caller must treat `None` as "do not touch the task registry for this URI at
+/// all", not as "install a no-op task".
+///
+/// [`handle_document_change`] passes [`CommitGuard::Unconditional`] and unwraps the `Some`
+/// unconditionally (preserving its exact prior behavior and `Result<JoinHandle<()>>` return
+/// type) — only a reparse triggered by something other than the document's own edit stream
+/// needs a real guard, and therefore ever observes `None`.
+pub(crate) async fn handle_document_change_guarded(
+    uri: Uri,
+    content: String,
+    version: Option<i32>,
+    guard: CommitGuard,
+    state: Arc<ServerState>,
+    client: Client,
+    config: Arc<RwLock<DepsConfig>>,
+) -> Result<Option<JoinHandle<()>>> {
     // Find appropriate ecosystem for this URI
     let ecosystem = match state.ecosystem_registry.get_for_uri(&uri) {
         Some(e) => e,
@@ -2045,15 +2130,17 @@ pub async fn handle_document_change(
     let (parse_result, diff) =
         parse_and_diff_manifest(&uri, &content, &state, ecosystem.as_ref()).await;
 
-    commit_parsed_document(
+    if !commit_parsed_document(
         &uri,
         ecosystem.as_ref(),
         content,
         parse_result,
         version,
-        &diff,
         &state,
-    );
+        CommitOptions { diff: &diff, guard },
+    ) {
+        return Ok(None);
+    }
 
     // Clone cache, diagnostics, and freshness config before spawning background task
     // (all read here, before any OSV request is built — FR-011).
@@ -2093,7 +2180,7 @@ pub async fn handle_document_change(
         deps_to_fetch,
     ));
 
-    Ok(task)
+    Ok(Some(task))
 }
 
 /// Config values snapshotted from `DepsConfig` before spawning [`run_document_change_task`]
@@ -5525,6 +5612,185 @@ tokio = "1.0"
 
             let doc = state.get_document(&uri).unwrap();
             assert_eq!(doc.ecosystem_id(), "npm");
+        }
+
+        /// Impl-critic S1 regression: a version-guarded reparse whose `expected_version` no
+        /// longer matches the document's *current* version (a concurrent `did_change` already
+        /// landed) must not commit — the older, guarded reparse would otherwise silently
+        /// revert the newer edit.
+        #[tokio::test]
+        async fn test_handle_document_change_guarded_skips_commit_when_version_changed() {
+            use crate::test_utils::test_helpers::create_test_client_and_config;
+
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/package.json");
+            let original_content = r#"{"dependencies": {"express": "^4.18.0"}}"#.to_string();
+            let (client, config) = create_test_client_and_config();
+
+            handle_document_open(
+                uri.clone(),
+                original_content,
+                Some(1),
+                Arc::clone(&state),
+                client.clone(),
+                Arc::clone(&config),
+            )
+            .await
+            .unwrap();
+
+            // A real, concurrent `did_change` lands and commits version 2 — simulating this
+            // landing while a watched-config-triggered reparse (still snapshotted at version
+            // 1) is in flight.
+            let concurrent_content = r#"{"dependencies": {"express": "^4.19.0"}}"#.to_string();
+            handle_document_change(
+                uri.clone(),
+                concurrent_content.clone(),
+                Some(2),
+                Arc::clone(&state),
+                client.clone(),
+                Arc::clone(&config),
+            )
+            .await
+            .unwrap();
+
+            // The watched-config-triggered reparse now runs, still expecting version 1 (its
+            // stale pre-race snapshot) and carrying content from before the concurrent edit.
+            let stale_content =
+                r#"{"dependencies": {"express": "^4.18.0", "lodash": "^4.0.0"}}"#.to_string();
+            let task = handle_document_change_guarded(
+                uri.clone(),
+                stale_content,
+                Some(3),
+                CommitGuard::ExpectVersion(Some(1)),
+                Arc::clone(&state),
+                client,
+                config,
+            )
+            .await
+            .unwrap();
+            assert!(
+                task.is_none(),
+                "a version mismatch must skip the commit and return None, never a sentinel \
+                 task (impl-critic S3)"
+            );
+
+            let doc = state.get_document(&uri).unwrap();
+            assert_eq!(
+                doc.content, concurrent_content,
+                "a stale guarded reparse must not overwrite content committed after its snapshot"
+            );
+            assert_eq!(doc.version, Some(2));
+        }
+
+        /// The mirror case: `expected_version` still matches the document's current version,
+        /// so the guarded reparse must commit normally.
+        #[tokio::test]
+        async fn test_handle_document_change_guarded_commits_when_version_matches() {
+            use crate::test_utils::test_helpers::create_test_client_and_config;
+
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/package.json");
+            let original_content = r#"{"dependencies": {"express": "^4.18.0"}}"#.to_string();
+            let (client, config) = create_test_client_and_config();
+
+            handle_document_open(
+                uri.clone(),
+                original_content,
+                Some(1),
+                Arc::clone(&state),
+                client.clone(),
+                Arc::clone(&config),
+            )
+            .await
+            .unwrap();
+
+            let new_content = r#"{"dependencies": {"express": "^4.19.0"}}"#.to_string();
+            let task = handle_document_change_guarded(
+                uri.clone(),
+                new_content.clone(),
+                Some(1),
+                CommitGuard::ExpectVersion(Some(1)),
+                Arc::clone(&state),
+                client,
+                config,
+            )
+            .await
+            .unwrap();
+            task.expect("a matching version must commit and spawn a real task")
+                .await
+                .unwrap();
+
+            let doc = state.get_document(&uri).unwrap();
+            assert_eq!(doc.content, new_content);
+        }
+
+        /// Impl-critic S3 regression: a skipped guarded reparse must never register a
+        /// sentinel task via `spawn_background_task` — doing so would abort whatever real
+        /// background task (e.g. a concurrent edit's own registry fetch + diagnostics
+        /// publish) is already registered for that URI. Unlike the two tests above, this one
+        /// exercises the actual task registry (`ServerState::spawn_background_task`), not
+        /// just the returned handle directly.
+        #[tokio::test]
+        async fn test_guarded_reparse_skip_does_not_abort_pre_existing_background_task() {
+            use crate::test_utils::test_helpers::create_test_client_and_config;
+            use std::sync::atomic::{AtomicBool, Ordering};
+
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/package.json");
+            let original_content = r#"{"dependencies": {"express": "^4.18.0"}}"#.to_string();
+            let (client, config) = create_test_client_and_config();
+
+            handle_document_open(
+                uri.clone(),
+                original_content,
+                Some(1),
+                Arc::clone(&state),
+                client.clone(),
+                Arc::clone(&config),
+            )
+            .await
+            .unwrap();
+
+            // Stands in for the real background task a concurrent `did_change` would already
+            // have installed by the time a stale, guarded reparse runs.
+            let ran_to_completion = Arc::new(AtomicBool::new(false));
+            let flag = Arc::clone(&ran_to_completion);
+            let pre_existing_task = tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                flag.store(true, Ordering::SeqCst);
+            });
+            state
+                .spawn_background_task(uri.clone(), pre_existing_task)
+                .await;
+
+            // A guarded reparse whose expected version no longer matches — must skip. Mirrors
+            // `Backend::handle_watched_config_change`'s exact branching: `spawn_background_task`
+            // is called only on `Some`, never on a skip.
+            let stale_content = r#"{"dependencies": {"express": "^4.19.0"}}"#.to_string();
+            let result = handle_document_change_guarded(
+                uri.clone(),
+                stale_content,
+                Some(2),
+                CommitGuard::ExpectVersion(Some(999)),
+                Arc::clone(&state),
+                client,
+                config,
+            )
+            .await
+            .unwrap();
+            assert!(result.is_none(), "a version mismatch must skip the commit");
+            if let Some(task) = result {
+                state.spawn_background_task(uri.clone(), task).await;
+            }
+
+            // If the pre-existing task had instead been aborted, it would never reach the
+            // `store(true, ...)` line above; give it well past its 50ms sleep to prove it ran
+            // to completion undisturbed.
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            assert!(
+                ran_to_completion.load(Ordering::SeqCst),
+                "the pre-existing background task must not be aborted by a skipped guarded reparse"
+            );
         }
     }
 

--- a/crates/deps-lsp/src/document/mod.rs
+++ b/crates/deps-lsp/src/document/mod.rs
@@ -12,6 +12,7 @@ mod osv_snapshot_tests;
 mod state;
 
 // Re-export all public items from submodules
+pub(crate) use lifecycle::{CommitGuard, handle_document_change_guarded};
 pub use lifecycle::{ensure_document_loaded, handle_document_change, handle_document_open};
 pub use loader::load_document_from_disk;
 pub(crate) use state::CLIENT_REFRESH_TIMEOUT;

--- a/crates/deps-lsp/src/server.rs
+++ b/crates/deps-lsp/src/server.rs
@@ -252,6 +252,90 @@ impl Backend {
         self.state.spawn_refresh_requests(&self.client);
     }
 
+    /// Reacts to a change in one of `ecosystem_id`'s
+    /// [`deps_core::Ecosystem::watched_config_filenames`] (issue #590) by fully re-parsing
+    /// every currently open document of that ecosystem.
+    ///
+    /// Unlike [`Self::handle_lockfile_change`], this cannot get away with refreshing only
+    /// `resolved_versions` and re-running diagnostics on the existing `ParseResult`: a
+    /// watched config file (e.g. npm's `pnpm-workspace.yaml` catalog, `.npmrc` registry
+    /// override) is resolved *inside* `parse_manifest` itself, so its effect is already
+    /// baked into the cached `ParseResult` and only a real re-parse picks up a change. Every
+    /// open document of the ecosystem is reparsed rather than only those under the changed
+    /// file's directory tree — the per-document "which config file did this resolve against"
+    /// walk each ecosystem does internally (e.g. `deps_npm::catalog::find_workspace_file`)
+    /// isn't exposed through the [`deps_core::Ecosystem`] trait the way
+    /// [`deps_core::lockfile::LockFileProvider::locate_lockfile`] is for lock files, and
+    /// re-parsing an already-open document is cheap.
+    ///
+    /// Each reparse is version-guarded ([`handle_document_change_guarded`]'s
+    /// `expected_version`): the content/version pair is snapshotted once, up front, but the
+    /// actual reparse for a given document is awaited one at a time — a concurrent
+    /// `did_change` for that same document can land and commit newer content while an earlier
+    /// document's reparse in this loop is still in flight. Without the guard, this call's
+    /// (now-stale) commit would silently overwrite that newer edit (impl-critic S1).
+    async fn handle_watched_config_change(&self, ecosystem_id: &str) {
+        let affected: Vec<(Uri, String, Option<i32>)> = self
+            .state
+            .documents
+            .iter()
+            .filter(|entry| entry.value().ecosystem_id() == ecosystem_id)
+            .map(|entry| {
+                (
+                    entry.key().clone(),
+                    entry.value().content.clone(),
+                    entry.value().version,
+                )
+            })
+            .collect();
+
+        if affected.is_empty() {
+            tracing::debug!(
+                "No open {} documents affected by watched config file change",
+                ecosystem_id
+            );
+            return;
+        }
+
+        tracing::info!(
+            "Reparsing {} document(s) affected by watched config file change",
+            affected.len()
+        );
+
+        for (uri, content, version) in affected {
+            match crate::document::handle_document_change_guarded(
+                uri.clone(),
+                content,
+                version,
+                crate::document::CommitGuard::ExpectVersion(version),
+                Arc::clone(&self.state),
+                self.client.clone(),
+                Arc::clone(&self.config),
+            )
+            .await
+            {
+                Ok(Some(task)) => self.state.spawn_background_task(uri, task).await,
+                // A skip (superseded by a concurrent `did_change`) must never touch the task
+                // registry for this URI — `spawn_background_task` unconditionally aborts
+                // whatever task is already registered there, which would cancel the
+                // concurrent edit's own, already-installed background task (impl-critic S3).
+                Ok(None) => tracing::debug!(
+                    "skipped stale reparse for {:?}: superseded by a concurrent edit",
+                    uri
+                ),
+                Err(e) => tracing::error!(
+                    "failed to reparse {:?} after watched config file change: {}",
+                    uri,
+                    e
+                ),
+            }
+        }
+
+        // Detached, capability-gated, timeout-bounded (issue #493): see
+        // `ServerState::spawn_refresh_requests` for rationale.
+        self.state.spawn_refresh_requests(&self.client);
+    }
+
     /// Check if client supports work done progress.
     async fn supports_progress(&self) -> bool {
         let caps = self.client_capabilities.read().await;
@@ -449,11 +533,15 @@ impl LanguageServer for Backend {
             tracing::error!("Cold start rate limiter cleanup task exited unexpectedly: {e}");
         });
 
-        // Register lock file watchers using patterns from all ecosystems. Timeout-bounded
-        // (issue #493 S1): tower-lsp-server 0.23.0 dispatches handlers via
-        // `buffer_unordered(4)`, so an unresponsive client hanging this await would
-        // permanently burn one of only 4 concurrent message slots for the session.
-        let patterns = self.state.ecosystem_registry.all_lockfile_patterns();
+        // Register lock file watchers using patterns from all ecosystems, plus each
+        // ecosystem's non-lockfile watched config files (e.g. npm's pnpm-workspace.yaml
+        // and .npmrc, issue #590) — one registration, since both are just glob-pattern
+        // watches to the client. Timeout-bounded (issue #493 S1): tower-lsp-server 0.23.0
+        // dispatches handlers via `buffer_unordered(4)`, so an unresponsive client hanging
+        // this await would permanently burn one of only 4 concurrent message slots for the
+        // session.
+        let mut patterns = self.state.ecosystem_registry.all_lockfile_patterns();
+        patterns.extend(self.state.ecosystem_registry.all_watched_config_patterns());
         match tokio::time::timeout(
             CLIENT_REFRESH_TIMEOUT,
             file_watcher::register_lock_file_watchers(&self.client, &patterns),
@@ -623,19 +711,38 @@ impl LanguageServer for Backend {
                 continue;
             };
 
-            let Some(ecosystem) = self.state.ecosystem_registry.get_for_lockfile(filename) else {
-                tracing::debug!("Skipping non-lock-file change: {}", filename);
+            if let Some(ecosystem) = self.state.ecosystem_registry.get_for_lockfile(filename) {
+                tracing::info!(
+                    "Lock file changed: {} (ecosystem: {})",
+                    filename,
+                    ecosystem.id()
+                );
+
+                self.state.lockfile_cache.invalidate(&path);
+                self.handle_lockfile_change(&path, ecosystem.id()).await;
                 continue;
-            };
+            }
 
-            tracing::info!(
-                "Lock file changed: {} (ecosystem: {})",
-                filename,
-                ecosystem.id()
-            );
+            if let Some(ecosystem) = self
+                .state
+                .ecosystem_registry
+                .get_for_watched_config(filename)
+            {
+                tracing::info!(
+                    "Watched config file changed: {} (ecosystem: {})",
+                    filename,
+                    ecosystem.id()
+                );
 
-            self.state.lockfile_cache.invalidate(&path);
-            self.handle_lockfile_change(&path, ecosystem.id()).await;
+                // No cache invalidation here (unlike the lock-file branch above): every
+                // `MtimeFileCache`-backed config cache (e.g. `PnpmWorkspaceCache`,
+                // `NpmConfigCache`) already invalidates itself by mtime on its next
+                // `get_or_parse` — the reparse below is what triggers that next call.
+                self.handle_watched_config_change(ecosystem.id()).await;
+                continue;
+            }
+
+            tracing::debug!("Skipping unrecognized watched-file change: {}", filename);
         }
     }
 
@@ -1146,6 +1253,94 @@ mod tests {
 
         let config = backend.config.read().await;
         assert!(config.inlay_hints.enabled);
+    }
+
+    /// Issue #590 end-to-end: an on-disk `pnpm-workspace.yaml` change, delivered via
+    /// `workspace/didChangeWatchedFiles`, must reparse an already-open `package.json` that
+    /// references its catalog — not just refresh cached resolved versions the way a lock
+    /// file change does (`Self::handle_lockfile_change`), since catalog resolution is baked
+    /// into the parse result itself (see `Self::handle_watched_config_change`'s doc).
+    #[tokio::test]
+    async fn test_watched_config_change_reparses_open_document_with_catalog_dependency() {
+        use tower_lsp_server::ls_types::{
+            FileChangeType, FileEvent, HoverContents, Position, TextDocumentIdentifier,
+            TextDocumentItem, TextDocumentPositionParams,
+        };
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let workspace_path = temp_dir.path().join("pnpm-workspace.yaml");
+        std::fs::write(&workspace_path, "catalog:\n  react: ^17.0.0\n").unwrap();
+
+        let manifest_path = temp_dir.path().join("package.json");
+        let content = r#"{"dependencies": {"react": "catalog:"}}"#;
+        std::fs::write(&manifest_path, content).unwrap();
+        let uri = Uri::from_file_path(&manifest_path).unwrap();
+
+        let (service, _socket) = tower_lsp_server::LspService::build(Backend::new).finish();
+        let backend = service.inner();
+
+        backend
+            .did_open(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: uri.clone(),
+                    language_id: "json".to_string(),
+                    version: 1,
+                    text: content.to_string(),
+                },
+            })
+            .await;
+
+        let hover_params = |uri: Uri| HoverParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri },
+                position: Position::new(0, 20), // inside "react"'s name
+            },
+            work_done_progress_params: Default::default(),
+        };
+
+        let hover = backend
+            .hover(hover_params(uri.clone()))
+            .await
+            .unwrap()
+            .expect("hover must fire for a catalog-resolved dependency");
+        let HoverContents::Markup(before) = hover.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(before.value.contains("^17.0.0"), "{}", before.value);
+
+        // Ensure a distinguishable mtime on filesystems with coarse timestamp resolution
+        // (matches `mtime_cache::tests::forward_mtime_bump_invalidates`).
+        let future = std::time::SystemTime::now() + std::time::Duration::from_secs(2);
+        std::fs::write(&workspace_path, "catalog:\n  react: ^18.3.0\n").unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&workspace_path)
+            .unwrap()
+            .set_modified(future)
+            .unwrap();
+
+        backend
+            .did_change_watched_files(DidChangeWatchedFilesParams {
+                changes: vec![FileEvent {
+                    uri: Uri::from_file_path(&workspace_path).unwrap(),
+                    typ: FileChangeType::CHANGED,
+                }],
+            })
+            .await;
+
+        let hover = backend
+            .hover(hover_params(uri))
+            .await
+            .unwrap()
+            .expect("hover must still fire after reparse");
+        let HoverContents::Markup(after) = hover.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(
+            after.value.contains("^18.3.0"),
+            "watched config file change did not trigger a reparse of the open document: {}",
+            after.value
+        );
     }
 
     #[test]

--- a/crates/deps-npm/src/ecosystem.rs
+++ b/crates/deps-npm/src/ecosystem.rs
@@ -204,6 +204,10 @@ impl Ecosystem for NpmEcosystem {
         &["package-lock.json"]
     }
 
+    fn watched_config_filenames(&self) -> &[&'static str] {
+        &["pnpm-workspace.yaml", ".npmrc"]
+    }
+
     fn parse_manifest<'a>(
         &'a self,
         content: &'a str,
@@ -463,6 +467,16 @@ mod tests {
         let cache = Arc::new(deps_core::HttpCache::new());
         let ecosystem = NpmEcosystem::new(cache);
         assert_eq!(ecosystem.lockfile_filenames(), &["package-lock.json"]);
+    }
+
+    #[test]
+    fn test_ecosystem_watched_config_filenames() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let ecosystem = NpmEcosystem::new(cache);
+        assert_eq!(
+            ecosystem.watched_config_filenames(),
+            &["pnpm-workspace.yaml", ".npmrc"]
+        );
     }
 
     #[test]

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -133,7 +133,10 @@ precedence over a top-level `registry=` override for a dependency in that scope.
 Scope keys are matched byte-exact, with no case folding, matching npm's own
 lookup. A `${VAR}`-style placeholder in either key's value is expanded from this
 LSP server's own process environment; an undefined variable makes the whole entry
-invalid (same outcome as an invalid URL, below).
+invalid (same outcome as an invalid URL, below). `deps-lsp` watches `.npmrc` for
+external changes (e.g. a `git checkout`) and reparses every open `package.json`
+to refresh pushed diagnostics, rather than waiting for that document's own next
+edit.
 
 **Authentication**: phase 1 carries **no** authentication at all. `_authToken`,
 `_auth`, `_password`, `_authIdent`, `always-auth`, and every `//<host>/:_*`
@@ -156,9 +159,6 @@ to `"all"` for npm's benefit also widens it for Cargo, and vice versa — see th
 setting's own doc above.
 
 **Known limitations**:
-- Editing `.npmrc` does not take effect until the affected `package.json` is next
-  reparsed (edited, or the document reopened) — there is no dedicated file
-  watcher for it yet.
 - Package-*name* completion (typing a brand-new dependency) always searches
   `registry.npmjs.org`, even for a scope resolved to a private registry — the
   string being searched is a prefix the user typed into the name field, not a
@@ -184,7 +184,10 @@ instead of an unresolvable raw string.
 single-root-per-tree behavior — nested/multiple workspace roots are not
 searched further). `catalog:` and `catalog:default` are equivalent references
 to the default catalog, which may be defined either as a top-level `catalog:`
-block or a `catalogs.default:` section (but never both — see below).
+block or a `catalogs.default:` section (but never both — see below). `deps-lsp`
+watches `pnpm-workspace.yaml` for external changes and reparses every open
+`package.json` to refresh pushed diagnostics, rather than waiting for that
+document's own next edit.
 
 **Fail-closed, never destructive**: whenever a `catalog:` specifier does not
 resolve to a parseable semver range — no `pnpm-workspace.yaml` found, the file
@@ -205,12 +208,6 @@ in this situation before returning any catalog map at all; this deliberately
 never per-key-merges the two sections.
 
 **Known limitations**:
-- Editing `pnpm-workspace.yaml` does not proactively refresh an already-open
-  `package.json`'s pushed diagnostics — the cached catalog map is refreshed on
-  that document's *next* reparse (open/edit/save, or any hover/completion/
-  inlay-hint pull request), matching `.npmrc`'s identical existing refresh
-  contract exactly; there is no dedicated file watcher for
-  `pnpm-workspace.yaml` (`deps-lsp`'s watcher only covers lockfile patterns).
 - `pnpm-lock.yaml` is not read for in-use/resolved-version detection (no
   `deps-npm` lockfile support for it yet — see the lock-file column above);
   this is a pre-existing gap shared with every other npm dependency in a pnpm


### PR DESCRIPTION
## Summary

- **#591**: `MtimeFileCache::get_or_parse` (crates/deps-core/src/mtime_cache.rs) now rejects config files over an 8 MiB cap via a pre-read `fs::metadata` check, instead of always reading the full file into memory before any YAML-safety guard runs. Rejection is deduped per `(path, mtime)` to avoid unbounded log growth. Single change point shared by every consumer (pnpm-workspace.yaml, .npmrc, Cargo config).
- **#590**: deps-lsp now registers `pnpm-workspace.yaml`/`.npmrc` as LSP file watchers (mirroring the existing lockfile-watcher pattern via a new `Ecosystem::watched_config_filenames()` trait method), reparsing already-open `package.json` documents when they change instead of waiting on the next edit to the manifest itself.

## Implementation notes

Reparsing on a watched-config change introduced a race with concurrent `did_change` edits (a stale reparse could clobber newer content, or — after the first fix — silently abort the newer edit's own background diagnostics task). Both are fixed via a new `CommitGuard`/`CommitOptions` mechanism on `commit_parsed_document`: a watched-config-triggered reparse commits only if the document's version hasn't changed since it was snapshotted, and a skipped reparse never touches the background-task registry for that document. The normal `did_change`/`did_open` path is unaffected (`CommitGuard::Unconditional`).

## Test plan

- [x] New regression test: oversized file never reaches `read_to_string` (parse-call counter stays 0)
- [x] New regression test: oversize warning fires once per distinct `(path, mtime)`, not once per call
- [x] New e2e test: editing `pnpm-workspace.yaml` on disk while a referencing `package.json` is open updates its hover without touching the `package.json` itself
- [x] New regression test: a stale/skipped watched-config reparse does not abort a concurrent edit's live background task
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4076 passed)
- [x] `cargo test --doc --workspace --all-features`
- [x] CI rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`)

Closes #591
Closes #590