### PR TITLE
refactor(deps-cargo,deps-npm,deps-nuget): hoist MAX_CONFIG_ANCESTOR_DEPTH onto canonical constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-go**: `$GOENV` `GOPROXY`/`GOPRIVATE` follow-up hardening — test-injectable `$GOENV` path, oversized-`GOPRIVATE`-pattern warning, expanded edge-case/integration test coverage, and `GOPROXY` `,`/`|` separator docs (#563)
 
 ### Fixed
-- **deps-cargo, deps-npm, deps-nuget**: ancestor-walk depth cap now imports `deps-core`'s canonical `MAX_CONFIG_ANCESTOR_DEPTH` instead of each declaring its own duplicate copy (resolves #611)
+- **deps-cargo, deps-npm, deps-nuget**: ancestor-walk depth cap now imports `deps-core`'s canonical `MAX_CONFIG_ANCESTOR_DEPTH` instead of each declaring its own duplicate copy (resolves #611) (#616)
 - **deps-core**: `MtimeFileCache` enforces an 8 MiB size cap (checked via `fs::metadata`) before reading a config file's content, instead of always reading the full file before any safety guard runs (resolves #591) (#595)
 - **deps-go**: oversized-`GOPRIVATE`-pattern warning now logs once per distinct `$GOENV` file content instead of once per LSP re-parse (resolves #565) (#567)
 - **deps-go**: a `GOPROXY` separator preceding a dropped invalid hop is now merged onto the surviving transition with most-permissive-wins, instead of being silently discarded (resolves #564) (#567)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-go**: `$GOENV` `GOPROXY`/`GOPRIVATE` follow-up hardening — test-injectable `$GOENV` path, oversized-`GOPRIVATE`-pattern warning, expanded edge-case/integration test coverage, and `GOPROXY` `,`/`|` separator docs (#563)
 
 ### Fixed
+- **deps-cargo, deps-npm, deps-nuget**: ancestor-walk depth cap now imports `deps-core`'s canonical `MAX_CONFIG_ANCESTOR_DEPTH` instead of each declaring its own duplicate copy (resolves #611)
 - **deps-core**: `MtimeFileCache` enforces an 8 MiB size cap (checked via `fs::metadata`) before reading a config file's content, instead of always reading the full file before any safety guard runs (resolves #591) (#595)
 - **deps-go**: oversized-`GOPRIVATE`-pattern warning now logs once per distinct `$GOENV` file content instead of once per LSP re-parse (resolves #565) (#567)
 - **deps-go**: a `GOPROXY` separator preceding a dropped invalid hop is now merged onto the surviving transition with most-permissive-wins, instead of being silently discarded (resolves #564) (#567)

--- a/crates/deps-cargo/src/parser.rs
+++ b/crates/deps-cargo/src/parser.rs
@@ -33,6 +33,7 @@ use crate::config::{
     AuthToken, ConfigFileCache, IndexTrust, RegistryIndex, RegistryIndexError, SourceReplacement,
 };
 use crate::types::{DependencySection, DependencySource, ParsedDependency};
+use deps_core::fs_probe::MAX_CONFIG_ANCESTOR_DEPTH;
 use deps_core::net_policy::RegistryAccessPolicy;
 use deps_core::{DepsError, Result};
 use std::any::Any;
@@ -567,16 +568,6 @@ fn span_to_range(content: &str, line_table: &LineOffsetTable, span: toml_span::S
     let end = line_table.byte_offset_to_position(content, span.end);
     Range::new(start, end)
 }
-
-/// Upper bound on how many ancestor directories [`discover_workspace`] climbs, independent
-/// of whether the filesystem root has been reached (spec NFR-005, plan-1b §1.5, critic N1).
-///
-/// Caps the previously-unbounded workspace-root search — today's manifest walk is unbounded
-/// and TOML-parses every ancestor `Cargo.toml` — and bounds the merged `.cargo/config.toml`
-/// discovery pass added alongside it. A workspace root or config file more than 64
-/// directories up is not a realistic layout; a hostile deeply-nested tree hits this cap
-/// instead of doing unbounded work per parse.
-pub(crate) const MAX_CONFIG_ANCESTOR_DEPTH: usize = 64;
 
 /// Result of [`discover_workspace`]'s merged ancestor walk.
 struct WorkspaceDiscovery {

--- a/crates/deps-core/src/fs_probe.rs
+++ b/crates/deps-core/src/fs_probe.rs
@@ -22,13 +22,11 @@ use std::path::Path;
 /// Shared upper bound on how many ancestor directories a config-file discovery walk
 /// climbs, independent of whether the filesystem root has been reached.
 ///
-/// `deps-cargo`, `deps-npm`, and `deps-nuget` each still carry their own pre-existing
-/// `MAX_CONFIG_ANCESTOR_DEPTH` copy of this same value (64) for their workspace-root /
-/// config-file ancestor walks; this is the canonical definition new call sites (starting
-/// with `deps-gradle`'s `load_gradle_properties`) should reuse directly rather than adding
-/// a further duplicate — see #611 for the tracked follow-up to hoist those three onto this
-/// one. 64 directories up is not a realistic project layout — a pathologically deep or
-/// hostile tree hits this cap instead of doing unbounded work per parse (CWE-400).
+/// `deps-gradle`, `deps-cargo`, `deps-npm`, and `deps-nuget` all import this canonical
+/// definition directly for their own workspace-root / config-file ancestor walks, rather
+/// than each declaring their own duplicate. 64 directories up is not a realistic project
+/// layout — a pathologically deep or hostile tree hits this cap instead of doing unbounded
+/// work per parse (CWE-400).
 pub const MAX_CONFIG_ANCESTOR_DEPTH: usize = 64;
 
 #[cfg(any(test, feature = "test-util"))]

--- a/crates/deps-npm/src/catalog.rs
+++ b/crates/deps-npm/src/catalog.rs
@@ -478,7 +478,7 @@ fn find_workspace_file(manifest_dir: &Path) -> Option<PathBuf> {
     let mut current = Some(manifest_dir);
     let mut depth = 0usize;
     while let Some(dir) = current {
-        if depth >= crate::config::MAX_CONFIG_ANCESTOR_DEPTH {
+        if depth >= deps_core::fs_probe::MAX_CONFIG_ANCESTOR_DEPTH {
             break;
         }
         depth += 1;

--- a/crates/deps-npm/src/config.rs
+++ b/crates/deps-npm/src/config.rs
@@ -43,6 +43,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use deps_core::PackageName;
+use deps_core::fs_probe::MAX_CONFIG_ANCESTOR_DEPTH;
 use deps_core::net_policy::{
     HostClass, IndexUrlError, PolicyGate, RegistryAccessPolicy, redact_userinfo, validate_index_url,
 };
@@ -374,11 +375,6 @@ fn resolve_entry(
         }
     }
 }
-
-/// Upper bound on the project-tier ancestor walk depth, matching `deps-cargo`'s
-/// `MAX_CONFIG_ANCESTOR_DEPTH`. `pub(crate)` so `crate::catalog::find_workspace_file` can
-/// reuse the same bound for its own ancestor walk.
-pub(crate) const MAX_CONFIG_ANCESTOR_DEPTH: usize = 64;
 
 /// Per-`.npmrc`-file-path memoization (FR-012), mirroring `deps-cargo::config::ConfigFileCache`
 /// exactly in shape.

--- a/crates/deps-nuget/src/config.rs
+++ b/crates/deps-nuget/src/config.rs
@@ -47,6 +47,7 @@ use std::sync::atomic::AtomicBool;
 
 use base64::Engine;
 use deps_core::PackageName;
+use deps_core::fs_probe::MAX_CONFIG_ANCESTOR_DEPTH;
 use deps_core::net_policy::{
     IndexUrlError, PolicyGate, RegistryAccessPolicy, redact_userinfo, validate_index_url,
 };
@@ -54,10 +55,6 @@ use deps_core::parser::DependencySource;
 use quick_xml::Reader;
 use quick_xml::events::Event;
 use zeroize::Zeroizing;
-
-/// Upper bound on the in-repo `NuGet.Config` ancestor walk, matching `deps-npm`'s/
-/// `deps-cargo`'s identical `MAX_CONFIG_ANCESTOR_DEPTH`.
-const MAX_CONFIG_ANCESTOR_DEPTH: usize = 64;
 
 /// Candidate filenames checked per directory, in order — real NuGet is case-insensitive on
 /// Linux/macOS and all three spellings occur in the wild. `is_file()` stats, not `read_dir`.


### PR DESCRIPTION
## Summary

- deps-cargo, deps-npm, and deps-nuget each carried their own private copy of `MAX_CONFIG_ANCESTOR_DEPTH` (the ancestor-walk depth cap, value 64) instead of importing the canonical `deps_core::fs_probe::MAX_CONFIG_ANCESTOR_DEPTH` introduced by #607/#608 and already used by deps-gradle.
- Migrated all three to import the canonical constant directly; no behavior change (comparison logic and value unchanged).
- Updated the canonical constant's doc comment (was still claiming the three copies existed and pointed at this issue as pending work) and added a CHANGELOG entry.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4264 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --all-features`
- [x] Confirmed deps-cargo's stat-counting/boundary tests and deps-npm's catalog.rs reuse still exercise the same depth-cap boundary, unweakened

Closes #611