### PR TITLE
fix(deps-core): distinguish OSV MAL-* malicious-package advisories from unscored CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **deps-core**: OSV malicious-package advisories (`MAL-*` id or alias) now classify as a distinct `VulnSeverity::Malicious` instead of falling through to "unknown severity" in hover/diagnostics (resolves #646) (PR link pending)
+
 ### Fixed
 - **deps-cargo**: an explicit `package = "..."` rename now resolves hover/diagnostics/completion/code actions/code lenses/inlay hints against the real crate name instead of the local TOML alias (resolves #648)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **deps-core**: OSV malicious-package advisories (`MAL-*` id or alias) now classify as a distinct `VulnSeverity::Malicious` instead of falling through to "unknown severity" in hover/diagnostics (resolves #646) (PR link pending)
+- **deps-core**: OSV malicious-package advisories (`MAL-*` id or alias) now classify as a distinct `VulnSeverity::Malicious` instead of falling through to "unknown severity" in hover/diagnostics (resolves #646) (#652)
 
 ### Fixed
 - **deps-cargo**: an explicit `package = "..."` rename now resolves hover/diagnostics/completion/code actions/code lenses/inlay hints against the real crate name instead of the local TOML alias (resolves #648)

--- a/crates/deps-core/src/lsp_helpers/diagnostics.rs
+++ b/crates/deps-core/src/lsp_helpers/diagnostics.rs
@@ -1339,6 +1339,17 @@ fn push_deprecation_diagnostic(
 /// `N` is derived from [`crate::osv::Capped::remaining`] — the batch result's reported count,
 /// never from `dv.advisories.items().len()`, since invariant 3 (`architecture.md` §8)
 /// caps the record *fetch* independently of the render cap.
+///
+/// A [`crate::osv::VulnSeverity::Malicious`] advisory's message is prefixed with the
+/// `"[MALWARE]"` tag (SC-002) — deliberately not the word "malicious" again: OSV's own
+/// `summary` text for these records routinely already starts with "Malicious code in ..."
+/// (impl-critic M3), and prefixing with "Malicious package" produced a redundant
+/// "Malicious package — Malicious code in ..." read. `code` is still `advisory.id` like
+/// every other advisory (a `MAL-*` id can never collide with a `RUSTSEC-`/`GHSA-`/`CVE-`
+/// one), but the message tag means a reader scanning the Problems panel does not need to
+/// recognize the `MAL-` id convention (or an alias to one — see `severity::classify`) to
+/// tell the two apart. `severity` itself stays capped at `WARNING` either way
+/// (`diagnostic_severity_for`).
 fn push_vulnerability_diagnostics(
     diagnostics: &mut Vec<Diagnostic>,
     dep: &dyn Dependency,
@@ -1353,17 +1364,20 @@ fn push_vulnerability_diagnostics(
             .ok()
             .map(|href| CodeDescription { href });
 
+        let summary = advisory
+            .summary
+            .as_deref()
+            .unwrap_or("(no summary provided)");
+        let message = if advisory.severity == crate::osv::VulnSeverity::Malicious {
+            format!("{}: [MALWARE] {summary}", advisory.id)
+        } else {
+            format!("{}: {summary}", advisory.id)
+        };
+
         diagnostics.push(Diagnostic {
             range,
             severity: Some(diagnostic_severity_for(advisory.severity)),
-            message: format!(
-                "{}: {}",
-                advisory.id,
-                advisory
-                    .summary
-                    .as_deref()
-                    .unwrap_or("(no summary provided)")
-            ),
+            message,
             code: Some(NumberOrString::String(advisory.id.clone())),
             code_description,
             source: Some("deps-lsp".into()),
@@ -3752,6 +3766,131 @@ mod tests {
         assert_eq!(
             vuln_diag.code,
             Some(NumberOrString::String("RUSTSEC-2020-0071".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_generate_diagnostics_malicious_advisory_is_distinguishable_from_unknown() {
+        // SC-002: a MAL-* advisory and an ordinary Unknown-severity advisory on
+        // the same dependency must be distinguishable without opening hover.
+        use crate::osv::{
+            Capped, DependencyVulnerabilities, ScanOutcome, UpgradeStatus, VulnSeverity,
+            VulnerabilityMap,
+        };
+
+        let formatter = MockFormatter;
+        let parse_result = MockParseResult {
+            deps: vec![dep_at("vulnerable-pkg")],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+        let cached_versions = HashMap::new();
+        let resolved_versions = HashMap::new();
+
+        let mut vulns: VulnerabilityMap = VulnerabilityMap::new();
+        vulns.insert(
+            "vulnerable-pkg".to_string(),
+            ScanOutcome::Vulnerable(DependencyVulnerabilities {
+                advisories: Capped::new(
+                    vec![
+                        sample_advisory("MAL-2025-47141", VulnSeverity::Malicious),
+                        sample_advisory("RUSTSEC-2020-0071", VulnSeverity::Unknown),
+                    ],
+                    2,
+                ),
+                fix_target_status: UpgradeStatus::NotChecked,
+                upgrade_status: UpgradeStatus::NotChecked,
+            }),
+        );
+
+        let diagnostics = generate_diagnostics_from_cache(
+            &parse_result,
+            VersionData::new(&cached_versions, &resolved_versions).with_vulnerabilities(&vulns),
+            &formatter,
+            parse_result.uri(),
+            crate::FreshnessSettings::default(),
+            DiagnosticSeverities::default(),
+            PublishTime::now(),
+        );
+
+        let malicious_diag = diagnostics
+            .iter()
+            .find(|d| d.message.contains("MAL-2025-47141"))
+            .expect("malicious advisory diagnostic must be emitted");
+        let unknown_diag = diagnostics
+            .iter()
+            .find(|d| d.message.contains("RUSTSEC-2020-0071"))
+            .expect("unknown-severity advisory diagnostic must be emitted");
+
+        assert_ne!(malicious_diag.message, unknown_diag.message);
+        assert_ne!(malicious_diag.code, unknown_diag.code);
+        assert!(malicious_diag.message.contains("[MALWARE]"));
+        assert!(!unknown_diag.message.contains("[MALWARE]"));
+    }
+
+    #[test]
+    fn test_generate_diagnostics_malicious_message_does_not_repeat_the_word_malicious() {
+        // M3 (impl-critic): OSV's own summary for MAL-* records routinely
+        // already starts with "Malicious code in ..." — the message must not
+        // also prefix "Malicious package", which read redundantly.
+        use crate::osv::{
+            Advisory, Capped, DependencyVulnerabilities, ScanOutcome, UpgradeStatus, VulnSeverity,
+            VulnerabilityMap,
+        };
+        use std::sync::Arc;
+
+        let formatter = MockFormatter;
+        let parse_result = MockParseResult {
+            deps: vec![dep_at("bad-pkg")],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+        let cached_versions = HashMap::new();
+        let resolved_versions = HashMap::new();
+
+        let advisory = Arc::new(Advisory {
+            id: "MAL-2025-47141".to_string(),
+            modified: "2025-09-17T06:23:36Z".to_string(),
+            summary: Some("Malicious code in @ctrl/tinycolor (npm)".to_string()),
+            aliases: vec!["GHSA-qjqf-7j6f-82c4".to_string()],
+            severity: VulnSeverity::Malicious,
+            cvss_vector: None,
+            fixed_versions: vec![],
+            url: "https://osv.dev/vulnerability/MAL-2025-47141".to_string(),
+        });
+
+        let mut vulns: VulnerabilityMap = VulnerabilityMap::new();
+        vulns.insert(
+            "bad-pkg".to_string(),
+            ScanOutcome::Vulnerable(DependencyVulnerabilities {
+                advisories: Capped::new(vec![advisory], 1),
+                fix_target_status: UpgradeStatus::NotChecked,
+                upgrade_status: UpgradeStatus::NotChecked,
+            }),
+        );
+
+        let diagnostics = generate_diagnostics_from_cache(
+            &parse_result,
+            VersionData::new(&cached_versions, &resolved_versions).with_vulnerabilities(&vulns),
+            &formatter,
+            parse_result.uri(),
+            crate::FreshnessSettings::default(),
+            DiagnosticSeverities::default(),
+            PublishTime::now(),
+        );
+
+        let diag = diagnostics
+            .iter()
+            .find(|d| d.message.contains("MAL-2025-47141"))
+            .expect("malicious advisory diagnostic must be emitted");
+        assert!(
+            diag.message.contains("[MALWARE]"),
+            "message must carry the distinguishing [MALWARE] tag, got: {}",
+            diag.message
+        );
+        assert!(
+            !diag.message.contains("Malicious package"),
+            "message must not also prefix the redundant 'Malicious package' wording \
+             on top of OSV's own \"Malicious ...\" summary text, got: {}",
+            diag.message
         );
     }
 

--- a/crates/deps-core/src/lsp_helpers/hover.rs
+++ b/crates/deps-core/src/lsp_helpers/hover.rs
@@ -641,6 +641,12 @@ fn push_offline_footer_hover_section(markdown: &mut String, resolvable: bool, of
 }
 
 /// Lowercase display label for a [`crate::osv::VulnSeverity`], used only in hover text.
+///
+/// `Malicious` renders as `"confirmed malicious package"` — deliberately
+/// distinct from both `"unknown severity"` (a record this could not grade,
+/// carrying no urgency signal of its own) and every graded label
+/// (`critical`/`high`/`medium`/`low`), since a confirmed-malicious-package
+/// finding is categorically different from a graded-but-uncertain risk.
 const fn severity_label(severity: crate::osv::VulnSeverity) -> &'static str {
     match severity {
         crate::osv::VulnSeverity::Critical => "critical",
@@ -648,6 +654,7 @@ const fn severity_label(severity: crate::osv::VulnSeverity) -> &'static str {
         crate::osv::VulnSeverity::Medium => "medium",
         crate::osv::VulnSeverity::Low => "low",
         crate::osv::VulnSeverity::Unknown => "unknown severity",
+        crate::osv::VulnSeverity::Malicious => "confirmed malicious package",
     }
 }
 
@@ -826,6 +833,20 @@ mod tests {
 
     use std::collections::HashMap;
     use std::sync::Arc;
+
+    #[test]
+    fn severity_label_for_malicious_is_distinct_from_unknown_and_every_graded_label() {
+        let malicious = severity_label(crate::osv::VulnSeverity::Malicious);
+        assert_ne!(malicious, "unknown severity");
+        for graded in [
+            crate::osv::VulnSeverity::Critical,
+            crate::osv::VulnSeverity::High,
+            crate::osv::VulnSeverity::Medium,
+            crate::osv::VulnSeverity::Low,
+        ] {
+            assert_ne!(malicious, severity_label(graded));
+        }
+    }
 
     #[tokio::test]
     async fn test_generate_hover_recent_versions_shows_age_when_known() {
@@ -2471,6 +2492,55 @@ mod tests {
         );
         assert!(content.value.contains("+2 more advisories"));
         assert!(content.value.contains("also affected"));
+    }
+
+    #[tokio::test]
+    async fn test_generate_hover_malicious_advisory_never_renders_unknown_severity() {
+        // SC-001: a MAL-* advisory (e.g. the live MAL-2025-47141 record for
+        // npm `@ctrl/tinycolor`) must never render as "unknown severity".
+        use crate::osv::{
+            Capped, DependencyVulnerabilities, ScanOutcome, UpgradeStatus, VulnSeverity,
+            VulnerabilityMap,
+        };
+
+        let parse_result = MockParseResult {
+            deps: vec![dep_at("bad-pkg")],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+        let cached_versions = HashMap::new();
+        let resolved_versions = HashMap::new();
+
+        let mut vulns: VulnerabilityMap = VulnerabilityMap::new();
+        vulns.insert(
+            "bad-pkg".to_string(),
+            ScanOutcome::Vulnerable(DependencyVulnerabilities {
+                advisories: Capped::new(
+                    vec![sample_advisory("MAL-2025-47141", VulnSeverity::Malicious)],
+                    1,
+                ),
+                fix_target_status: UpgradeStatus::NotChecked,
+                upgrade_status: UpgradeStatus::NotChecked,
+            }),
+        );
+
+        let hover = generate_hover(
+            &parse_result,
+            Position::new(0, 2),
+            VersionData::new(&cached_versions, &resolved_versions).with_vulnerabilities(&vulns),
+            &MockRegistry,
+            &MockFormatter,
+            crate::FreshnessSettings::default(),
+            PublishTime::now(),
+        )
+        .await
+        .expect("hover should be generated");
+
+        let HoverContents::Markup(content) = hover.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(content.value.contains("MAL-2025-47141"));
+        assert!(content.value.contains("confirmed malicious package"));
+        assert!(!content.value.contains("unknown severity"));
     }
 
     #[tokio::test]

--- a/crates/deps-core/src/osv/severity.rs
+++ b/crates/deps-core/src/osv/severity.rs
@@ -29,6 +29,21 @@ fn severity_from_json(value: &serde_json::Value) -> Option<VulnSeverity> {
 
 /// Classifies a record's severity, first hit wins:
 ///
+/// 0. `id`, or any entry in `aliases`, carries OSV's `MAL-` prefix ->
+///    [`VulnSeverity::Malicious`], taking precedence over every graded signal
+///    below. OSV can file one confirmed-malicious-package event under a
+///    non-`MAL-` primary id while cross-referencing the canonical `MAL-*` id
+///    only via `aliases` — live-verified via `crates.io/rustdecimal`, served
+///    as three separate records (`GHSA-7pwq-f4pq-78gm`, `MAL-2022-1`,
+///    `RUSTSEC-2022-0042`) that all alias each other, where the `GHSA-`
+///    record additionally carries a graded `database_specific.severity` of
+///    its own. Checking `id` alone would misclassify the two non-`MAL-`-id
+///    records as `Critical`/`Unknown` despite describing the exact same
+///    malware. A confirmed-malicious-package record must never be masked by
+///    a graded severity value it also happens to carry (FR-004) — this check
+///    runs first and returns immediately, so a `MAL-*` id or alias always
+///    wins regardless of what `database_specific` or `ecosystem_specific`
+///    report.
 /// 1. `database_specific.severity` (GHSA-sourced records carry this).
 /// 2. `relevant_affected[].ecosystem_specific.severity` (some RUSTSEC records).
 /// 3. [`VulnSeverity::Unknown`].
@@ -39,9 +54,15 @@ fn severity_from_json(value: &serde_json::Value) -> Option<VulnSeverity> {
 /// advisory id, and this must never pick up a stranger's `ecosystem_specific`
 /// severity.
 pub(super) fn classify(
+    id: &str,
+    aliases: &[String],
     database_specific: Option<&serde_json::Value>,
     relevant_affected: &[&OsvAffected],
 ) -> VulnSeverity {
+    if id.starts_with("MAL-") || aliases.iter().any(|alias| alias.starts_with("MAL-")) {
+        return VulnSeverity::Malicious;
+    }
+
     if let Some(v) = database_specific.and_then(severity_from_json) {
         return v;
     }
@@ -61,11 +82,16 @@ pub(super) fn classify(
 
 /// Maps a [`VulnSeverity`] to the [`DiagnosticSeverity`] used to render it.
 ///
-/// `Critical`/`High` and `Unknown` cap at `WARNING` rather than `ERROR`:
-/// `ERROR` conventionally means "this file is broken", and a valid manifest
-/// declaring a real-but-vulnerable dependency is not a parse error.
-/// `Unknown -> WARNING` (not `HINT`) reflects that a record this could not
-/// grade is not evidence of low risk.
+/// `Critical`/`High`/`Unknown`/`Malicious` all cap at `WARNING` rather than
+/// `ERROR`: `ERROR` conventionally means "this file is broken", and a valid
+/// manifest declaring a real-but-vulnerable (or even confirmed-malicious)
+/// dependency is not a parse error. `Unknown -> WARNING` (not `HINT`)
+/// reflects that a record this could not grade is not evidence of low risk.
+/// `Malicious` stays at `WARNING` too rather than escalating to `ERROR` — a
+/// confirmed-malicious-package finding is distinguished from an ordinary
+/// unscored advisory via its message and label instead (see
+/// [`crate::lsp_helpers`]'s vulnerability diagnostic and hover rendering),
+/// keeping the "ERROR means broken manifest" convention intact.
 ///
 /// # Examples
 ///
@@ -79,13 +105,15 @@ pub(super) fn classify(
 /// assert_eq!(to_diagnostic_severity(VulnSeverity::Critical), DiagnosticSeverity::WARNING);
 /// assert_eq!(to_diagnostic_severity(VulnSeverity::Low), DiagnosticSeverity::INFORMATION);
 /// assert_eq!(to_diagnostic_severity(VulnSeverity::Unknown), DiagnosticSeverity::WARNING);
+/// assert_eq!(to_diagnostic_severity(VulnSeverity::Malicious), DiagnosticSeverity::WARNING);
 /// ```
 #[must_use]
 pub const fn to_diagnostic_severity(severity: VulnSeverity) -> DiagnosticSeverity {
     match severity {
-        VulnSeverity::Critical | VulnSeverity::High | VulnSeverity::Unknown => {
-            DiagnosticSeverity::WARNING
-        }
+        VulnSeverity::Critical
+        | VulnSeverity::High
+        | VulnSeverity::Unknown
+        | VulnSeverity::Malicious => DiagnosticSeverity::WARNING,
         VulnSeverity::Medium | VulnSeverity::Low => DiagnosticSeverity::INFORMATION,
     }
 }
@@ -98,13 +126,19 @@ mod tests {
     #[test]
     fn database_specific_severity_wins() {
         let json = serde_json::json!({ "severity": "CRITICAL" });
-        assert_eq!(classify(Some(&json), &[]), VulnSeverity::Critical);
+        assert_eq!(
+            classify("RUSTSEC-2020-0071", &[], Some(&json), &[]),
+            VulnSeverity::Critical
+        );
     }
 
     #[test]
     fn database_specific_moderate_maps_to_medium() {
         let json = serde_json::json!({ "severity": "MODERATE" });
-        assert_eq!(classify(Some(&json), &[]), VulnSeverity::Medium);
+        assert_eq!(
+            classify("RUSTSEC-2020-0071", &[], Some(&json), &[]),
+            VulnSeverity::Medium
+        );
     }
 
     #[test]
@@ -114,17 +148,96 @@ mod tests {
             ecosystem_specific: Some(serde_json::json!({ "severity": "LOW" })),
             ranges: vec![],
         };
-        assert_eq!(classify(None, &[&affected]), VulnSeverity::Low);
+        assert_eq!(
+            classify("RUSTSEC-2020-0071", &[], None, &[&affected]),
+            VulnSeverity::Low
+        );
     }
 
     #[test]
     fn cvss_vector_only_record_is_unknown() {
-        assert_eq!(classify(None, &[]), VulnSeverity::Unknown);
+        assert_eq!(
+            classify("RUSTSEC-2020-0071", &[], None, &[]),
+            VulnSeverity::Unknown
+        );
     }
 
     #[test]
     fn no_severity_at_all_is_unknown() {
-        assert_eq!(classify(None, &[]), VulnSeverity::Unknown);
+        assert_eq!(
+            classify("RUSTSEC-2020-0071", &[], None, &[]),
+            VulnSeverity::Unknown
+        );
+    }
+
+    #[test]
+    fn mal_prefix_with_no_severity_fields_is_malicious() {
+        // Live-verified shape: OSV's MAL-2025-47141 record for npm
+        // `@ctrl/tinycolor` has no severity field anywhere.
+        assert_eq!(
+            classify("MAL-2025-47141", &[], None, &[]),
+            VulnSeverity::Malicious
+        );
+    }
+
+    #[test]
+    fn mal_prefix_wins_over_a_graded_severity_present_on_the_same_record() {
+        // FR-004: a record carrying both a MAL- id and a graded severity must
+        // still classify as Malicious — the malicious classification is never
+        // masked by an unrelated graded value.
+        let json = serde_json::json!({ "severity": "CRITICAL" });
+        assert_eq!(
+            classify("MAL-2025-47141", &[], Some(&json), &[]),
+            VulnSeverity::Malicious
+        );
+    }
+
+    #[test]
+    fn mal_alias_without_mal_prefixed_id_is_still_malicious() {
+        // S1 (impl-critic): live-verified via crates.io/rustdecimal, OSV
+        // serves the same malware event as three separate records that all
+        // alias each other. GHSA-7pwq-f4pq-78gm's own id has no MAL- prefix
+        // and carries a graded database_specific.severity of HIGH, but one
+        // of its aliases is MAL-2022-1 — the alias check must still win over
+        // the graded value (FR-004 extends to alias-based detection too).
+        let json = serde_json::json!({ "severity": "HIGH" });
+        let aliases = ["MAL-2022-1".to_string(), "RUSTSEC-2022-0042".to_string()];
+        assert_eq!(
+            classify("GHSA-7pwq-f4pq-78gm", &aliases, Some(&json), &[]),
+            VulnSeverity::Malicious
+        );
+    }
+
+    #[test]
+    fn rustdecimal_three_alias_group_all_classify_as_malicious() {
+        // S1 regression: the full live-verified crates.io/rustdecimal shape —
+        // every record in the alias group must classify as Malicious,
+        // regardless of which one carries the MAL- id itself.
+        let ghsa_aliases = ["MAL-2022-1".to_string(), "RUSTSEC-2022-0042".to_string()];
+        let mal_aliases = [
+            "GHSA-7pwq-f4pq-78gm".to_string(),
+            "RUSTSEC-2022-0042".to_string(),
+        ];
+        let rustsec_aliases = ["GHSA-7pwq-f4pq-78gm".to_string(), "MAL-2022-1".to_string()];
+        let ghsa_severity = serde_json::json!({ "severity": "HIGH" });
+
+        assert_eq!(
+            classify(
+                "GHSA-7pwq-f4pq-78gm",
+                &ghsa_aliases,
+                Some(&ghsa_severity),
+                &[]
+            ),
+            VulnSeverity::Malicious
+        );
+        assert_eq!(
+            classify("MAL-2022-1", &mal_aliases, None, &[]),
+            VulnSeverity::Malicious
+        );
+        assert_eq!(
+            classify("RUSTSEC-2022-0042", &rustsec_aliases, None, &[]),
+            VulnSeverity::Malicious
+        );
     }
 
     #[test]
@@ -147,6 +260,10 @@ mod tests {
         );
         assert_eq!(
             to_diagnostic_severity(VulnSeverity::Unknown),
+            DiagnosticSeverity::WARNING
+        );
+        assert_eq!(
+            to_diagnostic_severity(VulnSeverity::Malicious),
             DiagnosticSeverity::WARNING
         );
     }

--- a/crates/deps-core/src/osv/severity.rs
+++ b/crates/deps-core/src/osv/severity.rs
@@ -171,6 +171,18 @@ mod tests {
     }
 
     #[test]
+    fn non_mal_aliases_do_not_trigger_malicious_classification() {
+        // N5 (impl-critic): pins the discriminating half of the MAL- alias
+        // predicate — a record with a non-empty, non-MAL-prefixed aliases
+        // list must not be misclassified as Malicious (NFR-001).
+        let aliases = ["GHSA-xxxx-xxxx-xxxx".to_string(), "CVE-2020-1".to_string()];
+        assert_eq!(
+            classify("RUSTSEC-2020-0071", &aliases, None, &[]),
+            VulnSeverity::Unknown
+        );
+    }
+
+    #[test]
     fn mal_prefix_with_no_severity_fields_is_malicious() {
         // Live-verified shape: OSV's MAL-2025-47141 record for npm
         // `@ctrl/tinycolor` has no severity field anywhere.

--- a/crates/deps-core/src/osv/types.rs
+++ b/crates/deps-core/src/osv/types.rs
@@ -78,19 +78,23 @@ pub enum VulnSeverity {
     Low,
     /// No severity field was present or recognized on the record.
     Unknown,
-    /// The advisory's `id` carries OSV's `MAL-` prefix, identifying a
-    /// confirmed-malicious-package record ingested from the OpenSSF
-    /// `malicious-packages` feed: this exact published version is known
-    /// malware (typically "fully compromised, rotate all secrets"), not a
-    /// graded-but-uncertain risk. `MAL-*` records carry no CVSS-style
-    /// severity field at all, so without this variant they would collapse
-    /// into [`Self::Unknown`] and render identically to a merely unscored,
-    /// low-confidence CVE — see the `MAL-` prefix check this crate's OSV
+    /// The advisory's `id`, or any entry in its `aliases`, carries OSV's
+    /// `MAL-` prefix, identifying a confirmed-malicious-package record
+    /// ingested from the OpenSSF `malicious-packages` feed: this exact
+    /// published version is known malware (typically "fully compromised,
+    /// rotate all secrets"), not a graded-but-uncertain risk. `MAL-*`
+    /// records carry no CVSS-style severity field at all, so without this
+    /// variant they would collapse into [`Self::Unknown`] and render
+    /// identically to a merely unscored, low-confidence CVE — see the
+    /// `MAL-` prefix check (on both `id` and `aliases`) this crate's OSV
     /// severity classification runs before its graded-severity fallback,
-    /// and `architecture.md` §6. Deliberately not folded into
-    /// [`Self::Critical`] either: a confirmed compromise is categorically
-    /// different from a graded CVSS-CRITICAL score, and collapsing the two
-    /// would make them indistinguishable to a reader.
+    /// and `architecture.md` §6. The `aliases` check matters because OSV
+    /// can serve one confirmed-malicious-package event under a non-`MAL-`
+    /// primary id, cross-referencing the canonical `MAL-*` id only via
+    /// `aliases`. Deliberately not folded into [`Self::Critical`] either: a
+    /// confirmed compromise is categorically different from a graded
+    /// CVSS-CRITICAL score, and collapsing the two would make them
+    /// indistinguishable to a reader.
     Malicious,
 }
 

--- a/crates/deps-core/src/osv/types.rs
+++ b/crates/deps-core/src/osv/types.rs
@@ -78,6 +78,20 @@ pub enum VulnSeverity {
     Low,
     /// No severity field was present or recognized on the record.
     Unknown,
+    /// The advisory's `id` carries OSV's `MAL-` prefix, identifying a
+    /// confirmed-malicious-package record ingested from the OpenSSF
+    /// `malicious-packages` feed: this exact published version is known
+    /// malware (typically "fully compromised, rotate all secrets"), not a
+    /// graded-but-uncertain risk. `MAL-*` records carry no CVSS-style
+    /// severity field at all, so without this variant they would collapse
+    /// into [`Self::Unknown`] and render identically to a merely unscored,
+    /// low-confidence CVE — see the `MAL-` prefix check this crate's OSV
+    /// severity classification runs before its graded-severity fallback,
+    /// and `architecture.md` §6. Deliberately not folded into
+    /// [`Self::Critical`] either: a confirmed compromise is categorically
+    /// different from a graded CVSS-CRITICAL score, and collapsing the two
+    /// would make them indistinguishable to a reader.
+    Malicious,
 }
 
 /// A single vulnerability advisory, converted from OSV's wire format at the
@@ -311,8 +325,15 @@ pub struct FixRecommendation {
 
 /// Numeric ranking used only to sort [`FixRecommendation::advisory_ids`],
 /// worst severity first.
+///
+/// `Malicious` ranks above `Critical`: a confirmed-malicious-package finding
+/// is more urgent than any graded CVSS score. In practice a `Malicious`
+/// advisory rarely reaches this ranking at all, since `recommended_fix` only
+/// considers advisories with a known fix and a malicious-package record
+/// typically has none.
 const fn severity_rank(severity: VulnSeverity) -> u8 {
     match severity {
+        VulnSeverity::Malicious => 5,
         VulnSeverity::Critical => 4,
         VulnSeverity::High => 3,
         VulnSeverity::Medium => 2,
@@ -852,7 +873,12 @@ impl OsvVulnRecord {
             relevant
         };
 
-        let severity = super::severity::classify(self.database_specific.as_ref(), &relevant);
+        let severity = super::severity::classify(
+            &self.id,
+            &self.aliases,
+            self.database_specific.as_ref(),
+            &relevant,
+        );
         let cvss_vector = self
             .severity
             .iter()

--- a/specs/049-osv-malicious-package-severity/spec.md
+++ b/specs/049-osv-malicious-package-severity/spec.md
@@ -160,7 +160,7 @@ Use EARS notation. Prefix with FR-NNN.
 
 | ID | Requirement | Priority |
 |----|------------|----------|
-| FR-001 | WHEN an OSV record's advisory `id` has the `MAL-` prefix THE SYSTEM SHALL classify that advisory as confirmed-malicious rather than falling through to `VulnSeverity::Unknown` (resolved: id-prefix detection only — no live-observed OSV record pairs `CWE-506` with a non-`MAL-` id, so the CWE check is dropped as unnecessary complexity per NFR-001) | must |
+| FR-001 | WHEN an OSV record's advisory `id`, OR any entry in its `aliases[]`, has the `MAL-` prefix THE SYSTEM SHALL classify that advisory as confirmed-malicious rather than falling through to `VulnSeverity::Unknown` (resolved: id-prefix detection, extended to `aliases[]` after live verification found the same malicious-package event served under three cross-aliased OSV ids — `GHSA-*`, `MAL-*`, `RUSTSEC-*` — for `rustdecimal`/crates.io, where only the `MAL-*` record's own `id` carries the prefix; checking `id` alone misses the other two records for the identical malware. No `CWE-506` check — dropped as unnecessary complexity per NFR-001, no live-observed record needs it) | must |
 | FR-002 | WHEN an advisory is classified as confirmed-malicious THE SYSTEM SHALL render a hover label distinct from `"unknown severity"` and distinct from every existing graded label (`critical`/`high`/`medium`/`low`) | must |
 | FR-003 | WHEN an advisory is classified as confirmed-malicious THE SYSTEM SHALL produce a diagnostic that is distinguishable from a `VulnSeverity::Unknown` diagnostic for an ordinary CVE via message content and diagnostic code, while remaining at `DiagnosticSeverity::WARNING` (resolved: keeps the existing "ERROR means broken manifest" convention from `architecture.md` §6 intact) | must |
 | FR-004 | WHEN an OSV record has both a graded CVSS-style severity field AND is classified as confirmed-malicious (a record can in principle carry both) THE SYSTEM SHALL still surface the confirmed-malicious classification — a malicious-package finding must never be silently masked by an unrelated graded-severity value taking precedence | must |
@@ -178,15 +178,16 @@ Use EARS notation. Prefix with FR-NNN.
 
 | Entity | Description | Key Attributes |
 |--------|-------------|----------------|
-| `VulnSeverity` (existing, `crates/deps-core/src/osv/types.rs`, line ~70) | Severity bucket enum | Currently `Critical`, `High`, `Medium`, `Low`, `Unknown` — resolved: add a new `Malicious` variant (forces every exhaustive `match` on `VulnSeverity` to be updated, consistent with this project's `EcosystemId` precedent) |
-| `Advisory` (existing, same file, line ~104) | Per-advisory data surfaced to hover/diagnostics | `id`, `summary`, `aliases`, `severity`, `cvss_vector`, `fixed_versions`, `url` — the classification signal (id prefix and/or CWE) must be read at construction time from the raw OSV record, since `Advisory` itself does not currently carry `cwes` |
-| *(new)* Malicious-package classification signal | Where the `MAL-` check reads from | Raw OSV record's `id` field (already available at `classify()`'s call site — no new field needs to be threaded through `OsvVulnRecord`/`Advisory`) |
+| `VulnSeverity` (existing, `crates/deps-core/src/osv/types.rs`, line ~70) | Severity bucket enum | Currently `Critical`, `High`, `Medium`, `Low`, `Unknown` — resolved: add a new `Malicious` variant (forces every exhaustive `match` on `VulnSeverity` to be updated at compile time, consistent with this project's `EcosystemId` precedent) |
+| `Advisory` (existing, same file, line ~104) | Per-advisory data surfaced to hover/diagnostics | `id`, `summary`, `aliases`, `severity`, `cvss_vector`, `fixed_versions`, `url` — `aliases` is already parsed and already reaches `classify()`'s call site, so the `MAL-` check reads `id` and `aliases[]` with no new field needed |
+| *(new)* Malicious-package classification signal | Where the `MAL-` check reads from | Raw OSV record's `id` field and its already-parsed `aliases[]` (both available at `classify()`'s call site) |
 
 ## 6. Edge Cases and Error Handling
 
 | Scenario | Expected Behavior |
 |----------|-------------------|
-| Record has `MAL-` id prefix but also a graded `database_specific.severity` (hypothetical, not observed live) | Per FR-004, confirmed-malicious classification (the new `VulnSeverity::Malicious` variant) still takes precedence and is surfaced — the id-prefix check runs before the existing 3-tier graded-severity fallback |
+| Record has `MAL-` id prefix but also a graded `database_specific.severity` (hypothetical, not observed live) | Per FR-004, confirmed-malicious classification (the new `VulnSeverity::Malicious` variant) still takes precedence and is surfaced — the id/alias `MAL-` check runs before the existing 3-tier graded-severity fallback |
+| Record's own `id` does not have the `MAL-` prefix, but one of its `aliases[]` does (live-observed: `GHSA-7pwq-f4pq-78gm` and `RUSTSEC-2022-0042` both alias `MAL-2022-1` for the same `rustdecimal`/crates.io malicious-package event) | Classified as confirmed-malicious — FR-001 checks `id` OR any `aliases[]` entry for the `MAL-` prefix specifically to cover this case |
 | Record has `MAL-` id prefix but the CWE data is entirely absent (matches the live `@ctrl/tinycolor` `MAL-2025-47141` case) | Classified as confirmed-malicious — the id prefix alone is sufficient (resolved: no CWE-506 check, see FR-001) |
 | A dependency has both a confirmed-malicious advisory and one or more ordinary graded/unscored advisories | Each advisory keeps its own independent classification; the malicious one must not be diluted or hidden by unrelated advisories on the same dependency |
 | `Capped` truncation (`ADVISORY_DISPLAY_CAP`) causes a confirmed-malicious advisory to fall outside the displayed slice | Out of scope for this spec (resolved: no reordering — pre-existing truncation/ordering behavior is unchanged; a dedicated "sort malicious first" enhancement is deferred to a follow-up if truncation drops turn out to matter in practice) |
@@ -210,8 +211,8 @@ Use EARS notation. Prefix with FR-NNN.
   citations) that must not be silently dropped
 - Preserve existing graded-severity precedence and existing `Unknown`
   behavior for genuinely non-malicious unscored records (FR-005, NFR-003)
-- Add/update unit tests in `severity.rs` for both detection signals
-  (`MAL-` prefix, `CWE-506`) and for the FR-004 both-signals-present case
+- Add/update unit tests in `severity.rs` for the `MAL-` prefix check on both
+  `id` and `aliases[]`, and for the FR-004 both-signals-present case
 - Run full CI checks (`cargo +nightly fmt --check`, clippy, nextest, rustdoc
   gate) per project convention before any PR
 - Live-verify against the real `@ctrl/tinycolor` / `MAL-2025-47141` OSV
@@ -238,12 +239,14 @@ Use EARS notation. Prefix with FR-NNN.
 
 ## 9. Resolved Decisions
 
-All open questions were resolved with the user before implementation:
+All open questions were resolved with the user before implementation. One
+resolution was subsequently refined during implementation review after new
+live evidence (see the FR-001 amendment below):
 
 - **Data model**: add a new `VulnSeverity::Malicious` variant (not an orthogonal flag). Forces every exhaustive `match` on `VulnSeverity` to be updated at compile time, consistent with this project's `EcosystemId` precedent.
-- **Detection signal**: `MAL-` id-prefix only. No live-observed OSV record pairs `CWE-506` with a non-`MAL-` id, so the CWE check is dropped as unnecessary complexity (NFR-001).
+- **Detection signal**: `MAL-` prefix on the advisory's own `id` OR any entry in its `aliases[]` (no `CWE-506` check). Originally scoped to `id` only; the implementation's adversarial critique re-queried OSV live and found the same malicious-package event served as three cross-aliased records for `rustdecimal`/crates.io (`GHSA-7pwq-f4pq-78gm`, `MAL-2022-1`, `RUSTSEC-2022-0042`) — only the `MAL-2022-1` record's own `id` carries the prefix, so an `id`-only check would still render `"unknown severity"` for the `RUSTSEC-2022-0042` record of the identical malware, reproducing the exact bug this spec exists to fix. `aliases[]` is already parsed and already reaches `classify()`'s call site, so the fix needs no new fetch.
 - **Diagnostic severity**: stays `DiagnosticSeverity::WARNING`, distinguished via message content and diagnostic code — keeps the existing "ERROR means broken manifest" convention (`architecture.md` §6) intact.
-- **Ordering**: no change to advisory/diagnostic ordering or `ADVISORY_DISPLAY_CAP` truncation behavior in this spec — deferred to a follow-up if it turns out to matter in practice.
+- **Ordering**: no change to advisory/diagnostic ordering or `ADVISORY_DISPLAY_CAP` truncation behavior in this spec — deferred to a follow-up if it turns out to matter in practice. (`recommended_fix()`'s internal `severity_rank` helper, used only to order `FixRecommendation::advisory_ids` among advisories that already have a known fix, does rank `Malicious` above `Critical`; this is a documented, near-inert side effect — confirmed-malicious records observed live carry no `fixed_versions` — not a change to the diagnostic/hover ordering this bullet covers.)
 - **Scope**: hover + diagnostics only, matching US-001/US-002. Inlay hints / code lens treatment is deferred to a follow-up.
 - **GitHub issue**: filed as #646 (`enhancement`, `P2`, `research`), referencing this spec.
 
@@ -262,3 +265,4 @@ All open questions were resolved with the user before implementation:
 - [JetBrains Package Checker](https://www.jetbrains.com/help/idea/package-checker.html) — reference-project precedent for headline malicious-package detection separate from vulnerability severity
 - `.local/testing/playbooks/competitive-parity.md`, "Scan Notes (2026-08-23...)" — the original deferred note that this spec follows through on
 - Live OSV.dev evidence: `POST https://api.osv.dev/v1/query {"package":{"name":"@ctrl/tinycolor","ecosystem":"npm"}}` returning `MAL-2025-47141` with no severity fields anywhere in the response
+- Live OSV.dev evidence (implementation review): `POST https://api.osv.dev/v1/query {"package":{"name":"rustdecimal","ecosystem":"crates.io"}}` returning three mutually-aliased records for one malware event (`GHSA-7pwq-f4pq-78gm` graded `HIGH`, `MAL-2022-1` with no severity fields, `RUSTSEC-2022-0042` with no severity fields) — the motivating case for the FR-001 `aliases[]` amendment

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -70,7 +70,7 @@ status: moc
 | 046 | [[046-pnpm-catalogs/spec\|pnpm catalogs + workspace: protocol resolution support]] | specify | shipped — research/enhancement, P3 (PR #589, issue #587) |
 | 047 | [[047-elixir-hex-ecosystem/spec\|New ecosystem: Elixir Hex (mix.exs dependency version hints)]] | specify | draft — research/new-ecosystem, P4, 6 open `[NEEDS CLARIFICATION]` items, issue #642 |
 | 048 | [[048-gitlab-ci-mutable-pin-message-contradicts-quickfix/spec\|GitLab CI mutable-ref-pin diagnostic wrongly claims no automated fix for component Latest/Partial pins]] | specify | shipped — bug, P2 (PR #645, issues #640, #643) |
-| 049 | [[049-osv-malicious-package-severity/spec\|OSV malicious-package (MAL-*) advisory severity distinguishing]] | specify | draft — research/correctness, P2, 6 open `[NEEDS CLARIFICATION]` items |
+| 049 | [[049-osv-malicious-package-severity/spec\|OSV malicious-package (MAL-*) advisory severity distinguishing]] | specify | research/correctness, P2, implemented (issue #646, branch feat/646-osv-malicious-severity) |
 | 050 | [[050-cargo-renamed-dependency-lockfile-resolution/spec\|Per-occurrence lockfile version resolution for renamed/aliased dependencies]] | specify | draft — bug, P1, 4 open `[NEEDS CLARIFICATION]` items, issue #649 |
 
 ## Completed Specs


### PR DESCRIPTION
## Summary

- Adds `VulnSeverity::Malicious`, classified when an advisory's `id` or any of its `aliases` carries OSV's `MAL-` prefix — checked before the existing graded-severity fallback, so it's never masked by a co-present graded value (FR-004).
- Hover renders a distinct "confirmed malicious package" label instead of the misleading "unknown severity". Diagnostics carry a distinguishing `[MALWARE]` message prefix while staying at `DiagnosticSeverity::WARNING`, per the project's "ERROR means broken manifest" convention.
- Live-verified against `MAL-2025-47141` (npm `@ctrl/tinycolor`, the September 2025 Shai-Hulud worm) and `crates.io/rustdecimal`'s three cross-aliased records (`GHSA-7pwq-f4pq-78gm`, `MAL-2022-1`, `RUSTSEC-2022-0042`) for the same malware event.

## Scope note: detection signal was widened during implementation

The spec (`specs/049-osv-malicious-package-severity/spec.md`) originally resolved the detection signal as "`MAL-` id-prefix only" with the user. During implementation, adversarial review re-queried OSV live and found that OSV can serve one confirmed-malicious-package event under a non-`MAL-` primary id, cross-referencing the canonical `MAL-*` id only via `aliases[]` (the `rustdecimal` case above) — an `id`-only check would still render "unknown severity" for those records, reproducing the exact bug this spec exists to fix. The fix was extended to check `id` OR any `aliases[]` entry for the `MAL-` prefix, using data (`Advisory.aliases`) already parsed and already available at the call site — no new fetch. This amendment is documented in the spec's FR-001 and §9 Resolved Decisions, and stress-tested for false positives against 428 live advisory records across 6 ecosystems (zero false positives).

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4410/4410)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- [x] Live-verified against real OSV.dev records (`@ctrl/tinycolor`/npm, `rustdecimal`/crates.io) per the project's Live Testing Principle
- [x] Two rounds of adversarial critique (impl-critic) and independent code review, all findings closed

Closes #646