### PR TITLE
fix(deps-cargo): resolve package = "..." rename against the real crate name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **deps-cargo**: an explicit `package = "..."` rename now resolves hover/diagnostics/completion/code actions/code lenses/inlay hints against the real crate name instead of the local TOML alias (resolves #648)
+
 ## [0.13.0] - 2026-09-05
 
 ### Added

--- a/crates/deps-cargo/src/config.rs
+++ b/crates/deps-cargo/src/config.rs
@@ -1516,6 +1516,7 @@ token = "secret-token"
                     url: "my-corp".into(),
                 },
                 section: DependencySection::Dependencies,
+                package: None,
             },
             ParsedDependency {
                 name: "b".into(),
@@ -1526,6 +1527,7 @@ token = "secret-token"
                 features_range: None,
                 source: DependencySource::Registry,
                 section: DependencySection::Dependencies,
+                package: None,
             },
         ];
 

--- a/crates/deps-cargo/src/ecosystem.rs
+++ b/crates/deps-cargo/src/ecosystem.rs
@@ -336,6 +336,7 @@ mod tests {
             features_range: None,
             source: DependencySource::Registry,
             section: DependencySection::Dependencies,
+            package: None,
         }
     }
 

--- a/crates/deps-cargo/src/parser.rs
+++ b/crates/deps-cargo/src/parser.rs
@@ -435,6 +435,7 @@ fn parse_dependencies_section(
             features_range: None,
             source: DependencySource::Registry,
             section,
+            package: None,
         };
 
         if let Some(s) = value.as_str() {
@@ -467,6 +468,10 @@ fn parse_table_dependency(
     // value is collected here and applied to `dep.source` once the whole table has
     // been walked, so the result doesn't depend on that ordering (#393).
     let mut git_rev: Option<String> = None;
+    // `package` is likewise collected and applied only after the whole table has been
+    // walked, since alphabetically `"package"` (p) sorts before `"workspace"` (w) and
+    // may be visited before `workspace = true` is seen.
+    let mut package_rename: Option<String> = None;
 
     for (key, value) in table {
         match key.name.as_ref() {
@@ -512,6 +517,20 @@ fn parse_table_dependency(
                     };
                 }
             }
+            // `package = "..."` renames the dependency: the TOML table key becomes a
+            // local import alias, and `package` names the actual crate to resolve
+            // against the registry (Cargo's "renaming dependencies" feature). `dep.name`
+            // stays the alias — it anchors `name_range` for LSP positions — while
+            // `dep.package` becomes the registry lookup name via `Dependency::name()`.
+            // Applied after the loop (see `package_rename` above): combined with
+            // `workspace = true`, Cargo silently discards `package` and resolves by the
+            // table key alone (verified via `cargo metadata`), so it must not win here
+            // either.
+            "package" => {
+                if let Some(name) = value.as_str() {
+                    package_rename = Some(name.to_string());
+                }
+            }
             // `registry = "my-corp"` names an alternative registry defined in
             // `.cargo/config.toml`, not crates.io. deps-cargo has no client
             // for it, so it must not stay classified as the plain `Registry`
@@ -550,6 +569,15 @@ fn parse_table_dependency(
 
     if let DependencySource::Git { rev, .. } = &mut dep.source {
         *rev = git_rev;
+    }
+
+    // An empty `package = ""` is rejected by Cargo itself ("package name cannot be
+    // empty"), so it must not silently become a lookup key that clears every other
+    // consumer's diagnostic anchor.
+    if !matches!(dep.source, DependencySource::Workspace)
+        && let Some(name) = package_rename.filter(|s| !s.is_empty())
+    {
+        dep.package = Some(name.into());
     }
 }
 
@@ -771,6 +799,123 @@ serde = { version = "1.0", features = ["derive"] }"#;
         assert_eq!(result.dependencies.len(), 1);
         assert_eq!(result.dependencies[0].version_req, Some("1.0".into()));
         assert_eq!(result.dependencies[0].features, vec!["derive"]);
+    }
+
+    /// Issue #648's exact repro: `package = "..."` renames the dependency. The TOML table
+    /// key (`totally-nonexistent-alias-xyz123`) stays the alias, anchoring `name_range`, while
+    /// `Dependency::name()` resolves to the real registry name (`serde`) so hover/diagnostics/
+    /// completion/code-actions key off the crate that actually exists on crates.io.
+    #[test]
+    fn test_parse_table_dependency_with_package_rename_resolves_registry_name() {
+        use deps_core::Dependency as _;
+
+        let toml = r#"[dependencies]
+totally-nonexistent-alias-xyz123 = { package = "serde", version = "1" }"#;
+        let result = parse_cargo_toml(toml, &test_url()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name, "totally-nonexistent-alias-xyz123");
+        assert_eq!(dep.package, Some("serde".into()));
+        assert_eq!(dep.name(), "serde");
+        assert_eq!(dep.version_req, Some("1".into()));
+
+        // The alias's own source position, not serde's (nonexistent) one.
+        assert_eq!(dep.name_range.start.character, 0);
+        assert_eq!(
+            dep.name_range.end.character,
+            "totally-nonexistent-alias-xyz123".len() as u32
+        );
+    }
+
+    /// `package = ""`: Cargo itself rejects an empty package name at the manifest
+    /// level, so this LSP must not treat it as a valid rename target either — the
+    /// alias stays authoritative rather than resolving `Dependency::name()` to an
+    /// empty `PackageName` (which would otherwise surface a confusing "name cannot
+    /// be empty" diagnostic anchored on an otherwise-valid alias).
+    #[test]
+    fn test_parse_table_dependency_with_empty_package_string_is_ignored() {
+        use deps_core::Dependency as _;
+
+        let toml = r#"[dependencies]
+foo = { package = "", version = "1.0" }"#;
+        let result = parse_cargo_toml(toml, &test_url()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.package, None);
+        assert_eq!(dep.name(), "foo");
+    }
+
+    /// No-regression check: a dependency without `package = "..."` still resolves
+    /// `Dependency::name()` to the TOML table key, exactly as before this fix.
+    #[test]
+    fn test_parse_table_dependency_without_package_resolves_table_key() {
+        use deps_core::Dependency as _;
+
+        let toml = r#"[dependencies]
+serde = { version = "1.0", features = ["derive"] }"#;
+        let result = parse_cargo_toml(toml, &test_url()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.package, None);
+        assert_eq!(dep.name(), "serde");
+    }
+
+    /// `package = "..."` combined with `git`: the source classification is independent of
+    /// the rename, but the registry-lookup name must still resolve to the real crate.
+    #[test]
+    fn test_parse_git_dependency_with_package_rename() {
+        use deps_core::Dependency as _;
+
+        let toml = r#"[dependencies]
+my-fork = { package = "tower-lsp", git = "https://github.com/ebkalderon/tower-lsp" }"#;
+        let result = parse_cargo_toml(toml, &test_url()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name, "my-fork");
+        assert_eq!(dep.name(), "tower-lsp");
+        assert_matches!(dep.source, DependencySource::Git { .. });
+    }
+
+    /// `package = "..."` combined with `path`.
+    #[test]
+    fn test_parse_path_dependency_with_package_rename() {
+        use deps_core::Dependency as _;
+
+        let toml = r#"[dependencies]
+local-alias = { package = "local-crate", path = "../local" }"#;
+        let result = parse_cargo_toml(toml, &test_url()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name, "local-alias");
+        assert_eq!(dep.name(), "local-crate");
+        assert_matches!(dep.source, DependencySource::Path { .. });
+    }
+
+    /// `package = "..."` combined with `workspace = true`: verified via `cargo metadata`
+    /// that Cargo silently discards `package` in this combination — the TOML table key
+    /// is the only lookup key workspace-inheritance resolution ever uses, and a member's
+    /// `package` naming a *different* crate than the workspace's own dependency entry is
+    /// simply ignored, not an error. `Dependency::name()` must therefore stay the alias
+    /// here rather than resolve to a value Cargo itself never looks up.
+    #[test]
+    fn test_parse_workspace_dependency_with_package_rename_is_ignored() {
+        use deps_core::Dependency as _;
+
+        let toml = r#"[dependencies]
+ws-alias = { package = "ws-crate", workspace = true }"#;
+        let result = parse_cargo_toml(toml, &test_url()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name, "ws-alias");
+        assert_eq!(dep.package, None);
+        assert_eq!(dep.name(), "ws-alias");
+        assert_matches!(dep.source, DependencySource::Workspace);
     }
 
     #[test]

--- a/crates/deps-cargo/src/types.rs
+++ b/crates/deps-cargo/src/types.rs
@@ -26,6 +26,7 @@ pub use deps_core::parser::DependencySource;
 ///     features_range: None,
 ///     source: DependencySource::Registry,
 ///     section: DependencySection::Dependencies,
+///     package: None,
 /// };
 ///
 /// assert_eq!(dep.name, "serde");
@@ -33,6 +34,9 @@ pub use deps_core::parser::DependencySource;
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedDependency {
+    /// The TOML table key: the local import alias when [`Self::package`] is set,
+    /// otherwise the actual crate name. Always the position anchor for
+    /// [`Self::name_range`], regardless of renaming.
     pub name: deps_core::PackageName,
     pub name_range: Range,
     pub version_req: Option<deps_core::VersionReq>,
@@ -41,6 +45,16 @@ pub struct ParsedDependency {
     pub features_range: Option<Range>,
     pub source: DependencySource,
     pub section: DependencySection,
+    /// The real crate name from an explicit `package = "..."` key
+    /// ([renaming dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml)),
+    /// when present. `None` for an ordinary, non-renamed dependency, in which
+    /// case [`Self::name`] is both the local alias and the registry name.
+    ///
+    /// Never set when [`Self::source`] is [`DependencySource::Workspace`]: Cargo
+    /// silently discards `package` alongside `workspace = true` (the table key is
+    /// the only workspace-inheritance lookup key), so honoring it here would
+    /// resolve `Dependency::name()` to a value Cargo itself ignores.
+    pub package: Option<deps_core::PackageName>,
 }
 
 /// Section in Cargo.toml where a dependency is declared.
@@ -142,8 +156,10 @@ pub struct CrateInfo {
 // Trait implementations for deps-core integration
 
 impl deps_core::Dependency for ParsedDependency {
+    /// Returns the registry lookup name: [`Self::package`] when this dependency was
+    /// renamed via `package = "..."`, otherwise the TOML table key.
     fn name(&self) -> &deps_core::PackageName {
-        &self.name
+        self.package.as_ref().unwrap_or(&self.name)
     }
 
     fn name_range(&self) -> Range {

--- a/crates/deps-core/src/lsp_helpers/in_use_version.rs
+++ b/crates/deps-core/src/lsp_helpers/in_use_version.rs
@@ -567,4 +567,49 @@ mod tests {
             None
         );
     }
+
+    /// Known-limitation regression guard (deps-cargo `package = "..."` rename, issue
+    /// #648's follow-up): `resolved_versions` is keyed by name alone with one
+    /// highest-semver value per name (`ResolvedPackages`'s `best_package` collapse in
+    /// `crate::lockfile`), so two manifest occurrences of the same crate — one plain,
+    /// one renamed via `package = "..."` to select an older major — both resolve
+    /// `Dependency::name()` to the same registry name and therefore collide on the
+    /// same lockfile entry.
+    ///
+    /// This pins *today's* behavior (the renamed, older-major occurrence incorrectly
+    /// reports the newer major's lockfile version) so a fix — per-occurrence
+    /// resolution filtered by `version_requirement()`, the same class of gap as #394
+    /// — is a deliberate, visible behavior change here, not a silent one. Not a
+    /// desired outcome: see the critic handoff
+    /// (`.local/handoff/2026-09-05T23-48-31-critic.md`, finding S1) for the full
+    /// failure-mode analysis and the tracking follow-up.
+    #[test]
+    fn in_use_version_known_limitation_renamed_occurrence_collides_with_plain_one() {
+        use crate::VersionReq;
+        use crate::lsp_helpers::test_support::MockDep;
+
+        let renamed_old_major = MockDep {
+            name: PackageName::new("serde"),
+            version_req: VersionReq::new("0.9"),
+            version_range: tower_lsp_server::ls_types::Range::default(),
+            name_range: tower_lsp_server::ls_types::Range::default(),
+        };
+
+        let mut resolved_versions = HashMap::new();
+        resolved_versions.insert(PackageName::new("serde"), ConcreteVersion::from("1.0.219"));
+
+        let result = in_use_version(
+            &renamed_old_major,
+            "serde",
+            &resolved_versions,
+            &crate::lsp_helpers::test_support::MockFormatter,
+            EcosystemId::Cargo,
+        );
+
+        // Wrong today: this is `serde 0.9`'s occurrence, but the collapsed
+        // single-value-per-name map hands back the unrelated 1.x entry instead of
+        // `None` (which is what pre-#648 behavior produced for an unresolvable
+        // alias name — an honest "unknown" rather than a confidently wrong answer).
+        assert_eq!(result, Some("1.0.219".to_string()));
+    }
 }


### PR DESCRIPTION
## Summary
- Cargo's `package = "..."` dependency-rename syntax was silently ignored: the LSP always used the TOML table key (local alias) as the registry lookup name, producing wrong hover/diagnostics/completion/code actions/code lenses/inlay hints for any renamed dependency.
- `ParsedDependency` gains a `package: Option<PackageName>` field, populated by a new `"package"` arm in `parse_table_dependency`. `Dependency::name()` now returns it when present, falling back to the TOML table key otherwise. `name`/`name_range` still always anchor to the alias's source position, so diagnostic/hover positioning is unaffected.
- `package` is discarded when the same dependency also has `workspace = true` (verified against real Cargo behavior via `cargo metadata`: Cargo itself silently ignores `package` in that case), and an empty `package = ""` string is ignored rather than producing an empty registry name.
- Every downstream consumer of `Dependency::name()` (hover, diagnostics, code actions, code lenses, inlay hints, in-use-version/lockfile lookup, formatter, completion) picks up the fix automatically since none of them read the underlying struct field directly — confirmed by grep across `deps-core`/`deps-lsp`.

## Known limitation (tracked separately)
A regression test in `deps-core::lsp_helpers::in_use_version` pins a known limitation surfaced by adversarial review: `resolved_versions` collapses each lockfile package name to its single highest semver, so when a manifest has both a plain dependency and a `package = "..."`-renamed occurrence of an older major of the same crate, the renamed occurrence's in-use-version/vulnerability data gets attributed to the wrong installed version. A proper fix needs per-occurrence lockfile resolution filtered by `version_req` and is tracked in #649.

A pre-existing feature-completion ambiguity gap (#593) is slightly widened by this fix (a rename colliding with a plain dependency of the same crate via a different registry source now also hits that ambiguity) but not newly introduced.

## Test plan
- [x] `cargo nextest run -p deps-cargo -p deps-core --all-features --no-fail-fast` — 1208 passed, 0 failed
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --all-features`
- [x] Manually traced the issue's exact repro (`totally-nonexistent-alias-xyz123 = { package = "serde", version = "1" }`) through the new code path

Closes #648