### PR TITLE
fix(deps-core,deps-lsp): resolve renamed-dependency versions per manifest occurrence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: OSV malicious-package advisories (`MAL-*` id or alias) now classify as a distinct `VulnSeverity::Malicious` instead of falling through to "unknown severity" in hover/diagnostics (resolves #646) (#652)
 
 ### Fixed
+- **deps-core, deps-lsp**: hover/inlay-hint in-use-version and OSV vulnerability lookups now resolve each manifest occurrence against its own `version_requirement()` instead of a single collapsed lock-file value, so a renamed/aliased dependency pinned to a different major no longer mis-reports the other occurrence's version (resolves #649)
 - **deps-cargo**: an explicit `package = "..."` rename now resolves hover/diagnostics/completion/code actions/code lenses/inlay hints against the real crate name instead of the local TOML alias (resolves #648)
 
 ## [0.13.0] - 2026-09-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: OSV malicious-package advisories (`MAL-*` id or alias) now classify as a distinct `VulnSeverity::Malicious` instead of falling through to "unknown severity" in hover/diagnostics (resolves #646) (#652)
 
 ### Fixed
-- **deps-core, deps-lsp**: hover/inlay-hint in-use-version and OSV vulnerability lookups now resolve each manifest occurrence against its own `version_requirement()` instead of a single collapsed lock-file value, so a renamed/aliased dependency pinned to a different major no longer mis-reports the other occurrence's version (resolves #649)
+- **deps-core, deps-lsp**: hover/inlay-hint in-use-version and OSV vulnerability lookups now resolve each manifest occurrence against its own `version_requirement()` instead of a single collapsed lock-file value, so a renamed/aliased dependency pinned to a different major no longer mis-reports the other occurrence's version (resolves #649) (#653)
 - **deps-cargo**: an explicit `package = "..."` rename now resolves hover/diagnostics/completion/code actions/code lenses/inlay hints against the real crate name instead of the local TOML alias (resolves #648)
 
 ## [0.13.0] - 2026-09-05

--- a/crates/deps-cargo/tests/source_replace_test.rs
+++ b/crates/deps-cargo/tests/source_replace_test.rs
@@ -278,6 +278,7 @@ fn test_mirror_distinct_pinned_versions_produce_distinct_vulnerability_keys() {
     let keys = deps_core::osv::vulnerability_keys(
         &parse_result,
         &resolved,
+        None,
         &formatter,
         EcosystemId::Cargo,
     );

--- a/crates/deps-core/src/lockfile.rs
+++ b/crates/deps-core/src/lockfile.rs
@@ -281,19 +281,27 @@ pub struct ResolvedPackages {
     packages: HashMap<String, Vec<ResolvedPackage>>,
 }
 
+/// Orders two version strings, preferring a valid semver parse over a non-parseable one and
+/// falling back to a lexicographic compare when both (or neither) parse.
+///
+/// Shared by [`best_package`] and the per-occurrence candidate selection in
+/// [`crate::lsp_helpers::in_use_version`] (issue #649) so a lock file entry with a
+/// non-semver version string is never ordered by two diverging policies depending on which
+/// caller is asking.
+pub(crate) fn compare_lockfile_versions(a: &str, b: &str) -> std::cmp::Ordering {
+    match (semver::Version::parse(a), semver::Version::parse(b)) {
+        (Ok(va), Ok(vb)) => va.cmp(&vb),
+        (Ok(_), Err(_)) => std::cmp::Ordering::Greater,
+        (Err(_), Ok(_)) => std::cmp::Ordering::Less,
+        (Err(_), Err(_)) => a.cmp(b),
+    }
+}
+
 /// Returns the package with the highest semver version from a slice.
 fn best_package(packages: &[ResolvedPackage]) -> Option<&ResolvedPackage> {
-    packages.iter().max_by(|a, b| {
-        match (
-            semver::Version::parse(&a.version),
-            semver::Version::parse(&b.version),
-        ) {
-            (Ok(va), Ok(vb)) => va.cmp(&vb),
-            (Ok(_), Err(_)) => std::cmp::Ordering::Greater,
-            (Err(_), Ok(_)) => std::cmp::Ordering::Less,
-            (Err(_), Err(_)) => a.version.cmp(&b.version),
-        }
-    })
+    packages
+        .iter()
+        .max_by(|a, b| compare_lockfile_versions(&a.version, &b.version))
 }
 
 impl ResolvedPackages {
@@ -325,6 +333,21 @@ impl ResolvedPackages {
     /// Returns all stored versions for a package.
     pub fn get_all(&self, name: &str) -> Option<&[ResolvedPackage]> {
         self.packages.get(name).map(|v| v.as_slice())
+    }
+
+    /// Returns an iterator yielding every stored version for each unique package name,
+    /// unlike [`Self::iter`] which collapses each name down to `best_package`'s single
+    /// pick.
+    ///
+    /// The building block for per-occurrence lock-file resolution (issue #649): a caller
+    /// disambiguating two manifest occurrences of the same resolved package name (e.g. a
+    /// Cargo `package = "..."` rename pinning an older major alongside a plain dependency
+    /// on the current major) needs every retained version for that name, not just the one
+    /// [`Self::iter`]/[`Self::into_map`] would collapse it to.
+    pub fn iter_all(&self) -> impl Iterator<Item = (&String, &[ResolvedPackage])> {
+        self.packages
+            .iter()
+            .map(|(name, versions)| (name, versions.as_slice()))
     }
 
     /// Returns the number of unique package names.

--- a/crates/deps-core/src/lsp_helpers/code_actions.rs
+++ b/crates/deps-core/src/lsp_helpers/code_actions.rs
@@ -108,8 +108,14 @@ fn build_vulnerability_fix_action(
     // occurrence of a duplicated name is never built from another
     // occurrence's OSV result. See `crate::osv::vulnerability_keys`.
     let vuln_key = versions.ecosystem.and_then(|ecosystem| {
-        crate::osv::vulnerability_keys(parse_result, versions.resolved, formatter, ecosystem)
-            .remove(&dep.name_range())
+        crate::osv::vulnerability_keys(
+            parse_result,
+            versions.resolved,
+            versions.resolved_version_candidates,
+            formatter,
+            ecosystem,
+        )
+        .remove(&dep.name_range())
     });
     let outcome = versions.vulnerabilities.and_then(|m| {
         vuln_key
@@ -1654,6 +1660,7 @@ mod tests {
         let keys = crate::osv::vulnerability_keys(
             &parse_result,
             &resolved,
+            None,
             &IdentityFormatter,
             crate::EcosystemId::Cargo,
         );

--- a/crates/deps-core/src/lsp_helpers/diagnostics.rs
+++ b/crates/deps-core/src/lsp_helpers/diagnostics.rs
@@ -526,7 +526,13 @@ pub fn generate_diagnostics_from_cache(
     // fixtures) — the per-dep lookup below then falls back to the plain
     // name, unaffected.
     let vuln_keys = versions.ecosystem.map(|ecosystem| {
-        crate::osv::vulnerability_keys(parse_result, versions.resolved, formatter, ecosystem)
+        crate::osv::vulnerability_keys(
+            parse_result,
+            versions.resolved,
+            versions.resolved_version_candidates,
+            formatter,
+            ecosystem,
+        )
     });
 
     for dep in deps {
@@ -892,6 +898,7 @@ fn apply_in_use_yanked_rule(
                 ctx.dep,
                 ctx.normalized_name,
                 ctx.versions.resolved,
+                ctx.versions.resolved_version_candidates,
                 ctx.formatter,
                 ecosystem,
             )
@@ -3983,6 +3990,7 @@ mod tests {
         let keys = vulnerability_keys(
             &parse_result,
             &resolved_versions,
+            None,
             &formatter,
             crate::EcosystemId::Cargo,
         );
@@ -4032,6 +4040,112 @@ mod tests {
         assert_eq!(
             advisory_diags[0].range.start.line, 0,
             "must land on the vulnerable occurrence's own line, not the patched one"
+        );
+    }
+
+    /// Issue #649 US-002/SC-002, end-to-end through `generate_diagnostics_from_cache` with a
+    /// real `resolved_version_candidates` map — the largest gap flagged by the pre-review
+    /// test-coverage audit: every prior duplicate-name test disambiguated via a concrete
+    /// manifest pin (`=1.0.0`/`=2.0.0`) with `resolved_versions` empty, never exercising the
+    /// lockfile-candidates path at all. This mirrors the actual serde/serde_old rename
+    /// scenario: two occurrences share the resolved name `serde`, one plain (`"1.0"`,
+    /// resolving via the candidates map to `1.0.219`) and one renamed to an older major
+    /// (`"0.9"`, resolving to `0.9.15`) — an advisory affecting only `1.0.219` must anchor
+    /// solely on the plain occurrence.
+    #[test]
+    fn test_generate_diagnostics_vulnerability_attributed_via_resolved_version_candidates() {
+        use crate::osv::{
+            Capped, DependencyVulnerabilities, ScanOutcome, UpgradeStatus, VulnSeverity,
+            VulnerabilityMap, vulnerability_keys,
+        };
+        use tower_lsp_server::ls_types::{Position, Range};
+
+        let formatter = MockFormatter;
+
+        let current_major = MockDep {
+            name: "serde".into(),
+            version_req: "1.0".into(),
+            version_range: Range::new(Position::new(0, 8), Position::new(0, 13)),
+            name_range: Range::new(Position::new(0, 0), Position::new(0, 5)),
+        };
+        let renamed_old_major = MockDep {
+            name: "serde".into(),
+            version_req: "0.9".into(),
+            version_range: Range::new(Position::new(1, 8), Position::new(1, 13)),
+            name_range: Range::new(Position::new(1, 0), Position::new(1, 9)),
+        };
+        let parse_result = MockParseResult {
+            deps: vec![current_major, renamed_old_major],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+
+        let cached_versions = HashMap::new();
+        let mut resolved_versions = HashMap::new();
+        resolved_versions.insert("serde".into(), ConcreteVersion::from("1.0.219"));
+        let mut resolved_version_candidates = HashMap::new();
+        resolved_version_candidates.insert(
+            "serde".into(),
+            vec![
+                ConcreteVersion::from("0.9.15"),
+                ConcreteVersion::from("1.0.219"),
+            ],
+        );
+
+        let keys = vulnerability_keys(
+            &parse_result,
+            &resolved_versions,
+            Some(&resolved_version_candidates),
+            &formatter,
+            crate::EcosystemId::Cargo,
+        );
+        let deps = parse_result.dependencies();
+        let current_key = keys.get(&deps[0].name_range()).unwrap().clone();
+        let renamed_key = keys.get(&deps[1].name_range()).unwrap().clone();
+        assert_ne!(
+            current_key, renamed_key,
+            "occurrences resolving to different lockfile candidates must get distinct keys"
+        );
+
+        let mut vulns: VulnerabilityMap = VulnerabilityMap::new();
+        vulns.insert(
+            current_key,
+            ScanOutcome::Vulnerable(DependencyVulnerabilities {
+                advisories: Capped::new(
+                    vec![sample_advisory("RUSTSEC-2020-0071", VulnSeverity::High)],
+                    1,
+                ),
+                fix_target_status: UpgradeStatus::NotChecked,
+                upgrade_status: UpgradeStatus::NotChecked,
+            }),
+        );
+        vulns.insert(renamed_key, ScanOutcome::Clean);
+
+        let diagnostics = generate_diagnostics_from_cache(
+            &parse_result,
+            VersionData::new(&cached_versions, &resolved_versions)
+                .with_resolved_version_candidates(&resolved_version_candidates)
+                .with_vulnerabilities(&vulns)
+                .with_ecosystem(crate::EcosystemId::Cargo),
+            &formatter,
+            parse_result.uri(),
+            crate::FreshnessSettings::default(),
+            DiagnosticSeverities::default(),
+            PublishTime::now(),
+        );
+
+        let advisory_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("RUSTSEC-2020-0071"))
+            .collect();
+        assert_eq!(
+            advisory_diags.len(),
+            1,
+            "exactly one occurrence must get the advisory diagnostic, got: {diagnostics:?}"
+        );
+        assert_eq!(
+            advisory_diags[0].range.start.line, 0,
+            "the advisory affecting 1.0.219 must land on the plain (1.0) occurrence's line, \
+             not the renamed (0.9) occurrence sharing the same resolved name"
         );
     }
 

--- a/crates/deps-core/src/lsp_helpers/hover.rs
+++ b/crates/deps-core/src/lsp_helpers/hover.rs
@@ -148,11 +148,14 @@ pub async fn generate_hover<R: Registry + ?Sized>(
     let resolved: Option<&str> = if formatter.manifest_requirement_is_resolved_version(dep) {
         dep.version_requirement().map(VersionReq::as_str)
     } else {
-        versions
-            .resolved
-            .get(normalized_name.as_str())
-            .or_else(|| versions.resolved.get(dep.name()))
-            .map(ConcreteVersion::as_str)
+        in_use_version::resolve_occurrence_version(
+            dep,
+            normalized_name.as_str(),
+            versions.resolved,
+            versions.resolved_version_candidates,
+            formatter,
+        )
+        .map(ConcreteVersion::as_str)
     };
     push_current_or_requirement_hover_section(&mut markdown, dep, resolved);
 
@@ -274,8 +277,14 @@ pub async fn generate_hover<R: Registry + ?Sized>(
     // of a duplicated name never shows another occurrence's OSV result. See
     // `crate::osv::vulnerability_keys` for when qualification kicks in.
     let vuln_key = versions.ecosystem.and_then(|ecosystem| {
-        crate::osv::vulnerability_keys(parse_result, versions.resolved, formatter, ecosystem)
-            .remove(&dep.name_range())
+        crate::osv::vulnerability_keys(
+            parse_result,
+            versions.resolved,
+            versions.resolved_version_candidates,
+            formatter,
+            ecosystem,
+        )
+        .remove(&dep.name_range())
     });
     let vuln_outcome = versions.vulnerabilities.and_then(|m| {
         vuln_key
@@ -393,6 +402,7 @@ fn spawn_trust_signal_fetch(
             dep,
             normalized_name,
             versions.resolved,
+            versions.resolved_version_candidates,
             formatter,
             ecosystem,
         )?;
@@ -2575,6 +2585,7 @@ mod tests {
         let keys = crate::osv::vulnerability_keys(
             &parse_result,
             &resolved_versions,
+            None,
             &MockFormatter,
             crate::EcosystemId::Cargo,
         );
@@ -2637,6 +2648,124 @@ mod tests {
             panic!("expected markup hover contents");
         };
         assert!(vulnerable_content.value.contains("RUSTSEC-2020-0071"));
+    }
+
+    /// Issue #649 US-001/US-002/SC-001/SC-002, end-to-end through `generate_hover` with a
+    /// real `resolved_version_candidates` map (the largest gap flagged by the pre-review
+    /// test-coverage audit — every prior duplicate-name hover test disambiguated via a
+    /// concrete manifest pin, never exercising the lockfile-candidates path). Mirrors the
+    /// serde/serde_old rename scenario: both occurrences resolve the name `serde`, one
+    /// plain (`"1.0"`) and one renamed to an older major (`"0.9"`); the "Current" line must
+    /// show each occurrence's own resolved version (SC-001), and an advisory affecting only
+    /// the current major must not leak onto the renamed occurrence's hover (SC-002).
+    #[tokio::test]
+    async fn test_generate_hover_attributed_via_resolved_version_candidates() {
+        use crate::osv::{
+            Capped, DependencyVulnerabilities, ScanOutcome, UpgradeStatus, VulnSeverity,
+            VulnerabilityMap,
+        };
+
+        let current_major = MockDep {
+            name: "serde".into(),
+            version_req: "1.0".into(),
+            version_range: Range::new(Position::new(0, 8), Position::new(0, 13)),
+            name_range: Range::new(Position::new(0, 0), Position::new(0, 5)),
+        };
+        let renamed_old_major = MockDep {
+            name: "serde".into(),
+            version_req: "0.9".into(),
+            version_range: Range::new(Position::new(1, 8), Position::new(1, 13)),
+            name_range: Range::new(Position::new(1, 0), Position::new(1, 9)),
+        };
+        let parse_result = MockParseResult {
+            deps: vec![current_major, renamed_old_major],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+        let cached_versions = HashMap::new();
+        let mut resolved_versions = HashMap::new();
+        resolved_versions.insert("serde".into(), ConcreteVersion::from("1.0.219"));
+        let mut resolved_version_candidates = HashMap::new();
+        resolved_version_candidates.insert(
+            "serde".into(),
+            vec![
+                ConcreteVersion::from("0.9.15"),
+                ConcreteVersion::from("1.0.219"),
+            ],
+        );
+
+        let keys = crate::osv::vulnerability_keys(
+            &parse_result,
+            &resolved_versions,
+            Some(&resolved_version_candidates),
+            &MockFormatter,
+            crate::EcosystemId::Cargo,
+        );
+        let deps = parse_result.dependencies();
+        let current_key = keys.get(&deps[0].name_range()).unwrap().clone();
+        let renamed_key = keys.get(&deps[1].name_range()).unwrap().clone();
+        assert_ne!(current_key, renamed_key);
+
+        let mut vulns: VulnerabilityMap = VulnerabilityMap::new();
+        vulns.insert(
+            current_key,
+            ScanOutcome::Vulnerable(DependencyVulnerabilities {
+                advisories: Capped::new(
+                    vec![sample_advisory("RUSTSEC-2020-0071", VulnSeverity::Critical)],
+                    1,
+                ),
+                fix_target_status: UpgradeStatus::NotChecked,
+                upgrade_status: UpgradeStatus::NotChecked,
+            }),
+        );
+        vulns.insert(renamed_key, ScanOutcome::Clean);
+
+        let versions = VersionData::new(&cached_versions, &resolved_versions)
+            .with_resolved_version_candidates(&resolved_version_candidates)
+            .with_vulnerabilities(&vulns)
+            .with_ecosystem(crate::EcosystemId::Cargo);
+
+        let hover_on_renamed = generate_hover(
+            &parse_result,
+            Position::new(1, 2),
+            versions,
+            &MockRegistry,
+            &MockFormatter,
+            crate::FreshnessSettings::default(),
+            PublishTime::now(),
+        )
+        .await
+        .expect("hover should be generated");
+        let HoverContents::Markup(renamed_content) = hover_on_renamed.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(
+            renamed_content.value.contains("0.9.15"),
+            "renamed occurrence must show its own resolved version, not the collapsed 1.0.219: {}",
+            renamed_content.value
+        );
+        assert!(
+            !renamed_content.value.contains("RUSTSEC-2020-0071"),
+            "the renamed (0.9) occurrence must not show the other occurrence's advisory: {}",
+            renamed_content.value
+        );
+        assert!(renamed_content.value.contains("No known vulnerabilities"));
+
+        let hover_on_current = generate_hover(
+            &parse_result,
+            Position::new(0, 2),
+            versions,
+            &MockRegistry,
+            &MockFormatter,
+            crate::FreshnessSettings::default(),
+            PublishTime::now(),
+        )
+        .await
+        .expect("hover should be generated");
+        let HoverContents::Markup(current_content) = hover_on_current.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(current_content.value.contains("1.0.219"));
+        assert!(current_content.value.contains("RUSTSEC-2020-0071"));
     }
 
     /// #366, revised by the PR-431 review's Critical finding #3: a registry error

--- a/crates/deps-core/src/lsp_helpers/in_use_version.rs
+++ b/crates/deps-core/src/lsp_helpers/in_use_version.rs
@@ -216,6 +216,89 @@ fn is_concrete_version(requirement: &str, ecosystem: EcosystemId) -> bool {
     concrete_pin_version(requirement, ecosystem).is_some()
 }
 
+/// Picks the lock-file-resolved candidate that best matches one dependency occurrence's own
+/// version requirement (FR-001/FR-002), among a name's multiple retained lock-file entries.
+///
+/// Filters `candidates` down to those [`EcosystemFormatter::version_satisfies_requirement`]
+/// accepts, then returns the highest-semver entry among that satisfying subset — falling back
+/// to [`crate::lockfile`]'s lexicographic tiebreak for non-parseable versions
+/// ([`crate::lockfile::compare_lockfile_versions`]), the same ordering a single-candidate
+/// collapse already uses, so this never diverges from it. Returns `None` when nothing
+/// satisfies the requirement (FR-003) — the caller must not then substitute an arbitrary
+/// non-matching entry.
+/// Prefers [`RequirementResolution::compile_requirement`]'s precise, ecosystem-native
+/// comparator (e.g. `deps-cargo`'s real `semver::VersionReq` range semantics) over
+/// [`RequirementResolution::version_satisfies_requirement`]'s looser heuristic — critical
+/// here specifically because that heuristic's plain/partial-requirement branch requires
+/// *minor-version equality* (`is_same_major_minor`), so a caret-range requirement like
+/// Cargo's `"2.4"` (meaning `>=2.4.0, <3.0.0`) would wrongly reject a `2.9.4` candidate,
+/// turning a real match into a false FR-003 skip. `compile_requirement` is only used when
+/// it succeeds; an ecosystem that returns `None` (requirement fails to parse under its own
+/// comparator) falls back to the heuristic exactly as it did before this existed.
+fn version_matches_requirement(
+    formatter: &dyn EcosystemFormatter,
+    version: &ConcreteVersion,
+    requirement: &crate::VersionReq,
+) -> bool {
+    if let Some(matcher) = formatter.compile_requirement(requirement) {
+        matcher.matches(version) == Some(true)
+    } else {
+        formatter.version_satisfies_requirement(version, requirement.as_str())
+    }
+}
+
+fn best_candidate_for_requirement<'a>(
+    candidates: &'a [ConcreteVersion],
+    requirement: &crate::VersionReq,
+    formatter: &dyn EcosystemFormatter,
+) -> Option<&'a ConcreteVersion> {
+    candidates
+        .iter()
+        .filter(|v| version_matches_requirement(formatter, v, requirement))
+        .max_by(|a, b| crate::lockfile::compare_lockfile_versions(a.as_str(), b.as_str()))
+}
+
+/// Resolves one dependency occurrence's lock-file version, disambiguating by its own
+/// `version_requirement()` when the resolved name has more than one retained lock-file entry
+/// (issue #649).
+///
+/// `resolved_version_candidates` holds every retained lock-file entry per name (built from
+/// [`crate::lockfile::ResolvedPackages::iter_all`]) but, per NFR-003, is expected to carry an
+/// entry **only** for names with more than one occurrence — the common single-occurrence case
+/// falls straight through to `resolved_versions` (the fast `HashMap` lookup, unchanged from
+/// before this function existed, FR-005) without ever consulting the candidates map. The same
+/// fallback applies when `dep.version_requirement()` is `None` (edge case: a renamed
+/// occurrence with no version to disambiguate against) or when no candidate satisfies the
+/// requirement (FR-003) — that last case intentionally does not substitute the collapsed
+/// value, since it would be an arbitrary, possibly wrong, non-matching entry.
+///
+/// Shared by [`in_use_version`] and the resolved-version lookups in
+/// [`super::hover::generate_hover`] and [`super::inlay_hints::generate_inlay_hints`] so all
+/// three surfaces (hover, inlay hints, OSV target selection) apply the identical
+/// per-occurrence disambiguation policy (US-001/US-002).
+pub(crate) fn resolve_occurrence_version<'a>(
+    dep: &dyn Dependency,
+    normalized_name: &str,
+    resolved_versions: &'a HashMap<PackageName, ConcreteVersion>,
+    resolved_version_candidates: Option<&'a HashMap<PackageName, Vec<ConcreteVersion>>>,
+    formatter: &dyn EcosystemFormatter,
+) -> Option<&'a ConcreteVersion> {
+    let candidates = resolved_version_candidates.and_then(|candidates| {
+        candidates
+            .get(normalized_name)
+            .or_else(|| candidates.get(dep.name()))
+    });
+
+    match (candidates, dep.version_requirement()) {
+        (Some(candidates), Some(req)) if candidates.len() > 1 => {
+            best_candidate_for_requirement(candidates, req, formatter)
+        }
+        _ => resolved_versions
+            .get(normalized_name)
+            .or_else(|| resolved_versions.get(dep.name())),
+    }
+}
+
 /// The version of `dep` this project treats as actually in use.
 ///
 /// The lock-file-resolved version, else the declared requirement when it is
@@ -233,6 +316,11 @@ fn is_concrete_version(requirement: &str, ecosystem: EcosystemId) -> bool {
 /// (#394 S1) — all three need "what version does the user actually have"
 /// for the same reason: querying a fabricated version produces a silent
 /// false negative.
+///
+/// `resolved_version_candidates` disambiguates a name with more than one lock-file entry by
+/// the occurrence's own `version_requirement()` (issue #649) — see this module's
+/// `resolve_occurrence_version` for the exact policy. `None` (most callers with no such map
+/// to give) behaves exactly as before this parameter existed.
 ///
 /// # Examples
 ///
@@ -297,7 +385,7 @@ fn is_concrete_version(requirement: &str, ecosystem: EcosystemId) -> bool {
 /// // No lock file, but the requirement is already an exact pin — falls
 /// // back to it, stripped of its `=` marker.
 /// assert_eq!(
-///     in_use_version(&dep, "time", &resolved_versions, &SimpleFormatter, EcosystemId::Cargo),
+///     in_use_version(&dep, "time", &resolved_versions, None, &SimpleFormatter, EcosystemId::Cargo),
 ///     Some("0.1.43".to_string())
 /// );
 /// ```
@@ -305,29 +393,80 @@ pub fn in_use_version(
     dep: &dyn Dependency,
     normalized_name: &str,
     resolved_versions: &HashMap<PackageName, ConcreteVersion>,
+    resolved_version_candidates: Option<&HashMap<PackageName, Vec<ConcreteVersion>>>,
     formatter: &dyn EcosystemFormatter,
     ecosystem: EcosystemId,
 ) -> Option<String> {
     if formatter.manifest_requirement_is_resolved_version(dep) {
+        return dep
+            .version_requirement()
+            .and_then(|req| concrete_pin_version(req.as_str(), ecosystem))
+            .map(str::to_string);
+    }
+
+    resolve_occurrence_version(
+        dep,
+        normalized_name,
+        resolved_versions,
+        resolved_version_candidates,
+        formatter,
+    )
+    .map(ConcreteVersion::to_string)
+    .or_else(|| {
         dep.version_requirement()
             .and_then(|req| concrete_pin_version(req.as_str(), ecosystem))
             .map(str::to_string)
-    } else {
-        resolved_versions
-            .get(normalized_name)
-            .or_else(|| resolved_versions.get(dep.name()))
-            .map(ConcreteVersion::to_string)
-            .or_else(|| {
-                dep.version_requirement()
-                    .and_then(|req| concrete_pin_version(req.as_str(), ecosystem))
-                    .map(str::to_string)
-            })
-    }
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Minimal formatter with a real `compile_requirement` (Cargo-style `semver::VersionReq`
+    /// semantics), for tests that must distinguish `best_candidate_for_requirement`'s
+    /// precise `compile_requirement` path from `MockFormatter`'s heuristic-only fallback
+    /// (issue #649 critic finding C1).
+    struct CaretFormatter;
+
+    struct SemverMatcher(semver::VersionReq);
+    impl crate::lsp_helpers::RequirementMatcher for SemverMatcher {
+        fn matches(&self, version: &ConcreteVersion) -> Option<bool> {
+            version
+                .as_str()
+                .parse::<semver::Version>()
+                .ok()
+                .map(|v| self.0.matches(&v))
+        }
+    }
+
+    impl crate::lsp_helpers::PackageNaming for CaretFormatter {}
+    impl crate::lsp_helpers::PackageRendering for CaretFormatter {
+        fn format_version_for_text_edit(&self, version: &ConcreteVersion) -> String {
+            version.to_string()
+        }
+        fn package_url(&self, name: &PackageName) -> String {
+            name.to_string()
+        }
+    }
+    impl crate::lsp_helpers::RequirementResolution for CaretFormatter {
+        fn compile_requirement(
+            &self,
+            requirement: &crate::VersionReq,
+        ) -> Option<Box<dyn crate::lsp_helpers::RequirementMatcher>> {
+            requirement
+                .as_str()
+                .parse::<semver::VersionReq>()
+                .ok()
+                .map(|req| {
+                    Box::new(SemverMatcher(req)) as Box<dyn crate::lsp_helpers::RequirementMatcher>
+                })
+        }
+    }
+    impl crate::lsp_helpers::DiagnosticMessages for CaretFormatter {}
+    impl crate::lsp_helpers::DiagnosticPolicy for CaretFormatter {}
+    impl crate::lsp_helpers::SourcePolicy for CaretFormatter {}
+    impl crate::lsp_helpers::OsvNaming for CaretFormatter {}
 
     #[test]
     fn is_concrete_version_accepts_explicit_pins_in_any_ecosystem() {
@@ -568,23 +707,18 @@ mod tests {
         );
     }
 
-    /// Known-limitation regression guard (deps-cargo `package = "..."` rename, issue
-    /// #648's follow-up): `resolved_versions` is keyed by name alone with one
-    /// highest-semver value per name (`ResolvedPackages`'s `best_package` collapse in
-    /// `crate::lockfile`), so two manifest occurrences of the same crate — one plain,
-    /// one renamed via `package = "..."` to select an older major — both resolve
-    /// `Dependency::name()` to the same registry name and therefore collide on the
-    /// same lockfile entry.
-    ///
-    /// This pins *today's* behavior (the renamed, older-major occurrence incorrectly
-    /// reports the newer major's lockfile version) so a fix — per-occurrence
-    /// resolution filtered by `version_requirement()`, the same class of gap as #394
-    /// — is a deliberate, visible behavior change here, not a silent one. Not a
-    /// desired outcome: see the critic handoff
-    /// (`.local/handoff/2026-09-05T23-48-31-critic.md`, finding S1) for the full
-    /// failure-mode analysis and the tracking follow-up.
+    /// Regression guard for issue #649 (deps-cargo `package = "..."` rename, follow-up to
+    /// #648): two manifest occurrences of the same crate — one plain, one renamed via
+    /// `package = "..."` to select an older major — both resolve `Dependency::name()` to
+    /// the same registry name. Before this fix, both collided on `resolved_versions`'s
+    /// single collapsed highest-semver entry (asserted by a since-superseded version of
+    /// this test — see the critic handoff `.local/handoff/2026-09-05T23-48-31-critic.md`,
+    /// finding S1, for the original failure-mode analysis). With
+    /// `resolved_version_candidates` populated, each occurrence now resolves to the
+    /// lock-file entry that actually satisfies its own `version_requirement()`
+    /// (US-001/US-002, FR-001/FR-002).
     #[test]
-    fn in_use_version_known_limitation_renamed_occurrence_collides_with_plain_one() {
+    fn in_use_version_renamed_occurrence_resolves_its_own_major() {
         use crate::VersionReq;
         use crate::lsp_helpers::test_support::MockDep;
 
@@ -594,22 +728,269 @@ mod tests {
             version_range: tower_lsp_server::ls_types::Range::default(),
             name_range: tower_lsp_server::ls_types::Range::default(),
         };
+        let plain_current_major = MockDep {
+            name: PackageName::new("serde"),
+            version_req: VersionReq::new("1.0"),
+            version_range: tower_lsp_server::ls_types::Range::default(),
+            name_range: tower_lsp_server::ls_types::Range::default(),
+        };
 
         let mut resolved_versions = HashMap::new();
         resolved_versions.insert(PackageName::new("serde"), ConcreteVersion::from("1.0.219"));
+        let mut candidates = HashMap::new();
+        candidates.insert(
+            PackageName::new("serde"),
+            vec![
+                ConcreteVersion::from("0.9.15"),
+                ConcreteVersion::from("1.0.219"),
+            ],
+        );
 
-        let result = in_use_version(
+        let renamed_result = in_use_version(
             &renamed_old_major,
             "serde",
             &resolved_versions,
+            Some(&candidates),
+            &crate::lsp_helpers::test_support::MockFormatter,
+            EcosystemId::Cargo,
+        );
+        let plain_result = in_use_version(
+            &plain_current_major,
+            "serde",
+            &resolved_versions,
+            Some(&candidates),
             &crate::lsp_helpers::test_support::MockFormatter,
             EcosystemId::Cargo,
         );
 
-        // Wrong today: this is `serde 0.9`'s occurrence, but the collapsed
-        // single-value-per-name map hands back the unrelated 1.x entry instead of
-        // `None` (which is what pre-#648 behavior produced for an unresolvable
-        // alias name — an honest "unknown" rather than a confidently wrong answer).
+        assert_eq!(renamed_result, Some("0.9.15".to_string()));
+        assert_eq!(plain_result, Some("1.0.219".to_string()));
+    }
+
+    /// FR-003: when no lock-file candidate satisfies the occurrence's own requirement, the
+    /// result is the honest "no concrete version" skip — never an arbitrary non-matching
+    /// entry.
+    #[test]
+    fn in_use_version_no_candidate_satisfies_requirement_returns_none() {
+        use crate::VersionReq;
+        use crate::lsp_helpers::test_support::MockDep;
+
+        let dep = MockDep {
+            name: PackageName::new("serde"),
+            version_req: VersionReq::new("0.9"),
+            version_range: tower_lsp_server::ls_types::Range::default(),
+            name_range: tower_lsp_server::ls_types::Range::default(),
+        };
+
+        let resolved_versions = HashMap::new();
+        let mut candidates = HashMap::new();
+        candidates.insert(
+            PackageName::new("serde"),
+            vec![
+                ConcreteVersion::from("1.0.219"),
+                ConcreteVersion::from("1.1.0"),
+            ],
+        );
+
+        let result = in_use_version(
+            &dep,
+            "serde",
+            &resolved_versions,
+            Some(&candidates),
+            &crate::lsp_helpers::test_support::MockFormatter,
+            EcosystemId::Cargo,
+        );
+
+        assert_eq!(result, None);
+    }
+
+    /// Edge case (spec section 6): a renamed occurrence with no `version_requirement()` to
+    /// disambiguate against falls back to the collapsed highest-semver value, same as
+    /// before this fix — no new skip-reason variant.
+    #[test]
+    fn in_use_version_no_requirement_falls_back_to_collapsed_value() {
+        use crate::lsp_helpers::test_support::MockMarkedDep;
+
+        let dep = MockMarkedDep {
+            name: PackageName::new("serde"),
+            name_range: tower_lsp_server::ls_types::Range::default(),
+            markers: None,
+        };
+
+        let mut resolved_versions = HashMap::new();
+        resolved_versions.insert(PackageName::new("serde"), ConcreteVersion::from("1.0.219"));
+        let mut candidates = HashMap::new();
+        candidates.insert(
+            PackageName::new("serde"),
+            vec![
+                ConcreteVersion::from("0.9.15"),
+                ConcreteVersion::from("1.0.219"),
+            ],
+        );
+
+        let result = in_use_version(
+            &dep,
+            "serde",
+            &resolved_versions,
+            Some(&candidates),
+            &crate::lsp_helpers::test_support::MockFormatter,
+            EcosystemId::Cargo,
+        );
+
         assert_eq!(result, Some("1.0.219".to_string()));
+    }
+
+    /// FR-005/NFR-001: a single-candidate name (the dominant case, no rename involved)
+    /// behaves identically whether or not a candidates map is supplied — the fast path
+    /// never routes through the per-occurrence filter.
+    #[test]
+    fn in_use_version_single_candidate_matches_collapsed_fast_path() {
+        use crate::VersionReq;
+        use crate::lsp_helpers::test_support::MockDep;
+
+        let dep = MockDep {
+            name: PackageName::new("serde"),
+            version_req: VersionReq::new("1.0"),
+            version_range: tower_lsp_server::ls_types::Range::default(),
+            name_range: tower_lsp_server::ls_types::Range::default(),
+        };
+
+        let mut resolved_versions = HashMap::new();
+        resolved_versions.insert(PackageName::new("serde"), ConcreteVersion::from("1.0.219"));
+        let mut candidates = HashMap::new();
+        candidates.insert(
+            PackageName::new("serde"),
+            vec![ConcreteVersion::from("1.0.219")],
+        );
+
+        let with_candidates = in_use_version(
+            &dep,
+            "serde",
+            &resolved_versions,
+            Some(&candidates),
+            &crate::lsp_helpers::test_support::MockFormatter,
+            EcosystemId::Cargo,
+        );
+        let without_candidates = in_use_version(
+            &dep,
+            "serde",
+            &resolved_versions,
+            None,
+            &crate::lsp_helpers::test_support::MockFormatter,
+            EcosystemId::Cargo,
+        );
+
+        assert_eq!(with_candidates, Some("1.0.219".to_string()));
+        assert_eq!(with_candidates, without_candidates);
+    }
+
+    /// Edge case (spec section 6): non-semver-parseable versions among the candidates fall
+    /// back to `compare_lockfile_versions`'s lexicographic tiebreak, not a second, divergent
+    /// comparison policy.
+    #[test]
+    fn best_candidate_for_requirement_non_semver_uses_lexicographic_tiebreak() {
+        // Testing gap 2 fix: both candidates must actually satisfy the requirement and
+        // both must fail semver parsing, so `max_by` is genuinely invoked on two elements
+        // and falls all the way to `compare_lockfile_versions`'s `(Err, Err) => a.cmp(b)`
+        // branch — a single-match case (the previous version of this test) never calls the
+        // comparator at all. `MockFormatter` has no `compile_requirement` override (default
+        // `None`), so this exercises the `version_satisfies_requirement` fallback path:
+        // requirement `"1"` is a partial-version bare requirement, and both `"1-rc1"` and
+        // `"1-rc2"` satisfy it via the `starts_with` branch (`lsp_helpers::mod::is_same_major_minor`
+        // fails for both, since neither has a `.`, but `starts_with("1")` holds for both).
+        let candidates = vec![
+            ConcreteVersion::from("1-rc1"),
+            ConcreteVersion::from("1-rc2"),
+        ];
+
+        let result = best_candidate_for_requirement(
+            &candidates,
+            &crate::VersionReq::new("1"),
+            &crate::lsp_helpers::test_support::MockFormatter,
+        );
+
+        assert_eq!(result, Some(&ConcreteVersion::from("1-rc2")));
+    }
+
+    /// C1 fix regression guard: `best_candidate_for_requirement` must prefer
+    /// `compile_requirement`'s precise comparator over `version_satisfies_requirement`'s
+    /// heuristic. The heuristic's partial-requirement branch requires *minor-version
+    /// equality*, so a Cargo-style caret requirement `"2.4"` (meaning `>=2.4.0, <3.0.0`)
+    /// would wrongly reject `2.9.4` under the heuristic alone — this is the exact
+    /// false-negative the critic's C1 finding identified (a real dependency silently
+    /// dropped from in-use-version resolution, and therefore from the OSV scan).
+    #[test]
+    fn best_candidate_for_requirement_uses_compile_requirement_when_available() {
+        use crate::VersionReq;
+
+        let candidates = vec![
+            ConcreteVersion::from("1.3.2"),
+            ConcreteVersion::from("2.9.4"),
+        ];
+
+        // Bare "2.4" under Cargo's real semver semantics is a caret range matching
+        // 2.9.4, not 1.3.2 — but the heuristic's minor-equality check would reject both
+        // (neither candidate has minor "4"), producing a false FR-003 skip.
+        let result =
+            best_candidate_for_requirement(&candidates, &VersionReq::new("2.4"), &CaretFormatter);
+
+        assert_eq!(result, Some(&ConcreteVersion::from("2.9.4")));
+    }
+
+    /// FR-002: when more than one lock-file entry satisfies an occurrence's requirement,
+    /// the tiebreak must pick the highest-semver *among the satisfying subset*, not the
+    /// highest overall — `2.0.0` here is the highest candidate but does not satisfy `^1.0`,
+    /// so it must never be picked.
+    #[test]
+    fn best_candidate_for_requirement_picks_highest_of_satisfying_subset() {
+        use crate::VersionReq;
+
+        let candidates = vec![
+            ConcreteVersion::from("1.0.1"),
+            ConcreteVersion::from("1.0.5"),
+            ConcreteVersion::from("2.0.0"),
+        ];
+
+        let result =
+            best_candidate_for_requirement(&candidates, &VersionReq::new("^1.0"), &CaretFormatter);
+
+        assert_eq!(result, Some(&ConcreteVersion::from("1.0.5")));
+    }
+
+    /// FR-002 end-to-end through `in_use_version`/`resolve_occurrence_version`, not just the
+    /// isolated `best_candidate_for_requirement` helper.
+    #[test]
+    fn in_use_version_tiebreaks_among_multiple_satisfying_candidates() {
+        use crate::VersionReq;
+        use crate::lsp_helpers::test_support::MockDep;
+
+        let dep = MockDep {
+            name: PackageName::new("pkg"),
+            version_req: VersionReq::new("^1.0"),
+            version_range: tower_lsp_server::ls_types::Range::default(),
+            name_range: tower_lsp_server::ls_types::Range::default(),
+        };
+
+        let resolved_versions = HashMap::new();
+        let mut candidates = HashMap::new();
+        candidates.insert(
+            PackageName::new("pkg"),
+            vec![
+                ConcreteVersion::from("1.0.1"),
+                ConcreteVersion::from("1.0.5"),
+                ConcreteVersion::from("2.0.0"),
+            ],
+        );
+
+        let result = in_use_version(
+            &dep,
+            "pkg",
+            &resolved_versions,
+            Some(&candidates),
+            &CaretFormatter,
+            EcosystemId::Cargo,
+        );
+
+        assert_eq!(result, Some("1.0.5".to_string()));
     }
 }

--- a/crates/deps-core/src/lsp_helpers/inlay_hints.rs
+++ b/crates/deps-core/src/lsp_helpers/inlay_hints.rs
@@ -2,7 +2,7 @@ use tower_lsp_server::ls_types::{InlayHint, InlayHintKind, InlayHintLabel, Inlay
 
 use crate::{ConcreteVersion, EcosystemConfig, ParseResult};
 
-use super::{EcosystemFormatter, RequirementStatus, VersionData};
+use super::{EcosystemFormatter, RequirementStatus, VersionData, in_use_version};
 
 pub fn generate_inlay_hints(
     parse_result: &dyn ParseResult,
@@ -30,11 +30,14 @@ pub fn generate_inlay_hints(
                 dep.version_requirement()
                     .map(|r| ConcreteVersion::new(r.as_str()))
             } else {
-                versions
-                    .resolved
-                    .get(normalized_name.as_str())
-                    .or_else(|| versions.resolved.get(dep.name()))
-                    .cloned()
+                in_use_version::resolve_occurrence_version(
+                    dep,
+                    normalized_name.as_str(),
+                    versions.resolved,
+                    versions.resolved_version_candidates,
+                    formatter,
+                )
+                .cloned()
             };
 
         // Show loading hint if loading and no cached version

--- a/crates/deps-core/src/lsp_helpers/mod.rs
+++ b/crates/deps-core/src/lsp_helpers/mod.rs
@@ -19,7 +19,7 @@ mod hover;
 mod in_use_version;
 mod inlay_hints;
 #[cfg(test)]
-mod test_support;
+pub(crate) mod test_support;
 
 pub use code_actions::generate_code_actions;
 pub use code_lenses::{
@@ -432,6 +432,15 @@ pub struct VersionData<'a> {
     pub cached: &'a HashMap<PackageName, PackageVersions>,
     /// Versions actually resolved in the lock file, keyed by package name.
     pub resolved: &'a HashMap<PackageName, ConcreteVersion>,
+    /// Every lock-file-resolved version for a package name, when more than one is retained
+    /// (issue #649) — additive alongside [`Self::resolved`], which stays the single
+    /// collapsed value for the common case. `None` by default (most call sites have no such
+    /// map); [`crate::lsp_helpers::in_use_version`] and [`crate::osv::vulnerability_keys`]
+    /// consult it to disambiguate two manifest occurrences of one resolved name (e.g. a
+    /// Cargo `package = "..."` rename pinning an older major) by each occurrence's own
+    /// `version_requirement()`, falling back to [`Self::resolved`] when a name has at most
+    /// one candidate.
+    pub resolved_version_candidates: Option<&'a HashMap<PackageName, Vec<ConcreteVersion>>>,
     /// OSV scan results, keyed by normalized package name. `None` when no
     /// scan has run yet (e.g. the feature is disabled) — distinct from an
     /// empty map, which would mean "scanned, nothing found".
@@ -501,12 +510,38 @@ impl<'a> VersionData<'a> {
         Self {
             cached,
             resolved,
+            resolved_version_candidates: None,
             vulnerabilities: None,
             outcomes: None,
             ecosystem: None,
             offline: false,
             trust: None,
         }
+    }
+
+    /// Attaches the per-name lock-file candidates map, enabling the per-occurrence
+    /// disambiguation described on [`Self::resolved_version_candidates`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use deps_core::VersionData;
+    /// use std::collections::HashMap;
+    ///
+    /// let cached = HashMap::new();
+    /// let resolved = HashMap::new();
+    /// let candidates = HashMap::new();
+    /// let versions =
+    ///     VersionData::new(&cached, &resolved).with_resolved_version_candidates(&candidates);
+    /// assert!(versions.resolved_version_candidates.is_some());
+    /// ```
+    #[must_use]
+    pub const fn with_resolved_version_candidates(
+        mut self,
+        candidates: &'a HashMap<PackageName, Vec<ConcreteVersion>>,
+    ) -> Self {
+        self.resolved_version_candidates = Some(candidates);
+        self
     }
 
     /// Attaches an OSV scan result to this `VersionData`.

--- a/crates/deps-core/src/osv/types.rs
+++ b/crates/deps-core/src/osv/types.rs
@@ -639,7 +639,7 @@ pub type VulnerabilityMap = HashMap<String, ScanOutcome>;
 /// };
 /// let resolved: HashMap<PackageName, ConcreteVersion> = HashMap::new();
 ///
-/// let keys = vulnerability_keys(&parse_result, &resolved, &SimpleFormatter, EcosystemId::Cargo);
+/// let keys = vulnerability_keys(&parse_result, &resolved, None, &SimpleFormatter, EcosystemId::Cargo);
 /// let deps = parse_result.dependencies();
 /// let key0 = keys.get(&deps[0].name_range()).unwrap();
 /// let key1 = keys.get(&deps[1].name_range()).unwrap();
@@ -648,6 +648,7 @@ pub type VulnerabilityMap = HashMap<String, ScanOutcome>;
 pub fn vulnerability_keys(
     parse_result: &dyn crate::ParseResult,
     resolved: &HashMap<crate::PackageName, crate::ConcreteVersion>,
+    resolved_candidates: Option<&HashMap<crate::PackageName, Vec<crate::ConcreteVersion>>>,
     formatter: &dyn crate::lsp_helpers::EcosystemFormatter,
     ecosystem: crate::EcosystemId,
 ) -> HashMap<tower_lsp_server::ls_types::Range, String> {
@@ -661,12 +662,24 @@ pub fn vulnerability_keys(
     // lock file); every other source (git/path forks, a genuinely different private
     // registry) always carries "n", since their `ScanOutcome` is always
     // `Skipped(NonRegistrySource)` regardless of any declared version.
+    //
+    // `resolved_candidates` (issue #649) lets two occurrences of a renamed/aliased name
+    // pinned to different lock-file majors compute distinct `v:{version}` signatures
+    // instead of colliding on one collapsed value — see
+    // `crate::lsp_helpers::in_use_version::resolve_occurrence_version`.
     let signatures: Vec<(String, String)> = deps
         .iter()
         .map(|dep| {
             let name = formatter.normalize_package_name(dep.name());
             let signature = if formatter.source_is_public_registry_content(&dep.source()) {
-                match in_use_version(*dep, &name, resolved, formatter, ecosystem) {
+                match in_use_version(
+                    *dep,
+                    &name,
+                    resolved,
+                    resolved_candidates,
+                    formatter,
+                    ecosystem,
+                ) {
                     Some(v) => format!("v:{v}"),
                     None => "u".to_string(),
                 }
@@ -1164,5 +1177,100 @@ mod osv_version_validation_tests {
         for v in ["1.0.0\", git = \"evil", "1.0.0,2.0.0", "1.0.0\nEvil", ""] {
             assert!(!is_safe_version_string(v), "expected {v:?} to be rejected");
         }
+    }
+}
+
+/// Issue #649 FR-004: `vulnerability_keys` with a populated `resolved_candidates` map, the
+/// exact call shape `deps-lsp`'s `build_scan_targets`/phase A OSV scan use. Every production
+/// `vulnerability_keys` call site was migrated to accept this parameter, but per the
+/// pre-review test-coverage audit, every *test* call site only ever passed `None` — this
+/// closes that direct-coverage gap.
+#[cfg(test)]
+mod vulnerability_keys_candidates_tests {
+    use super::*;
+    use crate::lsp_helpers::test_support::{MockDep, MockFormatter};
+    use crate::{ConcreteVersion, EcosystemId, PackageName, ParseResult, VersionReq};
+    use tower_lsp_server::ls_types::{Position, Range};
+
+    #[test]
+    fn distinct_signatures_for_two_occurrences_resolving_to_different_candidates() {
+        // The serde/serde_old shape from issue #649: one plain occurrence pinned to the
+        // current major, one renamed occurrence pinned to an older major, both sharing the
+        // resolved package name `serde`.
+        let current_major = MockDep {
+            name: PackageName::new("serde"),
+            version_req: VersionReq::new("1.0"),
+            version_range: Range::new(Position::new(0, 0), Position::new(0, 4)),
+            name_range: Range::new(Position::new(0, 0), Position::new(0, 5)),
+        };
+        let renamed_old_major = MockDep {
+            name: PackageName::new("serde"),
+            version_req: VersionReq::new("0.9"),
+            version_range: Range::new(Position::new(1, 0), Position::new(1, 4)),
+            name_range: Range::new(Position::new(1, 0), Position::new(1, 9)),
+        };
+
+        struct TwoOccurrenceParseResult {
+            deps: Vec<MockDep>,
+            uri: tower_lsp_server::ls_types::Uri,
+        }
+        impl crate::ParseResult for TwoOccurrenceParseResult {
+            fn dependencies(&self) -> Vec<&dyn crate::Dependency> {
+                self.deps
+                    .iter()
+                    .map(|d| d as &dyn crate::Dependency)
+                    .collect()
+            }
+            fn workspace_root(&self) -> Option<&std::path::Path> {
+                None
+            }
+            fn uri(&self) -> &tower_lsp_server::ls_types::Uri {
+                &self.uri
+            }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+        }
+
+        let parse_result = TwoOccurrenceParseResult {
+            deps: vec![current_major, renamed_old_major],
+            uri: crate::test_util::test_uri("/test/Cargo.toml"),
+        };
+
+        let mut resolved = std::collections::HashMap::new();
+        resolved.insert(PackageName::new("serde"), ConcreteVersion::from("1.0.219"));
+        let mut candidates = std::collections::HashMap::new();
+        candidates.insert(
+            PackageName::new("serde"),
+            vec![
+                ConcreteVersion::from("0.9.15"),
+                ConcreteVersion::from("1.0.219"),
+            ],
+        );
+
+        let keys = vulnerability_keys(
+            &parse_result,
+            &resolved,
+            Some(&candidates),
+            &MockFormatter,
+            EcosystemId::Cargo,
+        );
+        let deps = parse_result.dependencies();
+        let current_key = keys.get(&deps[0].name_range()).unwrap();
+        let renamed_key = keys.get(&deps[1].name_range()).unwrap();
+
+        assert_ne!(
+            current_key, renamed_key,
+            "the current-major and renamed-old-major occurrences must not share an OSV key"
+        );
+        assert!(
+            current_key.ends_with("v:1.0.219"),
+            "current-major occurrence's key must carry its own resolved version: {current_key}"
+        );
+        assert!(
+            renamed_key.ends_with("v:0.9.15"),
+            "renamed occurrence's key must carry its own resolved version, not the collapsed \
+             1.0.219: {renamed_key}"
+        );
     }
 }

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -185,6 +185,14 @@ fn preserve_cache(new_state: &mut DocumentState, old_state: &DocumentState) {
     new_state
         .resolved_versions
         .clone_from(&old_state.resolved_versions);
+    // Must travel with `resolved_versions` (issue #649 critic S1): a per-occurrence
+    // resolution that only preserved the collapsed map while resetting this sibling to
+    // empty would silently reintroduce the mis-attribution bug for the ~100ms debounce +
+    // lockfile-reload window on every keystroke, since `resolve_occurrence_version` only
+    // consults the candidates map when it is populated.
+    new_state
+        .resolved_version_candidates
+        .clone_from(&old_state.resolved_version_candidates);
     // DocumentState is rebuilt on every change, so without this the OSV scan
     // result would be wiped on every keystroke — `run_osv_scan` overwrites it
     // once the (cheap, cache-backed) rescan completes, see §4.
@@ -347,6 +355,7 @@ const OSV_SCAN_TIMEOUT_CEILING_SECS: u64 = 30;
 fn collect_in_use_versions(
     parse_result: &dyn deps_core::ParseResult,
     resolved_versions: &HashMap<PackageName, ConcreteVersion>,
+    resolved_version_candidates: &HashMap<PackageName, Vec<ConcreteVersion>>,
     formatter: &dyn deps_core::lsp_helpers::EcosystemFormatter,
     ecosystem: EcosystemId,
 ) -> HashMap<PackageName, Vec<String>> {
@@ -361,6 +370,7 @@ fn collect_in_use_versions(
             dep,
             &normalized_name,
             resolved_versions,
+            Some(resolved_version_candidates),
             formatter,
             ecosystem,
         ) {
@@ -417,6 +427,7 @@ fn collect_in_use_versions(
 fn build_scan_targets(
     parse_result: &dyn deps_core::ParseResult,
     resolved_versions: &HashMap<PackageName, ConcreteVersion>,
+    resolved_version_candidates: &HashMap<PackageName, Vec<ConcreteVersion>>,
     formatter: &dyn deps_core::lsp_helpers::EcosystemFormatter,
     ecosystem: EcosystemId,
 ) -> (
@@ -427,8 +438,13 @@ fn build_scan_targets(
 
     let mut targets = Vec::new();
     let mut skipped = deps_core::osv::VulnerabilityMap::new();
-    let keys =
-        deps_core::osv::vulnerability_keys(parse_result, resolved_versions, formatter, ecosystem);
+    let keys = deps_core::osv::vulnerability_keys(
+        parse_result,
+        resolved_versions,
+        Some(resolved_version_candidates),
+        formatter,
+        ecosystem,
+    );
 
     for dep in parse_result.dependencies() {
         let normalized_name = formatter.normalize_package_name(dep.name());
@@ -456,6 +472,7 @@ fn build_scan_targets(
             dep,
             &normalized_name,
             resolved_versions,
+            Some(resolved_version_candidates),
             formatter,
             ecosystem,
         );
@@ -543,6 +560,7 @@ async fn run_osv_scan_phase_a(
         let (targets, skipped) = build_scan_targets(
             parse_result,
             &doc.resolved_versions,
+            &doc.resolved_version_candidates,
             ecosystem.formatter(),
             ecosystem_id,
         );
@@ -553,6 +571,7 @@ async fn run_osv_scan_phase_a(
         let vuln_keys = deps_core::osv::vulnerability_keys(
             parse_result,
             &doc.resolved_versions,
+            Some(&doc.resolved_version_candidates),
             ecosystem.formatter(),
             ecosystem_id,
         );
@@ -1700,13 +1719,17 @@ async fn run_document_open_background_task(
     tracing::debug!("background task started");
 
     // Load resolved versions from lock file first (instant, no network)
-    let resolved_versions = load_resolved_versions(&uri, &state, ecosystem.as_ref()).await;
+    let (resolved_versions, resolved_version_candidates) =
+        load_resolved_versions(&uri, &state, ecosystem.as_ref()).await;
 
     // Update document state with resolved versions immediately
     if !resolved_versions.is_empty()
         && let Some(mut doc) = state.documents.get_mut(&uri)
     {
-        doc.update_resolved_versions(resolved_versions.clone());
+        doc.update_resolved_versions(
+            resolved_versions.clone(),
+            resolved_version_candidates.clone(),
+        );
 
         // Use resolved versions as cached versions for instant display,
         // except for a dependency whose manifest requirement is itself
@@ -1783,6 +1806,7 @@ async fn run_document_open_background_task(
         let in_use = collect_in_use_versions(
             parse_result,
             &resolved_versions,
+            &resolved_version_candidates,
             ecosystem.formatter(),
             resolve_ecosystem_id(ecosystem.as_ref()),
         );
@@ -2111,6 +2135,9 @@ fn commit_parsed_document(
     for removed_dep in &diff.removed {
         doc_state.cached_versions.remove(removed_dep);
         doc_state.resolved_versions.remove(removed_dep);
+        // Raw-`dep.name()`-keyed, same as `resolved_versions` above (issue #649) — must be
+        // pruned alongside it so a removed dependency's stale candidates never linger.
+        doc_state.resolved_version_candidates.remove(removed_dep);
         doc_state
             .vulnerabilities
             .remove(&formatter.normalize_package_name(removed_dep));
@@ -2324,14 +2351,18 @@ async fn run_document_change_task(
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
     // Load resolved versions from lock file first (instant, no network)
-    let resolved_versions = load_resolved_versions(&uri, &state, ecosystem.as_ref()).await;
+    let (resolved_versions, resolved_version_candidates) =
+        load_resolved_versions(&uri, &state, ecosystem.as_ref()).await;
 
     // Update document state with resolved versions only
     // Do NOT touch cached_versions - they contain latest registry versions
     if !resolved_versions.is_empty()
         && let Some(mut doc) = state.documents.get_mut(&uri)
     {
-        doc.update_resolved_versions(resolved_versions.clone());
+        doc.update_resolved_versions(
+            resolved_versions.clone(),
+            resolved_version_candidates.clone(),
+        );
     }
 
     // Phase A OSV scan (only when a dependency was added or an existing
@@ -2399,6 +2430,7 @@ async fn run_document_change_task(
             &client,
             ecosystem.as_ref(),
             &resolved_versions,
+            &resolved_version_candidates,
             deps_to_fetch,
             config.freshness,
             config.cache.fetch_timeout_secs,
@@ -2536,6 +2568,7 @@ async fn fetch_registry_versions_for_change(
     client: &Client,
     ecosystem: &dyn Ecosystem,
     resolved_versions: &HashMap<PackageName, ConcreteVersion>,
+    resolved_version_candidates: &HashMap<PackageName, Vec<ConcreteVersion>>,
     deps_to_fetch: Vec<PackageName>,
     freshness_settings: deps_core::FreshnessSettings,
     fetch_timeout_secs: u64,
@@ -2600,6 +2633,7 @@ async fn fetch_registry_versions_for_change(
                     collect_in_use_versions(
                         pr,
                         resolved_versions,
+                        resolved_version_candidates,
                         ecosystem.formatter(),
                         resolve_ecosystem_id(ecosystem),
                     ),
@@ -2728,21 +2762,59 @@ fn cached_versions_from_lockfile(
         .collect()
 }
 
+/// Splits a parsed [`deps_core::lockfile::ResolvedPackages`] into the collapsed
+/// `dep_name -> version` map (`ResolvedPackages::iter`, unchanged FR-005 fast path) and a
+/// sibling `dep_name -> [version, ...]` map (issue #649) holding every retained lock-file
+/// entry for names with more than one — built from `ResolvedPackages::iter_all`, and
+/// deliberately omitting a single-occurrence name entirely (NFR-003: the common case never
+/// pays for a candidates-map lookup).
+///
+/// Shared by [`load_resolved_versions`] and `DepsLanguageServer`'s watched-lock-file-change
+/// handler (`server.rs`) — both re-parse a lock file and need the identical split.
+pub(crate) fn split_resolved_packages(
+    resolved: &deps_core::lockfile::ResolvedPackages,
+) -> (
+    HashMap<PackageName, ConcreteVersion>,
+    HashMap<PackageName, Vec<ConcreteVersion>>,
+) {
+    let versions = resolved
+        .iter()
+        .map(|(name, pkg)| (PackageName::new(name.as_str()), pkg.version.clone().into()))
+        .collect();
+    let candidates = resolved
+        .iter_all()
+        .filter(|(_, versions)| versions.len() > 1)
+        .map(|(name, versions)| {
+            (
+                PackageName::new(name.as_str()),
+                versions
+                    .iter()
+                    .map(|pkg| ConcreteVersion::from(pkg.version.clone()))
+                    .collect(),
+            )
+        })
+        .collect();
+    (versions, candidates)
+}
+
 /// Loads resolved versions from lock file for a given manifest URI.
 ///
-/// Uses the ecosystem's lockfile provider to parse the lock file.
-/// Returns a HashMap mapping package names to their resolved versions.
-/// Returns an empty HashMap if no lock file is found or parsing fails.
+/// Uses the ecosystem's lockfile provider to parse the lock file, then
+/// [`split_resolved_packages`]. Both returned maps are empty if no lock file is found or
+/// parsing fails.
 async fn load_resolved_versions(
     uri: &Uri,
     state: &ServerState,
     ecosystem: &dyn Ecosystem,
-) -> HashMap<PackageName, ConcreteVersion> {
+) -> (
+    HashMap<PackageName, ConcreteVersion>,
+    HashMap<PackageName, Vec<ConcreteVersion>>,
+) {
     let lock_provider = match ecosystem.lockfile_provider() {
         Some(p) => p,
         None => {
             tracing::debug!("No lock file provider for ecosystem {}", ecosystem.id());
-            return HashMap::new();
+            return (HashMap::new(), HashMap::new());
         }
     };
 
@@ -2750,7 +2822,7 @@ async fn load_resolved_versions(
         Some(path) => path,
         None => {
             tracing::debug!("No lock file found for {:?}", uri);
-            return HashMap::new();
+            return (HashMap::new(), HashMap::new());
         }
     };
 
@@ -2765,14 +2837,11 @@ async fn load_resolved_versions(
                 resolved.len(),
                 lockfile_path.display()
             );
-            resolved
-                .iter()
-                .map(|(name, pkg)| (PackageName::new(name.as_str()), pkg.version.clone().into()))
-                .collect()
+            split_resolved_packages(&resolved)
         }
         Err(e) => {
             tracing::warn!("Failed to parse lock file: {}", e);
-            HashMap::new()
+            (HashMap::new(), HashMap::new())
         }
     }
 }
@@ -2993,10 +3062,10 @@ mod tests {
                 PackageName::new("serde"),
                 PackageVersions::latest_only("1.0.0"),
             )]));
-            doc.update_resolved_versions(HashMap::from([(
-                PackageName::new("serde"),
-                ConcreteVersion::new("1.0.0"),
-            )]));
+            doc.update_resolved_versions(
+                HashMap::from([(PackageName::new("serde"), ConcreteVersion::new("1.0.0"))]),
+                HashMap::new(),
+            );
             doc.replace_outcomes(
                 DependencyOutcomes::new()
                     .with_fetch_failure("serde", FetchFailure::Transient)
@@ -6714,6 +6783,7 @@ dependencies = ["requests>=2.0.0"]
             let in_use = collect_in_use_versions(
                 parse_result.as_ref(),
                 &resolved_versions,
+                &HashMap::new(),
                 formatter,
                 EcosystemId::Pypi,
             );
@@ -7022,6 +7092,66 @@ tokio = "1.0"
             }
         }
 
+        /// Regression guard for issue #649 critic finding S1: `resolved_version_candidates`
+        /// must travel with `resolved_versions` through `preserve_cache`, not reset to empty
+        /// on every keystroke — a desync here would silently reintroduce #649's
+        /// mis-attribution bug for the debounce + lockfile-reload window between each edit
+        /// and `run_document_change_task`'s repopulation of the candidates map.
+        #[tokio::test]
+        async fn test_preserve_cache_carries_resolved_version_candidates_across_edit() {
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+
+            let content1 = r#"[dependencies]
+serde = "1.0"
+serde_old = { package = "serde", version = "0.9" }
+"#;
+
+            let ecosystem = state.ecosystem_registry.get("cargo").unwrap();
+            let parse_result1 = ecosystem.parse_manifest(content1, &uri).await.unwrap();
+            let doc_state1 = DocumentState::new_from_parse_result(
+                EcosystemId::Cargo,
+                content1.to_string(),
+                parse_result1,
+            );
+            state.update_document(uri.clone(), doc_state1);
+
+            // Manually populate the candidates map (simulating a completed lockfile load).
+            {
+                let mut doc = state.documents.get_mut(&uri).unwrap();
+                doc.resolved_versions
+                    .insert("serde".into(), "1.0.219".into());
+                doc.resolved_version_candidates
+                    .insert("serde".into(), vec!["0.9.15".into(), "1.0.219".into()]);
+            }
+
+            // Trivial re-edit (whitespace-only) — this must not reset the candidates map.
+            let content2 = r#"[dependencies]
+serde = "1.0"
+serde_old = { package = "serde", version = "0.9" }
+
+"#;
+            let parse_result2 = ecosystem.parse_manifest(content2, &uri).await.unwrap();
+            let mut doc_state2 = DocumentState::new_from_parse_result(
+                EcosystemId::Cargo,
+                content2.to_string(),
+                parse_result2,
+            );
+
+            if let Some(old_doc) = state.get_document(&uri) {
+                preserve_cache(&mut doc_state2, &old_doc);
+            }
+
+            assert_eq!(
+                doc_state2.resolved_version_candidates.get("serde"),
+                Some(&vec![
+                    ConcreteVersion::from("0.9.15"),
+                    ConcreteVersion::from("1.0.219")
+                ]),
+                "resolved_version_candidates must survive preserve_cache alongside resolved_versions"
+            );
+        }
+
         #[tokio::test]
         async fn test_preserve_cache_carries_vulnerabilities_across_edit() {
             use deps_core::osv::{ScanOutcome, VulnerabilityMap};
@@ -7245,6 +7375,67 @@ serde = "1.0"
             assert!(
                 doc.outcomes.deprecation("time").is_none(),
                 "removed dependency's deprecation entry must be pruned"
+            );
+        }
+
+        /// Regression guard for issue #649 critic finding S1: `resolved_version_candidates`
+        /// is raw-`dep.name()`-keyed exactly like `resolved_versions`, so it must be pruned
+        /// on dependency removal the same way, not left holding a stale candidates list for
+        /// a name no longer in the manifest.
+        #[tokio::test]
+        async fn test_resolved_version_candidates_pruned_on_dependency_removal() {
+            let state = Arc::new(ServerState::new());
+            let uri = deps_core::test_util::test_uri("/test/Cargo.toml");
+
+            let content1 = r#"[dependencies]
+serde = "1.0"
+serde_old = { package = "serde", version = "0.9" }
+"#;
+            let ecosystem = state.ecosystem_registry.get("cargo").unwrap();
+            let parse_result1 = ecosystem.parse_manifest(content1, &uri).await.unwrap();
+            let doc_state1 = DocumentState::new_from_parse_result(
+                EcosystemId::Cargo,
+                content1.to_string(),
+                parse_result1,
+            );
+            state.update_document(uri.clone(), doc_state1);
+
+            {
+                let mut doc = state.documents.get_mut(&uri).unwrap();
+                doc.resolved_versions
+                    .insert("serde".into(), "1.0.219".into());
+                doc.resolved_version_candidates
+                    .insert("serde".into(), vec!["0.9.15".into(), "1.0.219".into()]);
+            }
+
+            // Both manifest entries removed — `serde`'s candidates must be pruned along
+            // with `resolved_versions`, not left behind as stale data.
+            let content2 = "[dependencies]\n";
+            let old_deps: HashMap<PackageName, Vec<Option<VersionReq>>> =
+                std::iter::once((PackageName::new("serde"), vec![None])).collect();
+            let new_deps: HashMap<PackageName, Vec<Option<VersionReq>>> = HashMap::new();
+            let diff = DependencyDiff::compute(&old_deps, &new_deps);
+            assert_eq!(diff.removed, vec![PackageName::new("serde")]);
+
+            let parse_result2 = ecosystem.parse_manifest(content2, &uri).await.unwrap();
+            let mut doc_state2 = DocumentState::new_from_parse_result(
+                EcosystemId::Cargo,
+                content2.to_string(),
+                parse_result2,
+            );
+
+            if let Some(old_doc) = state.get_document(&uri) {
+                preserve_cache(&mut doc_state2, &old_doc);
+            }
+            for removed_dep in &diff.removed {
+                doc_state2.cached_versions.remove(removed_dep);
+                doc_state2.resolved_versions.remove(removed_dep);
+                doc_state2.resolved_version_candidates.remove(removed_dep);
+            }
+
+            assert!(
+                !doc_state2.resolved_version_candidates.contains_key("serde"),
+                "removed dependency's candidates entry must be pruned"
             );
         }
 
@@ -8543,8 +8734,13 @@ tokio = "1.0"
             let mut resolved = HashMap::new();
             resolved.insert(PackageName::new("time"), "0.1.43".into());
 
-            let (targets, skipped) =
-                build_scan_targets(&parse_result, &resolved, &MockFormatter, EcosystemId::Cargo);
+            let (targets, skipped) = build_scan_targets(
+                &parse_result,
+                &resolved,
+                &HashMap::new(),
+                &MockFormatter,
+                EcosystemId::Cargo,
+            );
             assert!(targets.is_empty());
             assert_matches!(
                 skipped.get("time"),
@@ -8564,8 +8760,13 @@ tokio = "1.0"
             let mut resolved = HashMap::new();
             resolved.insert(PackageName::new("serde"), "1.0.195".into());
 
-            let (targets, skipped) =
-                build_scan_targets(&parse_result, &resolved, &MockFormatter, EcosystemId::Cargo);
+            let (targets, skipped) = build_scan_targets(
+                &parse_result,
+                &resolved,
+                &HashMap::new(),
+                &MockFormatter,
+                EcosystemId::Cargo,
+            );
             assert_eq!(targets.len(), 1);
             assert_eq!(targets[0].version, "1.0.195");
             assert!(skipped.is_empty());
@@ -8650,6 +8851,7 @@ tokio = "1.0"
             let (targets, skipped) = build_scan_targets(
                 &parse_result,
                 &resolved,
+                &HashMap::new(),
                 &MockVPrefixFormatter,
                 EcosystemId::Go,
             );
@@ -8676,8 +8878,13 @@ tokio = "1.0"
             let mut resolved = HashMap::new();
             resolved.insert(PackageName::new("serde"), "1.0.195".into());
 
-            let (targets, skipped) =
-                build_scan_targets(&parse_result, &resolved, &MockFormatter, EcosystemId::Cargo);
+            let (targets, skipped) = build_scan_targets(
+                &parse_result,
+                &resolved,
+                &HashMap::new(),
+                &MockFormatter,
+                EcosystemId::Cargo,
+            );
             assert_eq!(targets.len(), 1);
             assert_eq!(targets[0].version, "1.0.195");
             assert_eq!(targets[0].display_version, "1.0.195");
@@ -8708,8 +8915,13 @@ tokio = "1.0"
             // tidy`) performed.
             resolved.insert(PackageName::new("github.com/pkg/errors"), "v0.9.1".into());
 
-            let (targets, skipped) =
-                build_scan_targets(&parse_result, &resolved, &MockGoFormatter, EcosystemId::Go);
+            let (targets, skipped) = build_scan_targets(
+                &parse_result,
+                &resolved,
+                &HashMap::new(),
+                &MockGoFormatter,
+                EcosystemId::Go,
+            );
             assert_eq!(targets.len(), 1);
             assert_eq!(targets[0].version, "v0.8.1");
             assert_eq!(targets[0].display_version, "v0.8.1");
@@ -8727,8 +8939,13 @@ tokio = "1.0"
             };
             let resolved = HashMap::new();
 
-            let (targets, skipped) =
-                build_scan_targets(&parse_result, &resolved, &MockFormatter, EcosystemId::Maven);
+            let (targets, skipped) = build_scan_targets(
+                &parse_result,
+                &resolved,
+                &HashMap::new(),
+                &MockFormatter,
+                EcosystemId::Maven,
+            );
             assert_eq!(targets.len(), 1);
             assert_eq!(targets[0].version, "2.14.1");
             assert!(skipped.is_empty());
@@ -8752,6 +8969,7 @@ tokio = "1.0"
             let (targets, skipped) = build_scan_targets(
                 &cargo_result,
                 &HashMap::new(),
+                &HashMap::new(),
                 &MockFormatter,
                 EcosystemId::Cargo,
             );
@@ -8768,6 +8986,7 @@ tokio = "1.0"
             };
             let (targets, skipped) = build_scan_targets(
                 &nuget_result,
+                &HashMap::new(),
                 &HashMap::new(),
                 &MockFormatter,
                 EcosystemId::NuGet,
@@ -8788,8 +9007,13 @@ tokio = "1.0"
             };
             let resolved = HashMap::new();
 
-            let (targets, skipped) =
-                build_scan_targets(&parse_result, &resolved, &MockFormatter, EcosystemId::Cargo);
+            let (targets, skipped) = build_scan_targets(
+                &parse_result,
+                &resolved,
+                &HashMap::new(),
+                &MockFormatter,
+                EcosystemId::Cargo,
+            );
             assert!(targets.is_empty());
             assert_matches!(
                 skipped.get("serde"),
@@ -8808,8 +9032,13 @@ tokio = "1.0"
             };
             let resolved = HashMap::new();
 
-            let (targets, skipped) =
-                build_scan_targets(&parse_result, &resolved, &MockFormatter, EcosystemId::Cargo);
+            let (targets, skipped) = build_scan_targets(
+                &parse_result,
+                &resolved,
+                &HashMap::new(),
+                &MockFormatter,
+                EcosystemId::Cargo,
+            );
             assert!(targets.is_empty());
             assert_matches!(
                 skipped.get("serde"),
@@ -8849,6 +9078,7 @@ tokio = "1.0"
                 let (targets, skipped) = build_scan_targets(
                     &parse_result,
                     &resolved,
+                    &HashMap::new(),
                     &MockFormatter,
                     EcosystemId::Cargo,
                 );
@@ -8888,8 +9118,13 @@ tokio = "1.0"
             };
             let resolved = HashMap::new();
 
-            let (targets, skipped) =
-                build_scan_targets(&parse_result, &resolved, &MockFormatter, EcosystemId::Maven);
+            let (targets, skipped) = build_scan_targets(
+                &parse_result,
+                &resolved,
+                &HashMap::new(),
+                &MockFormatter,
+                EcosystemId::Maven,
+            );
 
             assert_eq!(targets.len(), 1);
             assert_eq!(targets[0].key, "concrete");
@@ -8923,6 +9158,7 @@ tokio = "1.0"
             let in_use = collect_in_use_versions(
                 &parse_result,
                 &resolved,
+                &HashMap::new(),
                 &MockFormatter,
                 EcosystemId::Cargo,
             );
@@ -8948,6 +9184,7 @@ tokio = "1.0"
             let in_use = collect_in_use_versions(
                 &parse_result,
                 &resolved,
+                &HashMap::new(),
                 &MockFormatter,
                 EcosystemId::Maven,
             );
@@ -8975,6 +9212,7 @@ tokio = "1.0"
             let in_use = collect_in_use_versions(
                 &parse_result,
                 &resolved,
+                &HashMap::new(),
                 &MockFormatter,
                 EcosystemId::Pypi,
             );
@@ -8999,6 +9237,7 @@ tokio = "1.0"
             let in_use = collect_in_use_versions(
                 &parse_result,
                 &resolved,
+                &HashMap::new(),
                 &MockFormatter,
                 EcosystemId::Cargo,
             );
@@ -9025,6 +9264,7 @@ tokio = "1.0"
             let in_use = collect_in_use_versions(
                 &parse_result,
                 &resolved,
+                &HashMap::new(),
                 &MockFormatter,
                 EcosystemId::Cargo,
             );
@@ -9059,6 +9299,7 @@ tokio = "1.0"
             let in_use = collect_in_use_versions(
                 &parse_result,
                 &resolved,
+                &HashMap::new(),
                 &MockFormatter,
                 EcosystemId::Cargo,
             );

--- a/crates/deps-lsp/src/document/mod.rs
+++ b/crates/deps-lsp/src/document/mod.rs
@@ -14,6 +14,7 @@ mod state;
 
 // Re-export all public items from submodules
 pub(crate) use lifecycle::RefetchPolicy;
+pub(crate) use lifecycle::split_resolved_packages;
 pub use lifecycle::{ensure_document_loaded, handle_document_change, handle_document_open};
 pub use loader::load_document_from_disk;
 pub(crate) use state::CLIENT_REFRESH_TIMEOUT;

--- a/crates/deps-lsp/src/document/state.rs
+++ b/crates/deps-lsp/src/document/state.rs
@@ -80,6 +80,12 @@ pub struct DocumentState {
     pub cached_versions: HashMap<PackageName, PackageVersions>,
     /// Resolved versions from lock file
     pub resolved_versions: HashMap<PackageName, ConcreteVersion>,
+    /// Every lock-file-resolved version for a package name with more than one retained
+    /// entry (issue #649), built alongside [`Self::resolved_versions`] by the same lock
+    /// file load. Additive: only names with more than one occurrence get an entry here —
+    /// see [`deps_core::VersionData::resolved_version_candidates`] for the per-occurrence
+    /// disambiguation this enables.
+    pub resolved_version_candidates: HashMap<PackageName, Vec<ConcreteVersion>>,
     /// OSV.dev scan results, keyed by normalized package name. Empty until
     /// the first background scan completes; carried across document edits
     /// by `preserve_cache` so it is not wiped on every keystroke.
@@ -117,6 +123,7 @@ impl Clone for DocumentState {
             parse_result: self.parse_result.clone(),
             cached_versions: self.cached_versions.clone(),
             resolved_versions: self.resolved_versions.clone(),
+            resolved_version_candidates: self.resolved_version_candidates.clone(),
             vulnerabilities: self.vulnerabilities.clone(),
             outcomes: self.outcomes.clone(),
             parsed_at: self.parsed_at,
@@ -229,6 +236,10 @@ impl std::fmt::Debug for DocumentState {
             .field("has_parse_result", &self.parse_result.is_some())
             .field("cached_versions_count", &self.cached_versions.len())
             .field("resolved_versions_count", &self.resolved_versions.len())
+            .field(
+                "resolved_version_candidates_count",
+                &self.resolved_version_candidates.len(),
+            )
             .field("vulnerabilities_count", &self.vulnerabilities.len())
             .field("yanked_versions_count", &self.outcomes.yanked_count())
             .field("deprecations_count", &self.outcomes.deprecation_count())
@@ -256,6 +267,7 @@ impl DocumentState {
             parse_result: Some(Arc::from(parse_result)),
             cached_versions: HashMap::new(),
             resolved_versions: HashMap::new(),
+            resolved_version_candidates: HashMap::new(),
             vulnerabilities: VulnerabilityMap::new(),
             outcomes: DependencyOutcomes::new(),
             parsed_at: Instant::now(),
@@ -276,6 +288,7 @@ impl DocumentState {
             parse_result: None,
             cached_versions: HashMap::new(),
             resolved_versions: HashMap::new(),
+            resolved_version_candidates: HashMap::new(),
             vulnerabilities: VulnerabilityMap::new(),
             outcomes: DependencyOutcomes::new(),
             parsed_at: Instant::now(),
@@ -312,9 +325,19 @@ impl DocumentState {
         self.cached_versions = versions;
     }
 
-    /// Updates the resolved versions from lock file.
-    pub fn update_resolved_versions(&mut self, versions: HashMap<PackageName, ConcreteVersion>) {
+    /// Updates the resolved versions from lock file, together with the per-name candidates
+    /// map (issue #649).
+    ///
+    /// Takes both in one call, rather than two separate setters, so the two can never drift
+    /// out of sync — the same rationale [`PackageVersions::published_at`](deps_core::PackageVersions)
+    /// documents for bundling `latest`/`published_at` together.
+    pub fn update_resolved_versions(
+        &mut self,
+        versions: HashMap<PackageName, ConcreteVersion>,
+        candidates: HashMap<PackageName, Vec<ConcreteVersion>>,
+    ) {
         self.resolved_versions = versions;
+        self.resolved_version_candidates = candidates;
     }
 
     /// Updates the OSV.dev scan results.
@@ -2037,7 +2060,7 @@ mod tests {
             let mut resolved = HashMap::new();
             resolved.insert("serde".into(), "1.0.195".into());
 
-            state.update_resolved_versions(resolved);
+            state.update_resolved_versions(resolved, HashMap::new());
             assert_eq!(state.resolved_versions.len(), 1);
             assert_eq!(
                 state.resolved_versions.get("serde"),

--- a/crates/deps-lsp/src/handlers/code_actions.rs
+++ b/crates/deps-lsp/src/handlers/code_actions.rs
@@ -40,6 +40,7 @@ pub async fn handle_code_actions(
         parse_result,
         cached_versions,
         resolved_versions,
+        resolved_version_candidates,
         vulnerabilities,
         outcomes,
         content,
@@ -53,6 +54,7 @@ pub async fn handle_code_actions(
                 parse_result,
                 doc.cached_versions.clone(),
                 doc.resolved_versions.clone(),
+                doc.resolved_version_candidates.clone(),
                 doc.vulnerabilities.clone(),
                 doc.outcomes.clone(),
                 doc.content.clone(),
@@ -69,6 +71,7 @@ pub async fn handle_code_actions(
             position,
             uri,
             VersionData::new(&cached_versions, &resolved_versions)
+                .with_resolved_version_candidates(&resolved_version_candidates)
                 .with_vulnerabilities(&vulnerabilities)
                 .with_outcomes(&outcomes)
                 .with_ecosystem(ecosystem_id)

--- a/crates/deps-lsp/src/handlers/diagnostics.rs
+++ b/crates/deps-lsp/src/handlers/diagnostics.rs
@@ -176,6 +176,7 @@ pub(crate) async fn generate_diagnostics_internal(
             parse_result,
             doc.cached_versions.clone(),
             doc.resolved_versions.clone(),
+            doc.resolved_version_candidates.clone(),
             doc.vulnerabilities.clone(),
             doc.outcomes.clone(),
         ))
@@ -190,6 +191,7 @@ pub(crate) async fn generate_diagnostics_internal(
         parse_result,
         cached_versions,
         resolved_versions,
+        resolved_version_candidates,
         vulnerabilities,
         outcomes,
     )) = extracted
@@ -201,6 +203,7 @@ pub(crate) async fn generate_diagnostics_internal(
         .generate_diagnostics(
             parse_result.as_ref(),
             VersionData::new(&cached_versions, &resolved_versions)
+                .with_resolved_version_candidates(&resolved_version_candidates)
                 .with_vulnerabilities(&vulnerabilities)
                 .with_outcomes(&outcomes)
                 .with_ecosystem(ecosystem_id)
@@ -1064,7 +1067,7 @@ serde = "1.0.0"
             // in-use-version check (#263), not the manifest-requirement check (#247).
             let mut resolved = std::collections::HashMap::new();
             resolved.insert("left-pad".into(), "1.0.1".into());
-            doc_state.update_resolved_versions(resolved);
+            doc_state.update_resolved_versions(resolved, std::collections::HashMap::new());
 
             doc_state.replace_outcomes(deps_core::DependencyOutcomes::new().with_yanked(
                 "left-pad",

--- a/crates/deps-lsp/src/handlers/hover.rs
+++ b/crates/deps-lsp/src/handlers/hover.rs
@@ -46,6 +46,7 @@ pub async fn handle_hover(
         parse_result,
         cached_versions,
         resolved_versions,
+        resolved_version_candidates,
         vulnerabilities,
         outcomes,
     ) = state
@@ -58,6 +59,7 @@ pub async fn handle_hover(
                 parse_result,
                 doc.cached_versions.clone(),
                 doc.resolved_versions.clone(),
+                doc.resolved_version_candidates.clone(),
                 doc.vulnerabilities.clone(),
                 doc.outcomes.clone(),
             ))
@@ -65,6 +67,7 @@ pub async fn handle_hover(
         .flatten()?;
 
     let mut versions = VersionData::new(&cached_versions, &resolved_versions)
+        .with_resolved_version_candidates(&resolved_version_candidates)
         .with_vulnerabilities(&vulnerabilities)
         .with_outcomes(&outcomes)
         .with_ecosystem(ecosystem_id)

--- a/crates/deps-lsp/src/handlers/inlay_hints.rs
+++ b/crates/deps-lsp/src/handlers/inlay_hints.rs
@@ -57,6 +57,7 @@ pub async fn handle_inlay_hints(
             parse_result,
             doc.cached_versions.clone(),
             doc.resolved_versions.clone(),
+            doc.resolved_version_candidates.clone(),
             doc.loading_state,
         ))
     }) else {
@@ -64,8 +65,14 @@ pub async fn handle_inlay_hints(
         return vec![];
     };
 
-    let Some((ecosystem, parse_result, cached_versions, resolved_versions, loading_state)) =
-        extracted
+    let Some((
+        ecosystem,
+        parse_result,
+        cached_versions,
+        resolved_versions,
+        resolved_version_candidates,
+        loading_state,
+    )) = extracted
     else {
         return vec![];
     };
@@ -82,7 +89,8 @@ pub async fn handle_inlay_hints(
     ecosystem
         .generate_inlay_hints(
             parse_result.as_ref(),
-            VersionData::new(&cached_versions, &resolved_versions),
+            VersionData::new(&cached_versions, &resolved_versions)
+                .with_resolved_version_candidates(&resolved_version_candidates),
             loading_state,
             &ecosystem_config,
         )

--- a/crates/deps-lsp/src/server.rs
+++ b/crates/deps-lsp/src/server.rs
@@ -6,7 +6,7 @@ use crate::file_watcher;
 use crate::handlers::{
     code_actions, code_lens, completion, diagnostics, document_link, hover, inlay_hints,
 };
-use deps_core::{PackageName, is_safe_version_string};
+use deps_core::is_safe_version_string;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -232,16 +232,13 @@ impl Backend {
         );
 
         // Reload lock file (cache was invalidated, so this re-parses)
-        let resolved_versions = match self
+        let (resolved_versions, resolved_version_candidates) = match self
             .state
             .lockfile_cache
             .get_or_parse(lock_provider.as_ref(), lockfile_path)
             .await
         {
-            Ok(packages) => packages
-                .iter()
-                .map(|(name, pkg)| (PackageName::new(name.as_str()), pkg.version.clone().into()))
-                .collect::<HashMap<PackageName, deps_core::ConcreteVersion>>(),
+            Ok(packages) => crate::document::split_resolved_packages(&packages),
             Err(e) => {
                 tracing::error!("Failed to reload lock file: {}", e);
                 self.client
@@ -250,7 +247,7 @@ impl Backend {
                         format!("Failed to reload lock file: {e}"),
                     )
                     .await;
-                HashMap::new()
+                (HashMap::new(), HashMap::new())
             }
         };
 
@@ -273,7 +270,10 @@ impl Backend {
 
         for uri in affected_uris {
             if let Some(mut doc) = self.state.documents.get_mut(&uri) {
-                doc.update_resolved_versions(resolved_versions.clone());
+                doc.update_resolved_versions(
+                    resolved_versions.clone(),
+                    resolved_version_candidates.clone(),
+                );
             }
 
             // Issue #636 introduced `loading_ceiling`'s dependency-count parameter: before

--- a/specs/050-cargo-renamed-dependency-lockfile-resolution/spec.md
+++ b/specs/050-cargo-renamed-dependency-lockfile-resolution/spec.md
@@ -10,7 +10,7 @@ tags:
   - deps-cargo
   - lockfile
 created: 2026-09-06
-status: draft
+status: specified
 related:
   - "[[constitution]]"
   - "[[023-cargo-custom-registries/spec|Cargo custom/private registry & source-replacement resolution]]"
@@ -76,11 +76,11 @@ queried at all — a false negative. Hover/inlay hints report "in use:
 
 PR #650 deliberately left this unresolved (added a regression test pinning
 the current known-limitation behavior rather than fixing it) and filed
-issue #649 for the architectural follow-up this spec covers. `[NEEDS CLARIFICATION:
-should this spec also account for #394's original scenario (duplicate names
-across `[target.'cfg(...)'.dependencies]` blocks in deps-lsp's own manifest-side
-HashMap), or is that a separate, already-closed concern (#394/PR #404) that
-should stay out of scope here? See Open Questions.]`
+issue #649 for the architectural follow-up this spec covers. #394's original
+scenario (duplicate names across `[target.'cfg(...)'.dependencies]` blocks)
+was fixed at the manifest-parsing layer by PR #404 and is a separate,
+already-closed concern — this spec is scoped purely to the lock-file
+resolution layer.
 
 ### Goal
 
@@ -160,7 +160,7 @@ Use EARS notation. Prefix with FR-NNN.
 | FR-003 | WHEN no lock-file entry for a name satisfies an occurrence's `version_requirement()`, THE SYSTEM SHALL return the existing "no concrete version" outcome for that occurrence (matching pre-#648 honest-skip behavior) rather than falling back to an arbitrary non-matching entry | must |
 | FR-004 | WHEN `vulnerability_keys()` computes a per-occurrence OSV cache-key signature, THE SYSTEM SHALL derive it from the per-occurrence resolved version produced by FR-001, so two occurrences of the same name pinned to different satisfying versions receive distinct signatures | must |
 | FR-005 | WHEN only a single manifest occurrence exists for a given resolved package name (the common case, no rename/alias involved), THE SYSTEM SHALL produce identical in-use-version and OSV-signature results to the current behavior — this is a correctness fix for the multi-occurrence case, not a behavior change for the single-occurrence case | must |
-| FR-006 | WHEN a downstream ecosystem/caller still needs "the single best version for this name regardless of any specific occurrence" (e.g. `[NEEDS CLARIFICATION: does any current caller of `ResolvedPackages::get_version`/`into_map` need this collapsed semantics preserved, or can every current caller be migrated to the per-occurrence lookup? see Open Questions]`), THE SYSTEM SHALL continue to expose that collapsed lookup as a distinct, explicitly-named API rather than removing it | should |
+| FR-006 | WHEN a downstream ecosystem/caller still needs "the single best version for this name regardless of any specific occurrence" (resolved: no current caller outside `in_use_version`/`vulnerability_keys` needs migrating — `ResolvedPackages::get`/`get_version`/`into_map` keep their existing collapsed semantics untouched as the fast-path default), THE SYSTEM SHALL continue to expose that collapsed lookup as a distinct, explicitly-named API rather than removing it | should |
 
 ## 4. Non-Functional Requirements
 
@@ -176,7 +176,7 @@ Use EARS notation. Prefix with FR-NNN.
 | Entity | Description | Key Attributes |
 |--------|-------------|----------------|
 | `ResolvedPackages` (existing, `crates/deps-core/src/lockfile.rs:280`) | Per-lockfile collection of resolved packages, already `Vec`-per-name internally | `packages: HashMap<String, Vec<ResolvedPackage>>`; `get_all()` (line 326) already exposes the full per-name `Vec` — likely the primary building block for the fix |
-| `resolved_versions: HashMap<PackageName, ConcreteVersion>` (existing, threaded through `deps-lsp::document::lifecycle` and `deps-core::lsp_helpers::in_use_version`/`deps-core::osv::vulnerability_keys`) | The collapsed one-value-per-name shape causing this bug | `[NEEDS CLARIFICATION: does this type change shape entirely (e.g. `HashMap<PackageName, Vec<ConcreteVersion>>`, or `HashMap<PackageName, ResolvedPackages>`-like), or does `load_resolved_versions()` keep building this exact type for the single-occurrence fast path while a new, separate lookup handles the multi-occurrence/version_req-aware case? See Open Questions — this is the central design decision of this spec.]` |
+| `resolved_versions: HashMap<PackageName, ConcreteVersion>` (existing, threaded through `deps-lsp::document::lifecycle` and `deps-core::lsp_helpers::in_use_version`/`deps-core::osv::vulnerability_keys`) | The collapsed one-value-per-name shape causing this bug | Resolved: `load_resolved_versions()` keeps building this exact type unchanged (fast path, FR-005/NFR-001). A new sibling map, `resolved_version_candidates: HashMap<PackageName, Vec<ConcreteVersion>>` (sourced from `ResolvedPackages::get_all()`), is threaded alongside it; `in_use_version()`/`vulnerability_keys()` consult the candidates map first when more than one entry exists for a name, filtering by the occurrence's `version_requirement()` (FR-001-FR-003), and fall back to the existing collapsed map when only one candidate exists — additive, no existing call site changes shape |
 | `Dependency::version_requirement()` (existing, `crates/deps-core/src/ecosystem.rs` trait method) | Already available per-occurrence, already used elsewhere in `in_use_version()` for the concrete-pin fallback path (line 321-323) | Returns `Option<&VersionReq>` — the natural filter key for FR-001's per-occurrence match |
 
 ## 6. Edge Cases and Error Handling
@@ -184,7 +184,7 @@ Use EARS notation. Prefix with FR-NNN.
 | Scenario | Expected Behavior |
 |----------|-------------------|
 | Two occurrences of the same resolved name, both with a `version_requirement()` satisfied by the same single lock-file entry (i.e. no actual rename scenario, just two manifest sections referencing the same crate at compatible versions — the common/default case) | Both occurrences resolve to that one entry; behavior identical to today (FR-005) |
-| A renamed occurrence's `version_requirement()` is `None` (no version specified, relying on the lock file entirely) | `[NEEDS CLARIFICATION: with no version_requirement to filter by, is falling back to the collapsed highest-semver entry (today's behavior) acceptable here, or does this need its own honest "ambiguous — cannot disambiguate without a stated requirement" skip reason? See Open Questions.]` |
+| A renamed occurrence's `version_requirement()` is `None` (no version specified, relying on the lock file entirely) | Resolved: fall back to the collapsed highest-semver entry (today's behavior) — no new skip-reason variant. This is no worse than pre-#648 (which had no data at all for this alias) and avoids adding diagnostic-surface complexity for a case that has no requirement to disambiguate against in the first place |
 | A workspace-inherited dependency (`workspace = true`) combined with a rename (`package = "..."` is already discarded when `workspace = true` is present per #648's fix) | Not a multi-occurrence-same-name scenario introduced by this bug — `package` is ignored in that case already, so only one occurrence's worth of resolution applies; no special handling needed beyond what #648 already does |
 | Lock file has only one entry for a name, but two manifest occurrences both reference it (no actual version conflict, just aliasing to the same version) | Both occurrences correctly resolve to that single entry — FR-001's per-occurrence filter degenerates to the current single-value lookup when there is nothing to disambiguate |
 | `ResolvedPackages::get_all()` returns entries whose versions fail to parse as semver (non-semver lock-file version string) | Reuse `best_package()`'s existing fallback ordering (lexicographic string compare) for the tiebreak among non-parseable versions — do not introduce a second, divergent version-comparison policy |
@@ -239,36 +239,29 @@ Use EARS notation. Prefix with FR-NNN.
 - Ship this without live-testing the two-major rename reproduction from
   issue #649, per the project's Live Testing Principle
 
-## 9. Open Questions
+## 9. Open Questions (resolved)
 
-- [NEEDS CLARIFICATION: Should the fix change `resolved_versions`'s shape
-  (e.g. `HashMap<PackageName, Vec<ConcreteVersion>>` or storing
-  `ResolvedPackages` itself further downstream instead of pre-collapsing at
-  `load_resolved_versions()`), or add a new, separate version-req-aware
-  lookup function that callers (`in_use_version`, `vulnerability_keys`) opt
-  into, leaving `resolved_versions`'s current shape as a fast-path default
-  for the overwhelmingly common single-occurrence case? The former is more
-  uniform but touches more call sites; the latter is lower-risk but adds a
-  second lookup path callers must remember to use correctly.]
-- [NEEDS CLARIFICATION: Is #394's original scenario (duplicate dependency
-  names across `[target.'cfg(...)'.dependencies]` blocks, fixed in
-  PR #404 at the `deps-lsp` manifest-parsing layer, not the lockfile layer)
-  actually the same underlying limitation this spec should also revisit, or
-  a fully separate, already-closed concern? The issue explicitly calls out
-  "same limitation class as #394" — worth confirming whether #404's fix
-  already solved the manifest side and this spec is purely the lockfile
-  side, or whether there's remaining overlap.]
-- [NEEDS CLARIFICATION: When a renamed occurrence has no `version_requirement()`
-  at all (relying entirely on the lock file), what should the per-occurrence
-  filter do — fall back to the collapsed highest-semver entry (today's
-  behavior, potentially still wrong but no worse than before), or introduce
-  a new explicit "ambiguous, cannot disambiguate" skip outcome distinct from
-  `SkipReason::NoConcreteVersion`?]
-- [NEEDS CLARIFICATION: Should this fix be implemented as a single PR, or
-  does the FR-006/NFR-001 backward-compatibility surface (10 `LockFileProvider`
-  implementations, multiple `deps-core` call sites) warrant splitting into
-  staged PRs the way #023 (Cargo custom registries) or #041 (credential
-  redaction hardening) were staged?]
+- **Data-model shape**: additive — keep `resolved_versions` unchanged and add
+  a sibling `resolved_version_candidates: HashMap<PackageName, Vec<ConcreteVersion>>`
+  that `in_use_version()`/`vulnerability_keys()` consult first, falling back
+  to the collapsed map for the single-occurrence case. Chosen over reshaping
+  `resolved_versions` itself because it satisfies NFR-001/FR-005 (zero
+  behavior change for the dominant single-occurrence path, zero call-site
+  churn outside the two consumers that need per-occurrence data) and matches
+  the project's MVP/minimal-change convention over a more "uniform" but
+  higher-blast-radius rewrite touching all 10 `LockFileProvider` call sites.
+- **#394 overlap**: separate, already-closed concern — #404 fixed the
+  manifest-parsing layer; this spec is scoped purely to lock-file resolution.
+  No overlap requiring revisiting.
+- **No `version_requirement()` case**: fall back to the collapsed
+  highest-semver entry (today's behavior) rather than a new skip-reason
+  variant — no worse than before, avoids new diagnostic-surface complexity.
+- **Single PR vs staged**: single PR. The additive design above keeps the
+  change confined to `deps-core::lockfile`, `deps-core::lsp_helpers::in_use_version`,
+  `deps-core::osv::types`, and `deps-lsp::document::lifecycle`'s
+  `load_resolved_versions()`, with no `LockFileProvider` trait signature
+  change — unlike #023/#041, there is no independently-shippable phase
+  boundary here that would justify staging.
 
 ## 10. References
 

--- a/specs/050-cargo-renamed-dependency-lockfile-resolution/spec.md
+++ b/specs/050-cargo-renamed-dependency-lockfile-resolution/spec.md
@@ -10,7 +10,7 @@ tags:
   - deps-cargo
   - lockfile
 created: 2026-09-06
-status: specified
+status: shipped
 related:
   - "[[constitution]]"
   - "[[023-cargo-custom-registries/spec|Cargo custom/private registry & source-replacement resolution]]"

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -71,7 +71,7 @@ status: moc
 | 047 | [[047-elixir-hex-ecosystem/spec\|New ecosystem: Elixir Hex (mix.exs dependency version hints)]] | specify | draft — research/new-ecosystem, P4, 6 open `[NEEDS CLARIFICATION]` items, issue #642 |
 | 048 | [[048-gitlab-ci-mutable-pin-message-contradicts-quickfix/spec\|GitLab CI mutable-ref-pin diagnostic wrongly claims no automated fix for component Latest/Partial pins]] | specify | shipped — bug, P2 (PR #645, issues #640, #643) |
 | 049 | [[049-osv-malicious-package-severity/spec\|OSV malicious-package (MAL-*) advisory severity distinguishing]] | specify | research/correctness, P2, implemented (issue #646, branch feat/646-osv-malicious-severity) |
-| 050 | [[050-cargo-renamed-dependency-lockfile-resolution/spec\|Per-occurrence lockfile version resolution for renamed/aliased dependencies]] | specify | draft — bug, P1, 4 open `[NEEDS CLARIFICATION]` items, issue #649 |
+| 050 | [[050-cargo-renamed-dependency-lockfile-resolution/spec\|Per-occurrence lockfile version resolution for renamed/aliased dependencies]] | specify | bug, P1, clarifications resolved, issue #649 — in progress |
 
 ## Completed Specs
 

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -71,7 +71,7 @@ status: moc
 | 047 | [[047-elixir-hex-ecosystem/spec\|New ecosystem: Elixir Hex (mix.exs dependency version hints)]] | specify | draft — research/new-ecosystem, P4, 6 open `[NEEDS CLARIFICATION]` items, issue #642 |
 | 048 | [[048-gitlab-ci-mutable-pin-message-contradicts-quickfix/spec\|GitLab CI mutable-ref-pin diagnostic wrongly claims no automated fix for component Latest/Partial pins]] | specify | shipped — bug, P2 (PR #645, issues #640, #643) |
 | 049 | [[049-osv-malicious-package-severity/spec\|OSV malicious-package (MAL-*) advisory severity distinguishing]] | specify | research/correctness, P2, implemented (issue #646, branch feat/646-osv-malicious-severity) |
-| 050 | [[050-cargo-renamed-dependency-lockfile-resolution/spec\|Per-occurrence lockfile version resolution for renamed/aliased dependencies]] | specify | bug, P1, clarifications resolved, issue #649 — in progress |
+| 050 | [[050-cargo-renamed-dependency-lockfile-resolution/spec\|Per-occurrence lockfile version resolution for renamed/aliased dependencies]] | specify | shipped — bug, P1 (PR #653, issue #649) |
 
 ## Completed Specs
 


### PR DESCRIPTION
## Summary

- Fixes issue #649, a follow-up regression exposed by #648/#650: when a `Cargo.lock` holds two different major versions of the same crate (one referenced directly, one via a `package = "..."` rename), the renamed occurrence's in-use-version and OSV vulnerability data was silently mis-attributed to the other occurrence's version.
- Adds an additive `resolved_version_candidates` map (sourced from `ResolvedPackages::get_all()`) alongside the existing collapsed `resolved_versions` map. `in_use_version()` and `vulnerability_keys()` now resolve each manifest occurrence against its own `version_requirement()` when more than one lock-file candidate exists for a name, instead of a single collapsed highest-semver value shared by every occurrence.
- The single-occurrence-per-name path (the overwhelming common case) is byte-for-byte unchanged — no `LockFileProvider` trait or ecosystem-crate changes across any of the 10 implementations.
- Design follows `specs/050-cargo-renamed-dependency-lockfile-resolution/spec.md`, whose open `[NEEDS CLARIFICATION]` items were resolved before implementation started.

## Caught during review

- The candidate filter initially used `EcosystemFormatter::version_satisfies_requirement`, an imprecise string heuristic that `deps-cargo`'s own `compile_requirement` doc explicitly documents as unsuitable for this — it would have silently dropped ordinary duplicate-major dependencies (e.g. `bitflags` 1.x + 2.x present in this repo's own lockfile) out of OSV scanning entirely. Fixed to try `compile_requirement`'s precise comparator first, falling back to the heuristic only when unavailable.
- `resolved_version_candidates` was not being carried through `preserve_cache` / removed-dependency pruning, so it would reset to empty on every document edit while `resolved_versions` survived — reintroducing the original bug for the debounce window. Fixed to keep both maps in sync everywhere.

## Known scope boundary

When a renamed occurrence has no explicit `version_requirement()` at all (relying entirely on the lock file), it still falls back to the collapsed highest-semver value by design (see spec section 6/9) — this one narrow mis-attribution scenario from the original issue can still occur. Not fixed here; documented as an accepted, spec-level tradeoff rather than an oversight.

## Testing

- Live-tested against a real `cargo generate-lockfile`-produced lockfile (`serde` 0.9.15 + 1.0.229) via the actual `deps-lsp` binary over stdio: `serde` now hovers "Current: 1.0.229", `serde_old` (aliased via `package = "serde"`) now hovers "Current: 0.9.15".
- Added unit tests for the FR-002 tiebreak (multiple satisfying candidates), FR-004/SC-002 OSV per-occurrence attribution (`vulnerability_keys`, `generate_diagnostics_from_cache`, `generate_hover`), and updated PR #650's regression test to assert the corrected behavior instead of the previously-pinned known limitation.
- Full workspace check suite green: `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo nextest run --workspace --all-features --no-fail-fast` (4413 passed), doctests, and the project's stricter rustdoc gate (`RUSTFLAGS`/`RUSTDOCFLAGS=-D warnings`).

Closes #649