### PR TITLE
refactor(deps-gradle): unify Groovy/Kotlin DSL dependency extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-go**: `$GOENV` `GOPROXY`/`GOPRIVATE` follow-up hardening — test-injectable `$GOENV` path, oversized-`GOPRIVATE`-pattern warning, expanded edge-case/integration test coverage, and `GOPROXY` `,`/`|` separator docs (#563)
 
 ### Fixed
+- **deps-gradle**: Kotlin DSL parser now shares a single capture-to-`GradleDependency` builder with Groovy DSL and recognizes the legacy `compile`/`testCompile`/`provided` configurations (resolves #625)
 - **deps-composer**: a `require`/`require-dev` entry whose value isn't a string (e.g. an object) is now skipped instead of producing a dependency entry queried against Packagist (resolves #621) (#623)
 - **deps-cargo, deps-npm, deps-nuget**: ancestor-walk depth cap now imports `deps-core`'s canonical `MAX_CONFIG_ANCESTOR_DEPTH` instead of each declaring its own duplicate copy (resolves #611) (#616)
 - **deps-core**: `MtimeFileCache` enforces an 8 MiB size cap (checked via `fs::metadata`) before reading a config file's content, instead of always reading the full file before any safety guard runs (resolves #591) (#595)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-go**: `$GOENV` `GOPROXY`/`GOPRIVATE` follow-up hardening — test-injectable `$GOENV` path, oversized-`GOPRIVATE`-pattern warning, expanded edge-case/integration test coverage, and `GOPROXY` `,`/`|` separator docs (#563)
 
 ### Fixed
-- **deps-gradle**: Kotlin DSL parser now shares a single capture-to-`GradleDependency` builder with Groovy DSL and recognizes the legacy `compile`/`testCompile`/`provided` configurations (resolves #625)
+- **deps-gradle**: Kotlin DSL parser now shares a single capture-to-`GradleDependency` builder with Groovy DSL and recognizes the legacy `compile`/`testCompile`/`provided` configurations (resolves #625) (#626)
 - **deps-composer**: a `require`/`require-dev` entry whose value isn't a string (e.g. an object) is now skipped instead of producing a dependency entry queried against Packagist (resolves #621) (#623)
 - **deps-cargo, deps-npm, deps-nuget**: ancestor-walk depth cap now imports `deps-core`'s canonical `MAX_CONFIG_ANCESTOR_DEPTH` instead of each declaring its own duplicate copy (resolves #611) (#616)
 - **deps-core**: `MtimeFileCache` enforces an 8 MiB size cap (checked via `fs::metadata`) before reading a config file's content, instead of always reading the full file before any safety guard runs (resolves #591) (#595)

--- a/crates/deps-gradle/src/parser/groovy.rs
+++ b/crates/deps-gradle/src/parser/groovy.rs
@@ -2,7 +2,7 @@
 //!
 //! Regex-based extraction of dependency declarations from dependencies { } blocks.
 
-use crate::parser::{GradleParseResult, find_name_range, find_version_range};
+use crate::parser::{CONFIGURATIONS, GradleParseResult, build_dependency};
 use crate::types::GradleDependency;
 use deps_core::Result;
 use regex::Regex;
@@ -53,23 +53,6 @@ static RE_PLATFORM_NO_VERSION_WITHOUT_PARENS: LazyLock<Regex> = LazyLock::new(||
         .expect("RE_PLATFORM_NO_VERSION_WITHOUT_PARENS")
 });
 
-const CONFIGURATIONS: &[&str] = &[
-    "implementation",
-    "api",
-    "compileOnly",
-    "runtimeOnly",
-    "testImplementation",
-    "testRuntimeOnly",
-    "annotationProcessor",
-    "kapt",
-    "classpath",
-    "ksp",
-    "testCompileOnly",
-    "compile",
-    "testCompile",
-    "provided",
-];
-
 /// Runs `re` over `line`, filters matches to known `CONFIGURATIONS`, dedups
 /// against `matched_positions` (shared across all patterns tried on this
 /// line), and pushes a [`GradleDependency`] for each surviving match.
@@ -97,28 +80,7 @@ fn extract_matches(
         }
         matched_positions.push(start);
 
-        let group_id = caps.get(2).map_or("", |m| m.as_str()).to_string();
-        let artifact_id = caps.get(3).map_or("", |m| m.as_str()).to_string();
-        let name = format!("{group_id}:{artifact_id}");
-        let name_range = find_name_range(line, line_u32, &group_id, &artifact_id);
-
-        let (version_req, version_range) = if has_version {
-            let version = caps.get(4).map_or("", |m| m.as_str()).trim().to_string();
-            let version_range = find_version_range(line, line_u32, &version);
-            (Some(version.into()), Some(version_range))
-        } else {
-            (None, None)
-        };
-
-        dependencies.push(GradleDependency {
-            group_id,
-            artifact_id,
-            name: name.into(),
-            name_range,
-            version_req,
-            version_range,
-            configuration: config.to_string(),
-        });
+        dependencies.push(build_dependency(&caps, line, line_u32, has_version, config));
     }
 }
 
@@ -294,6 +256,19 @@ mod tests {
         assert_eq!(result.dependencies.len(), 4);
         assert_eq!(result.dependencies[1].configuration, "testImplementation");
         assert_eq!(result.dependencies[2].configuration, "compileOnly");
+    }
+
+    #[test]
+    fn test_parse_legacy_configurations() {
+        // compile/testCompile/provided predate #625's unification but were
+        // never covered by a dedicated test; guard the shared CONFIGURATIONS
+        // list now that both DSLs read from it.
+        let content = "dependencies {\n    compile 'org.springframework.boot:spring-boot-starter:3.2.0'\n    testCompile 'junit:junit:4.13.2'\n    provided 'javax.servlet:javax.servlet-api:4.0.1'\n}\n";
+        let result = parse_groovy_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 3);
+        assert_eq!(result.dependencies[0].configuration, "compile");
+        assert_eq!(result.dependencies[1].configuration, "testCompile");
+        assert_eq!(result.dependencies[2].configuration, "provided");
     }
 
     #[test]

--- a/crates/deps-gradle/src/parser/kotlin.rs
+++ b/crates/deps-gradle/src/parser/kotlin.rs
@@ -2,8 +2,7 @@
 //!
 //! Regex-based extraction of dependency declarations from dependencies { } blocks.
 
-use crate::parser::{GradleParseResult, find_name_range, find_version_range};
-use crate::types::GradleDependency;
+use crate::parser::{CONFIGURATIONS, GradleParseResult, build_dependency};
 use deps_core::Result;
 use regex::Regex;
 use std::sync::LazyLock;
@@ -31,20 +30,6 @@ static RE_PLATFORM_NO_VERSION: LazyLock<Regex> = LazyLock::new(|| {
     )
     .expect("RE_PLATFORM_NO_VERSION")
 });
-
-const CONFIGURATIONS: &[&str] = &[
-    "implementation",
-    "api",
-    "compileOnly",
-    "runtimeOnly",
-    "testImplementation",
-    "testRuntimeOnly",
-    "annotationProcessor",
-    "kapt",
-    "classpath",
-    "ksp",
-    "testCompileOnly",
-];
 
 pub fn parse_kotlin_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
     let mut dependencies = Vec::new();
@@ -91,25 +76,7 @@ pub fn parse_kotlin_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
             if !CONFIGURATIONS.contains(&config) {
                 continue;
             }
-
-            let group_id = caps.get(2).map_or("", |m| m.as_str()).to_string();
-            let artifact_id = caps.get(3).map_or("", |m| m.as_str()).to_string();
-            let version = caps.get(4).map_or("", |m| m.as_str()).trim().to_string();
-            let name = format!("{group_id}:{artifact_id}");
-
-            // name_range covers the full "group:artifact" portion of the string
-            let name_range = find_name_range(line, line_u32, &group_id, &artifact_id);
-            let version_range = find_version_range(line, line_u32, &version);
-
-            dependencies.push(GradleDependency {
-                group_id,
-                artifact_id,
-                name: name.into(),
-                name_range,
-                version_req: Some(version.into()),
-                version_range: Some(version_range),
-                configuration: config.to_string(),
-            });
+            dependencies.push(build_dependency(&caps, line, line_u32, true, config));
         }
 
         // Try pattern without version (only if no versioned match on this line)
@@ -134,21 +101,7 @@ pub fn parse_kotlin_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
             if already_matched.contains(&match_start) {
                 continue;
             }
-
-            let group_id = caps.get(2).map_or("", |m| m.as_str()).to_string();
-            let artifact_id = caps.get(3).map_or("", |m| m.as_str()).to_string();
-            let name = format!("{group_id}:{artifact_id}");
-            let name_range = find_name_range(line, line_u32, &group_id, &artifact_id);
-
-            dependencies.push(GradleDependency {
-                group_id,
-                artifact_id,
-                name: name.into(),
-                name_range,
-                version_req: None,
-                version_range: None,
-                configuration: config.to_string(),
-            });
+            dependencies.push(build_dependency(&caps, line, line_u32, false, config));
         }
 
         // Same as above, for platform()/enforcedPlatform()-wrapped BOM coordinates
@@ -167,24 +120,7 @@ pub fn parse_kotlin_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
             if !CONFIGURATIONS.contains(&config) {
                 continue;
             }
-
-            let group_id = caps.get(2).map_or("", |m| m.as_str()).to_string();
-            let artifact_id = caps.get(3).map_or("", |m| m.as_str()).to_string();
-            let version = caps.get(4).map_or("", |m| m.as_str()).trim().to_string();
-            let name = format!("{group_id}:{artifact_id}");
-
-            let name_range = find_name_range(line, line_u32, &group_id, &artifact_id);
-            let version_range = find_version_range(line, line_u32, &version);
-
-            dependencies.push(GradleDependency {
-                group_id,
-                artifact_id,
-                name: name.into(),
-                name_range,
-                version_req: Some(version.into()),
-                version_range: Some(version_range),
-                configuration: config.to_string(),
-            });
+            dependencies.push(build_dependency(&caps, line, line_u32, true, config));
         }
 
         for caps in RE_PLATFORM_NO_VERSION.captures_iter(line) {
@@ -196,21 +132,7 @@ pub fn parse_kotlin_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
             if already_matched_platform.contains(&match_start) {
                 continue;
             }
-
-            let group_id = caps.get(2).map_or("", |m| m.as_str()).to_string();
-            let artifact_id = caps.get(3).map_or("", |m| m.as_str()).to_string();
-            let name = format!("{group_id}:{artifact_id}");
-            let name_range = find_name_range(line, line_u32, &group_id, &artifact_id);
-
-            dependencies.push(GradleDependency {
-                group_id,
-                artifact_id,
-                name: name.into(),
-                name_range,
-                version_req: None,
-                version_range: None,
-                configuration: config.to_string(),
-            });
+            dependencies.push(build_dependency(&caps, line, line_u32, false, config));
         }
     }
 
@@ -286,6 +208,47 @@ mod tests {
         assert_eq!(result.dependencies[1].configuration, "compileOnly");
         assert_eq!(result.dependencies[2].configuration, "runtimeOnly");
         assert_eq!(result.dependencies[3].configuration, "kapt");
+    }
+
+    #[test]
+    fn test_parse_legacy_configurations() {
+        // Kotlin DSL scripts migrated from (or targeting) pre-Gradle-7 builds
+        // can still use the legacy `compile`/`testCompile`/`provided` words —
+        // Gradle parses them regardless of DSL, so they must be recognized
+        // here just as they are in groovy.rs.
+        let content = r#"dependencies {
+    compile("org.springframework.boot:spring-boot-starter:3.2.0")
+    testCompile("junit:junit:4.13.2")
+    provided("javax.servlet:javax.servlet-api:4.0.1")
+}
+"#;
+        let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 3);
+        assert_eq!(result.dependencies[0].configuration, "compile");
+        assert_eq!(result.dependencies[1].configuration, "testCompile");
+        assert_eq!(result.dependencies[2].configuration, "provided");
+    }
+
+    #[test]
+    fn test_parse_legacy_configuration_no_version() {
+        let content = "dependencies {\n    provided(\"javax.servlet:javax.servlet-api\")\n}\n";
+        let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].configuration, "provided");
+        assert!(result.dependencies[0].version_req.is_none());
+    }
+
+    #[test]
+    fn test_parse_legacy_configuration_platform() {
+        let content = "dependencies {\n    compile(platform(\"org.springframework.boot:spring-boot-dependencies:3.2.0\"))\n}\n";
+        let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].configuration, "compile");
+        assert_eq!(
+            result.dependencies[0].name,
+            "org.springframework.boot:spring-boot-dependencies"
+        );
+        assert_eq!(result.dependencies[0].version_req, Some("3.2.0".into()));
     }
 
     #[test]

--- a/crates/deps-gradle/src/parser/mod.rs
+++ b/crates/deps-gradle/src/parser/mod.rs
@@ -10,11 +10,80 @@ pub mod settings;
 
 use crate::types::GradleDependency;
 use deps_core::Result;
+use regex::Captures;
 use std::any::Any;
 use std::collections::HashMap;
 use tower_lsp_server::ls_types::{Position, Range, Uri};
 
 pub use deps_core::lsp_helpers::LineOffsetTable;
+
+/// Configuration words recognized as dependency declarations in both Groovy
+/// and Kotlin Gradle DSLs.
+///
+/// Includes the pre-Gradle-7 legacy configurations `compile`, `testCompile`,
+/// and `provided`: Gradle still parses them regardless of which DSL a build
+/// script uses, so a `build.gradle.kts` migrated from an old `build.gradle`
+/// (or targeting a project not yet updated) can legitimately contain them.
+/// Restricting recognition to one DSL would be silent drift, not an
+/// intentional scoping decision.
+pub(crate) const CONFIGURATIONS: &[&str] = &[
+    "implementation",
+    "api",
+    "compileOnly",
+    "runtimeOnly",
+    "testImplementation",
+    "testRuntimeOnly",
+    "annotationProcessor",
+    "kapt",
+    "classpath",
+    "ksp",
+    "testCompileOnly",
+    "compile",
+    "testCompile",
+    "provided",
+];
+
+/// Builds a [`GradleDependency`] from a regex match's captures.
+///
+/// All Groovy and Kotlin DSL regex variants share identical capture group
+/// indices — 1: configuration, 2: group id, 3: artifact id, 4: version (when
+/// present) — so `has_version` alone distinguishes the two capture shapes.
+pub(crate) fn build_dependency(
+    caps: &Captures<'_>,
+    line: &str,
+    line_idx: u32,
+    has_version: bool,
+    config: &str,
+) -> GradleDependency {
+    debug_assert_eq!(
+        caps.len(),
+        if has_version { 5 } else { 4 },
+        "regex capture count must match has_version so group 4 (version) is only read when present"
+    );
+
+    let group_id = caps.get(2).map_or("", |m| m.as_str()).to_string();
+    let artifact_id = caps.get(3).map_or("", |m| m.as_str()).to_string();
+    let name = format!("{group_id}:{artifact_id}");
+    let name_range = find_name_range(line, line_idx, &group_id, &artifact_id);
+
+    let (version_req, version_range) = if has_version {
+        let version = caps.get(4).map_or("", |m| m.as_str()).trim().to_string();
+        let version_range = find_version_range(line, line_idx, &version);
+        (Some(version.into()), Some(version_range))
+    } else {
+        (None, None)
+    };
+
+    GradleDependency {
+        group_id,
+        artifact_id,
+        name: name.into(),
+        name_range,
+        version_req,
+        version_range,
+        configuration: config.to_string(),
+    }
+}
 
 #[derive(Debug)]
 pub struct GradleParseResult {


### PR DESCRIPTION
## Summary
- Extract a shared `build_dependency()` helper and canonical `CONFIGURATIONS` list into `crates/deps-gradle/src/parser/mod.rs`, replacing `kotlin.rs`'s 4 duplicated capture-processing blocks (the pattern PR #537 had already unified for `groovy.rs`).
- Each DSL keeps its own dedup strategy around the shared call: Groovy's `matched_positions` global dedup, Kotlin's per-pair `already_matched`/`already_matched_platform`.
- Resolve the `CONFIGURATIONS` drift explicitly: Kotlin DSL now also recognizes the legacy `compile`/`testCompile`/`provided` configurations, previously Groovy-only. Gradle parses these configurations at the engine level regardless of which DSL wrote the build script, so the prior Kotlin-only restriction was undocumented drift rather than a deliberate scoping decision.
- Added a `debug_assert_eq!` on regex capture-group count in `build_dependency` so future capture-index drift between the two DSLs fails loudly in tests instead of silently mis-assigning fields.
- Added test coverage: Kotlin legacy-config + no-version, legacy-config + `platform()`; Groovy legacy-config (`compile`/`testCompile`/`provided`), closing a pre-existing gap where Groovy supported these configs without a dedicated test.

Verified live (throwaway scratch crate driving `parse_gradle` over ~20 manifests) that the unified extraction path produces identical `GradleDependency` values to the pre-refactor duplicated blocks for every pattern shape in both DSLs, and that dedup state does not leak between call sites.

Three pre-existing issues were identified during review but are out of scope for this refactor and will be filed separately:
- `CONFIGURATIONS` is still missing several currently-valid Gradle configs (`androidTestImplementation`, `debugImplementation`, `compileOnlyApi`, `testFixturesImplementation`).
- `find_version_range` keys off the line's second `:` rather than the match span, so two same-line/same-version dependencies can share a mis-attributed `version_range`.
- A line starting with the literal word `dependencies` (e.g. `dependenciesInfo { ... }`) can be scanned outside a real `dependencies { }` block.

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4290 passed, 0 failed, 49 skipped)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`

Closes #625