### PR TITLE
fix(deps-lsp): bound diagnostics Loading skip and supervise background task panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-go**: `$GOENV` `GOPROXY`/`GOPRIVATE` follow-up hardening — test-injectable `$GOENV` path, oversized-`GOPRIVATE`-pattern warning, expanded edge-case/integration test coverage, and `GOPROXY` `,`/`|` separator docs (#563)
 
 ### Fixed
+- **deps-lsp**: diagnostics no longer stay stuck forever for a document that never leaves `LoadingState::Loading` (e.g. a background fetch task panic) — a fetch-timeout-derived ceiling now forces it to `Failed`, and a panicking background task is now supervised instead of silently discarding its result (resolves #632)
 - **deps-gradle**: recognize modern/variant configuration names (`androidTestImplementation`, `debugImplementation`, `compileOnlyApi`, `kaptAndroidTest`, etc.) instead of a fixed literal whitelist (resolves #627) (#631)
 - **deps-gradle**: fix mis-attributed name/version ranges for same-line dependencies sharing an identical coordinate or version (resolves #628) (#631)
 - **deps-gradle**: fix `dependencies { }` block guard false-positiving on unrelated blocks like `dependenciesInfo { }` (resolves #629) (#631)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-go**: `$GOENV` `GOPROXY`/`GOPRIVATE` follow-up hardening — test-injectable `$GOENV` path, oversized-`GOPRIVATE`-pattern warning, expanded edge-case/integration test coverage, and `GOPROXY` `,`/`|` separator docs (#563)
 
 ### Fixed
-- **deps-lsp**: diagnostics no longer stay stuck forever for a document that never leaves `LoadingState::Loading` (e.g. a background fetch task panic) — a fetch-timeout-derived ceiling now forces it to `Failed`, and a panicking background task is now supervised instead of silently discarding its result (resolves #632)
+- **deps-lsp**: diagnostics no longer stay stuck forever for a document that never leaves `LoadingState::Loading` (e.g. a background fetch task panic) — a fetch-timeout-derived ceiling now forces it to `Failed`, and a panicking background task is now supervised instead of silently discarding its result (resolves #632) (#635)
 - **deps-gradle**: recognize modern/variant configuration names (`androidTestImplementation`, `debugImplementation`, `compileOnlyApi`, `kaptAndroidTest`, etc.) instead of a fixed literal whitelist (resolves #627) (#631)
 - **deps-gradle**: fix mis-attributed name/version ranges for same-line dependencies sharing an identical coordinate or version (resolves #628) (#631)
 - **deps-gradle**: fix `dependencies { }` block guard false-positiving on unrelated blocks like `dependenciesInfo { }` (resolves #629) (#631)

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -1959,6 +1959,7 @@ async fn run_document_open_background_task(
         freshness_settings,
         diagnostic_severities,
         offline,
+        diagnostics::loading_ceiling(cache_config.fetch_timeout_secs),
     )
     .await;
 
@@ -2377,6 +2378,7 @@ async fn run_document_change_task(
             config.freshness,
             config.diagnostic_severities,
             config.offline,
+            config.cache.fetch_timeout_secs,
         )
         .await;
         return;
@@ -2465,6 +2467,7 @@ async fn run_document_change_task(
         config.freshness,
         config.diagnostic_severities,
         config.offline,
+        config.cache.fetch_timeout_secs,
     )
     .await;
 }
@@ -2512,6 +2515,7 @@ async fn generate_and_publish_diagnostics(
     freshness_settings: deps_core::FreshnessSettings,
     diagnostic_severities: deps_core::DiagnosticSeverities,
     offline: bool,
+    fetch_timeout_secs: u64,
 ) {
     let diags = diagnostics::generate_diagnostics_internal(
         Arc::clone(state),
@@ -2519,6 +2523,7 @@ async fn generate_and_publish_diagnostics(
         freshness_settings,
         diagnostic_severities,
         offline,
+        diagnostics::loading_ceiling(fetch_timeout_secs),
     )
     .await;
     client.publish_diagnostics(uri.clone(), diags, None).await;
@@ -3119,6 +3124,9 @@ mod tests {
                 deps_core::FreshnessSettings::default(),
                 deps_core::DiagnosticSeverities::default(),
                 false,
+                diagnostics::loading_ceiling(
+                    crate::config::CacheConfig::default().fetch_timeout_secs,
+                ),
             )
             .await;
 
@@ -3211,6 +3219,9 @@ mod tests {
                 deps_core::FreshnessSettings::default(),
                 deps_core::DiagnosticSeverities::default(),
                 false,
+                diagnostics::loading_ceiling(
+                    crate::config::CacheConfig::default().fetch_timeout_secs,
+                ),
             )
             .await;
 

--- a/crates/deps-lsp/src/document/state.rs
+++ b/crates/deps-lsp/src/document/state.rs
@@ -519,8 +519,16 @@ pub struct ServerState {
     pub(crate) workspace_registry_ecosystems: Vec<&'static str>,
     /// Cold start rate limiter
     pub cold_start_limiter: ColdStartLimiter,
-    /// Background task handles
-    tasks: tokio::sync::RwLock<HashMap<Uri, JoinHandle<()>>>,
+    /// Background task handles, keyed by URI.
+    ///
+    /// Stores each task's [`tokio::task::Id`] alongside its [`tokio::task::AbortHandle`]
+    /// rather than its `JoinHandle`: the supervisor task [`Self::spawn_background_task`]
+    /// spawns alongside it owns the actual `JoinHandle` for the task's whole lifetime (to
+    /// detect a panic — issue #632), so the registry only needs enough to cancel, plus the
+    /// id so a belated supervisor can tell whether it is still the current task for its URI
+    /// before acting on a panic (issue #632 critic S3 — see
+    /// [`Self::is_current_background_task`]).
+    tasks: tokio::sync::RwLock<HashMap<Uri, (tokio::task::Id, tokio::task::AbortHandle)>>,
     /// Whether the client advertised `window.workDoneProgress` support during
     /// `initialize`. Set once, read from spawned lifecycle tasks that have no
     /// direct access to `ClientCapabilities` (see `RegistryProgress::start` call
@@ -880,23 +888,135 @@ impl ServerState {
         self.documents.remove(uri)
     }
 
-    /// Spawns a background task for a document.
+    /// Spawns a background task for a document, supervising it for panics.
     ///
-    /// If a task already exists for the given URI, it is aborted before
-    /// the new task is registered. This ensures only one background task
-    /// runs per document.
+    /// If a task already exists for the given URI, it is aborted before the new task is
+    /// registered. This ensures only one background task runs per document.
     ///
-    /// Typical use case: fetching version data asynchronously after
-    /// document open or change.
-    pub async fn spawn_background_task(&self, uri: Uri, task: JoinHandle<()>) {
-        let mut tasks = self.tasks.write().await;
+    /// Typical use case: fetching version data asynchronously after document open or
+    /// change.
+    ///
+    /// Takes `self: &Arc<Self>` (rather than `&self`) because this also spawns a
+    /// supervisor task that awaits `task` for its whole lifetime (issue #632): if the
+    /// background fetch task panics instead of reaching `DocumentState::set_loaded`/
+    /// `set_failed`, the document's `loading_state` would otherwise stay `Loading`
+    /// forever, permanently suppressing diagnostics for it. The supervisor forces
+    /// `loading_state` to `Failed` only on a genuine panic — never when `task` is
+    /// cancelled (a newer call to this method, or [`Self::cancel_background_task`]
+    /// superseding it), since an intentionally aborted task's document state is already
+    /// owned by whatever superseded it. It additionally re-checks whether it is still the
+    /// current task for its URI right before writing (issue #632 critic S3): a task that
+    /// already panicked (finished, not cancelled) before a newer task was registered for
+    /// the same URI must not have its belated supervisor clobber that newer task's
+    /// in-flight load.
+    pub async fn spawn_background_task(self: &Arc<Self>, uri: Uri, task: JoinHandle<()>) {
+        let task_id = task.id();
+        let abort_handle = task.abort_handle();
 
-        // Cancel existing task if any
-        if let Some(old_task) = tasks.remove(&uri) {
-            old_task.abort();
+        {
+            let mut tasks = self.tasks.write().await;
+            // Cancel existing task if any
+            if let Some((_, old_task)) = tasks.insert(uri.clone(), (task_id, abort_handle)) {
+                old_task.abort();
+            }
         }
 
-        tasks.insert(uri, task);
+        let state = Arc::clone(self);
+        tokio::spawn(async move {
+            if let Err(join_error) = task.await
+                && !join_error.is_cancelled()
+            {
+                if !state.is_current_background_task(&uri, task_id).await {
+                    tracing::debug!(
+                        "background task for {:?} panicked ({}) after being superseded; \
+                         ignoring stale panic",
+                        uri,
+                        join_error
+                    );
+                    return;
+                }
+                tracing::error!(
+                    "background task for {:?} panicked ({}); forcing loading_state to Failed",
+                    uri,
+                    join_error
+                );
+                state.force_document_failed_with_not_attempted(&uri);
+            }
+        });
+    }
+
+    /// Whether `task_id` is still the background task currently registered for `uri`
+    /// (issue #632 critic S3).
+    ///
+    /// A background task's own supervisor (see [`Self::spawn_background_task`]) checks
+    /// this immediately before forcing a panicked task's document to `Failed`: by the
+    /// time a supervisor observes a panic, a newer [`Self::spawn_background_task`] call
+    /// may already have superseded it (aborting an already-finished — and thus
+    /// unabortable — handle is a documented no-op), and that newer task now owns the
+    /// document's `loading_state`.
+    async fn is_current_background_task(&self, uri: &Uri, task_id: tokio::task::Id) -> bool {
+        self.tasks
+            .read()
+            .await
+            .get(uri)
+            .is_some_and(|(current_id, _)| *current_id == task_id)
+    }
+
+    /// Forces `uri`'s document out of `Loading` into `Failed`, seeding a
+    /// [`deps_core::FetchFailure::NotAttempted`] finding for every dependency that has
+    /// neither a cached registry version nor a lockfile-resolved one (issue #632 critic
+    /// S2).
+    ///
+    /// Without the seeding, `generate_diagnostics_from_cache`'s unknown-package rule would
+    /// render every such dependency as "Unknown package" — a registry lookup that was
+    /// never actually attempted looks identical to one that came back empty — instead of
+    /// "lookup could not be determined", turning a silently suppressed diagnostic into a
+    /// misleading one. `set_fetch_failure_if_absent` (already used for a similar
+    /// never-queried case, source collisions — see `document::lifecycle`) never clobbers a
+    /// genuine `Actionable`/`Transient` finding a partial fetch may have already recorded
+    /// for the same dependency.
+    ///
+    /// A no-op if the document is missing, or (issue #632 critic M3) if it isn't currently
+    /// `Loading` — this must never clobber a document that a newer background task has
+    /// already taken past `Loading`, or one that panicked before ever reaching
+    /// `DocumentState::set_loading`.
+    pub(crate) fn force_document_failed_with_not_attempted(&self, uri: &Uri) {
+        let Some(mut doc) = self.documents.get_mut(uri) else {
+            return;
+        };
+        if doc.loading_state != LoadingState::Loading {
+            return;
+        }
+
+        let not_attempted: Vec<String> = self
+            .ecosystem_registry
+            .get(doc.ecosystem_id())
+            .zip(doc.parse_result())
+            .map(|(ecosystem, parse_result)| {
+                let formatter = ecosystem.formatter();
+                parse_result
+                    .dependencies()
+                    .into_iter()
+                    .filter(|dep| formatter.can_resolve_source(&dep.source()))
+                    .map(|dep| dep.name().clone())
+                    .filter(|name| {
+                        !doc.cached_versions.contains_key(name)
+                            && !doc.resolved_versions.contains_key(name)
+                    })
+                    .map(|name| formatter.normalize_package_name(&name))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        if !not_attempted.is_empty() {
+            let mut outcomes = doc.outcomes.clone();
+            for name in not_attempted {
+                outcomes.set_fetch_failure_if_absent(name, deps_core::FetchFailure::NotAttempted);
+            }
+            doc.replace_outcomes(outcomes);
+        }
+
+        doc.set_failed();
     }
 
     /// Cancels the background task for a document.
@@ -904,7 +1024,7 @@ impl ServerState {
     /// If no task exists, this is a no-op.
     pub async fn cancel_background_task(&self, uri: &Uri) {
         let mut tasks = self.tasks.write().await;
-        if let Some(task) = tasks.remove(uri) {
+        if let Some((_, task)) = tasks.remove(uri) {
             task.abort();
         }
     }
@@ -1433,7 +1553,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_server_state_background_tasks() {
-        let state = ServerState::new();
+        let state = Arc::new(ServerState::new());
         let uri = deps_core::test_util::test_uri("/test.toml");
 
         let task = tokio::spawn(async {
@@ -1446,7 +1566,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_spawn_background_task_cancels_previous() {
-        let state = ServerState::new();
+        let state = Arc::new(ServerState::new());
         let uri = deps_core::test_util::test_uri("/test.toml");
 
         let task1 = tokio::spawn(async {
@@ -1463,8 +1583,162 @@ mod tests {
 
     #[tokio::test]
     async fn test_cancel_background_task_nonexistent() {
-        let state = ServerState::new();
+        let state = Arc::new(ServerState::new());
         let uri = deps_core::test_util::test_uri("/test.toml");
+        state.cancel_background_task(&uri).await;
+    }
+
+    /// Polls every 5ms until `condition` returns true or `timeout` elapses (issue #632
+    /// critic M4): avoids racing a fixed `sleep` against the supervisor's real
+    /// `JoinHandle::await`, which is slower and more variable under load than a plain
+    /// timer, so a fixed-sleep assertion can flake on a busy CI runner.
+    async fn poll_until(timeout: std::time::Duration, mut condition: impl FnMut() -> bool) -> bool {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            if condition() {
+                return true;
+            }
+            if std::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+    }
+
+    /// Issue #632: a background task that panics (rather than cleanly completing or
+    /// being aborted) must not leave the document stuck in `LoadingState::Loading`
+    /// forever — the supervisor spawned by `spawn_background_task` must force it to
+    /// `Failed`.
+    #[tokio::test]
+    async fn test_spawn_background_task_panic_marks_document_failed() {
+        let state = Arc::new(ServerState::new());
+        let uri = deps_core::test_util::test_uri("/test.toml");
+
+        let mut doc = DocumentState::new_without_parse_result(EcosystemId::Cargo, String::new());
+        doc.set_loading();
+        state.update_document(uri.clone(), doc);
+
+        let task = tokio::spawn(async {
+            panic!("simulated background task panic");
+        });
+        state.spawn_background_task(uri.clone(), task).await;
+
+        let reached_failed = poll_until(std::time::Duration::from_secs(1), || {
+            state
+                .get_document(&uri)
+                .is_some_and(|d| d.loading_state == LoadingState::Failed)
+        })
+        .await;
+        assert!(
+            reached_failed,
+            "supervisor did not force loading_state to Failed within 1s"
+        );
+    }
+
+    /// Issue #632 critic M3: a task that panics *before* the document ever reaches
+    /// `Loading` (e.g. a panic during setup, prior to the first `set_loading` call) must
+    /// not force it into `Failed` — there is no in-flight load to fail, and doing so
+    /// would misrepresent an `Idle` document as a failed fetch attempt.
+    #[tokio::test]
+    async fn test_spawn_background_task_panic_does_not_mark_idle_document_failed() {
+        let state = Arc::new(ServerState::new());
+        let uri = deps_core::test_util::test_uri("/test.toml");
+
+        let doc = DocumentState::new_without_parse_result(EcosystemId::Cargo, String::new());
+        assert_eq!(doc.loading_state, LoadingState::Idle);
+        state.update_document(uri.clone(), doc);
+
+        let task = tokio::spawn(async {
+            panic!("simulated pre-loading panic");
+        });
+        state.spawn_background_task(uri.clone(), task).await;
+
+        // Give the supervisor ample time to (incorrectly, pre-fix) act.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let doc = state.get_document(&uri).unwrap();
+        assert_eq!(
+            doc.loading_state,
+            LoadingState::Idle,
+            "a panic before the document ever reached Loading must not force it to Failed"
+        );
+    }
+
+    /// Issue #632 companion: an intentionally aborted task (superseded by a newer
+    /// `spawn_background_task` call) must NOT be treated as a failure — the new task
+    /// owns the document state from this point on.
+    #[tokio::test]
+    async fn test_spawn_background_task_abort_does_not_mark_document_failed() {
+        let state = Arc::new(ServerState::new());
+        let uri = deps_core::test_util::test_uri("/test.toml");
+
+        let mut doc = DocumentState::new_without_parse_result(EcosystemId::Cargo, String::new());
+        doc.set_loading();
+        state.update_document(uri.clone(), doc);
+
+        let task1 = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        });
+        state.spawn_background_task(uri.clone(), task1).await;
+
+        // Superseding the task aborts it — this must not be mistaken for a panic.
+        let task2_done = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&task2_done);
+        let task2 = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            flag.store(true, Ordering::SeqCst);
+        });
+        state.spawn_background_task(uri.clone(), task2).await;
+
+        poll_until(std::time::Duration::from_secs(1), || {
+            task2_done.load(Ordering::SeqCst)
+        })
+        .await;
+        // Give task1's supervisor a further moment to (incorrectly, pre-fix) act on the
+        // cancellation it observes.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let doc = state.get_document(&uri).unwrap();
+        assert_eq!(
+            doc.loading_state,
+            LoadingState::Loading,
+            "an aborted (superseded) task must not force the document to Failed"
+        );
+    }
+
+    /// Issue #632 critic S3: a supervisor for a task that has already been superseded by
+    /// a newer `spawn_background_task` call for the same URI must recognize it is no
+    /// longer current. Tests `ServerState::is_current_background_task` directly rather
+    /// than racing a real panic against a real re-registration — that race's winner
+    /// depends on scheduler timing, but the identity check must be correct regardless of
+    /// who wins it.
+    #[tokio::test]
+    async fn test_is_current_background_task_detects_supersession() {
+        let state = Arc::new(ServerState::new());
+        let uri = deps_core::test_util::test_uri("/test.toml");
+
+        let task_a = tokio::spawn(std::future::pending::<()>());
+        let id_a = task_a.id();
+        state.spawn_background_task(uri.clone(), task_a).await;
+        assert!(
+            state.is_current_background_task(&uri, id_a).await,
+            "A must be current right after being registered"
+        );
+
+        let task_b = tokio::spawn(std::future::pending::<()>());
+        let id_b = task_b.id();
+        state.spawn_background_task(uri.clone(), task_b).await;
+
+        assert!(
+            !state.is_current_background_task(&uri, id_a).await,
+            "A's id must no longer be current once B supersedes it — a belated \
+             supervisor for A must not force-fail B's in-flight load"
+        );
+        assert!(
+            state.is_current_background_task(&uri, id_b).await,
+            "B must be the current task after superseding A"
+        );
+
         state.cancel_background_task(&uri).await;
     }
 

--- a/crates/deps-lsp/src/handlers/diagnostics.rs
+++ b/crates/deps-lsp/src/handlers/diagnostics.rs
@@ -4,9 +4,38 @@ use crate::config::{DepsConfig, DiagnosticsConfig};
 use crate::document::{ServerState, ensure_document_loaded};
 use deps_core::VersionData;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::RwLock;
 use tower_lsp_server::Client;
 use tower_lsp_server::ls_types::{Diagnostic, Uri};
+
+/// How many multiples of `cache.fetch_timeout_secs` a document may stay in
+/// [`deps_core::LoadingState::Loading`] before diagnostics generation gives up waiting
+/// and forces it to `Failed`, falling through to whatever cache is already available
+/// (issue #632).
+///
+/// This alone under-estimates the legitimate (non-stuck) worst case for a large
+/// manifest (issue #632 critic S1): a single package fetch can take up to roughly
+/// `2 * fetch_timeout_secs` (the primary registry call plus its own timeout-bounded
+/// `get_latest_matching_from` fallback — see `document::lifecycle::fetch_and_classify_package`),
+/// run `cache.max_concurrent_fetches`-wide via `buffer_unordered` — so `N` dependencies
+/// take roughly `ceil(N / C) * 2T` even when nothing is wrong. With the defaults
+/// (T=10s, C=20), a 60-dependency manifest alone already reaches ~60s. Combined with
+/// [`MIN_LOADING_CEILING`], the effective ceiling is `max(3T, 120s)` — generous-but-bounded
+/// headroom, not a precise duration model: this exists to recover from a background task
+/// that never reaches `set_loaded`/`set_failed` (a hang the per-package timeout alone
+/// doesn't cover, e.g. a `DashMap` deadlock), not to model the exact fetch duration.
+pub(crate) const LOADING_CEILING_MULTIPLIER: u32 = 3;
+
+/// Floor under the [`LOADING_CEILING_MULTIPLIER`]-scaled ceiling (issue #632 critic S1):
+/// keeps a small `fetch_timeout_secs` from producing an unrealistically tight ceiling.
+pub(crate) const MIN_LOADING_CEILING: Duration = Duration::from_secs(120);
+
+/// Computes the loading ceiling from the configured per-package fetch timeout. See
+/// [`LOADING_CEILING_MULTIPLIER`] and [`MIN_LOADING_CEILING`].
+pub(crate) fn loading_ceiling(fetch_timeout_secs: u64) -> Duration {
+    (Duration::from_secs(fetch_timeout_secs) * LOADING_CEILING_MULTIPLIER).max(MIN_LOADING_CEILING)
+}
 
 /// Handles diagnostic requests using trait-based delegation.
 pub async fn handle_diagnostics(
@@ -23,16 +52,17 @@ pub async fn handle_diagnostics(
     }
 
     // Snapshot before generating diagnostics (Copy value, no lock held across the call)
-    let (freshness, offline) = {
+    let (freshness, offline, ceiling) = {
         let full_config = full_config.read().await;
         (
             full_config.freshness.to_settings(),
             full_config.network.offline,
+            loading_ceiling(full_config.cache.fetch_timeout_secs),
         )
     };
     let severities = config.to_severities();
 
-    generate_diagnostics_internal(state, uri, freshness, severities, offline).await
+    generate_diagnostics_internal(state, uri, freshness, severities, offline, ceiling).await
 }
 
 /// Internal diagnostic generation without cold start support.
@@ -44,7 +74,37 @@ pub(crate) async fn generate_diagnostics_internal(
     freshness: deps_core::FreshnessSettings,
     severities: deps_core::DiagnosticSeverities,
     offline: bool,
+    loading_ceiling: Duration,
 ) -> Vec<Diagnostic> {
+    // Skip diagnostics while versions are still loading to avoid false "Unknown package"
+    // warnings from empty cache — but only up to `loading_ceiling` (issue #632): if the
+    // background fetch task panicked or otherwise never reached `set_loaded`/`set_failed`,
+    // `loading_state` would otherwise stay `Loading` forever and permanently suppress
+    // diagnostics for this document. Past the ceiling, force the document to `Failed`
+    // *before* the extraction below (critic M1/S2) — a bare read-only fallthrough would
+    // leave `loading_state` stuck (re-warning on every request, and leaving inlay
+    // hints/`is_ready_for_batch_update` believing the document is still loading) and would
+    // leave `outcomes` empty, misrendering every unresolved dependency as "Unknown
+    // package" instead of "lookup could not be determined". `unwrap_or(Duration::MAX)`
+    // (critic M2) treats a `Loading` document with no recorded start time — a state the
+    // public API can't actually reach, but the fields are both `pub` — as already past the
+    // ceiling rather than never.
+    let past_ceiling = state
+        .with_document(uri, |doc| {
+            doc.loading_state == deps_core::LoadingState::Loading
+                && doc.loading_duration().unwrap_or(Duration::MAX) >= loading_ceiling
+        })
+        .unwrap_or(false);
+    if past_ceiling {
+        tracing::warn!(
+            "Loading exceeded ceiling ({:?}) for {:?}; forcing Failed and falling through \
+             to diagnostics with available cache",
+            loading_ceiling,
+            uri
+        );
+        state.force_document_failed_with_not_attempted(uri);
+    }
+
     // Own everything `generate_diagnostics` needs and release the DashMap shard `Ref`
     // before awaiting it (#333): `with_document` only ever hands `extract` a borrowed
     // `&DocumentState` synchronously, so the guard can't leak across the `.await` below.
@@ -57,9 +117,8 @@ pub(crate) async fn generate_diagnostics_internal(
             return None;
         };
 
-        // Skip diagnostics while versions are still loading to avoid
-        // false "Unknown package" warnings from empty cache
-        // TODO(critic): bound this skip by loading_started_at.elapsed() — see #592 residual
+        // The ceiling check above already forced a stuck document out of `Loading`, so
+        // this only ever suppresses a document that is genuinely, recently loading.
         if doc.loading_state == deps_core::LoadingState::Loading {
             return None;
         }
@@ -116,6 +175,16 @@ mod tests {
     use deps_core::EcosystemId;
 
     // Generic tests (no feature flag required)
+
+    #[test]
+    fn test_loading_ceiling_scales_with_fetch_timeout() {
+        // Critic S1: the default `fetch_timeout_secs` (10s) scales to 30s, well under
+        // `MIN_LOADING_CEILING` — the floor must win.
+        assert_eq!(loading_ceiling(10), Duration::from_secs(120));
+        assert_eq!(loading_ceiling(1), Duration::from_secs(120));
+        // A large `fetch_timeout_secs` scales past the floor.
+        assert_eq!(loading_ceiling(50), Duration::from_secs(150));
+    }
 
     #[tokio::test]
     async fn test_handle_diagnostics_missing_document() {
@@ -441,6 +510,161 @@ serde = "1.0.0"
             let (client, full_config) = create_test_client_and_config();
             let result = handle_diagnostics(state, &uri, &config, client, full_config).await;
             assert!(result.is_empty());
+        }
+
+        /// Issue #632: a document stuck in `Loading` past `loading_ceiling` must fall
+        /// through to diagnostics generated from whatever cache is already available,
+        /// instead of returning nothing forever (e.g. a background fetch task that
+        /// panicked without reaching `set_loaded`/`set_failed`).
+        #[tokio::test]
+        async fn test_generate_diagnostics_internal_falls_through_after_loading_ceiling_exceeded() {
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+
+            let ecosystem = state.ecosystem_registry.get("cargo").unwrap();
+            let content = "[dependencies]\nserde = \"1.0.0\"\n".to_string();
+            let parse_result = ecosystem
+                .parse_manifest(&content, &uri)
+                .await
+                .expect("Failed to parse manifest");
+
+            let mut doc_state =
+                DocumentState::new_from_parse_result(EcosystemId::Cargo, content, parse_result);
+            let mut cached = std::collections::HashMap::new();
+            cached.insert(
+                "serde".into(),
+                deps_core::PackageVersions {
+                    latest: "2.0.0".into(),
+                    available: std::sync::Arc::from(vec!["2.0.0".into(), "1.0.0".into()]),
+                    yanked: std::sync::Arc::from(Vec::new()),
+                    published_at: None,
+                },
+            );
+            doc_state.update_cached_versions(cached);
+            doc_state.set_loading();
+            state.update_document(uri.clone(), doc_state);
+
+            // Let real elapsed time exceed a deliberately tiny ceiling.
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+            let result = generate_diagnostics_internal(
+                Arc::clone(&state),
+                &uri,
+                deps_core::FreshnessSettings::default(),
+                deps_core::DiagnosticSeverities::default(),
+                false,
+                std::time::Duration::from_millis(1),
+            )
+            .await;
+
+            assert_eq!(
+                result.len(),
+                1,
+                "expected the outdated diagnostic to render from cache once the loading \
+                 ceiling is exceeded, got: {result:?}"
+            );
+
+            // Critic M1: the fallthrough must repair `loading_state`, not just read past
+            // it — otherwise inlay hints/code lens keep believing the document is still
+            // loading, and this same warning would refire on every subsequent request.
+            let doc = state.get_document(&uri).unwrap();
+            assert_eq!(doc.loading_state, deps_core::LoadingState::Failed);
+        }
+
+        /// Issue #632 critic S2: forcing a stuck-`Loading` document to `Failed` must seed
+        /// a `NotAttempted` fetch-failure finding for every dependency with neither a
+        /// cached nor a lockfile-resolved version — otherwise the unknown-package rule
+        /// renders it as "Unknown package" (a registry lookup that never happened looks
+        /// identical to one that came back empty), turning a silently suppressed
+        /// diagnostic into a misleading one.
+        #[tokio::test]
+        async fn test_generate_diagnostics_internal_ceiling_exceeded_seeds_not_attempted_instead_of_unknown_package()
+         {
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+
+            let ecosystem = state.ecosystem_registry.get("cargo").unwrap();
+            // No cached_versions/resolved_versions seeded for "serde" at all — the exact
+            // "never actually fetched" shape S2 covers.
+            let content = "[dependencies]\nserde = \"1.0.0\"\n".to_string();
+            let parse_result = ecosystem
+                .parse_manifest(&content, &uri)
+                .await
+                .expect("Failed to parse manifest");
+
+            let mut doc_state =
+                DocumentState::new_from_parse_result(EcosystemId::Cargo, content, parse_result);
+            doc_state.set_loading();
+            state.update_document(uri.clone(), doc_state);
+
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+            let result = generate_diagnostics_internal(
+                Arc::clone(&state),
+                &uri,
+                deps_core::FreshnessSettings::default(),
+                deps_core::DiagnosticSeverities::default(),
+                false,
+                std::time::Duration::from_millis(1),
+            )
+            .await;
+
+            assert_eq!(
+                result.len(),
+                1,
+                "expected exactly one diagnostic, got: {result:?}"
+            );
+            assert!(
+                result[0].message.contains("could not be determined"),
+                "expected the 'lookup could not be determined' message, got: {:?}",
+                result[0].message
+            );
+            assert!(
+                !result[0].message.contains("Unknown package"),
+                "a dependency that was never actually fetched must not render as 'Unknown \
+                 package', got: {:?}",
+                result[0].message
+            );
+
+            let doc = state.get_document(&uri).unwrap();
+            assert_eq!(doc.loading_state, deps_core::LoadingState::Failed);
+        }
+
+        /// Issue #632 companion: within the ceiling, the pre-existing suppression must
+        /// still apply — no diagnostics render for a document that is still legitimately
+        /// loading.
+        #[tokio::test]
+        async fn test_generate_diagnostics_internal_still_suppressed_within_loading_ceiling() {
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+
+            let ecosystem = state.ecosystem_registry.get("cargo").unwrap();
+            let content = "[dependencies]\nserde = \"1.0.0\"\n".to_string();
+            let parse_result = ecosystem
+                .parse_manifest(&content, &uri)
+                .await
+                .expect("Failed to parse manifest");
+
+            let mut doc_state =
+                DocumentState::new_from_parse_result(EcosystemId::Cargo, content, parse_result);
+            doc_state.set_loading();
+            state.update_document(uri.clone(), doc_state);
+
+            let result = generate_diagnostics_internal(
+                Arc::clone(&state),
+                &uri,
+                deps_core::FreshnessSettings::default(),
+                deps_core::DiagnosticSeverities::default(),
+                false,
+                std::time::Duration::from_secs(60),
+            )
+            .await;
+
+            assert!(
+                result.is_empty(),
+                "expected diagnostics to stay suppressed within the loading ceiling, got: \
+                 {result:?}"
+            );
         }
 
         /// End-to-end coverage for issue #206's unsatisfiable-requirement diagnostic,

--- a/crates/deps-lsp/src/server.rs
+++ b/crates/deps-lsp/src/server.rs
@@ -253,12 +253,13 @@ impl Backend {
         // `handle_diagnostics` (which re-reads `self.config` per URI) would hold this
         // guard across a nested read of the same write-preferring `RwLock` — a writer
         // queued in between would then block that nested read forever.
-        let (freshness, severities, offline) = {
+        let (freshness, severities, offline, loading_ceiling) = {
             let config = self.config.read().await;
             (
                 config.freshness.to_settings(),
                 config.diagnostics.to_severities(),
                 config.network.offline,
+                diagnostics::loading_ceiling(config.cache.fetch_timeout_secs),
             )
         };
 
@@ -273,6 +274,7 @@ impl Backend {
                 freshness,
                 severities,
                 offline,
+                loading_ceiling,
             )
             .await;
 


### PR DESCRIPTION
## Summary

- `generate_diagnostics_internal` no longer suppresses diagnostics forever when a document's `loading_state` stays at `Loading`. The skip is bounded by a fetch-timeout-derived ceiling (`max(fetch_timeout_secs * 3, 120s)`), falling through to diagnostics from whatever cache is available once exceeded, and repairing `loading_state` in the process.
- `ServerState::spawn_background_task` now supervises the spawned task's `JoinHandle`: a genuine panic forces the document to `Failed` (seeding `FetchFailure::NotAttempted` so diagnostics render "registry lookup failed" instead of a false "Unknown package" storm), while intentional aborts (a superseding task, explicit cancellation) are left untouched via a task-identity guard.
- Closes the two failure modes identified in #632: an unbounded skip with no recovery path, and a discarded `JoinHandle` result that let a panicked fetch task strand a document in `Loading` indefinitely.

## Non-blocking follow-ups (flagged during review)

- The ceiling formula does not factor in dependency count or `max_concurrent_fetches`; at very low concurrency settings on a large manifest it could theoretically still be exceeded legitimately. Worth a follow-up issue if it proves to matter in practice.
- A narrow, effectively unreachable window exists between a task's `tokio::spawn` and its registry insertion where a stale supervisor could still observe a since-superseded task id as current.

Closes #632

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4320 passed, 49 skipped)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --all-features`
- [x] New regression tests cover: ceiling boundary conditions, panic-triggered supervision, abort/cancellation not triggering false failure, and task-identity guard against stale supervisors