### PR TITLE
release: v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Security
-- **CI**: pin every third-party `uses:` action across `.github/workflows/*.yml` to a full commit SHA instead of a mutable tag, closing the tag-retargeting supply-chain exposure on this repository's own CI (resolves #641) (#644)
-
-### Changed
-- **deps-core, deps-npm, deps-composer**: `deps-npm` and `deps-composer` now share a single `deps_core::json_helpers::string_valued_entries` helper (and its test coverage) for skipping non-string dependency-map values, instead of each crate carrying its own duplicated guard and tests (resolves #624) (#630)
+## [0.13.0] - 2026-09-05
 
 ### Added
 - **deps-core, deps-github-actions, deps-gitlab-ci, deps-lsp**: bulk "Pin N {noun} to commit SHA" code lens generalized cross-ecosystem — GitLab CI `include:` entries now get the same batch quickfix GitHub Actions workflows already had (resolves #640) (#645)
@@ -59,10 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-deno**: `parse_deno_json` now checks the parsed AST's nesting depth against `deps_core::MAX_JSON_NESTING_DEPTH` (64), tightening `jsonc-parser`'s own existing internal recursion cap (512) for consistency with deps-npm/deps-composer's JSON depth guard — hardening, not a vulnerability fix, since `deno.json`/`deno.jsonc` parsing was already bounded (resolves #618) (#620)
 - **deps-npm**: a `dependencies`/`devDependencies`/`peerDependencies`/`optionalDependencies` entry whose value is not a JSON string (e.g. an object) is now skipped instead of being queried against the registry and reported as an unknown package (resolves #619) (#622)
 
-### Removed
-- **Breaking (pre-1.0, public API)**: **deps-core**: removed `find_json_section_byte_range` from `parser`'s public API, superseded by the AST-based `deps_core::json_ast` module (#613) (#617)
-
 ### Changed
+- **deps-core, deps-npm, deps-composer**: `deps-npm` and `deps-composer` now share a single `deps_core::json_helpers::string_valued_entries` helper (and its test coverage) for skipping non-string dependency-map values, instead of each crate carrying its own duplicated guard and tests (resolves #624) (#630)
 - **deps-lsp**: the #590 watched-config-file reparse path now also sends `workspace/diagnostic/refresh` (previously only inlay-hint/code-lens refresh), matching #592's config-change reparse — a deliberate improvement, not a side effect (resolves #592) (#600)
 - **MSRV bumped to 1.98** — unlocks `assert_matches!` (replacing `assert!(matches!(...))` in tests) and `str::strip_circumfix` (replacing chained `strip_prefix`/`strip_suffix` in `deps-core`, `deps-gradle`, `deps-pypi`) (resolves #549) (#594)
 - **deps-nuget**: `NuGetSourceChain.hops`/`NuGetRegistry::with_base` now carry per-hop credential/slot data (`ResolvedHop`) instead of a bare feed URL; `deps_lsp::register_ecosystems` now takes an `&EcosystemRuntime` instead of a bare `Arc<RegistryAccessPolicy>` — both breaking, pre-1.0, no alias (#572)
@@ -72,7 +66,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-pypi, deps-nuget, deps-go**: consolidated three independently hand-rolled "hash an ordered routing chain into an opaque identity key" implementations into a single `deps_core::hash_routing_key` helper; resulting chain-key digest values change (process-local cache keys only, never persisted or compared cross-process, so this is not observable); `deps_go::config::ChainSeparator` no longer derives `Hash` (breaking, pre-1.0, no alias) (resolves #579) (#584)
 - **deps-core, deps-lsp**: decomposed `generate_hover` and `fetch_latest_versions_parallel`/`handle_document_open` into named, independently-testable helpers — pure refactor, no behavior change (resolves #586, #585) (#588)
 
+### Removed
+- **Breaking (pre-1.0, public API)**: **deps-core**: removed `find_json_section_byte_range` from `parser`'s public API, superseded by the AST-based `deps_core::json_ast` module (#613) (#617)
+
 ### Security
+- **CI**: pin every third-party `uses:` action across `.github/workflows/*.yml` to a full commit SHA instead of a mutable tag, closing the tag-retargeting supply-chain exposure on this repository's own CI (resolves #641) (#644)
 - **deps-core, deps-nuget**: credential material and its construction intermediates now zeroize on drop (resolves #574) (#577)
 
 ## [0.12.1] - 2026-09-03
@@ -796,7 +794,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TLS enforced via rustls
 - cargo-deny configured for vulnerability scanning
 
-[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.12.1...HEAD
+[Unreleased]: https://github.com/bug-ops/deps-lsp/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/bug-ops/deps-lsp/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/bug-ops/deps-lsp/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/bug-ops/deps-lsp/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/bug-ops/deps-lsp/compare/v0.11.0...v0.11.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
+checksum = "515a1f282e33d55983c499d7e9e87082e81cbc32974825bf9032f928392d5844"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -80,9 +80,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
@@ -151,9 +151,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -266,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+checksum = "2fe67f2944eef52fc7b106b8c9450d243a88701a0c065f7f57235e76abaed7df"
 dependencies = [
  "compression-core",
  "flate2",
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+checksum = "6e8ccc4ea9f6acc32d102c0f6d471d11d913ad15f20c04de743374861fa1d414"
 
 [[package]]
 name = "console"
@@ -320,9 +320,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -373,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -383,18 +383,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crunchy"
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "deps-bundler"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "deps-core",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "deps-cargo"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "bytes",
  "criterion",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "deps-composer"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "deps-core",
  "mockito",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "deps-core"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "bytes",
  "criterion",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "deps-dart"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "deps-core",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "deps-deno"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "deps-core",
  "deps-npm",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "deps-github-actions"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "dashmap",
  "deps-core",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "deps-gitlab-ci"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "bytes",
  "dashmap",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "deps-go"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "dashmap",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "deps-gradle"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "deps-core",
  "deps-maven",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "deps-lsp"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "dashmap",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "deps-maven"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "bytes",
  "dashmap",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "deps-npm"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "dashmap",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "deps-nuget"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "base64",
  "bytes",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "deps-pypi"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "dashmap",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "deps-swift"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "bytes",
  "dashmap",
@@ -816,7 +816,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -870,18 +870,19 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -978,7 +979,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1150,9 +1151,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1316,9 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -1419,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1552,9 +1553,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -1562,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "wasi",
@@ -2013,7 +2014,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2294,7 +2295,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2374,9 +2375,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "socket2"
@@ -2413,9 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2513,7 +2514,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2577,9 +2578,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2614,14 +2615,14 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",
@@ -2915,9 +2916,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2928,9 +2929,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.77"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2938,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2948,31 +2949,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3268,8 +3269,14 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/deps-zed"]
 resolver = "3"
 
 [workspace.package]
-version = "0.12.1"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.98"
 authors = ["Andrei G"]
@@ -16,22 +16,22 @@ base64 = "0.22"
 bytes = "1"
 criterion = "0.8"
 dashmap = "6.2"
-deps-bundler = { version = "0.12.1", path ="crates/deps-bundler" }
-deps-cargo = { version = "0.12.1", path ="crates/deps-cargo" }
-deps-composer = { version = "0.12.1", path ="crates/deps-composer" }
-deps-core = { version = "0.12.1", path ="crates/deps-core" }
-deps-dart = { version = "0.12.1", path ="crates/deps-dart" }
-deps-deno = { version = "0.12.1", path ="crates/deps-deno" }
-deps-github-actions = { version = "0.12.1", path ="crates/deps-github-actions" }
-deps-gitlab-ci = { version = "0.12.1", path ="crates/deps-gitlab-ci" }
-deps-go = { version = "0.12.1", path ="crates/deps-go" }
-deps-gradle = { version = "0.12.1", path ="crates/deps-gradle" }
-deps-lsp = { version = "0.12.1", path ="crates/deps-lsp" }
-deps-maven = { version = "0.12.1", path ="crates/deps-maven" }
-deps-npm = { version = "0.12.1", path ="crates/deps-npm" }
-deps-nuget = { version = "0.12.1", path ="crates/deps-nuget" }
-deps-pypi = { version = "0.12.1", path ="crates/deps-pypi" }
-deps-swift = { version = "0.12.1", path ="crates/deps-swift" }
+deps-bundler = { version = "0.13.0", path ="crates/deps-bundler" }
+deps-cargo = { version = "0.13.0", path ="crates/deps-cargo" }
+deps-composer = { version = "0.13.0", path ="crates/deps-composer" }
+deps-core = { version = "0.13.0", path ="crates/deps-core" }
+deps-dart = { version = "0.13.0", path ="crates/deps-dart" }
+deps-deno = { version = "0.13.0", path ="crates/deps-deno" }
+deps-github-actions = { version = "0.13.0", path ="crates/deps-github-actions" }
+deps-gitlab-ci = { version = "0.13.0", path ="crates/deps-gitlab-ci" }
+deps-go = { version = "0.13.0", path ="crates/deps-go" }
+deps-gradle = { version = "0.13.0", path ="crates/deps-gradle" }
+deps-lsp = { version = "0.13.0", path ="crates/deps-lsp" }
+deps-maven = { version = "0.13.0", path ="crates/deps-maven" }
+deps-npm = { version = "0.13.0", path ="crates/deps-npm" }
+deps-nuget = { version = "0.13.0", path ="crates/deps-nuget" }
+deps-pypi = { version = "0.13.0", path ="crates/deps-pypi" }
+deps-swift = { version = "0.13.0", path ="crates/deps-swift" }
 dirs = "6"
 futures = "0.3"
 insta = "1.48"

--- a/crates/deps-bundler/README.md
+++ b/crates/deps-bundler/README.md
@@ -23,7 +23,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-bundler = "0.12"
+deps-bundler = "0.13"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-cargo/README.md
+++ b/crates/deps-cargo/README.md
@@ -25,7 +25,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-cargo = "0.12"
+deps-cargo = "0.13"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-composer/README.md
+++ b/crates/deps-composer/README.md
@@ -28,7 +28,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-composer = "0.12"
+deps-composer = "0.13"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-core/README.md
+++ b/crates/deps-core/README.md
@@ -33,7 +33,7 @@ This crate provides the shared infrastructure used by all ecosystem-specific cra
 
 ```toml
 [dependencies]
-deps-core = "0.12"
+deps-core = "0.13"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-dart/README.md
+++ b/crates/deps-dart/README.md
@@ -23,7 +23,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-dart = "0.12"
+deps-dart = "0.13"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-deno/README.md
+++ b/crates/deps-deno/README.md
@@ -22,7 +22,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-deno = "0.12"
+deps-deno = "0.13"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-github-actions/README.md
+++ b/crates/deps-github-actions/README.md
@@ -44,7 +44,7 @@ implements `deps_core::Ecosystem`.
 
 ```toml
 [dependencies]
-deps-github-actions = "0.12"
+deps-github-actions = "0.13"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-gitlab-ci/README.md
+++ b/crates/deps-gitlab-ci/README.md
@@ -37,7 +37,7 @@ provides parsing and registry integration for `.gitlab-ci.yml` and `.gitlab/ci/*
 
 ```toml
 [dependencies]
-deps-gitlab-ci = "0.12"
+deps-gitlab-ci = "0.13"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-go/README.md
+++ b/crates/deps-go/README.md
@@ -25,7 +25,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-go = "0.12"
+deps-go = "0.13"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-gradle/README.md
+++ b/crates/deps-gradle/README.md
@@ -27,7 +27,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-gradle = "0.12"
+deps-gradle = "0.13"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-lsp/README.md
+++ b/crates/deps-lsp/README.md
@@ -45,7 +45,7 @@ All ecosystems are enabled by default. Disable unused ones to reduce binary size
 
 ```toml
 [dependencies]
-deps-lsp = { version = "0.12", default-features = false, features = ["cargo", "npm"] }
+deps-lsp = { version = "0.13", default-features = false, features = ["cargo", "npm"] }
 ```
 
 | Feature | Ecosystem | Default |
@@ -63,6 +63,7 @@ deps-lsp = { version = "0.12", default-features = false, features = ["cargo", "n
 | `nuget` | C# / .csproj, Directory.Packages.props, packages.config | Yes |
 | `deno` | Deno (JSR/npm) / deno.json, deno.jsonc | Yes |
 | `github-actions` | YAML / .github/workflows/*.yml, *.yaml | Yes |
+| `gitlab-ci` | YAML / .gitlab-ci.yml, .gitlab/ci/*.yml | Yes |
 
 `deno` pulls in `deps-npm` transitively (`DenoRegistry` delegates `npm:` specifiers to it, per its D3 architecture), even when the `npm` feature itself is disabled.
 

--- a/crates/deps-maven/README.md
+++ b/crates/deps-maven/README.md
@@ -24,7 +24,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-maven = "0.12"
+deps-maven = "0.13"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-npm/README.md
+++ b/crates/deps-npm/README.md
@@ -25,7 +25,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-npm = "0.12"
+deps-npm = "0.13"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-nuget/README.md
+++ b/crates/deps-nuget/README.md
@@ -28,7 +28,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-nuget = "0.12"
+deps-nuget = "0.13"
 ```
 
 ## Usage

--- a/crates/deps-pypi/README.md
+++ b/crates/deps-pypi/README.md
@@ -28,7 +28,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-pypi = "0.12"
+deps-pypi = "0.13"
 ```
 
 > [!IMPORTANT]

--- a/crates/deps-swift/README.md
+++ b/crates/deps-swift/README.md
@@ -26,7 +26,7 @@ This crate is part of the [deps-lsp](https://github.com/bug-ops/deps-lsp) worksp
 
 ```toml
 [dependencies]
-deps-swift = "0.12"
+deps-swift = "0.13"
 ```
 
 > [!IMPORTANT]

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -1088,30 +1088,28 @@ message is shown verbatim, which is the useful part), just not an automated rena
 | Composer | Yes, with replace action | `abandoned` (bare `true`, or a string naming a successor package) |
 | Cargo, Go, PyPI, Bundler, Dart, Maven, Gradle, Swift, NuGet, Deno | Not yet | No registry-native package-level deprecation signal wired up yet (tracked as fast-follows; Dart's `isDiscontinued`/`replacedBy` and PyPI's PEP 792 `project-status` already exist on the wire and are the best next targets) |
 
-### Mutable-Ref-Pin Diagnostic (issue #473)
+### Mutable-Ref-Pin Diagnostic (issue #473, #634)
 
-**GitHub Actions only.** A `uses:` step pinned to a mutable ref — a tag (`actions/checkout@v4`)
-or, in a future iteration, a branch — can silently start running different code than the
-workflow file shows: a compromised or republished tag changes what CI executes without a single
-line of the workflow file changing. This is a distinct, additive signal from the outdated-version
-diagnostic above (configurable via `diagnostics.mutable_ref_pin_severity`, default HINT) — a step
-can be up to date on its tag and still vulnerable to tag mutation, so both diagnostics can fire
-independently on the same step with distinct codes:
+**GitHub Actions and GitLab CI/CD.** A dependency or include pinned to a mutable ref can silently
+start running different code than the workflow/manifest file shows: a compromised or republished tag
+changes what CI executes without a single line of the file changing. This is a distinct, additive
+signal from the outdated-version diagnostic above (configurable via
+`diagnostics.mutable_ref_pin_severity`, default HINT) — a pin can be up to date on its tag and
+still vulnerable to tag mutation, so both diagnostics can fire independently on the same target
+with distinct codes:
+
+**GitHub Actions:** A `uses:` step pinned to a mutable ref — a tag (`actions/checkout@v4`)
+or, in a future iteration, a branch — is flagged via this diagnostic:
 
 ```
 actions/checkout is pinned to the mutable tag ref `v4`; pin to a full commit SHA to guard against tag mutation
 ```
 
-The diagnostic fires for two kinds of tags:
+**GitHub Actions:** The diagnostic fires for two kinds of tags:
 - **Semantic-version-shaped tags** (`v1.2.3`, `v4.0`, etc.) — detected by text pattern and confirmed via the registry.
 - **Literal-named tags** (non-version-like names such as `cargo-deny`, `latest-stable`) — these do not look tag-shaped to the parser, but when the registry confirms they are real tags, they become eligible for this diagnostic too (issue #551).
 
-Unlike every other diagnostic in this project, severity alone cannot silence this one —
-`DiagnosticSeverity` has no suppression value. Set `diagnostics.mutable_ref_pin_enabled` to
-`false` in initialization options to turn it off entirely for teams that intentionally accept
-tag pinning.
-
-**"Pin `<name>` to commit SHA" quick fix.** When offered, rewrites the step's ref to
+**"Pin `<name>` to commit SHA" quick fix (GitHub Actions).** When offered, rewrites the step's ref to
 `<sha> # <tag>` — the exact same `{sha} # {tag}` shape the outdated-SHA-update quick fix already
 produces for a SHA-pinned step, reusing the tag/SHA cross-reference already populated by the
 existing outdated-version check (zero new network calls). The quick fix is withheld, not offered
@@ -1127,10 +1125,30 @@ with a wrong or destructive edit, in three cases:
   than starting a YAML comment — a `uses:` value GitHub Actions rejects. Re-pin a quoted step by
   hand, or remove the quotes first.
 
-**Out of scope for this iteration:** branch pins (`@main`) get no diagnostic yet — no
+**Out of scope for GitHub Actions this iteration:** branch pins (`@main`) get no diagnostic yet — no
 tag-to-SHA-style index exists for branches, and adding one would require a new network call per
 branch; reusable-workflow calls (`owner/repo/.github/workflows/x.yml@ref`) and `./local`/
 `docker://` references are not resolvable refs and get no diagnostic either.
+
+**GitLab CI/CD:** The diagnostic fires for:
+- **`include: - project:`** pins to a mutable tag or branch ref — the ref is resolved against the GitLab
+  repository-tags API. The diagnostic fires for tag-shaped refs (semantically-versioned or literal-named
+  tags confirmed as real).
+- **`include: - component:`** pins to `~latest` or a partial-semver version (e.g. `1.2` for a component
+  published via releases) — while not a branch-vs-tag confusion risk like GitHub Actions, these are still
+  mutable in the sense that the pin can resolve to a different release if the GitLab project publishes a
+  new one (resolved against the project-releases API).
+
+**"Pin to commit SHA" quick fix (GitLab CI/CD).** For `project:` includes, rewrites the tag/branch ref to
+its resolved commit SHA; for `component:` includes with `~latest`/partial pins that have already been
+resolved against the releases API, shows the fix was available (resolves #643). The quick fix is withheld in
+the same cases as GitHub Actions: SHA not yet known (still loading), or for literal-named tags (same
+branch/tag ambiguity safety concern).
+
+Unlike every other diagnostic in this project, severity alone cannot silence this one —
+`DiagnosticSeverity` has no suppression value. Set `diagnostics.mutable_ref_pin_enabled` to
+`false` in initialization options to turn it off entirely for teams that intentionally accept
+mutable pins.
 
 ### Bulk "Pin All to SHA" Code Lens (issue #633, generalized cross-ecosystem in #640)
 

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -64,12 +64,12 @@ status: moc
 | 040 | [[040-github-token-redaction-trusted-origin-pin/spec\|GitHub auth token redaction and trusted-origin pinning]] | specify | shipped — security/hardening, P3 (PR #487, issue #484) |
 | 041 | [[041-credential-redaction-hardening/spec\|Redact user:pass@ credentials from registry-index logs and errors]] | specify | shipped — security, P2, two stages (PR #529 issue #522, PR #540 issue #536) |
 | 042 | [[042-docker-base-image-ecosystem/spec\|New ecosystem: Dockerfile FROM base-image tag/digest freshness]] | specify | draft — research/new ecosystem, P4, 5 open `[NEEDS CLARIFICATION]` items, no user demand signal (issue #557) |
-| 043 | [[043-nuget-feed-authentication/spec\|NuGet Feed Authentication (credentialed NuGet.Config sources)]] | specify | draft — enhancement/security, P3, design finalized via 3-round architect/critic review, no open clarifications (issues #561, #562) |
+| 043 | [[043-nuget-feed-authentication/spec\|NuGet Feed Authentication (credentialed NuGet.Config sources)]] | specify | shipped — enhancement/security, P3 (PR #572, issues #561, #562) |
 | 044 | [[044-precommit-hooks-ecosystem/spec\|New ecosystem: pre-commit hooks (.pre-commit-config.yaml repo/rev pins)]] | specify | draft — research/new ecosystem, P4, 6 open `[NEEDS CLARIFICATION]` items, no tracking issue filed yet |
-| 045 | [[045-secret-accessor-auditable-naming/spec\|Rename Redacted<T>/wrapper as_str() secret accessors to an auditable name]] | specify | enhancement/security, P3, ready for implementation (issue #581) |
-| 046 | [[046-pnpm-catalogs/spec\|pnpm catalogs + workspace: protocol resolution support]] | specify | research/enhancement, P3, clarifications resolved 2026-09-04, ready for implementation (issue #587) |
+| 045 | [[045-secret-accessor-auditable-naming/spec\|Rename Redacted<T>/wrapper as_str() secret accessors to an auditable name]] | specify | shipped — enhancement/security, P3 (PR #582, issue #581) |
+| 046 | [[046-pnpm-catalogs/spec\|pnpm catalogs + workspace: protocol resolution support]] | specify | shipped — research/enhancement, P3 (PR #589, issue #587) |
 | 047 | [[047-elixir-hex-ecosystem/spec\|New ecosystem: Elixir Hex (mix.exs dependency version hints)]] | specify | draft — research/new-ecosystem, P4, 6 open `[NEEDS CLARIFICATION]` items, issue #642 |
-| 048 | [[048-gitlab-ci-mutable-pin-message-contradicts-quickfix/spec\|GitLab CI mutable-ref-pin diagnostic wrongly claims no automated fix for component Latest/Partial pins]] | specify | approved — bug, P2, 0 open `[NEEDS CLARIFICATION]` items, issue #643, in implementation on `feat/640-643-gitlab-ci-pin-parity` |
+| 048 | [[048-gitlab-ci-mutable-pin-message-contradicts-quickfix/spec\|GitLab CI mutable-ref-pin diagnostic wrongly claims no automated fix for component Latest/Partial pins]] | specify | shipped — bug, P2 (PR #645, issues #640, #643) |
 | 049 | [[049-osv-malicious-package-severity/spec\|OSV malicious-package (MAL-*) advisory severity distinguishing]] | specify | draft — research/correctness, P2, 6 open `[NEEDS CLARIFICATION]` items |
 
 ## Completed Specs


### PR DESCRIPTION
## Summary

- Bump version from 0.12.1 to 0.13.0
- Finalize CHANGELOG.md's [0.13.0] section, consolidating duplicate Changed/Security headers accumulated under Unreleased
- Refresh crate READMEs' pinned dependency versions and add the missing gitlab-ci row to deps-lsp's feature table
- Update docs/ECOSYSTEM_GUIDE.md's mutable-ref-pin section to cover GitLab CI/CD
- Mark specs 043/045/046/048 as shipped in specs/MOC-specs.md

## Checklist

- [x] Version updated in all manifests
- [x] CHANGELOG.md has release section with date
- [x] README reflects new version
- [x] All CI checks pass
- [ ] Ready for tagging after merge