### PR TITLE
fix(deps-gradle): configuration recognition, range attribution, block-guard fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-go**: `$GOENV` `GOPROXY`/`GOPRIVATE` follow-up hardening — test-injectable `$GOENV` path, oversized-`GOPRIVATE`-pattern warning, expanded edge-case/integration test coverage, and `GOPROXY` `,`/`|` separator docs (#563)
 
 ### Fixed
-- **deps-gradle**: recognize modern/variant configuration names (`androidTestImplementation`, `debugImplementation`, `compileOnlyApi`, `kaptAndroidTest`, etc.) instead of a fixed literal whitelist (resolves #627)
-- **deps-gradle**: fix mis-attributed name/version ranges for same-line dependencies sharing an identical coordinate or version (resolves #628)
-- **deps-gradle**: fix `dependencies { }` block guard false-positiving on unrelated blocks like `dependenciesInfo { }` (resolves #629)
+- **deps-gradle**: recognize modern/variant configuration names (`androidTestImplementation`, `debugImplementation`, `compileOnlyApi`, `kaptAndroidTest`, etc.) instead of a fixed literal whitelist (resolves #627) (#631)
+- **deps-gradle**: fix mis-attributed name/version ranges for same-line dependencies sharing an identical coordinate or version (resolves #628) (#631)
+- **deps-gradle**: fix `dependencies { }` block guard false-positiving on unrelated blocks like `dependenciesInfo { }` (resolves #629) (#631)
 - **deps-gradle**: Kotlin DSL parser now shares a single capture-to-`GradleDependency` builder with Groovy DSL and recognizes the legacy `compile`/`testCompile`/`provided` configurations (resolves #625) (#626)
 - **deps-composer**: a `require`/`require-dev` entry whose value isn't a string (e.g. an object) is now skipped instead of producing a dependency entry queried against Packagist (resolves #621) (#623)
 - **deps-cargo, deps-npm, deps-nuget**: ancestor-walk depth cap now imports `deps-core`'s canonical `MAX_CONFIG_ANCESTOR_DEPTH` instead of each declaring its own duplicate copy (resolves #611) (#616)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-go**: `$GOENV` `GOPROXY`/`GOPRIVATE` follow-up hardening — test-injectable `$GOENV` path, oversized-`GOPRIVATE`-pattern warning, expanded edge-case/integration test coverage, and `GOPROXY` `,`/`|` separator docs (#563)
 
 ### Fixed
+- **deps-gradle**: recognize modern/variant configuration names (`androidTestImplementation`, `debugImplementation`, `compileOnlyApi`, `kaptAndroidTest`, etc.) instead of a fixed literal whitelist (resolves #627)
+- **deps-gradle**: fix mis-attributed name/version ranges for same-line dependencies sharing an identical coordinate or version (resolves #628)
+- **deps-gradle**: fix `dependencies { }` block guard false-positiving on unrelated blocks like `dependenciesInfo { }` (resolves #629)
 - **deps-gradle**: Kotlin DSL parser now shares a single capture-to-`GradleDependency` builder with Groovy DSL and recognizes the legacy `compile`/`testCompile`/`provided` configurations (resolves #625) (#626)
 - **deps-composer**: a `require`/`require-dev` entry whose value isn't a string (e.g. an object) is now skipped instead of producing a dependency entry queried against Packagist (resolves #621) (#623)
 - **deps-cargo, deps-npm, deps-nuget**: ancestor-walk depth cap now imports `deps-core`'s canonical `MAX_CONFIG_ANCESTOR_DEPTH` instead of each declaring its own duplicate copy (resolves #611) (#616)

--- a/crates/deps-gradle/src/parser/groovy.rs
+++ b/crates/deps-gradle/src/parser/groovy.rs
@@ -2,7 +2,9 @@
 //!
 //! Regex-based extraction of dependency declarations from dependencies { } blocks.
 
-use crate::parser::{CONFIGURATIONS, GradleParseResult, build_dependency};
+use crate::parser::{
+    GradleParseResult, build_dependency, is_dependency_configuration, opens_dependencies_block,
+};
 use crate::types::GradleDependency;
 use deps_core::Result;
 use regex::Regex;
@@ -53,7 +55,7 @@ static RE_PLATFORM_NO_VERSION_WITHOUT_PARENS: LazyLock<Regex> = LazyLock::new(||
         .expect("RE_PLATFORM_NO_VERSION_WITHOUT_PARENS")
 });
 
-/// Runs `re` over `line`, filters matches to known `CONFIGURATIONS`, dedups
+/// Runs `re` over `line`, filters matches to known dependency configurations, dedups
 /// against `matched_positions` (shared across all patterns tried on this
 /// line), and pushes a [`GradleDependency`] for each surviving match.
 ///
@@ -71,7 +73,7 @@ fn extract_matches(
 ) {
     for caps in re.captures_iter(line) {
         let config = caps.get(1).map_or("", |m| m.as_str());
-        if !CONFIGURATIONS.contains(&config) {
+        if !is_dependency_configuration(config) {
             continue;
         }
         let start = caps.get(0).map_or(0, |m| m.start());
@@ -94,9 +96,7 @@ pub fn parse_groovy_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
     for (line_idx, line) in content.lines().enumerate() {
         let trimmed = line.trim();
 
-        if !in_dependencies_block
-            && (trimmed == "dependencies {" || trimmed.starts_with("dependencies {"))
-        {
+        if !in_dependencies_block && opens_dependencies_block(trimmed) {
             in_dependencies_block = true;
             deps_brace_depth = brace_depth + 1;
         }
@@ -114,7 +114,7 @@ pub fn parse_groovy_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
             }
         }
 
-        if !in_dependencies_block && !line.trim_start().starts_with("dependencies") {
+        if !in_dependencies_block && !opens_dependencies_block(trimmed) {
             continue;
         }
 
@@ -259,6 +259,15 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_bare_annotation_processor() {
+        // Bare (no variant prefix) form of a CONFIGURATION_SUFFIXES entry.
+        let content = "dependencies {\n    annotationProcessor 'com.example:foo:1.0'\n}\n";
+        let result = parse_groovy_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].configuration, "annotationProcessor");
+    }
+
+    #[test]
     fn test_parse_legacy_configurations() {
         // compile/testCompile/provided predate #625's unification but were
         // never covered by a dedicated test; guard the shared CONFIGURATIONS
@@ -400,6 +409,111 @@ mod tests {
             "org.springframework.boot:spring-boot-dependencies"
         );
         assert!(result.dependencies[0].version_req.is_none());
+    }
+
+    #[test]
+    fn test_parse_modern_configurations() {
+        // #627: androidTestImplementation, debugImplementation, compileOnlyApi,
+        // and testFixturesImplementation were missing from the whitelist and
+        // parsed to zero results.
+        let content = "dependencies {\n    androidTestImplementation 'a:b:1.0'\n    debugImplementation 'c:d:2.0'\n    compileOnlyApi 'e:f:3.0'\n    testFixturesImplementation 'g:h:4.0'\n}\n";
+        let result = parse_groovy_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 4);
+        assert_eq!(
+            result.dependencies[0].configuration,
+            "androidTestImplementation"
+        );
+        assert_eq!(result.dependencies[1].configuration, "debugImplementation");
+        assert_eq!(result.dependencies[2].configuration, "compileOnlyApi");
+        assert_eq!(
+            result.dependencies[3].configuration,
+            "testFixturesImplementation"
+        );
+    }
+
+    #[test]
+    fn test_same_line_dependencies_distinct_version_ranges() {
+        // #628: three dependencies sharing an identical version string on
+        // one line must each resolve to their own position, not collapse to
+        // the first dependency's position.
+        let content = "dependencies {\n    implementation(\"com.example:foo:1.0.0\"); implementation(\"com.example:bar:1.0.0\"); implementation(\"com.example:baz:1.0.0\")\n}\n";
+        let result = parse_groovy_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 3);
+        let ranges: Vec<_> = result
+            .dependencies
+            .iter()
+            .map(|d| d.version_range.expect("version_range"))
+            .collect();
+        assert_ne!(ranges[0], ranges[1]);
+        assert_ne!(ranges[1], ranges[2]);
+        assert_ne!(ranges[0], ranges[2]);
+        assert!(ranges[1].start.character > ranges[0].start.character);
+        assert!(ranges[2].start.character > ranges[1].start.character);
+    }
+
+    #[test]
+    fn test_same_line_duplicate_coordinate_distinct_name_ranges() {
+        // Regression for the S1 gap found in review of #628: two
+        // dependencies with an *identical coordinate* (not just the same
+        // version) on one line must each get their own name_range, since
+        // name_range uniquely keys OSV/diagnostic lookups.
+        let content = "dependencies {\n    implementation(\"com.example:lib:1.0.0\"); testImplementation(\"com.example:lib:1.0.0\")\n}\n";
+        let result = parse_groovy_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 2);
+        let first = result.dependencies[0].name_range;
+        let second = result.dependencies[1].name_range;
+        assert_ne!(first, second);
+        assert!(second.start.character > first.start.character);
+    }
+
+    #[test]
+    fn test_dependencies_info_block_not_scanned() {
+        // #629: `dependenciesInfo { }` (Android Gradle Plugin block) must not
+        // be mistaken for the `dependencies { }` block due to a prefix match.
+        // The dependency call must be on the SAME line as the block opener —
+        // a multi-line form doesn't discriminate old vs. new guard code,
+        // since the old guard only checked the continuation line's prefix.
+        let content = "dependenciesInfo { compile(\"com.example:foo:1.0.0\") }\n";
+        let result = parse_groovy_dsl(content, &make_uri()).unwrap();
+        assert!(result.dependencies.is_empty());
+    }
+
+    #[test]
+    fn test_dependencies_block_tolerates_extra_whitespace_before_brace() {
+        // S2: the block-open guard must not regress `dependencies` followed
+        // by more than one space/tab before `{`.
+        let content = "dependencies  {\n    implementation 'a:b:1.0'\n}\n";
+        let result = parse_groovy_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+
+        let content_tab = "dependencies\t{\n    implementation 'a:b:1.0'\n}\n";
+        let result_tab = parse_groovy_dsl(content_tab, &make_uri()).unwrap();
+        assert_eq!(result_tab.dependencies.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_kapt_ksp_prefix_variants() {
+        // S3: kapt/ksp follow a prefix convention (word + capitalized
+        // variant), not the suffix convention used by Implementation/Api.
+        let content = "dependencies {\n    kaptTest 'a:b:1.0'\n    kaptAndroidTest 'c:d:2.0'\n    kspDebug 'e:f:3.0'\n}\n";
+        let result = parse_groovy_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 3);
+        assert_eq!(result.dependencies[0].configuration, "kaptTest");
+        assert_eq!(result.dependencies[1].configuration, "kaptAndroidTest");
+        assert_eq!(result.dependencies[2].configuration, "kspDebug");
+    }
+
+    #[test]
+    fn test_suffix_matching_accepts_near_miss_configuration_name() {
+        // Documents a known, accepted tradeoff of suffix-based matching
+        // (#627): a name ending in a recognized suffix is treated as a
+        // dependency configuration even if it isn't a real Gradle one. Risk
+        // is bounded — a coordinate-shaped string literal is still required,
+        // and Gradle itself would reject an actually-unknown configuration.
+        let content = "dependencies {\n    someRandomApi 'a:b:1.0'\n}\n";
+        let result = parse_groovy_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].configuration, "someRandomApi");
     }
 
     #[test]

--- a/crates/deps-gradle/src/parser/kotlin.rs
+++ b/crates/deps-gradle/src/parser/kotlin.rs
@@ -2,7 +2,9 @@
 //!
 //! Regex-based extraction of dependency declarations from dependencies { } blocks.
 
-use crate::parser::{CONFIGURATIONS, GradleParseResult, build_dependency};
+use crate::parser::{
+    GradleParseResult, build_dependency, is_dependency_configuration, opens_dependencies_block,
+};
 use deps_core::Result;
 use regex::Regex;
 use std::sync::LazyLock;
@@ -43,9 +45,7 @@ pub fn parse_kotlin_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
         let trimmed = line.trim();
 
         // Detect entry into dependencies { block
-        if !in_dependencies_block
-            && (trimmed == "dependencies {" || trimmed.starts_with("dependencies {"))
-        {
+        if !in_dependencies_block && opens_dependencies_block(trimmed) {
             in_dependencies_block = true;
             deps_brace_depth = brace_depth + 1;
         }
@@ -64,7 +64,7 @@ pub fn parse_kotlin_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
             }
         }
 
-        if !in_dependencies_block && !line.trim_start().starts_with("dependencies") {
+        if !in_dependencies_block && !opens_dependencies_block(trimmed) {
             continue;
         }
 
@@ -73,7 +73,7 @@ pub fn parse_kotlin_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
         // Try pattern with version first
         for caps in RE_WITH_VERSION.captures_iter(line) {
             let config = caps.get(1).map_or("", |m| m.as_str());
-            if !CONFIGURATIONS.contains(&config) {
+            if !is_dependency_configuration(config) {
                 continue;
             }
             dependencies.push(build_dependency(&caps, line, line_u32, true, config));
@@ -85,15 +85,13 @@ pub fn parse_kotlin_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
             .captures_iter(line)
             .filter_map(|c| {
                 let config = c.get(1)?.as_str();
-                CONFIGURATIONS
-                    .contains(&config)
-                    .then_some(c.get(0)?.start())
+                is_dependency_configuration(config).then_some(c.get(0)?.start())
             })
             .collect();
 
         for caps in RE_NO_VERSION.captures_iter(line) {
             let config = caps.get(1).map_or("", |m| m.as_str());
-            if !CONFIGURATIONS.contains(&config) {
+            if !is_dependency_configuration(config) {
                 continue;
             }
             // Skip if this match overlaps with a versioned match
@@ -109,15 +107,13 @@ pub fn parse_kotlin_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
             .captures_iter(line)
             .filter_map(|c| {
                 let config = c.get(1)?.as_str();
-                CONFIGURATIONS
-                    .contains(&config)
-                    .then_some(c.get(0)?.start())
+                is_dependency_configuration(config).then_some(c.get(0)?.start())
             })
             .collect();
 
         for caps in RE_PLATFORM_WITH_VERSION.captures_iter(line) {
             let config = caps.get(1).map_or("", |m| m.as_str());
-            if !CONFIGURATIONS.contains(&config) {
+            if !is_dependency_configuration(config) {
                 continue;
             }
             dependencies.push(build_dependency(&caps, line, line_u32, true, config));
@@ -125,7 +121,7 @@ pub fn parse_kotlin_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
 
         for caps in RE_PLATFORM_NO_VERSION.captures_iter(line) {
             let config = caps.get(1).map_or("", |m| m.as_str());
-            if !CONFIGURATIONS.contains(&config) {
+            if !is_dependency_configuration(config) {
                 continue;
             }
             let match_start = caps.get(0).map_or(0, |m| m.start());
@@ -208,6 +204,15 @@ mod tests {
         assert_eq!(result.dependencies[1].configuration, "compileOnly");
         assert_eq!(result.dependencies[2].configuration, "runtimeOnly");
         assert_eq!(result.dependencies[3].configuration, "kapt");
+    }
+
+    #[test]
+    fn test_parse_bare_annotation_processor() {
+        // Bare (no variant prefix) form of a CONFIGURATION_SUFFIXES entry.
+        let content = "dependencies {\n    annotationProcessor(\"com.example:foo:1.0\")\n}\n";
+        let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].configuration, "annotationProcessor");
     }
 
     #[test]
@@ -376,6 +381,117 @@ mod tests {
         assert_eq!(result.dependencies.len(), 1);
         assert_eq!(result.dependencies[0].name, "junit:junit-bom");
         assert_eq!(result.dependencies[0].version_req, Some("5.10.0".into()));
+    }
+
+    #[test]
+    fn test_parse_modern_configurations() {
+        // #627: androidTestImplementation, debugImplementation, compileOnlyApi,
+        // and testFixturesImplementation were missing from the whitelist and
+        // parsed to zero results.
+        let content = r#"dependencies {
+    androidTestImplementation("a:b:1.0")
+    debugImplementation("c:d:2.0")
+    compileOnlyApi("e:f:3.0")
+    testFixturesImplementation("g:h:4.0")
+}
+"#;
+        let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 4);
+        assert_eq!(
+            result.dependencies[0].configuration,
+            "androidTestImplementation"
+        );
+        assert_eq!(result.dependencies[1].configuration, "debugImplementation");
+        assert_eq!(result.dependencies[2].configuration, "compileOnlyApi");
+        assert_eq!(
+            result.dependencies[3].configuration,
+            "testFixturesImplementation"
+        );
+    }
+
+    #[test]
+    fn test_same_line_dependencies_distinct_version_ranges() {
+        // #628: three dependencies sharing an identical version string on
+        // one line must each resolve to their own position, not collapse to
+        // the first dependency's position.
+        let content = "dependencies {\n    implementation(\"com.example:foo:1.0.0\"); implementation(\"com.example:bar:1.0.0\"); implementation(\"com.example:baz:1.0.0\")\n}\n";
+        let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 3);
+        let ranges: Vec<_> = result
+            .dependencies
+            .iter()
+            .map(|d| d.version_range.expect("version_range"))
+            .collect();
+        assert_ne!(ranges[0], ranges[1]);
+        assert_ne!(ranges[1], ranges[2]);
+        assert_ne!(ranges[0], ranges[2]);
+        assert!(ranges[1].start.character > ranges[0].start.character);
+        assert!(ranges[2].start.character > ranges[1].start.character);
+    }
+
+    #[test]
+    fn test_same_line_duplicate_coordinate_distinct_name_ranges() {
+        // Regression for the S1 gap found in review of #628: two
+        // dependencies with an *identical coordinate* (not just the same
+        // version) on one line must each get their own name_range, since
+        // name_range uniquely keys OSV/diagnostic lookups.
+        let content = "dependencies {\n    implementation(\"com.example:lib:1.0.0\"); testImplementation(\"com.example:lib:1.0.0\")\n}\n";
+        let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 2);
+        let first = result.dependencies[0].name_range;
+        let second = result.dependencies[1].name_range;
+        assert_ne!(first, second);
+        assert!(second.start.character > first.start.character);
+    }
+
+    #[test]
+    fn test_dependencies_info_block_not_scanned() {
+        // #629: `dependenciesInfo { }` (Android Gradle Plugin block) must not
+        // be mistaken for the `dependencies { }` block due to a prefix match.
+        // The dependency call must be on the SAME line as the block opener —
+        // a multi-line form doesn't discriminate old vs. new guard code,
+        // since the old guard only checked the continuation line's prefix.
+        let content = "dependenciesInfo { compile(\"com.example:foo:1.0.0\") }\n";
+        let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
+        assert!(result.dependencies.is_empty());
+    }
+
+    #[test]
+    fn test_dependencies_block_tolerates_extra_whitespace_before_brace() {
+        // S2: the block-open guard must not regress `dependencies` followed
+        // by more than one space/tab before `{`.
+        let content = "dependencies  {\n    implementation(\"a:b:1.0\")\n}\n";
+        let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+
+        let content_tab = "dependencies\t{\n    implementation(\"a:b:1.0\")\n}\n";
+        let result_tab = parse_kotlin_dsl(content_tab, &make_uri()).unwrap();
+        assert_eq!(result_tab.dependencies.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_kapt_ksp_prefix_variants() {
+        // S3: kapt/ksp follow a prefix convention (word + capitalized
+        // variant), not the suffix convention used by Implementation/Api.
+        let content = "dependencies {\n    kaptTest(\"a:b:1.0\")\n    kaptAndroidTest(\"c:d:2.0\")\n    kspDebug(\"e:f:3.0\")\n}\n";
+        let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 3);
+        assert_eq!(result.dependencies[0].configuration, "kaptTest");
+        assert_eq!(result.dependencies[1].configuration, "kaptAndroidTest");
+        assert_eq!(result.dependencies[2].configuration, "kspDebug");
+    }
+
+    #[test]
+    fn test_suffix_matching_accepts_near_miss_configuration_name() {
+        // Documents a known, accepted tradeoff of suffix-based matching
+        // (#627): a name ending in a recognized suffix is treated as a
+        // dependency configuration even if it isn't a real Gradle one. Risk
+        // is bounded — a coordinate-shaped string literal is still required,
+        // and Gradle itself would reject an actually-unknown configuration.
+        let content = "dependencies {\n    someRandomApi(\"a:b:1.0\")\n}\n";
+        let result = parse_kotlin_dsl(content, &make_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert_eq!(result.dependencies[0].configuration, "someRandomApi");
     }
 
     #[test]

--- a/crates/deps-gradle/src/parser/mod.rs
+++ b/crates/deps-gradle/src/parser/mod.rs
@@ -17,31 +17,76 @@ use tower_lsp_server::ls_types::{Position, Range, Uri};
 
 pub use deps_core::lsp_helpers::LineOffsetTable;
 
-/// Configuration words recognized as dependency declarations in both Groovy
-/// and Kotlin Gradle DSLs.
+/// Configuration words that follow neither the suffix convention
+/// ([`CONFIGURATION_SUFFIXES`]) nor the prefix convention
+/// ([`CONFIGURATION_PREFIXES`]) and must be matched literally.
 ///
 /// Includes the pre-Gradle-7 legacy configurations `compile`, `testCompile`,
 /// and `provided`: Gradle still parses them regardless of which DSL a build
 /// script uses, so a `build.gradle.kts` migrated from an old `build.gradle`
 /// (or targeting a project not yet updated) can legitimately contain them.
 /// Restricting recognition to one DSL would be silent drift, not an
-/// intentional scoping decision.
-pub(crate) const CONFIGURATIONS: &[&str] = &[
-    "implementation",
-    "api",
-    "compileOnly",
-    "runtimeOnly",
-    "testImplementation",
-    "testRuntimeOnly",
-    "annotationProcessor",
-    "kapt",
-    "classpath",
-    "ksp",
-    "testCompileOnly",
-    "compile",
-    "testCompile",
-    "provided",
+/// intentional scoping decision. `classpath` has no variant form at all.
+const CONFIGURATION_LITERALS: &[&str] = &["classpath", "compile", "testCompile", "provided"];
+
+/// `(bare, suffix)` pairs for configuration base words that Gradle core
+/// plugins (`java`, `java-library`) and common first-party plugins (Android
+/// Gradle Plugin, `java-test-fixtures`) combine with an arbitrary
+/// variant/source-set prefix, e.g. `debugImplementation`,
+/// `androidTestImplementation`, `testFixturesImplementation` — and
+/// `compileOnlyApi`, matched by the `Api` suffix.
+///
+/// `bare` is the word used with no prefix (`implementation`); `suffix` is the
+/// same word capitalized, as it appears after a prefix. A literal whitelist
+/// can't keep up with plugin-registered configurations following this
+/// convention (arbitrary build types/flavors in Android, custom source
+/// sets), so membership is decided by suffix instead — safe because Gradle
+/// itself treats any name ending in one of these words as that kind of
+/// configuration.
+const CONFIGURATION_SUFFIXES: &[(&str, &str)] = &[
+    ("implementation", "Implementation"),
+    ("api", "Api"),
+    ("compileOnly", "CompileOnly"),
+    ("runtimeOnly", "RuntimeOnly"),
+    ("annotationProcessor", "AnnotationProcessor"),
 ];
+
+/// Kotlin annotation-processing plugin configurations (`kapt`, KSP's `ksp`)
+/// follow a *prefix* convention instead: bare for the main source set, or
+/// `<word><Variant>` for others — e.g. `kaptTest`, `kaptAndroidTest`,
+/// `kspDebug`, `kspCommonMainMetadata`. [`CONFIGURATION_SUFFIXES`] can't
+/// express this since the variant comes after the word, not before it.
+const CONFIGURATION_PREFIXES: &[&str] = &["kapt", "ksp"];
+
+/// Returns whether `config` is a recognized Gradle dependency configuration
+/// word: a legacy literal ([`CONFIGURATION_LITERALS`]), a name ending in one
+/// of [`CONFIGURATION_SUFFIXES`]'s base words, or a name starting with one of
+/// [`CONFIGURATION_PREFIXES`]'s words followed by a capitalized variant.
+pub(crate) fn is_dependency_configuration(config: &str) -> bool {
+    CONFIGURATION_LITERALS.contains(&config)
+        || CONFIGURATION_SUFFIXES
+            .iter()
+            .any(|(bare, suffix)| config == *bare || config.ends_with(suffix))
+        || CONFIGURATION_PREFIXES.iter().any(|prefix| {
+            config == *prefix
+                || config
+                    .strip_prefix(prefix)
+                    .is_some_and(|rest| rest.starts_with(|c: char| c.is_ascii_uppercase()))
+        })
+}
+
+/// Returns whether `trimmed` (a line with surrounding whitespace stripped)
+/// opens a Gradle `dependencies { }` block.
+///
+/// Requires the brace to follow the `dependencies` keyword (any amount of
+/// whitespace, including none, in between) so that unrelated blocks whose
+/// name merely starts with the word — e.g. Android's `dependenciesInfo { }`
+/// — aren't mistaken for it.
+pub(crate) fn opens_dependencies_block(trimmed: &str) -> bool {
+    trimmed
+        .strip_prefix("dependencies")
+        .is_some_and(|rest| rest.trim_start().starts_with('{'))
+}
 
 /// Builds a [`GradleDependency`] from a regex match's captures.
 ///
@@ -61,14 +106,15 @@ pub(crate) fn build_dependency(
         "regex capture count must match has_version so group 4 (version) is only read when present"
     );
 
+    let match_start = caps.get(0).map_or(0, |m| m.start());
     let group_id = caps.get(2).map_or("", |m| m.as_str()).to_string();
     let artifact_id = caps.get(3).map_or("", |m| m.as_str()).to_string();
     let name = format!("{group_id}:{artifact_id}");
-    let name_range = find_name_range(line, line_idx, &group_id, &artifact_id);
+    let name_range = find_name_range(line, line_idx, match_start, &group_id, &artifact_id);
 
     let (version_req, version_range) = if has_version {
         let version = caps.get(4).map_or("", |m| m.as_str()).trim().to_string();
-        let version_range = find_version_range(line, line_idx, &version);
+        let version_range = find_version_range(line, line_idx, match_start, &version);
         (Some(version.into()), Some(version_range))
     } else {
         (None, None)
@@ -174,16 +220,25 @@ pub(crate) fn utf16_len(s: &str) -> usize {
     s.chars().map(|c| c.len_utf16()).sum()
 }
 
-/// Finds the LSP range of `"group_id:artifact_id"` within `line`.
+/// Finds the LSP range of `"group_id:artifact_id"` within the dependency
+/// declaration's own match span (`line[match_start..]`), not the whole line.
+///
+/// Scoping to `match_start` matters when two dependencies share an identical
+/// coordinate on one line — e.g.
+/// `implementation("a:b:1.0.0"); testImplementation("a:b:1.0.0")` — so the
+/// second dependency's range isn't mis-attributed to the first's position.
 pub(crate) fn find_name_range(
     line: &str,
     line_idx: u32,
+    match_start: usize,
     group_id: &str,
     artifact_id: &str,
 ) -> Range {
+    let scoped = &line[match_start..];
     let search = format!("{group_id}:{artifact_id}");
-    if let Some(col) = line.find(&search) {
-        let col_u32 = utf16_len(&line[..col]) as u32;
+    if let Some(rel) = scoped.find(&search) {
+        let abs_start = match_start + rel;
+        let col_u32 = utf16_len(&line[..abs_start]) as u32;
         let end_u32 = col_u32 + utf16_len(&search) as u32;
         Range::new(
             Position::new(line_idx, col_u32),
@@ -194,18 +249,31 @@ pub(crate) fn find_name_range(
     }
 }
 
-/// Finds the LSP range of `version` in `line` after the second `:`.
-pub(crate) fn find_version_range(line: &str, line_idx: u32, version: &str) -> Range {
-    let second_colon = line
+/// Finds the LSP range of `version` after the second `:` within the
+/// dependency declaration's own match span (`line[match_start..]`), not the
+/// whole line.
+///
+/// Scoping to `match_start` matters when two dependencies share the same
+/// version string on one line — e.g.
+/// `implementation("a:b:1.0.0"); implementation("c:d:1.0.0")` — so the
+/// second dependency's range isn't mis-attributed to the first's position.
+pub(crate) fn find_version_range(
+    line: &str,
+    line_idx: u32,
+    match_start: usize,
+    version: &str,
+) -> Range {
+    let scoped = &line[match_start..];
+    let second_colon = scoped
         .char_indices()
         .filter(|(_, c)| *c == ':')
         .nth(1)
         .map(|(i, _)| i);
 
     if let Some(colon_pos) = second_colon {
-        let after_colon = &line[colon_pos + 1..];
+        let after_colon = &scoped[colon_pos + 1..];
         if let Some(rel) = after_colon.find(version) {
-            let abs_start = colon_pos + 1 + rel;
+            let abs_start = match_start + colon_pos + 1 + rel;
             let col_start = utf16_len(&line[..abs_start]) as u32;
             let col_end = col_start + utf16_len(version) as u32;
             return Range::new(
@@ -365,18 +433,83 @@ mod tests {
     #[test]
     fn test_find_name_range() {
         let line = "    implementation(\"com.example:lib:1.0.0\")";
-        let range = find_name_range(line, 5, "com.example", "lib");
+        let range = find_name_range(line, 5, 0, "com.example", "lib");
         assert_eq!(range.start.line, 5);
         assert!(range.start.character > 0);
     }
 
     #[test]
+    fn test_find_name_range_scoped_to_match_start() {
+        // Two dependencies with an identical coordinate on one line: scoping
+        // the search to the second dependency's match_start must not return
+        // the first dependency's name_range.
+        let line = "implementation(\"a:b:1.0.0\"); testImplementation(\"a:b:1.0.0\")";
+        let second_match_start = line.rfind("testImplementation").unwrap();
+        let range = find_name_range(line, 0, second_match_start, "a", "b");
+        let first_range = find_name_range(line, 0, 0, "a", "b");
+        assert_ne!(range.start.character, first_range.start.character);
+        assert!(range.start.character > second_match_start as u32);
+    }
+
+    #[test]
+    fn test_is_dependency_configuration_kapt_ksp_prefix_variants() {
+        for config in [
+            "kapt",
+            "kaptTest",
+            "kaptAndroidTest",
+            "ksp",
+            "kspDebug",
+            "kspCommonMainMetadata",
+        ] {
+            assert!(
+                is_dependency_configuration(config),
+                "{config} should be recognized"
+            );
+        }
+        // "kaptx" has no capitalized variant boundary after the prefix.
+        assert!(!is_dependency_configuration("kaptx"));
+    }
+
+    #[test]
+    fn test_is_dependency_configuration_suffix_near_miss_is_accepted() {
+        // Known, documented tradeoff of suffix-matching: any name ending in
+        // a recognized suffix is accepted even if it isn't a real Gradle
+        // configuration, since a coordinate-shaped string literal argument
+        // is still required and Gradle itself would reject the unknown name.
+        assert!(is_dependency_configuration("someRandomApi"));
+        assert!(is_dependency_configuration("myOwnImplementation"));
+    }
+
+    #[test]
+    fn test_opens_dependencies_block_tolerates_extra_whitespace() {
+        assert!(opens_dependencies_block("dependencies  {"));
+        assert!(opens_dependencies_block("dependencies\t{"));
+        assert!(opens_dependencies_block("dependencies {"));
+        assert!(opens_dependencies_block("dependencies{"));
+        assert!(!opens_dependencies_block("dependenciesInfo {"));
+        assert!(!opens_dependencies_block("dependenciesInfo{"));
+    }
+
+    #[test]
     fn test_find_version_range() {
         let line = "    implementation(\"com.example:lib:1.0.0\")";
-        let range = find_version_range(line, 5, "1.0.0");
+        let range = find_version_range(line, 5, 0, "1.0.0");
         assert_eq!(range.start.line, 5);
         // "1.0.0" is 5 chars, end = start + 5
         assert_eq!(range.end.character - range.start.character, 5);
+    }
+
+    #[test]
+    fn test_find_version_range_scoped_to_match_start() {
+        // Two dependencies sharing the same version on one line: scoping the
+        // search to the second dependency's match_start must not return the
+        // first dependency's colon/version position.
+        let line = "implementation(\"a:b:1.0.0\"); implementation(\"c:d:1.0.0\")";
+        let second_match_start = line.rfind("implementation").unwrap();
+        let range = find_version_range(line, 0, second_match_start, "1.0.0");
+        let first_range = find_version_range(line, 0, 0, "1.0.0");
+        assert_ne!(range.start.character, first_range.start.character);
+        assert!(range.start.character > second_match_start as u32);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes three parser bugs in `crates/deps-gradle` found during review of #626, plus follow-up gaps found while reviewing the initial fix:

- Configuration recognition now uses suffix matching (`Implementation`, `Api`, `CompileOnly`, `RuntimeOnly`, `AnnotationProcessor`) and prefix matching (`kapt`, `ksp`) instead of a fixed literal whitelist, so variant/source-set names like `androidTestImplementation`, `debugImplementation`, `compileOnlyApi`, `kaptAndroidTest`, and `kspDebug` are recognized.
- `find_name_range` and `find_version_range` are now scoped to each match's own position on the line, so multiple dependencies sharing an identical coordinate or version string on one line no longer collide on the same LSP range (this also fixes a `HashMap<Range, _>` key collision affecting OSV vulnerability data and diagnostics).
- The `dependencies { }` block-entry guard now requires the brace to actually follow the `dependencies` keyword, so unrelated blocks like Android's `dependenciesInfo { }` are no longer mistaken for it, while still tolerating any amount of whitespace before the brace.

Applies identically to both the Groovy and Kotlin DSL parsers.

## Test plan

- [x] Added/extended unit tests covering all three original scenarios plus the follow-up fixes (configuration prefix matching, name/version range scoping for 3+ same-line dependencies, single-line block-guard regression)
- [x] Added `.local/testing/regressions.md` entries for all six scenarios (local only, not part of this diff)
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4311/4311 passed)
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --all-features`)

Closes #627
Closes #628
Closes #629