### PR TITLE
GitHub Actions: bulk pin all mutable-tag actions to commit SHA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-npm, deps-composer**: `deps-npm` and `deps-composer` now share a single `deps_core::json_helpers::string_valued_entries` helper (and its test coverage) for skipping non-string dependency-map values, instead of each crate carrying its own duplicated guard and tests (resolves #624) (#630)
 
 ### Added
-- **deps-github-actions, deps-lsp**: bulk "Pin N actions to commit SHA" code lens for GitHub Actions workflows, applying every resolvable mutable-tag `uses:` pin in one edit via the existing per-step quickfix's `TagIndex` lookup (resolves #633)
+- **deps-github-actions, deps-lsp**: bulk "Pin N actions to commit SHA" code lens for GitHub Actions workflows, applying every resolvable mutable-tag `uses:` pin in one edit via the existing per-step quickfix's `TagIndex` lookup (resolves #633) (#639)
 - **deps-gitlab-ci**: mutable-ref SHA-pin diagnostic and "Pin to commit SHA" quickfix for `include: - project:`/`component:` entries (resolves #634)
 - **deps-lsp**: `workspace/didChangeConfiguration` now re-parses and forces a full re-fetch for every open document affected by a live-reloaded setting that alters registry routing (`registries.workspace_registries`, `registries.nuget_user_profile_sources`, `registries.gitlab_instance_host`), bounded by a server-wide fetch-concurrency cap shared with cold-start loading (resolves #592) (#600)
 - **deps-npm, deps-lsp**: watch `pnpm-workspace.yaml`/`.npmrc` for external changes and reparse already-open `package.json` documents so catalog/registry-resolved diagnostics stay current (resolves #590) (#595)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-npm, deps-composer**: `deps-npm` and `deps-composer` now share a single `deps_core::json_helpers::string_valued_entries` helper (and its test coverage) for skipping non-string dependency-map values, instead of each crate carrying its own duplicated guard and tests (resolves #624) (#630)
 
 ### Added
+- **deps-github-actions, deps-lsp**: bulk "Pin N actions to commit SHA" code lens for GitHub Actions workflows, applying every resolvable mutable-tag `uses:` pin in one edit via the existing per-step quickfix's `TagIndex` lookup (resolves #633)
 - **deps-gitlab-ci**: mutable-ref SHA-pin diagnostic and "Pin to commit SHA" quickfix for `include: - project:`/`component:` entries (resolves #634)
 - **deps-lsp**: `workspace/didChangeConfiguration` now re-parses and forces a full re-fetch for every open document affected by a live-reloaded setting that alters registry routing (`registries.workspace_registries`, `registries.nuget_user_profile_sources`, `registries.gitlab_instance_host`), bounded by a server-wide fetch-concurrency cap shared with cold-start loading (resolves #592) (#600)
 - **deps-npm, deps-lsp**: watch `pnpm-workspace.yaml`/`.npmrc` for external changes and reparse already-open `package.json` documents so catalog/registry-resolved diagnostics stay current (resolves #590) (#595)

--- a/crates/deps-core/src/ecosystem.rs
+++ b/crates/deps-core/src/ecosystem.rs
@@ -640,6 +640,17 @@ pub trait Ecosystem: Send + Sync + private::Sealed {
 
     /// Generate the "Update N outdated dependencies" code lens for the document.
     ///
+    /// `severities` is unused by the default implementation (the shared "update all
+    /// outdated" lens has no enable/disable toggle of its own — that's `code_lens.enabled`
+    /// in `deps-lsp`'s config, gating the whole handler before this method is ever
+    /// called) but is threaded through so an override can gate an *additional*,
+    /// ecosystem-specific lens on a `DiagnosticSeverities` flag the way
+    /// `generate_diagnostics`'s `severities` parameter already does — see
+    /// `deps_github_actions::GithubActionsEcosystem`'s override, which gates its bulk
+    /// "Pin N actions to commit SHA" lens on `severities.mutable_ref_pin_enabled` so
+    /// disabling that flag suppresses the lens the same way it suppresses the
+    /// diagnostic (issue #633).
+    ///
     /// Default implementation delegates to `lsp_helpers::generate_code_lenses` using
     /// `self.formatter()`. Override only if custom behavior is needed.
     fn generate_code_lenses<'a>(
@@ -649,6 +660,7 @@ pub trait Ecosystem: Send + Sync + private::Sealed {
         versions: VersionData<'a>,
         uri: &'a Uri,
         command_id: &'a str,
+        _severities: crate::lsp_helpers::DiagnosticSeverities,
     ) -> BoxFuture<'a, Vec<CodeLens>> {
         Box::pin(async move {
             crate::lsp_helpers::generate_code_lenses(

--- a/crates/deps-core/src/lsp_helpers/code_lenses.rs
+++ b/crates/deps-core/src/lsp_helpers/code_lenses.rs
@@ -198,6 +198,23 @@ pub fn collect_update_all_edits(
         });
     }
 
+    dedup_overlapping_edits(edits, "collect_update_all_edits")
+}
+
+/// Sorts `edits` by start position and drops any edit whose start falls before the
+/// previous (surviving) edit's end — a `WorkspaceEdit` protocol violation no LSP client
+/// can apply.
+///
+/// `caller` names the collector in the `tracing::warn!` emitted for each dropped edit, so
+/// a log line is traceable back to which bulk command produced it.
+///
+/// Shared by every "collect edits for a bulk `WorkspaceEdit`" aggregator in the
+/// workspace (issue #633 critic M3: a sibling collector omitting this pass — while every
+/// current parser happens not to produce overlapping spans — is exactly the kind of
+/// divergence the project's cross-ecosystem-consistency rule exists to catch) —
+/// currently [`collect_update_all_edits`] and
+/// `deps_github_actions::ecosystem::collect_pin_all_to_sha_edits`.
+pub fn dedup_overlapping_edits(mut edits: Vec<TextEdit>, caller: &str) -> Vec<TextEdit> {
     edits.sort_by_key(|edit| (edit.range.start.line, edit.range.start.character));
 
     let mut non_overlapping: Vec<TextEdit> = Vec::with_capacity(edits.len());
@@ -209,7 +226,8 @@ pub fn collect_update_all_edits(
         if overlaps_prev {
             tracing::warn!(
                 range = ?edit.range,
-                "collect_update_all_edits: dropping overlapping TextEdit"
+                caller,
+                "dropping overlapping TextEdit"
             );
             continue;
         }

--- a/crates/deps-core/src/lsp_helpers/mod.rs
+++ b/crates/deps-core/src/lsp_helpers/mod.rs
@@ -22,7 +22,7 @@ mod inlay_hints;
 mod test_support;
 
 pub use code_actions::generate_code_actions;
-pub use code_lenses::{collect_update_all_edits, generate_code_lenses};
+pub use code_lenses::{collect_update_all_edits, dedup_overlapping_edits, generate_code_lenses};
 pub use diagnostics::{
     DEPRECATED_DIAGNOSTIC_CODE, DiagnosticSeverities, UNSATISFIABLE_DIAGNOSTIC_CODE,
     compile_requirement_unless, generate_diagnostics_from_cache, requirement_is_unsatisfiable,

--- a/crates/deps-github-actions/README.md
+++ b/crates/deps-github-actions/README.md
@@ -30,6 +30,9 @@ implements `deps_core::Ecosystem`.
   `@v4`) gets an additive, independent diagnostic recommending SHA pinning, plus a "Pin to
   commit SHA" quick fix rewriting it to `@<sha> # <tag>` when the tag's commit is already
   known; on by default, configurable via `mutable_ref_pin_severity`/`mutable_ref_pin_enabled`
+- **Bulk "Pin all to SHA" code lens** (issue #633) — a "Pin N actions to commit SHA" lens
+  applies the per-step quick fix above to every resolvable mutable-tag step in one edit,
+  reusing the same `TagIndex` lookup at zero additional network cost
 - **Release-freshness signal (partial)** (issue #486) — `GithubActionsRegistry::
   get_versions_with_release_dates`, invoked via `Registry::get_versions_with` when
   freshness rendering is enabled, attaches GitHub Release publish timestamps to
@@ -93,6 +96,10 @@ against the tag with zero SHA-to-tag network resolution.
   (`uses: "actions/checkout@v4"`) — the ref sits inside the quotes there, and appending
   `# <tag>` would corrupt the value instead of adding a YAML comment; the diagnostic still
   fires, just without the automated fix
+- Both the "Pin to commit SHA" quick fix and the bulk "Pin all to SHA" lens are withheld
+  for a `uses:` step written in YAML flow style (`{uses: actions/checkout@v4, with:
+  {node: 20}}`) — appending `# <tag>` would comment out the rest of the flow collection
+  and produce invalid YAML; block-style steps (the common case) are unaffected
 
 ## License
 

--- a/crates/deps-github-actions/src/ecosystem.rs
+++ b/crates/deps-github-actions/src/ecosystem.rs
@@ -4,8 +4,8 @@ use dashmap::DashMap;
 use std::any::Any;
 use std::sync::Arc;
 use tower_lsp_server::ls_types::{
-    CodeAction, CodeActionKind, Diagnostic, Hover, HoverContents, NumberOrString, Position,
-    TextEdit, Uri, WorkspaceEdit,
+    CodeAction, CodeActionKind, CodeLens, Command, Diagnostic, Hover, HoverContents,
+    NumberOrString, Position, Range, TextEdit, Uri, WorkspaceEdit,
 };
 
 use deps_core::{
@@ -75,6 +75,24 @@ impl GithubActionsEcosystem {
             registry,
             formatter,
         }
+    }
+
+    /// Builds the bulk "Pin all to SHA" edits for `parse_result` (issue #633), one per
+    /// `PinStyle::Tag` step resolvable via this ecosystem's own `TagIndex`-backed
+    /// formatter — the same edits the "Pin N actions to commit SHA" code lens counts and
+    /// the `deps-lsp.pinAllToSha` command applies.
+    ///
+    /// `pub`, not `pub(crate)`: `deps-lsp`'s command handler recomputes these edits fresh
+    /// at execution time (mirroring `deps_core::collect_update_all_edits`'s recompute-at-
+    /// click-time contract for `deps-lsp.updateAllOutdated`) and needs the concrete
+    /// formatter this method wraps, since `Ecosystem::formatter()` only exposes the
+    /// trait-object view.
+    #[must_use]
+    pub fn collect_pin_all_to_sha_edits(
+        &self,
+        parse_result: &dyn ParseResultTrait,
+    ) -> Vec<TextEdit> {
+        collect_pin_all_to_sha_edits(parse_result, &self.formatter)
     }
 }
 
@@ -223,6 +241,45 @@ impl Ecosystem for GithubActionsEcosystem {
                 &self.formatter,
             ));
             actions
+        })
+    }
+
+    /// Appends the "Pin N actions to commit SHA" bulk code lens (issue #633) to the
+    /// shared default's "Update N outdated dependencies" lens — an independent, additive
+    /// lens bound to its own command, mirroring how [`Self::generate_diagnostics`] and
+    /// [`Self::generate_code_actions`] above append their own GHA-specific signal without
+    /// altering the shared default's output.
+    fn generate_code_lenses<'a>(
+        &'a self,
+        parse_result: &'a dyn ParseResultTrait,
+        content: &'a str,
+        versions: deps_core::VersionData<'a>,
+        uri: &'a Uri,
+        command_id: &'a str,
+        severities: deps_core::lsp_helpers::DiagnosticSeverities,
+    ) -> deps_core::ecosystem::BoxFuture<'a, Vec<CodeLens>> {
+        Box::pin(async move {
+            let mut lenses = deps_core::lsp_helpers::generate_code_lenses(
+                parse_result,
+                content,
+                versions,
+                self.formatter(),
+                uri,
+                command_id,
+            );
+            // Same on/off toggle as `mutable_ref_pin_diagnostics` (issue #633): unlike a
+            // quickfix (pull-based, invoked per-position), a lens is push-based and
+            // permanently rendered, so a user who disables the mutable-ref-pin signal
+            // must not still see a standing "Pin N actions to commit SHA" banner on
+            // every workflow.
+            if severities.mutable_ref_pin_enabled {
+                lenses.extend(build_pin_all_to_sha_lens(
+                    parse_result,
+                    uri,
+                    &self.formatter,
+                ));
+            }
+            lenses
         })
     }
 
@@ -513,30 +570,11 @@ fn build_sha_pin_action(
         .find(|d| formatter.is_position_on_dependency(*d, position))?;
 
     let gha_dep = dep.as_any().downcast_ref::<GithubActionsDependency>()?;
-    if gha_dep.pin != Some(PinStyle::Tag) {
-        return None;
-    }
-    // FR-010: for a quoted `uses:` scalar, `version_range` sits inside the quotes —
-    // writing `{sha} # {tag}` there corrupts the value instead of adding a YAML comment
-    // (security audit finding, spec 031 FR-010). Withhold rather than risk that edit.
-    if !gha_dep.is_plain_scalar {
-        return None;
-    }
-    let version_range = gha_dep.version_range?;
-    let tag = gha_dep
-        .version_req
-        .as_ref()
-        .map(deps_core::VersionReq::as_str)?;
-    let new_text = formatter.sha_pin_replacement_for(&gha_dep.name, tag)?;
+    let text_edit = sha_pin_text_edit_for(dep, formatter)?;
+    let diagnostic_range = text_edit.range;
 
     let mut changes = std::collections::HashMap::new();
-    changes.insert(
-        uri.clone(),
-        vec![TextEdit {
-            range: version_range,
-            new_text,
-        }],
-    );
+    changes.insert(uri.clone(), vec![text_edit]);
 
     Some(CodeAction {
         title: format!("Pin {} to commit SHA", gha_dep.name),
@@ -547,9 +585,99 @@ fn build_sha_pin_action(
         }),
         data: Some(serde_json::json!({
             "diagnostic_codes": [MUTABLE_REF_PIN_DIAGNOSTIC_CODE],
-            "diagnostic_range": version_range,
+            "diagnostic_range": diagnostic_range,
         })),
         ..Default::default()
+    })
+}
+
+/// Builds the `{sha} # {tag}` [`TextEdit`] for a single `PinStyle::Tag` step, shared by
+/// [`build_sha_pin_action`] (wraps it into a per-position quickfix) and
+/// [`collect_pin_all_to_sha_edits`] (the bulk "Pin all to SHA" code lens, issue #633).
+///
+/// `None` for anything but a plain-scalar `PinStyle::Tag` step with a resolvable
+/// `TagIndex` entry — the same withholding guards `build_sha_pin_action`'s doc comment
+/// describes (FR-010's quoted-scalar guard, and a `TagIndex` cache miss).
+fn sha_pin_text_edit_for(
+    dep: &dyn deps_core::Dependency,
+    formatter: &GithubActionsFormatter,
+) -> Option<TextEdit> {
+    let gha_dep = dep.as_any().downcast_ref::<GithubActionsDependency>()?;
+    if gha_dep.pin != Some(PinStyle::Tag) {
+        return None;
+    }
+    // FR-010: for a quoted `uses:` scalar, `version_range` sits inside the quotes —
+    // writing `{sha} # {tag}` there corrupts the value instead of adding a YAML comment
+    // (security audit finding, spec 031 FR-010). Withhold rather than risk that edit.
+    if !gha_dep.is_plain_scalar {
+        return None;
+    }
+    // Security audit finding (issue #633): for a `uses:` step written in YAML flow
+    // style (`{uses: actions/checkout@v4, with: {node: 20}}`), appending `# <tag>`
+    // right after the ref comments out the rest of the flow collection, producing
+    // invalid (unterminated) YAML instead of merely leaving the step unpinned.
+    // Withhold rather than risk corrupting the workflow.
+    if !gha_dep.is_last_on_line {
+        return None;
+    }
+    let version_range = gha_dep.version_range?;
+    let tag = gha_dep
+        .version_req
+        .as_ref()
+        .map(deps_core::VersionReq::as_str)?;
+    let new_text = formatter.sha_pin_replacement_for(&gha_dep.name, tag)?;
+    Some(TextEdit {
+        range: version_range,
+        new_text,
+    })
+}
+
+/// Builds one [`TextEdit`] per `PinStyle::Tag` step in `parse_result` resolvable to a
+/// commit SHA via `formatter`'s `TagIndex` — the bulk counterpart to
+/// [`build_sha_pin_action`]'s single-step quickfix (issue #633). A step with no
+/// resolvable `TagIndex` entry (cache miss) is silently skipped, exactly like that
+/// quickfix's own withholding behavior — never blocking on, or triggering, a fetch.
+fn collect_pin_all_to_sha_edits(
+    parse_result: &dyn ParseResultTrait,
+    formatter: &GithubActionsFormatter,
+) -> Vec<TextEdit> {
+    let edits: Vec<TextEdit> = parse_result
+        .dependencies()
+        .into_iter()
+        .filter_map(|dep| sha_pin_text_edit_for(dep, formatter))
+        .collect();
+    deps_core::lsp_helpers::dedup_overlapping_edits(edits, "collect_pin_all_to_sha_edits")
+}
+
+/// Zero or one lens for "Pin N actions to commit SHA" (issue #633), the bulk counterpart
+/// of [`build_sha_pin_action`]'s per-step quickfix. Mirrors
+/// `deps_core::lsp_helpers::generate_code_lenses`'s shape: no lens when there is nothing
+/// to pin, so an all-SHA-pinned (or empty) workflow gets no permanent line-0 annotation.
+fn build_pin_all_to_sha_lens(
+    parse_result: &dyn ParseResultTrait,
+    uri: &Uri,
+    formatter: &GithubActionsFormatter,
+) -> Option<CodeLens> {
+    let edits = collect_pin_all_to_sha_edits(parse_result, formatter);
+    if edits.is_empty() {
+        return None;
+    }
+
+    let count = edits.len();
+    let title = if count == 1 {
+        "Pin 1 action to commit SHA".to_string()
+    } else {
+        format!("Pin {count} actions to commit SHA")
+    };
+
+    Some(CodeLens {
+        range: Range::new(Position::new(0, 0), Position::new(0, 0)),
+        command: Some(Command {
+            title,
+            command: crate::PIN_ALL_TO_SHA_COMMAND_ID.to_string(),
+            arguments: Some(vec![serde_json::json!({ "uri": uri })]),
+        }),
+        data: None,
     })
 }
 
@@ -1029,6 +1157,39 @@ mod tests {
         );
     }
 
+    /// Security audit finding (issue #633): a `uses:` step written in YAML flow-mapping
+    /// style has real content (`, with: {...}}`) after the ref on the same line — the
+    /// quickfix must withhold itself even on a `TagIndex` hit, since appending `# v4`
+    /// would comment out the rest of the flow mapping and produce invalid, unterminated
+    /// YAML (reproduced live by the security audit against a real `yaml_rust2` re-parse).
+    #[test]
+    fn test_build_sha_pin_action_no_quickfix_for_flow_mapping_step() {
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let content = "steps:\n  - {uses: actions/checkout@v4, with: {node: 20}}\n";
+        let parse_result = crate::parser::parse_workflow_yaml(content, &uri).unwrap();
+        assert!(!parse_result.dependencies[0].is_last_on_line);
+
+        let formatter = GithubActionsFormatter {
+            tag_index: Arc::new(dashmap::DashMap::new()),
+        };
+        let mut index = crate::registry::TagIndex::default();
+        index.tag_to_sha.insert("v4".to_string(), "a".repeat(40));
+        formatter.tag_index.insert(
+            deps_core::PackageName::new("actions/checkout"),
+            Arc::new(index),
+        );
+
+        let position = deps_core::ParseResult::dependencies(&parse_result)[0]
+            .version_range()
+            .unwrap()
+            .start;
+
+        assert!(
+            build_sha_pin_action(&parse_result, position, &uri, &formatter).is_none(),
+            "a flow-mapping uses: step must withhold the quickfix even on a TagIndex hit"
+        );
+    }
+
     #[test]
     fn test_ecosystem_id_and_display_name() {
         let cache = Arc::new(deps_core::HttpCache::new());
@@ -1301,6 +1462,317 @@ mod tests {
             "a quoted uses: scalar offers no SHA-pin quickfix even on a TagIndex hit, so the \
              footer must not be restored; got: {}",
             content.value
+        );
+    }
+
+    // --- issue #633: bulk "Pin all to SHA" code lens ---
+
+    async fn code_lenses_for(content: &str, eco: &GithubActionsEcosystem) -> Vec<CodeLens> {
+        code_lenses_for_with_severities(
+            content,
+            eco,
+            deps_core::lsp_helpers::DiagnosticSeverities::default(),
+        )
+        .await
+    }
+
+    async fn code_lenses_for_with_severities(
+        content: &str,
+        eco: &GithubActionsEcosystem,
+        severities: deps_core::lsp_helpers::DiagnosticSeverities,
+    ) -> Vec<CodeLens> {
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let parse_result = eco.parse_manifest(content, &uri).await.unwrap();
+        let cached = HashMap::new();
+        let resolved = HashMap::new();
+
+        eco.generate_code_lenses(
+            parse_result.as_ref(),
+            content,
+            deps_core::VersionData::new(&cached, &resolved),
+            &uri,
+            "deps-lsp.updateAllOutdated",
+            severities,
+        )
+        .await
+    }
+
+    fn seed_tag(eco: &GithubActionsEcosystem, name: &str, tag: &str, sha: &str) {
+        let mut index = crate::registry::TagIndex::default();
+        index.tag_to_sha.insert(tag.to_string(), sha.to_string());
+        eco.formatter
+            .tag_index
+            .insert(deps_core::PackageName::new(name), Arc::new(index));
+    }
+
+    #[tokio::test]
+    async fn test_generate_code_lenses_pin_all_lens_present_for_resolvable_tag_pins() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = GithubActionsEcosystem::new(cache);
+        seed_tag(&eco, "actions/checkout", "v4", &"a".repeat(40));
+        seed_tag(&eco, "actions/setup-node", "v3", &"b".repeat(40));
+
+        let content = "steps:\n\
+             \x20 - uses: actions/checkout@v4\n\
+             \x20 - uses: actions/setup-node@v3\n";
+        let lenses = code_lenses_for(content, &eco).await;
+
+        let pin_all = lenses
+            .iter()
+            .find(|l| {
+                l.command
+                    .as_ref()
+                    .is_some_and(|c| c.command == crate::PIN_ALL_TO_SHA_COMMAND_ID)
+            })
+            .expect("expected a Pin-all-to-SHA lens");
+        let command = pin_all.command.as_ref().unwrap();
+        assert_eq!(command.title, "Pin 2 actions to commit SHA");
+        assert_eq!(command.command, crate::PIN_ALL_TO_SHA_COMMAND_ID);
+    }
+
+    /// Issue #633 critic S1: `severities.mutable_ref_pin_enabled` is the designated
+    /// on/off switch for the mutable-ref-pin *diagnostic* (`DiagnosticSeverity` has no
+    /// suppression value — see `mutable_ref_pin_diagnostics`'s own gate in
+    /// `generate_diagnostics`), and a lens is push-based/permanently rendered unlike the
+    /// pull-based per-step quickfix — so disabling the flag must also suppress this lens,
+    /// not just the diagnostic, or a user who opts out still gets a standing banner.
+    #[tokio::test]
+    async fn test_generate_code_lenses_pin_all_lens_absent_when_mutable_ref_pin_disabled() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = GithubActionsEcosystem::new(cache);
+        seed_tag(&eco, "actions/checkout", "v4", &"a".repeat(40));
+
+        let content = "steps:\n  - uses: actions/checkout@v4\n";
+        let severities = deps_core::lsp_helpers::DiagnosticSeverities {
+            mutable_ref_pin_enabled: false,
+            ..deps_core::lsp_helpers::DiagnosticSeverities::default()
+        };
+        let lenses = code_lenses_for_with_severities(content, &eco, severities).await;
+
+        assert!(
+            !lenses.iter().any(|l| l
+                .command
+                .as_ref()
+                .is_some_and(|c| c.command == crate::PIN_ALL_TO_SHA_COMMAND_ID)),
+            "mutable_ref_pin_enabled: false must suppress the Pin-all-to-SHA lens, \
+             mirroring the diagnostic's own suppression: {lenses:?}"
+        );
+    }
+
+    /// Companion to the disabled-flag test above: the *default* (enabled) flag must not
+    /// accidentally suppress the sibling "Update N outdated dependencies" lens — the two
+    /// lenses are independent, and this gate must be scoped to the pin-all lens only.
+    #[tokio::test]
+    async fn test_generate_code_lenses_update_all_outdated_lens_unaffected_by_mutable_ref_pin_flag()
+    {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = GithubActionsEcosystem::new(cache);
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let content = "steps:\n  - uses: actions/checkout@v3\n";
+        let parse_result = eco.parse_manifest(content, &uri).await.unwrap();
+        let mut cached = HashMap::new();
+        cached.insert(
+            deps_core::PackageName::new("actions/checkout"),
+            deps_core::PackageVersions::latest_only("v4"),
+        );
+        let resolved = HashMap::new();
+        let severities = deps_core::lsp_helpers::DiagnosticSeverities {
+            mutable_ref_pin_enabled: false,
+            ..deps_core::lsp_helpers::DiagnosticSeverities::default()
+        };
+
+        let lenses = eco
+            .generate_code_lenses(
+                parse_result.as_ref(),
+                content,
+                deps_core::VersionData::new(&cached, &resolved),
+                &uri,
+                "deps-lsp.updateAllOutdated",
+                severities,
+            )
+            .await;
+
+        assert!(
+            lenses.iter().any(|l| l
+                .command
+                .as_ref()
+                .is_some_and(|c| c.command == "deps-lsp.updateAllOutdated")),
+            "the update-all-outdated lens must be unaffected by mutable_ref_pin_enabled: {lenses:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_code_lenses_pin_all_lens_singular_title_for_one_step() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = GithubActionsEcosystem::new(cache);
+        seed_tag(&eco, "actions/checkout", "v4", &"a".repeat(40));
+
+        let content = "steps:\n  - uses: actions/checkout@v4\n";
+        let lenses = code_lenses_for(content, &eco).await;
+
+        let pin_all = lenses
+            .iter()
+            .find(|l| {
+                l.command
+                    .as_ref()
+                    .is_some_and(|c| c.command == crate::PIN_ALL_TO_SHA_COMMAND_ID)
+            })
+            .expect("expected a Pin-all-to-SHA lens");
+        assert_eq!(
+            pin_all.command.as_ref().unwrap().title,
+            "Pin 1 action to commit SHA"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_code_lenses_pin_all_lens_absent_when_no_tag_pins() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = GithubActionsEcosystem::new(cache);
+
+        let content = format!("steps:\n  - uses: actions/checkout@{}\n", "a".repeat(40));
+        let lenses = code_lenses_for(&content, &eco).await;
+
+        assert!(
+            !lenses.iter().any(|l| l
+                .command
+                .as_ref()
+                .is_some_and(|c| c.command == crate::PIN_ALL_TO_SHA_COMMAND_ID)),
+            "an already-SHA-pinned workflow must get no Pin-all-to-SHA lens: {lenses:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_code_lenses_pin_all_lens_absent_when_tag_index_miss() {
+        // No `seed_tag` call: the TagIndex has no entry, so every Tag-pinned step is a
+        // cache miss and must be skipped gracefully — not blocking, not erroring.
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = GithubActionsEcosystem::new(cache);
+
+        let content = "steps:\n  - uses: actions/checkout@v4\n";
+        let lenses = code_lenses_for(content, &eco).await;
+
+        assert!(
+            !lenses.iter().any(|l| l
+                .command
+                .as_ref()
+                .is_some_and(|c| c.command == crate::PIN_ALL_TO_SHA_COMMAND_ID)),
+            "a TagIndex cache miss must be skipped gracefully, not surfaced as a lens \
+             promising a no-op edit: {lenses:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_code_lenses_pin_all_lens_skips_unresolvable_step_but_counts_others() {
+        // A mix of one resolvable Tag pin and one cache-miss Tag pin: the lens must count
+        // only the resolvable one, silently skipping the other rather than refusing the
+        // whole lens or counting a step it cannot actually edit.
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = GithubActionsEcosystem::new(cache);
+        seed_tag(&eco, "actions/checkout", "v4", &"a".repeat(40));
+
+        let content = "steps:\n\
+             \x20 - uses: actions/checkout@v4\n\
+             \x20 - uses: some-org/unresolved-action@v1\n";
+        let lenses = code_lenses_for(content, &eco).await;
+
+        let pin_all = lenses
+            .iter()
+            .find(|l| {
+                l.command
+                    .as_ref()
+                    .is_some_and(|c| c.command == crate::PIN_ALL_TO_SHA_COMMAND_ID)
+            })
+            .expect("expected a Pin-all-to-SHA lens for the one resolvable step");
+        assert_eq!(
+            pin_all.command.as_ref().unwrap().title,
+            "Pin 1 action to commit SHA"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_collect_pin_all_to_sha_edits_produces_correct_workspace_edit_for_multiple_steps()
+    {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = GithubActionsEcosystem::new(cache);
+        let sha1 = "a".repeat(40);
+        let sha2 = "b".repeat(40);
+        seed_tag(&eco, "actions/checkout", "v4", &sha1);
+        seed_tag(&eco, "actions/setup-node", "v3", &sha2);
+
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let content = "steps:\n\
+             \x20 - uses: actions/checkout@v4\n\
+             \x20 - uses: actions/setup-node@v3\n";
+        let parse_result = eco.parse_manifest(content, &uri).await.unwrap();
+        let deps = deps_core::ParseResult::dependencies(parse_result.as_ref());
+        let checkout_range = deps
+            .iter()
+            .find(|d| d.name().as_str() == "actions/checkout")
+            .and_then(|d| d.version_range())
+            .expect("actions/checkout must have a version_range");
+        let setup_node_range = deps
+            .iter()
+            .find(|d| d.name().as_str() == "actions/setup-node")
+            .and_then(|d| d.version_range())
+            .expect("actions/setup-node must have a version_range");
+
+        let edits = eco.collect_pin_all_to_sha_edits(parse_result.as_ref());
+        assert_eq!(edits.len(), 2);
+        // M1 (critic): the entire risk of this feature is writing 40+ chars at the wrong
+        // span, so the range each edit targets must be pinned, not just its text —
+        // proving the aggregator's dep-to-range mapping doesn't swap or shift.
+        let checkout_edit = edits
+            .iter()
+            .find(|e| e.new_text == format!("{sha1} # v4"))
+            .expect("expected an edit for actions/checkout");
+        assert_eq!(checkout_edit.range, checkout_range);
+        let setup_node_edit = edits
+            .iter()
+            .find(|e| e.new_text == format!("{sha2} # v3"))
+            .expect("expected an edit for actions/setup-node");
+        assert_eq!(setup_node_edit.range, setup_node_range);
+    }
+
+    #[tokio::test]
+    async fn test_collect_pin_all_to_sha_edits_empty_for_branch_and_quoted_scalar() {
+        // A `PinStyle::Branch` step and a quoted-scalar `PinStyle::Tag` step must both be
+        // withheld, matching `build_sha_pin_action`'s own guards (FR-005/plan §11,
+        // FR-010) — the bulk aggregator must never be laxer than the per-step quickfix.
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = GithubActionsEcosystem::new(cache);
+        seed_tag(&eco, "some-org/some-action", "main", &"a".repeat(40));
+        seed_tag(&eco, "actions/checkout", "v4", &"b".repeat(40));
+
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let content = "steps:\n\
+             \x20 - uses: some-org/some-action@main\n\
+             \x20 - uses: \"actions/checkout@v4\"\n";
+        let parse_result = eco.parse_manifest(content, &uri).await.unwrap();
+
+        let edits = eco.collect_pin_all_to_sha_edits(parse_result.as_ref());
+        assert!(
+            edits.is_empty(),
+            "a branch pin and a quoted-scalar tag pin must both be withheld: {edits:?}"
+        );
+    }
+
+    /// Security audit finding (issue #633): the bulk aggregator must skip a flow-mapping
+    /// `uses:` step the same way the per-step quickfix does — a click on "Pin N actions
+    /// to commit SHA" must never turn a real click into workflow-wide YAML corruption.
+    #[tokio::test]
+    async fn test_collect_pin_all_to_sha_edits_empty_for_flow_mapping_step() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = GithubActionsEcosystem::new(cache);
+        seed_tag(&eco, "actions/checkout", "v4", &"a".repeat(40));
+
+        let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+        let content = "steps:\n  - {uses: actions/checkout@v4, with: {node: 20}}\n";
+        let parse_result = eco.parse_manifest(content, &uri).await.unwrap();
+
+        let edits = eco.collect_pin_all_to_sha_edits(parse_result.as_ref());
+        assert!(
+            edits.is_empty(),
+            "a flow-mapping tag pin must be withheld, not corrupted: {edits:?}"
         );
     }
 }

--- a/crates/deps-github-actions/src/formatter.rs
+++ b/crates/deps-github-actions/src/formatter.rs
@@ -647,6 +647,7 @@ mod tests {
             pin,
             source: DependencySource::Registry,
             is_plain_scalar: true,
+            is_last_on_line: true,
         }
     }
 

--- a/crates/deps-github-actions/src/lib.rs
+++ b/crates/deps-github-actions/src/lib.rs
@@ -47,6 +47,15 @@ pub use types::{
 /// Open Questions), so generalizing into `deps-core` would be premature.
 pub const MUTABLE_REF_PIN_DIAGNOSTIC_CODE: &str = "mutable-ref-pin";
 
+/// `workspace/executeCommand` id for the "Pin N actions to commit SHA" bulk code lens
+/// (issue #633).
+///
+/// Bulk counterpart of the per-step "Pin to commit SHA" quickfix (issue #473): rewrites
+/// every `PinStyle::Tag` step in a workflow that has a resolvable `TagIndex` entry in one
+/// `WorkspaceEdit`, mirroring `deps-lsp`'s `deps-lsp.updateAllOutdated` command for the
+/// "Update N outdated dependencies" lens.
+pub const PIN_ALL_TO_SHA_COMMAND_ID: &str = "deps-lsp.pinAllToSha";
+
 /// Whether `name` matches the `owner/repo` GitHub identifier shape this crate accepts:
 /// `[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+`, with neither segment being exactly `.`/`..` (see
 /// [`deps_core::is_dot_segment`]).

--- a/crates/deps-github-actions/src/parser.rs
+++ b/crates/deps-github-actions/src/parser.rs
@@ -45,6 +45,33 @@ pub(crate) use deps_core::lsp_helpers::is_tag_shaped;
 /// preceded by whitespace is not a YAML comment and is skipped (only the *first*
 /// whitespace-preceded `#` is considered); a shape-rejected token (`# v4`, `# v4.2`) or
 /// no `#` at all yields `None` — the ref degrades to a bare, commentless pin.
+/// Whether nothing unsafe to overwrite follows the ref on its source line: only
+/// whitespace, or a whitespace-preceded YAML comment (the same comment-start rule
+/// [`extract_comment_tag`] uses), all the way to end of line.
+///
+/// Security audit finding (pre-existing in the #473 quickfix, now shared by the bulk
+/// pin-all-to-SHA aggregator, issue #633): a SHA-pin edit appends `# <tag>` right after
+/// the ref, turning everything after it into a YAML comment. For a `uses:` step written
+/// in **block** style that is safe — nothing meaningful follows on the line. For a step
+/// written in YAML **flow** style (`{uses: actions/checkout@v4, with: {node: 20}}`), real
+/// YAML content (`, with: {...}}`) follows the ref on the same line, and commenting it out
+/// produces invalid YAML (an unterminated flow mapping) — silently breaking the workflow
+/// rather than merely leaving it unpinned. This function has no notion of flow vs. block
+/// context itself; it just checks "would writing a comment here swallow real content",
+/// which is true in exactly the flow-style case and false for ordinary block-style lines.
+fn ref_is_last_token_on_line(rest_of_line: &str) -> bool {
+    let bytes = rest_of_line.as_bytes();
+    for (i, &b) in bytes.iter().enumerate() {
+        if b == b'#' && i > 0 && bytes[i - 1].is_ascii_whitespace() {
+            return true;
+        }
+        if !b.is_ascii_whitespace() {
+            return false;
+        }
+    }
+    true
+}
+
 fn extract_comment_tag(rest_of_line: &str) -> Option<(&str, usize)> {
     let bytes = rest_of_line.as_bytes();
     for i in 0..bytes.len() {
@@ -329,6 +356,7 @@ fn build_dependency(
                 path: trimmed_value,
             },
             is_plain_scalar,
+            is_last_on_line: true,
         }),
         ParsedUses::Docker => Some(GithubActionsDependency {
             name: trimmed_value.clone().into(),
@@ -339,6 +367,7 @@ fn build_dependency(
             pin: None,
             source: DependencySource::Url { url: trimmed_value },
             is_plain_scalar,
+            is_last_on_line: true,
         }),
         ParsedUses::NoAt { name } => {
             let name_end = span_start + name.len();
@@ -351,6 +380,7 @@ fn build_dependency(
                 pin: None,
                 source: DependencySource::Registry,
                 is_plain_scalar,
+                is_last_on_line: true,
             })
         }
         ParsedUses::Ref {
@@ -380,14 +410,21 @@ fn build_dependency(
                         url: format!("https://github.com/{name}"),
                     },
                     is_plain_scalar,
+                    is_last_on_line: true,
                 });
             }
 
-            if is_full_sha(&ref_text) {
-                let rest_of_line = &content[ref_end..];
-                let rest_of_line_end = rest_of_line.find('\n').unwrap_or(rest_of_line.len());
-                let rest_of_line = &rest_of_line[..rest_of_line_end];
+            let rest_of_line = &content[ref_end..];
+            let rest_of_line_end = rest_of_line.find('\n').unwrap_or(rest_of_line.len());
+            let rest_of_line = &rest_of_line[..rest_of_line_end];
+            // Security audit finding (issue #633): computed for every ref-pinned form,
+            // not just the SHA-with-comment case below, since the mutable-tag SHA-pin
+            // edit (`sha_pin_text_edit_for`) needs it for `PinStyle::Tag` too — a flow-
+            // style step (`{uses: actions/checkout@v4, with: {...}}`) has real YAML
+            // content after the ref that a trailing `# <tag>` comment would swallow.
+            let is_last_on_line = ref_is_last_token_on_line(rest_of_line);
 
+            if is_full_sha(&ref_text) {
                 let comment = is_plain_scalar
                     .then(|| extract_comment_tag(rest_of_line))
                     .flatten();
@@ -404,6 +441,7 @@ fn build_dependency(
                         }),
                         source: DependencySource::Registry,
                         is_plain_scalar,
+                        is_last_on_line,
                     },
                     None => GithubActionsDependency {
                         name: name.into(),
@@ -414,6 +452,7 @@ fn build_dependency(
                         pin: Some(PinStyle::Sha { comment_tag: None }),
                         source: DependencySource::Registry,
                         is_plain_scalar,
+                        is_last_on_line,
                     },
                 });
             }
@@ -432,6 +471,7 @@ fn build_dependency(
                 pin: Some(pin),
                 source: DependencySource::Registry,
                 is_plain_scalar,
+                is_last_on_line,
             })
         }
         ParsedUses::Malformed => {
@@ -876,6 +916,67 @@ mod tests {
         let content = "steps:\n  - uses: 'actions/checkout@v4'\n";
         let result = parse_workflow_yaml(content, &test_uri()).unwrap();
         assert!(!result.dependencies[0].is_plain_scalar);
+    }
+
+    // --- issue #633 security audit finding: `is_last_on_line` / YAML flow-style guard ---
+
+    #[test]
+    fn test_ref_is_last_token_on_line_true_for_empty_and_whitespace_only() {
+        assert!(ref_is_last_token_on_line(""));
+        assert!(ref_is_last_token_on_line("   "));
+    }
+
+    #[test]
+    fn test_ref_is_last_token_on_line_true_for_trailing_comment() {
+        assert!(ref_is_last_token_on_line(" # my note"));
+    }
+
+    #[test]
+    fn test_ref_is_last_token_on_line_false_for_flow_collection_continuation() {
+        // The exact shape from the security audit's reproduction: `, with: {node: 20}}`
+        // immediately follows a tag ref inside a YAML flow mapping.
+        assert!(!ref_is_last_token_on_line(", with: {node: 20}}"));
+        assert!(!ref_is_last_token_on_line("}"));
+        assert!(!ref_is_last_token_on_line("]"));
+    }
+
+    /// Regression for the security audit's live reproduction: a `uses:` step written in
+    /// YAML flow-mapping style has real content (`, with: {...}}`) after the ref on the
+    /// same line — `is_last_on_line` must be `false` so a SHA-pin edit is withheld
+    /// (`sha_pin_text_edit_for`'s guard) rather than commenting out the rest of the flow
+    /// collection and producing invalid, unterminated YAML.
+    #[test]
+    fn test_flow_mapping_uses_step_is_not_last_on_line() {
+        let content = "steps:\n  - {uses: actions/checkout@v4, with: {node: 20}}\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name(), "actions/checkout");
+        assert_matches!(dep.pin, Some(PinStyle::Tag));
+        assert!(
+            !dep.is_last_on_line,
+            "a flow-mapping uses: step must not be considered safe for a trailing comment"
+        );
+    }
+
+    /// Non-regression companion: a flow-*sequence* step (`steps: [{uses: ...}]`) has the
+    /// same corruption risk and must be caught the same way.
+    #[test]
+    fn test_flow_sequence_uses_step_is_not_last_on_line() {
+        let content = "steps: [{uses: actions/checkout@v4, with: {node: 20}}]\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        assert!(!result.dependencies[0].is_last_on_line);
+    }
+
+    /// Non-regression: an ordinary block-style step (the overwhelming common case) must
+    /// keep `is_last_on_line: true` — the guard must not withhold the quickfix/bulk lens
+    /// for every step, only the genuinely unsafe flow-style ones.
+    #[test]
+    fn test_block_style_uses_step_is_last_on_line() {
+        let content = "steps:\n  - uses: actions/checkout@v4\n";
+        let result = parse_workflow_yaml(content, &test_uri()).unwrap();
+        assert!(result.dependencies[0].is_last_on_line);
     }
 
     #[test]

--- a/crates/deps-github-actions/src/types.rs
+++ b/crates/deps-github-actions/src/types.rs
@@ -65,6 +65,20 @@ pub struct GithubActionsDependency {
     /// follow the ref text — see `crate::formatter::GithubActionsFormatter::sha_pin_replacement_for`'s
     /// caller.
     pub is_plain_scalar: bool,
+    /// Whether only whitespace, or a whitespace-preceded YAML comment, follows the ref
+    /// text on its source line — `true` for `None`-`pin`/non-ref sources, where the value
+    /// is irrelevant.
+    ///
+    /// `false` for a `uses:` step written in YAML **flow** style
+    /// (`{uses: actions/checkout@v4, with: {node: 20}}`), where real YAML content
+    /// (`, with: {...}}`) follows the ref on the same line. A SHA-pin edit appends
+    /// `# <tag>` right after the ref text — safe for ordinary block-style lines, but for
+    /// a flow-style line it turns the rest of the flow collection into a comment,
+    /// producing invalid (unterminated) YAML. A SHA-pin code action must check this
+    /// alongside [`Self::is_plain_scalar`] before writing any such edit (security audit
+    /// finding, issue #633) — see
+    /// `crate::formatter::GithubActionsFormatter::sha_pin_replacement_for`'s caller.
+    pub is_last_on_line: bool,
 }
 
 impl deps_core::ecosystem::Dependency for GithubActionsDependency {
@@ -178,6 +192,7 @@ mod tests {
             pin: Some(PinStyle::Tag),
             source: DependencySource::Registry,
             is_plain_scalar: true,
+            is_last_on_line: true,
         };
         assert_eq!(dep.name(), "actions/checkout");
         assert_eq!(
@@ -200,6 +215,7 @@ mod tests {
             }),
             source: DependencySource::Registry,
             is_plain_scalar: true,
+            is_last_on_line: true,
         };
         assert_eq!(dep.version_literal(), dep.version_literal.as_deref());
         assert_ne!(
@@ -240,6 +256,7 @@ mod tests {
                 pin: Some(PinStyle::Tag),
                 source: DependencySource::Registry,
                 is_plain_scalar: true,
+                is_last_on_line: true,
             }],
             uri,
         };

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -3423,6 +3423,7 @@ mod tests {
                 _versions: VersionData<'a>,
                 _uri: &'a Uri,
                 _command_id: &'a str,
+                _severities: DiagnosticSeverities,
             ) -> BoxFuture<'a, Vec<CodeLens>> {
                 Box::pin(async move { vec![] })
             }

--- a/crates/deps-lsp/src/handlers/code_lens.rs
+++ b/crates/deps-lsp/src/handlers/code_lens.rs
@@ -45,7 +45,10 @@ pub async fn handle_code_lens(
         return vec![];
     }
 
-    let offline = { config.read().await.network.offline };
+    let (offline, severities) = {
+        let config = config.read().await;
+        (config.network.offline, config.diagnostics.to_severities())
+    };
 
     // Own everything `generate_code_lenses` needs and release the DashMap shard `Ref`
     // before awaiting it (#333): `with_document` only ever hands `extract` a borrowed
@@ -85,6 +88,7 @@ pub async fn handle_code_lens(
             VersionData::new(&cached_versions, &resolved_versions).with_offline(offline),
             uri,
             COMMAND_ID,
+            severities,
         )
         .await
 }

--- a/crates/deps-lsp/src/server.rs
+++ b/crates/deps-lsp/src/server.rs
@@ -34,6 +34,12 @@ mod commands {
     /// Command to update every outdated dependency in a document, bound to the code
     /// lens produced by `handlers::code_lens`.
     pub(super) const UPDATE_ALL_OUTDATED: &str = crate::handlers::code_lens::COMMAND_ID;
+    /// Command to pin every mutable-tag GitHub Actions step to a commit SHA, bound to
+    /// the "Pin N actions to commit SHA" lens `deps-github-actions` produces (issue
+    /// #633). GitHub-Actions-specific, so only registered/dispatched when that ecosystem
+    /// feature is enabled.
+    #[cfg(feature = "github-actions")]
+    pub(super) const PIN_ALL_TO_SHA: &str = deps_github_actions::PIN_ALL_TO_SHA_COMMAND_ID;
 }
 
 /// Parses a [`DepsConfig`] from a raw JSON settings payload (client
@@ -419,10 +425,16 @@ impl Backend {
                 ..Default::default()
             })),
             execute_command_provider: Some(ExecuteCommandOptions {
-                commands: vec![
-                    commands::UPDATE_VERSION.into(),
-                    commands::UPDATE_ALL_OUTDATED.into(),
-                ],
+                commands: {
+                    #[allow(unused_mut)]
+                    let mut cmds = vec![
+                        commands::UPDATE_VERSION.into(),
+                        commands::UPDATE_ALL_OUTDATED.into(),
+                    ];
+                    #[cfg(feature = "github-actions")]
+                    cmds.push(commands::PIN_ALL_TO_SHA.into());
+                    cmds
+                },
                 ..Default::default()
             }),
             ..Default::default()
@@ -997,6 +1009,14 @@ impl LanguageServer for Backend {
             self.execute_update_all_outdated(update_args.uri).await;
         }
 
+        #[cfg(feature = "github-actions")]
+        if params.command == commands::PIN_ALL_TO_SHA
+            && let Some(args) = params.arguments.first()
+            && let Ok(pin_args) = serde_json::from_value::<PinAllToShaArgs>(args.clone())
+        {
+            self.execute_pin_all_to_sha(pin_args.uri).await;
+        }
+
         Ok(None)
     }
 }
@@ -1105,8 +1125,22 @@ impl Backend {
             .and_then(|we| we.document_changes)
             .unwrap_or(false);
 
-        let edit = build_update_all_outdated_edit(&uri, version, edits, supports_document_changes);
+        let edit = build_batch_workspace_edit(&uri, version, edits, supports_document_changes);
+        self.apply_batch_edit(&uri, edit, "dependency updates")
+            .await;
+    }
 
+    /// Applies `edit` via `workspace/applyEdit`, warning the client through
+    /// `window/showMessage` on rejection, error, or timeout.
+    ///
+    /// Shared by [`Self::execute_update_all_outdated`] and (when the `github-actions`
+    /// feature is enabled) `execute_pin_all_to_sha` (issue #633): both bulk commands
+    /// recompute their own edits, but converge on identical apply/response handling.
+    /// `what` names the batch's contents for the user-facing failure messages (critic
+    /// M2: the messages must not say "dependency updates" for a command that updates
+    /// nothing, e.g. `deps-lsp.pinAllToSha`) — e.g. `"dependency updates"` or
+    /// `"SHA pins"`.
+    async fn apply_batch_edit(&self, uri: &Uri, edit: WorkspaceEdit, what: &str) {
         match tokio::time::timeout(CLIENT_REFRESH_TIMEOUT, self.client.apply_edit(edit)).await {
             Ok(Ok(response)) if response.applied => {}
             Ok(Ok(response)) => {
@@ -1118,7 +1152,7 @@ impl Backend {
                 self.client
                     .show_message(
                         MessageType::WARNING,
-                        "deps-lsp: failed to apply dependency updates",
+                        format!("deps-lsp: failed to apply {what}"),
                     )
                     .await;
             }
@@ -1127,7 +1161,7 @@ impl Backend {
                 self.client
                     .show_message(
                         MessageType::WARNING,
-                        "deps-lsp: failed to apply dependency updates",
+                        format!("deps-lsp: failed to apply {what}"),
                     )
                     .await;
             }
@@ -1140,12 +1174,89 @@ impl Backend {
                     .show_message(
                         MessageType::WARNING,
                         format!(
-                            "deps-lsp: the editor did not respond to the update within {CLIENT_REFRESH_TIMEOUT:?}"
+                            "deps-lsp: the editor did not respond to the {what} within {CLIENT_REFRESH_TIMEOUT:?}"
                         ),
                     )
                     .await;
             }
         }
+    }
+
+    /// Recomputes and applies the batch, version-guarded `WorkspaceEdit` for
+    /// `deps-lsp.pinAllToSha` (issue #633) — the GitHub-Actions-specific bulk
+    /// counterpart of [`Self::execute_update_all_outdated`], sharing its readiness
+    /// contract (see that method's doc comment) but sourcing edits from
+    /// [`deps_github_actions::GithubActionsEcosystem::collect_pin_all_to_sha_edits`]
+    /// instead of `deps_core::collect_update_all_edits`. Refused (same warning) when the
+    /// document's ecosystem is not GitHub Actions, so a stale or forged command against a
+    /// non-GHA document is a no-op rather than a panic.
+    #[cfg(feature = "github-actions")]
+    #[allow(clippy::await_holding_invalid_type)]
+    async fn execute_pin_all_to_sha(&self, uri: Uri) {
+        let Some(doc) = self.state.get_document(&uri) else {
+            self.warn_update_all_outdated_not_ready().await;
+            return;
+        };
+
+        if !doc.is_ready_for_batch_update() {
+            drop(doc);
+            self.warn_update_all_outdated_not_ready().await;
+            return;
+        }
+
+        let Some(ecosystem) = self.state.ecosystem_registry.get(doc.ecosystem_id()) else {
+            tracing::warn!("Unknown ecosystem for {:?}", uri);
+            drop(doc);
+            self.warn_update_all_outdated_not_ready().await;
+            return;
+        };
+
+        let Some(gha_ecosystem) = ecosystem
+            .as_any()
+            .downcast_ref::<deps_github_actions::GithubActionsEcosystem>()
+        else {
+            tracing::warn!(
+                "deps-lsp.pinAllToSha invoked for a non-GitHub-Actions document: {:?}",
+                uri
+            );
+            drop(doc);
+            self.warn_update_all_outdated_not_ready().await;
+            return;
+        };
+
+        let Some(parse_result) = doc.parse_result() else {
+            tracing::warn!("No parse result for {:?}", uri);
+            drop(doc);
+            self.warn_update_all_outdated_not_ready().await;
+            return;
+        };
+
+        let edits = gha_ecosystem.collect_pin_all_to_sha_edits(parse_result);
+        let version = doc.version;
+        drop(doc);
+
+        if edits.is_empty() {
+            self.client
+                .show_message(
+                    MessageType::INFO,
+                    "deps-lsp: no mutable-tag actions to pin to commit SHA",
+                )
+                .await;
+            return;
+        }
+
+        let supports_document_changes = self
+            .client_capabilities
+            .read()
+            .await
+            .as_ref()
+            .and_then(|c| c.workspace.as_ref())
+            .and_then(|w| w.workspace_edit.as_ref())
+            .and_then(|we| we.document_changes)
+            .unwrap_or(false);
+
+        let edit = build_batch_workspace_edit(&uri, version, edits, supports_document_changes);
+        self.apply_batch_edit(&uri, edit, "SHA pins").await;
     }
 }
 
@@ -1192,13 +1303,23 @@ struct UpdateAllOutdatedArgs {
     uri: Uri,
 }
 
-/// Builds the `WorkspaceEdit` for `deps-lsp.updateAllOutdated`.
+/// Arguments for `deps-lsp.pinAllToSha` (issue #633) — the URI only, same shape and
+/// rationale as [`UpdateAllOutdatedArgs`]: edits are recomputed at execution time (see
+/// `Backend::execute_pin_all_to_sha`), never baked into the command arguments.
+#[cfg(feature = "github-actions")]
+#[derive(serde::Deserialize)]
+struct PinAllToShaArgs {
+    uri: Uri,
+}
+
+/// Builds the `WorkspaceEdit` for a bulk command (`deps-lsp.updateAllOutdated`,
+/// `deps-lsp.pinAllToSha`) from its already-computed `edits`.
 ///
 /// Emits `document_changes` (versioned per `TextDocumentEdit`) when
 /// `supports_document_changes` is `true` — gated on the client's
 /// `workspace.workspaceEdit.documentChanges` capability — and falls back to the untyped
 /// `changes` map otherwise.
-fn build_update_all_outdated_edit(
+fn build_batch_workspace_edit(
     uri: &Uri,
     version: Option<i32>,
     edits: Vec<TextEdit>,
@@ -1645,6 +1766,38 @@ mod tests {
         assert_eq!(commands::UPDATE_ALL_OUTDATED, "deps-lsp.updateAllOutdated");
     }
 
+    #[cfg(feature = "github-actions")]
+    #[test]
+    fn test_server_capabilities_execute_command_includes_pin_all_to_sha() {
+        let caps = Backend::server_capabilities();
+        let execute = caps
+            .execute_command_provider
+            .expect("execute command provider should exist");
+        assert!(
+            execute
+                .commands
+                .contains(&commands::PIN_ALL_TO_SHA.to_string())
+        );
+    }
+
+    #[cfg(feature = "github-actions")]
+    #[test]
+    fn test_commands_pin_all_to_sha_matches_ecosystem_command_id() {
+        assert_eq!(commands::PIN_ALL_TO_SHA, "deps-lsp.pinAllToSha");
+        assert_eq!(
+            commands::PIN_ALL_TO_SHA,
+            deps_github_actions::PIN_ALL_TO_SHA_COMMAND_ID
+        );
+    }
+
+    #[cfg(feature = "github-actions")]
+    #[test]
+    fn test_pin_all_to_sha_args_deserialization() {
+        let json = serde_json::json!({ "uri": "file:///repo/.github/workflows/ci.yml" });
+        let args: PinAllToShaArgs = serde_json::from_value(json).unwrap();
+        assert_eq!(args.uri.as_str(), "file:///repo/.github/workflows/ci.yml");
+    }
+
     #[test]
     fn test_update_all_outdated_args_deserialization() {
         let json = serde_json::json!({ "uri": "file:///test/Cargo.toml" });
@@ -1653,14 +1806,14 @@ mod tests {
     }
 
     #[test]
-    fn test_build_update_all_outdated_edit_uses_document_changes_with_version() {
+    fn test_build_batch_workspace_edit_uses_document_changes_with_version() {
         let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
         let edits = vec![TextEdit {
             range: Range::default(),
             new_text: "1.2.0".into(),
         }];
 
-        let edit = build_update_all_outdated_edit(&uri, Some(7), edits, true);
+        let edit = build_batch_workspace_edit(&uri, Some(7), edits, true);
 
         assert!(edit.changes.is_none());
         let DocumentChanges::Edits(doc_edits) =
@@ -1675,14 +1828,14 @@ mod tests {
     }
 
     #[test]
-    fn test_build_update_all_outdated_edit_falls_back_to_changes_map() {
+    fn test_build_batch_workspace_edit_falls_back_to_changes_map() {
         let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
         let edits = vec![TextEdit {
             range: Range::default(),
             new_text: "1.2.0".into(),
         }];
 
-        let edit = build_update_all_outdated_edit(&uri, Some(7), edits, false);
+        let edit = build_batch_workspace_edit(&uri, Some(7), edits, false);
 
         assert!(edit.document_changes.is_none());
         let changes = edit.changes.expect("changes present");
@@ -2464,6 +2617,272 @@ mod tests {
 
             let result = backend.execute_command(command_params(&uri)).await;
             assert!(result.is_ok());
+        }
+    }
+
+    #[cfg(feature = "github-actions")]
+    mod pin_all_to_sha_execute_command_tests {
+        use super::*;
+        use crate::document::DocumentState;
+        use deps_core::EcosystemId;
+        use std::sync::Arc;
+
+        fn command_params(uri: &Uri) -> ExecuteCommandParams {
+            ExecuteCommandParams {
+                command: commands::PIN_ALL_TO_SHA.to_string(),
+                arguments: vec![serde_json::json!({ "uri": uri.as_str() })],
+                work_done_progress_params: Default::default(),
+            }
+        }
+
+        /// Seeds `ecosystem`'s shared `TagIndex` for `name` with one `tag -> sha` entry —
+        /// same pattern `handlers::code_lens::cross_ecosystem_tests::seed_gha_tag_index`
+        /// uses, downcasting through `Ecosystem::registry()`/`Registry::as_any()` since
+        /// this module never drives a live registry fetch.
+        fn seed_gha_tag_index(
+            ecosystem: &dyn deps_core::Ecosystem,
+            name: &str,
+            tag: &str,
+            sha: &str,
+        ) {
+            let registry = ecosystem.registry();
+            let gha_registry = registry
+                .as_any()
+                .downcast_ref::<deps_github_actions::GithubActionsRegistry>()
+                .expect("github-actions ecosystem must back onto a GithubActionsRegistry");
+            let mut index = deps_github_actions::registry::TagIndex::default();
+            index.tag_to_sha.insert(tag.to_string(), sha.to_string());
+            gha_registry
+                .tag_index()
+                .insert(deps_core::PackageName::new(name), Arc::new(index));
+        }
+
+        /// Recomputes the bulk pin-all-to-SHA edit count directly, the same call
+        /// `Backend::execute_pin_all_to_sha` makes — used to pin each test's actual
+        /// discriminating precondition (issue #633 critic S2: `execute_command` returns
+        /// `Ok(None)` on every path, including every refusal branch, so asserting only
+        /// `result.is_ok()` cannot tell "applied N edits" apart from "silently refused").
+        fn gha_edit_count(
+            ecosystem: &dyn deps_core::Ecosystem,
+            parse_result: &dyn deps_core::ParseResult,
+        ) -> usize {
+            ecosystem
+                .as_any()
+                .downcast_ref::<deps_github_actions::GithubActionsEcosystem>()
+                .expect("github-actions ecosystem must back onto a GithubActionsEcosystem")
+                .collect_pin_all_to_sha_edits(parse_result)
+                .len()
+        }
+
+        #[tokio::test]
+        async fn test_execute_command_pin_all_to_sha_closed_document_no_op() {
+            let (service, _socket) = tower_lsp_server::LspService::build(Backend::new).finish();
+            let backend = service.inner();
+            let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+
+            assert!(backend.state.get_document(&uri).is_none());
+
+            let result = backend.execute_command(command_params(&uri)).await;
+            assert!(result.is_ok());
+            assert!(
+                backend.state.get_document(&uri).is_none(),
+                "a refused command must not create a document"
+            );
+        }
+
+        /// Mirrors `execute_update_all_outdated`'s own
+        /// `test_execute_command_update_all_outdated_loading_document_no_op`: the
+        /// readiness-gate refusal branch (`!doc.is_ready_for_batch_update()`) had zero
+        /// test coverage for this command before this test (tester finding).
+        #[tokio::test]
+        async fn test_execute_command_pin_all_to_sha_loading_document_no_op() {
+            let (service, _socket) = tower_lsp_server::LspService::build(Backend::new).finish();
+            let backend = service.inner();
+            let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+
+            let ecosystem = backend
+                .state
+                .ecosystem_registry
+                .get("github-actions")
+                .unwrap();
+            let content = "steps:\n  - uses: actions/checkout@v4\n".to_string();
+            let parse_result = ecosystem.parse_manifest(&content, &uri).await.unwrap();
+            let mut doc_state = DocumentState::new_from_parse_result(
+                EcosystemId::GithubActions,
+                content.clone(),
+                parse_result,
+            );
+            doc_state.set_version(Some(1));
+            doc_state.set_loading();
+            // Pin the precondition directly: this fixture must actually be "not ready"
+            // per the same predicate `execute_command` consults, not just assumed to be.
+            assert!(!doc_state.is_ready_for_batch_update());
+            backend.state.update_document(uri.clone(), doc_state);
+
+            let result = backend.execute_command(command_params(&uri)).await;
+            assert!(result.is_ok());
+            assert_eq!(
+                backend.state.get_document(&uri).unwrap().content,
+                content,
+                "a refused command must not touch document content"
+            );
+        }
+
+        /// Mirrors `execute_update_all_outdated`'s own
+        /// `test_execute_command_update_all_outdated_no_version_no_op` (tester finding).
+        #[tokio::test]
+        async fn test_execute_command_pin_all_to_sha_no_version_no_op() {
+            // `version: None` mirrors a document populated from disk after a missed
+            // didOpen (server restart/crash) — must be refused even though loaded and
+            // not `Loading`.
+            let (service, _socket) = tower_lsp_server::LspService::build(Backend::new).finish();
+            let backend = service.inner();
+            let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+
+            let ecosystem = backend
+                .state
+                .ecosystem_registry
+                .get("github-actions")
+                .unwrap();
+            let content = "steps:\n  - uses: actions/checkout@v4\n";
+            let parse_result = ecosystem.parse_manifest(content, &uri).await.unwrap();
+            let mut doc_state = DocumentState::new_from_parse_result(
+                EcosystemId::GithubActions,
+                content.to_string(),
+                parse_result,
+            );
+            doc_state.set_loaded();
+            // `version` deliberately left as `None`.
+            assert!(!doc_state.is_ready_for_batch_update());
+            backend.state.update_document(uri.clone(), doc_state);
+
+            let result = backend.execute_command(command_params(&uri)).await;
+            assert!(result.is_ok());
+        }
+
+        #[tokio::test]
+        async fn test_execute_command_pin_all_to_sha_no_resolvable_step_shows_info_message() {
+            // No `TagIndex` seeded: the one Tag-pinned step is a cache miss, so
+            // `collect_pin_all_to_sha_edits` returns empty and the command must be a
+            // no-op (informational message, not a warning/panic).
+            let (service, _socket) = tower_lsp_server::LspService::build(Backend::new).finish();
+            let backend = service.inner();
+            let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+            let content = "steps:\n  - uses: actions/checkout@v4\n";
+
+            let ecosystem = backend
+                .state
+                .ecosystem_registry
+                .get("github-actions")
+                .unwrap();
+            let parse_result = ecosystem.parse_manifest(content, &uri).await.unwrap();
+            // Pin the precondition the refusal actually depends on: a genuine `TagIndex`
+            // cache miss, not e.g. a wrong downcast or an empty method body.
+            assert_eq!(
+                gha_edit_count(ecosystem.as_ref(), parse_result.as_ref()),
+                0,
+                "fixture must have zero resolvable edits for this to test the no-op path"
+            );
+            let mut doc_state = DocumentState::new_from_parse_result(
+                EcosystemId::GithubActions,
+                content.to_string(),
+                parse_result,
+            );
+            doc_state.set_version(Some(1));
+            doc_state.set_loaded();
+            backend.state.update_document(uri.clone(), doc_state);
+
+            let result = backend.execute_command(command_params(&uri)).await;
+            assert!(result.is_ok());
+        }
+
+        #[tokio::test]
+        async fn test_execute_command_pin_all_to_sha_applies_edit_for_resolvable_steps() {
+            let (service, _socket) = tower_lsp_server::LspService::build(Backend::new).finish();
+            let backend = service.inner();
+            let uri = deps_core::test_util::test_uri("/repo/.github/workflows/ci.yml");
+            let content = "steps:\n\
+                 \x20 - uses: actions/checkout@v4\n\
+                 \x20 - uses: actions/setup-node@v3\n";
+
+            let ecosystem = backend
+                .state
+                .ecosystem_registry
+                .get("github-actions")
+                .unwrap();
+            seed_gha_tag_index(
+                ecosystem.as_ref(),
+                "actions/checkout",
+                "v4",
+                &"a".repeat(40),
+            );
+            let parse_result = ecosystem.parse_manifest(content, &uri).await.unwrap();
+            // Pin the precondition this test actually exercises: exactly one of the two
+            // steps is resolvable (the other has no seeded `TagIndex` entry) — without
+            // this, the test below cannot distinguish "applied 1 edit" from "refused,
+            // showed an info message" (both return `Ok(None)`, critic S2).
+            assert_eq!(
+                gha_edit_count(ecosystem.as_ref(), parse_result.as_ref()),
+                1,
+                "fixture must have exactly one resolvable edit for this to test the \
+                 apply-edit path, not the no-resolvable-step refusal"
+            );
+            let mut doc_state = DocumentState::new_from_parse_result(
+                EcosystemId::GithubActions,
+                content.to_string(),
+                parse_result,
+            );
+            doc_state.set_version(Some(1));
+            doc_state.set_loaded();
+            backend.state.update_document(uri.clone(), doc_state);
+
+            // This test `Backend` is never `initialize`d, so `apply_edit` returns `Err`
+            // (documented `apply_edit` behavior) — exercises the same not-a-panic
+            // apply-failure path `execute_update_all_outdated`'s own test covers,
+            // proving the command reaches (and survives) the apply step rather than
+            // being refused earlier.
+            let result = backend.execute_command(command_params(&uri)).await;
+            assert!(result.is_ok());
+        }
+
+        #[tokio::test]
+        async fn test_execute_command_pin_all_to_sha_non_gha_document_no_op() {
+            // A stale/forged command against a document whose ecosystem is not GitHub
+            // Actions must be refused, not panic on the downcast.
+            let (service, _socket) = tower_lsp_server::LspService::build(Backend::new).finish();
+            let backend = service.inner();
+            let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+
+            let ecosystem = backend.state.ecosystem_registry.get("cargo").unwrap();
+            // Pin the precondition this test actually depends on: the downcast
+            // `execute_pin_all_to_sha` performs must genuinely fail for this fixture,
+            // not merely "some cargo-flavored content" that happens to also pass.
+            assert!(
+                ecosystem
+                    .as_any()
+                    .downcast_ref::<deps_github_actions::GithubActionsEcosystem>()
+                    .is_none(),
+                "fixture must back onto a non-GitHub-Actions ecosystem for this to test \
+                 the downcast-refusal path"
+            );
+            let content = "[dependencies]\nserde = \"1.0.0\"\n".to_string();
+            let parse_result = ecosystem.parse_manifest(&content, &uri).await.unwrap();
+            let mut doc_state = DocumentState::new_from_parse_result(
+                EcosystemId::Cargo,
+                content.clone(),
+                parse_result,
+            );
+            doc_state.set_version(Some(1));
+            doc_state.set_loaded();
+            backend.state.update_document(uri.clone(), doc_state);
+
+            let result = backend.execute_command(command_params(&uri)).await;
+            assert!(result.is_ok());
+            assert_eq!(
+                backend.state.get_document(&uri).unwrap().content,
+                content,
+                "a refused command must not touch document content"
+            );
         }
     }
 }

--- a/crates/deps-lsp/src/test_utils.rs
+++ b/crates/deps-lsp/src/test_utils.rs
@@ -189,6 +189,7 @@ pub(crate) mod blocking_ecosystem {
             _versions: VersionData<'a>,
             _uri: &'a Uri,
             _command_id: &'a str,
+            _severities: DiagnosticSeverities,
         ) -> BoxFuture<'a, Vec<CodeLens>> {
             Box::pin(async move {
                 if matches!(self.hook, BlockingHook::CodeLenses) {

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -1132,6 +1132,47 @@ tag-to-SHA-style index exists for branches, and adding one would require a new n
 branch; reusable-workflow calls (`owner/repo/.github/workflows/x.yml@ref`) and `./local`/
 `docker://` references are not resolvable refs and get no diagnostic either.
 
+### Bulk "Pin All to SHA" Code Lens (issue #633)
+
+**GitHub Actions only.** A workflow with at least one mutable-tag `uses:` step resolvable
+to a commit SHA shows a second code lens alongside `Update N outdated dependencies`,
+titled `Pin N actions to commit SHA`. Clicking it rewrites every such step in one batch
+edit — the bulk counterpart of the per-step "Pin `<name>` to commit SHA" quickfix
+documented above, reusing the exact same `TagIndex` lookup (**zero additional network
+calls**: bulk-pinning N actions costs N hashmap lookups, not N registry fetches).
+
+A step is included only when the per-step quickfix would also offer it — the bulk lens is
+never laxer than the single-step fix:
+
+- Only a statically-classified `PinStyle::Tag` step is pinned; a registry-confirmed
+  literal-named tag (the `PinStyle::Branch` case from the diagnostic section above) has no
+  automated fix here either, for the same branch/tag name-collision safety reason.
+- A step whose tag has no resolvable `TagIndex` entry yet (cache miss — e.g. the document
+  was opened before the registry fetch completed) is silently skipped, not blocked on or
+  turned into an extra fetch.
+- A quoted `uses:` scalar (`uses: "actions/checkout@v4"`) is skipped, matching the
+  per-step quickfix's own guard against corrupting the quoted value.
+- A `uses:` step written in YAML **flow** style (`{uses: actions/checkout@v4, with:
+  {node: 20}}`) is skipped: appending `# <tag>` right after the ref would comment out the
+  rest of the flow collection, producing invalid (unterminated) YAML instead of merely
+  leaving the step unpinned. Ordinary block-style steps — the overwhelming majority of
+  real workflows — are unaffected.
+
+The lens itself is omitted entirely — no permanent line-0 annotation — when nothing in the
+document is eligible: an all-SHA-pinned workflow, an empty workflow, or one where every tag
+is still an unresolved cache miss. It is also omitted whenever
+`diagnostics.mutable_ref_pin_enabled` is `false` — the same on/off switch that silences the
+mutable-ref-pin diagnostic above, since a lens is permanently rendered (unlike the pull-based
+per-step quickfix) and must respect the same opt-out.
+
+**Known limitations.** The lens counts only steps resolvable via the live `TagIndex`, while
+the mutable-ref-pin diagnostic flags every `PinStyle::Tag` step regardless of resolvability —
+so a workflow can show more mutable-ref-pin squiggles than the lens's own count, and clicking
+the lens can leave some squiggles in place (the steps it genuinely could not resolve). The
+lens's displayed count can also drift from the number of edits actually applied if a
+background fetch for another open workflow evicts a `TagIndex` entry between render and
+click (the shared index is bounded to 256 repositories).
+
 ### GitHub Actions: Non-Semver Tag Handling (issue #550)
 
 When a GitHub Action repository has only tags that don't parse as full semantic versions — such as


### PR DESCRIPTION
## Summary

Adds a GitHub-Actions-specific bulk "Pin N actions to commit SHA" code lens, aggregating every resolvable mutable-tag `uses:` step in a workflow into a single WorkspaceEdit. Reuses the existing per-step quickfix's `TagIndex` lookup, so no additional registry calls are made (N hashmap lookups, not N network requests).

- New command `deps-lsp.pinAllToSha`, gated on the `github-actions` feature.
- `GithubActionsEcosystem::generate_code_lenses` override adds the new lens alongside the existing "Update N outdated dependencies" one, and respects `severities.mutable_ref_pin_enabled` the same way the per-line diagnostic does.
- `Backend::execute_pin_all_to_sha` recomputes edits fresh from in-memory state at execution time (not embedded in the lens), mirroring `execute_update_all_outdated`.
- Shared `sha_pin_text_edit_for` helper extracted from `build_sha_pin_action`, reused by both the per-line quickfix and the new bulk aggregator.
- `dedup_overlapping_edits` extracted into `deps-core`, shared by both the existing "update all outdated" aggregator and the new one.

## Security fix included

While validating this feature (which ships as a supply-chain-security remediation tool), a pre-existing bug was found and fixed: the SHA-pin edit guard only checked `is_plain_scalar`, not YAML *flow* context. A `uses:` step inside a flow mapping/sequence (`{...}`/`[...]`) would have its `# <tag>` trailing comment swallow the closing brace, silently corrupting the workflow. This affected the original per-line quickfix too, but the new bulk lens turns it from a deliberate single-line click into a one-click risk across an entire file. A new `is_last_on_line` flag (computed in the parser) now withholds the edit for such steps instead, with regression tests reproducing the exact repro case.

## Scope

Out of scope per the issue: `crates/deps-gitlab-ci` has no equivalent per-line foundation yet, so a bulk variant there is tracked separately. `crates/deps-zed` (submodule) untouched.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4376 passed, +12 new tests, 0 failed)
- [x] `cargo test --workspace --doc --all-features`
- [x] Strict rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`)
- [x] Reviewed via multi-agent pipeline: independent test-coverage, performance, security, and adversarial-critique validation, followed by code review — all findings addressed and independently re-verified

Closes #633