### PR TITLE
fix(deps-core): correct stale DNS-rebinding doc in net_policy.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: OSV malicious-package advisories (`MAL-*` id or alias) now classify as a distinct `VulnSeverity::Malicious` instead of falling through to "unknown severity" in hover/diagnostics (resolves #646) (#652)
 
 ### Fixed
-- **deps-core**: `net_policy.rs` doc comment no longer describes the DNS-rebinding gap as open — it is already closed by `BlockedAddrResolver` (resolves #655)
+- **deps-core**: `net_policy.rs` doc comment no longer describes the DNS-rebinding gap as open — it is already closed by `BlockedAddrResolver` (resolves #655) (#656)
 - **deps-core, deps-lsp**: hover/inlay-hint in-use-version and OSV vulnerability lookups now resolve each manifest occurrence against its own `version_requirement()` instead of a single collapsed lock-file value, so a renamed/aliased dependency pinned to a different major no longer mis-reports the other occurrence's version (resolves #649) (#653)
 - **deps-cargo**: an explicit `package = "..."` rename now resolves hover/diagnostics/completion/code actions/code lenses/inlay hints against the real crate name instead of the local TOML alias (resolves #648)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: OSV malicious-package advisories (`MAL-*` id or alias) now classify as a distinct `VulnSeverity::Malicious` instead of falling through to "unknown severity" in hover/diagnostics (resolves #646) (#652)
 
 ### Fixed
+- **deps-core**: `net_policy.rs` doc comment no longer describes the DNS-rebinding gap as open — it is already closed by `BlockedAddrResolver` (resolves #655)
 - **deps-core, deps-lsp**: hover/inlay-hint in-use-version and OSV vulnerability lookups now resolve each manifest occurrence against its own `version_requirement()` instead of a single collapsed lock-file value, so a renamed/aliased dependency pinned to a different major no longer mis-reports the other occurrence's version (resolves #649) (#653)
 - **deps-cargo**: an explicit `package = "..."` rename now resolves hover/diagnostics/completion/code actions/code lenses/inlay hints against the real crate name instead of the local TOML alias (resolves #648)
 

--- a/crates/deps-core/src/net_policy.rs
+++ b/crates/deps-core/src/net_policy.rs
@@ -21,9 +21,12 @@ use std::sync::atomic::{AtomicU8, Ordering};
 /// [`WorkspaceRegistryAccess`].
 ///
 /// Computed from the URL alone (see [`classify_host`]) — never from a DNS resolution, so an
-/// attacker-controlled hostname that merely *resolves* to a blocked range is not caught here
-/// (the residual risk spec NFR-003/§5 of the plan documents; closing it needs a
-/// `reqwest::dns::Resolve` filter, deferred as a follow-up).
+/// attacker-controlled hostname that merely *resolves* to a blocked range is not caught here.
+/// This residual scope is by design, not an open gap: the DNS-rebinding TOCTOU it would
+/// otherwise allow is closed separately, at connect time, by `crate::cache`'s
+/// `BlockedAddrResolver` (a `reqwest::dns::Resolve` implementation, fail-closed on lookup
+/// errors, wired into every client via `build_guarded_client`) — see [`classify_addr`], its
+/// counterpart for already-resolved addresses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HostClass {
     /// `127.0.0.0/8`, `::1`, `localhost`, `*.localhost`.


### PR DESCRIPTION
## Summary
- `HostClass`'s doc comment in `crates/deps-core/src/net_policy.rs` described the DNS-rebinding TOCTOU gap as an open, deferred risk requiring a future `reqwest::dns::Resolve` filter.
- That filter already exists and is wired into every guarded client: `cache.rs`'s `BlockedAddrResolver`, closed by `#449`/`#455` (merged as PR `#457`/`#460`).
- Updated the doc to point at the actual guard instead of describing it as future work. `classify_host`'s own "no DNS resolution" behavior remains correct and intentional — only the "open residual risk" framing was stale.

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run -p deps-core --all-features --no-fail-fast`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`

Closes #655