### PR TITLE
refactor(deps-core,deps-npm,deps-composer): share non-string dependency value skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- **deps-core, deps-npm, deps-composer**: `deps-npm` and `deps-composer` now share a single `deps_core::json_helpers::string_valued_entries` helper (and its test coverage) for skipping non-string dependency-map values, instead of each crate carrying its own duplicated guard and tests (resolves #624)
+- **deps-core, deps-npm, deps-composer**: `deps-npm` and `deps-composer` now share a single `deps_core::json_helpers::string_valued_entries` helper (and its test coverage) for skipping non-string dependency-map values, instead of each crate carrying its own duplicated guard and tests (resolves #624) (#630)
 
 ### Added
 - **deps-lsp**: `workspace/didChangeConfiguration` now re-parses and forces a full re-fetch for every open document affected by a live-reloaded setting that alters registry routing (`registries.workspace_registries`, `registries.nuget_user_profile_sources`, `registries.gitlab_instance_host`), bounded by a server-wide fetch-concurrency cap shared with cold-start loading (resolves #592) (#600)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **deps-core, deps-npm, deps-composer**: `deps-npm` and `deps-composer` now share a single `deps_core::json_helpers::string_valued_entries` helper (and its test coverage) for skipping non-string dependency-map values, instead of each crate carrying its own duplicated guard and tests (resolves #624)
+
 ### Added
 - **deps-lsp**: `workspace/didChangeConfiguration` now re-parses and forces a full re-fetch for every open document affected by a live-reloaded setting that alters registry routing (`registries.workspace_registries`, `registries.nuget_user_profile_sources`, `registries.gitlab_instance_host`), bounded by a server-wide fetch-concurrency cap shared with cold-start loading (resolves #592) (#600)
 - **deps-npm, deps-lsp**: watch `pnpm-workspace.yaml`/`.npmrc` for external changes and reparse already-open `package.json` documents so catalog/registry-resolved diagnostics stay current (resolves #590) (#595)

--- a/crates/deps-composer/src/parser.rs
+++ b/crates/deps-composer/src/parser.rs
@@ -7,6 +7,7 @@
 use crate::types::{ComposerDependency, ComposerSection};
 use deps_core::Result;
 use deps_core::json_ast::{JsonAst, JsonSection};
+use deps_core::json_helpers::string_valued_entries;
 use deps_core::lsp_helpers::LineOffsetTable;
 use serde_json::Value;
 use std::any::Any;
@@ -179,24 +180,21 @@ fn parse_section(
 ) -> Vec<ComposerDependency> {
     let mut result = Vec::new();
 
-    for (name, value) in deps {
+    // A manifest entry whose value isn't a string (e.g. an object) is not a valid dependency
+    // declaration — `string_valued_entries` skips it rather than fabricating an entry with no
+    // `version_req` that would still be queried against the registry (#621, same bug class as
+    // npm's #619).
+    for (name, version_req) in string_valued_entries(deps) {
         if is_platform_package(name) {
             continue;
         }
 
-        // A manifest entry whose value isn't a string (e.g. an object) is not a valid
-        // dependency declaration — skip it rather than fabricating an entry with no
-        // `version_req` that would still be queried against the registry (#621, same bug
-        // class as npm's #619).
-        let Some(version_req) = value.as_str() else {
-            continue;
-        };
         let (name_range, version_range) = positions
             .and_then(|s| s.position(name, content, line_table))
             .unwrap_or_default();
 
         result.push(ComposerDependency {
-            name: name.clone().into(),
+            name: name.into(),
             name_range,
             version_req: Some(version_req.into()),
             version_range,
@@ -367,7 +365,8 @@ mod tests {
     fn test_non_string_dependency_value_is_skipped() {
         // #621, same bug class as npm's #619: an object-valued entry (e.g. accidentally
         // nested config) is not a valid dependency declaration and must not be surfaced or
-        // queried against the registry.
+        // queried against the registry. Full coverage of every non-string value kind lives in
+        // `deps_core::json_helpers::string_valued_entries`'s own tests (#624).
         let json = r#"{
   "require": {
     "nested-shadow": { "acme/express": "0.0.1" },
@@ -382,33 +381,16 @@ mod tests {
     }
 
     #[test]
-    fn test_various_non_string_dependency_value_kinds_are_skipped() {
-        // #621: `value.as_str()` returns `None` uniformly for every non-string JSON kind, not
-        // just objects — cover number, bool, null and array alongside one valid entry.
-        let json = r#"{
-  "require": {
-    "bad/number": 1,
-    "bad/bool": true,
-    "bad/null": null,
-    "bad/array": ["1.0.0"],
-    "symfony/console": "^6.0"
-  }
-}"#;
-
-        let result = parse_composer_json(json, &test_uri()).unwrap();
-        assert_eq!(result.dependencies.len(), 1);
-        assert_eq!(result.dependencies[0].name, "symfony/console");
-        assert_eq!(result.dependencies[0].version_req, Some("^6.0".into()));
-    }
-
-    #[test]
-    fn test_all_invalid_dependency_values_in_section_yields_empty_list() {
-        // #621: a section present in the manifest but whose every entry has a non-string
-        // value must resolve to an empty list, not an error or a panic.
+    fn test_all_invalid_dependency_values_skipped_across_both_sections_end_to_end() {
+        // #621: end-to-end confirmation that the skip applies uniformly across `require` and
+        // `require-dev`, and to more than one non-string kind — this only guards the
+        // parser/helper wiring; full value-kind coverage lives in
+        // `deps_core::json_helpers::string_valued_entries`'s own tests (#624).
         let json = r#"{
   "require": {
     "bad/object": { "nested": "0.0.1" },
-    "bad/number": 1
+    "bad/number": 1,
+    "symfony/console": "^6.0"
   },
   "require-dev": {
     "bad/object-dev": { "nested": "0.0.1" }
@@ -416,7 +398,8 @@ mod tests {
 }"#;
 
         let result = parse_composer_json(json, &test_uri()).unwrap();
-        assert_eq!(result.dependencies.len(), 0);
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].name, "symfony/console");
     }
 
     /// #424: `minimum-stability` is parsed from the manifest root when present.

--- a/crates/deps-core/src/json_helpers.rs
+++ b/crates/deps-core/src/json_helpers.rs
@@ -1,0 +1,86 @@
+//! Shared `serde_json`-side helpers for parsing a JSON manifest's *semantic* dependency-map
+//! content (#624).
+//!
+//! `deps-npm` and `deps-composer` each parse a dependency section as a raw
+//! `serde_json::Map<String, Value>` and apply the same "is this a valid dependency
+//! declaration" rule to every entry — this module is where that rule lives, so both crates
+//! share one implementation and one set of tests instead of duplicating both.
+//!
+//! This is a different concern from [`crate::json_ast`], which recovers a dependency's
+//! *position* in the source text from a separate jsonc-AST parse of the same content — this
+//! module never touches that AST, only the `serde_json::Value` tree callers already hold.
+
+/// Iterates a JSON object's entries, yielding only those whose value is a plain string.
+///
+/// A manifest entry whose value isn't a string (e.g. an object, number, bool, null, or array)
+/// is not a valid dependency declaration — callers skip it rather than fabricating an entry
+/// with no version requirement that would still be queried against the registry (`deps-npm`
+/// #619, `deps-composer` #621).
+///
+/// Yields entries in `entries`' own iteration order, which `serde_json::Map` derives from
+/// either `BTreeMap` (sorted by key) or `IndexMap` (insertion order), depending on this
+/// build's `serde_json/preserve_order` feature unification — do not write a test against a
+/// specific order without accounting for that.
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::json_helpers::string_valued_entries;
+/// use serde_json::json;
+///
+/// let deps = json!({"express": "^4.18.2", "nested-shadow": {"express": "0.0.1"}});
+/// let deps = deps.as_object().unwrap();
+///
+/// let entries: Vec<_> = string_valued_entries(deps).collect();
+/// assert_eq!(entries, vec![("express", "^4.18.2")]);
+/// ```
+pub fn string_valued_entries(
+    entries: &serde_json::Map<String, serde_json::Value>,
+) -> impl Iterator<Item = (&str, &str)> {
+    entries
+        .iter()
+        .filter_map(|(name, value)| Some((name.as_str(), value.as_str()?)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- `string_valued_entries` (#624: consolidated from deps-npm #619 / deps-composer #621) ---
+
+    #[test]
+    fn test_string_valued_entries_skips_every_non_string_value_kind() {
+        let deps = serde_json::json!({
+            "bad-object": {"nested": "0.0.1"},
+            "bad-number": 1,
+            "bad-bool": true,
+            "bad-null": null,
+            "bad-array": ["1.0.0"],
+            "express": "^4.18.2",
+        });
+        let deps = deps.as_object().unwrap();
+
+        let mut entries: Vec<_> = string_valued_entries(deps).collect();
+        entries.sort_unstable();
+        assert_eq!(entries, vec![("express", "^4.18.2")]);
+    }
+
+    #[test]
+    fn test_string_valued_entries_all_invalid_yields_empty() {
+        let deps = serde_json::json!({
+            "bad-object": {"nested": "0.0.1"},
+            "bad-number": 1,
+        });
+        let deps = deps.as_object().unwrap();
+
+        assert_eq!(string_valued_entries(deps).count(), 0);
+    }
+
+    #[test]
+    fn test_string_valued_entries_empty_object_yields_empty() {
+        let deps = serde_json::json!({});
+        let deps = deps.as_object().unwrap();
+
+        assert_eq!(string_valued_entries(deps).count(), 0);
+    }
+}

--- a/crates/deps-core/src/lib.rs
+++ b/crates/deps-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod freshness;
 pub mod fs_probe;
 pub mod github;
 pub mod json_ast;
+pub mod json_helpers;
 pub mod lockfile;
 pub mod lsp_helpers;
 pub mod macros;
@@ -45,6 +46,7 @@ pub use freshness::{
     DEFAULT_COOLDOWN_SECS, FreshnessSettings, PublishTime, format_relative_age, is_within_cooldown,
 };
 pub use json_ast::{JsonAst, JsonSection, find_last_prop};
+pub use json_helpers::string_valued_entries;
 pub use lockfile::{
     LockFileProvider, ResolvedPackage, ResolvedPackages, ResolvedSource, read_lockfile_content,
 };

--- a/crates/deps-npm/src/parser.rs
+++ b/crates/deps-npm/src/parser.rs
@@ -7,6 +7,7 @@ use crate::config::{NpmConfig, NpmParseContext, NpmRegistryIndex};
 use crate::types::{NpmDependency, NpmDependencySection};
 use deps_core::Result;
 use deps_core::json_ast::{JsonAst, JsonSection};
+use deps_core::json_helpers::string_valued_entries;
 use deps_core::lsp_helpers::LineOffsetTable;
 use serde_json::Value;
 use std::any::Any;
@@ -208,20 +209,16 @@ fn parse_dependency_section(
 ) -> Vec<NpmDependency> {
     let mut result = Vec::new();
 
-    for (name, value) in deps {
-        // A manifest entry whose value isn't a string (e.g. an object) is not a valid
-        // dependency declaration — skip it rather than fabricating an entry with no
-        // `version_req` that would still be queried against the registry (#619).
-        let Some(version_req) = value.as_str() else {
-            continue;
-        };
-
+    // A manifest entry whose value isn't a string (e.g. an object) is not a valid dependency
+    // declaration — `string_valued_entries` skips it rather than fabricating an entry with no
+    // `version_req` that would still be queried against the registry (#619).
+    for (name, version_req) in string_valued_entries(deps) {
         let (name_range, version_range) = positions
             .and_then(|s| s.position(name, content, line_table))
             .unwrap_or_default();
 
         result.push(NpmDependency {
-            name: name.clone().into(),
+            name: name.into(),
             name_range,
             version_req: Some(version_req.into()),
             version_range,
@@ -359,6 +356,8 @@ mod tests {
     fn test_non_string_dependency_value_is_skipped() {
         // #619: an object-valued entry (e.g. accidentally nested config) is not a valid
         // dependency declaration and must not be surfaced or queried against the registry.
+        // Full coverage of every non-string value kind lives in
+        // `deps_core::json_helpers::string_valued_entries`'s own tests (#624).
         let json = r#"{
   "dependencies": {
     "nested-shadow": { "express": "0.0.1" },
@@ -373,15 +372,13 @@ mod tests {
     }
 
     #[test]
-    fn test_various_non_string_dependency_value_kinds_are_skipped() {
-        // #619: `value.as_str()` returns `None` uniformly for every non-string JSON kind, not
-        // just objects — cover number, bool, null and array alongside one valid entry.
+    fn test_non_string_dependency_value_of_another_kind_is_skipped_end_to_end() {
+        // #619: end-to-end confirmation that a non-object non-string kind (number) is skipped
+        // too, not just objects — this only guards the parser/helper wiring; full value-kind
+        // coverage lives in `deps_core::json_helpers::string_valued_entries`'s own tests (#624).
         let json = r#"{
   "dependencies": {
     "bad-number": 1,
-    "bad-bool": true,
-    "bad-null": null,
-    "bad-array": ["1.0.0"],
     "express": "^4.18.2"
   }
 }"#;
@@ -389,22 +386,6 @@ mod tests {
         let result = parse_package_json(json, &test_uri()).unwrap();
         assert_eq!(result.dependencies.len(), 1);
         assert_eq!(result.dependencies[0].name, "express");
-        assert_eq!(result.dependencies[0].version_req, Some("^4.18.2".into()));
-    }
-
-    #[test]
-    fn test_all_invalid_dependency_values_in_section_yields_empty_list() {
-        // #619: a section present in the manifest but whose every entry has a non-string value
-        // must resolve to an empty list, not an error or a panic.
-        let json = r#"{
-  "dependencies": {
-    "bad-object": { "nested": "0.0.1" },
-    "bad-number": 1
-  }
-}"#;
-
-        let result = parse_package_json(json, &test_uri()).unwrap();
-        assert_eq!(result.dependencies.len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- deps-npm (#619) and deps-composer (#621) each independently added an identical guard skipping non-string dependency-map values, and each carried its own ~60-line duplicated test suite for it.
- Consolidates both into a new `deps_core::json_helpers::string_valued_entries` helper and its own test suite; both crates now call the shared helper instead of duplicating the guard.
- End-to-end test coverage per crate was kept (not fully removed) — restored to cover a second value kind and, for composer, a second manifest section — so integration coverage isn't narrower than before the refactor.

Closes #624

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4287 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] `cargo test --workspace --doc --all-features` (new helper's doctest included)