### PR TITLE
fix(deps-npm): resolve npm: package-alias protocol against the real package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: `net_policy.rs` doc comment no longer describes the DNS-rebinding gap as open — it is already closed by `BlockedAddrResolver` (resolves #655) (#656)
 - **deps-core, deps-lsp**: hover/inlay-hint in-use-version and OSV vulnerability lookups now resolve each manifest occurrence against its own `version_requirement()` instead of a single collapsed lock-file value, so a renamed/aliased dependency pinned to a different major no longer mis-reports the other occurrence's version (resolves #649) (#653)
 - **deps-cargo**: an explicit `package = "..."` rename now resolves hover/diagnostics/completion/code actions/code lenses/inlay hints against the real crate name instead of the local TOML alias (resolves #648)
+- **deps-npm**: an `npm:<pkg>@<range>` alias value now resolves hover/diagnostics/completion/`.npmrc` routing/OSV lookups/lockfile in-use-version against the real package name instead of the local `package.json` alias key (resolves #654)
+- **deps-core, deps-deno**: extracted `deps-deno`'s scope-aware `@scope/pkg` name-boundary parser into a shared `deps_core::package::npm_style_name_boundary` helper, reused by the `deps-npm` alias fix above instead of a per-crate reimplementation
+
+### Changed
+- **deps-npm**: `package-lock.json` parsing now prefers a package entry's own `name` field (npm writes this when it differs from the physical `node_modules/` path, e.g. for an `npm:` alias) over the lockfile-key-derived name
 
 ## [0.13.0] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: `net_policy.rs` doc comment no longer describes the DNS-rebinding gap as open — it is already closed by `BlockedAddrResolver` (resolves #655) (#656)
 - **deps-core, deps-lsp**: hover/inlay-hint in-use-version and OSV vulnerability lookups now resolve each manifest occurrence against its own `version_requirement()` instead of a single collapsed lock-file value, so a renamed/aliased dependency pinned to a different major no longer mis-reports the other occurrence's version (resolves #649) (#653)
 - **deps-cargo**: an explicit `package = "..."` rename now resolves hover/diagnostics/completion/code actions/code lenses/inlay hints against the real crate name instead of the local TOML alias (resolves #648)
-- **deps-npm**: an `npm:<pkg>@<range>` alias value now resolves hover/diagnostics/completion/`.npmrc` routing/OSV lookups/lockfile in-use-version against the real package name instead of the local `package.json` alias key (resolves #654)
-- **deps-core, deps-deno**: extracted `deps-deno`'s scope-aware `@scope/pkg` name-boundary parser into a shared `deps_core::package::npm_style_name_boundary` helper, reused by the `deps-npm` alias fix above instead of a per-crate reimplementation
+- **deps-npm**: an `npm:<pkg>@<range>` alias value now resolves hover/diagnostics/completion/`.npmrc` routing/OSV lookups/lockfile in-use-version against the real package name instead of the local `package.json` alias key (resolves #654) (#657)
+- **deps-core, deps-deno**: extracted `deps-deno`'s scope-aware `@scope/pkg` name-boundary parser into a shared `deps_core::package::npm_style_name_boundary` helper, reused by the `deps-npm` alias fix above instead of a per-crate reimplementation (#657)
 
 ### Changed
-- **deps-npm**: `package-lock.json` parsing now prefers a package entry's own `name` field (npm writes this when it differs from the physical `node_modules/` path, e.g. for an `npm:` alias) over the lockfile-key-derived name
+- **deps-npm**: `package-lock.json` parsing now prefers a package entry's own `name` field (npm writes this when it differs from the physical `node_modules/` path, e.g. for an `npm:` alias) over the lockfile-key-derived name (#657)
 
 ## [0.13.0] - 2026-09-05
 

--- a/crates/deps-core/src/package.rs
+++ b/crates/deps-core/src/package.rs
@@ -390,6 +390,53 @@ impl PartialEq<&str> for ConcreteVersion {
     }
 }
 
+/// Length, in bytes, of an `@scope/pkg` or unscoped `pkg` name at the start of `rest`.
+///
+/// Follows the scoped-package grammar shared by npm-style ecosystems: the name runs up to
+/// (but excludes) the first `@` or `/` after it, without mistaking a scoped name's own
+/// leading `@` or inner `/` for that boundary.
+///
+/// Shared by `deps-npm`'s `npm:` alias parsing (issue #654) and `deps-deno`'s
+/// `jsr:`/`npm:` specifier grammar (`deps_deno::specifier::parse_specifier`) — both need
+/// the identical scope-aware boundary, and a per-crate reimplementation had drifted looser
+/// than this one (accepting `"@/pkg"`, `"@scope/"`, and a lone `"@"` as valid names).
+///
+/// Returns `None` for a malformed scoped name (empty scope `"@/pkg"`, missing `/` `"@std"`,
+/// or an empty package segment `"@std/"`) or an empty unscoped name (`rest` is empty, or
+/// starts with `@`/`/`).
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::package::npm_style_name_boundary;
+///
+/// assert_eq!(npm_style_name_boundary("react@^18.0.0"), Some(5));
+/// assert_eq!(npm_style_name_boundary("@scope/pkg@^1.0.0"), Some(10));
+/// assert_eq!(npm_style_name_boundary("@scope/pkg"), Some(10));
+/// assert_eq!(npm_style_name_boundary("@/pkg"), None);
+/// assert_eq!(npm_style_name_boundary("@scope/"), None);
+/// assert_eq!(npm_style_name_boundary("@"), None);
+/// assert_eq!(npm_style_name_boundary(""), None);
+/// ```
+#[must_use]
+pub fn npm_style_name_boundary(rest: &str) -> Option<usize> {
+    if let Some(after_at) = rest.strip_prefix('@') {
+        let slash_rel = after_at.find('/')?;
+        if slash_rel == 0 {
+            return None; // empty scope, e.g. "@/pkg"
+        }
+        let after_slash = &after_at[slash_rel + 1..];
+        let pkg_end_rel = after_slash.find(['@', '/']).unwrap_or(after_slash.len());
+        if pkg_end_rel == 0 {
+            return None; // empty pkg name, e.g. "@scope/"
+        }
+        Some(1 + slash_rel + 1 + pkg_end_rel)
+    } else {
+        let end = rest.find(['@', '/']).unwrap_or(rest.len());
+        (end > 0).then_some(end)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{ConcreteVersion, PackageName, VersionReq};

--- a/crates/deps-deno/src/specifier.rs
+++ b/crates/deps-deno/src/specifier.rs
@@ -173,26 +173,9 @@ pub fn parse_specifier(value: &str) -> Option<ParsedSpecifier> {
     let (scheme, rest) = split_scheme(value)?;
     let prefix_len = value.len() - rest.len();
 
-    let name_end_in_rest = if let Some(after_at) = rest.strip_prefix('@') {
-        // Scoped: exactly two segments, "@scope/pkg".
-        let slash_rel = after_at.find('/')?;
-        if slash_rel == 0 {
-            return None; // empty scope, e.g. "jsr:@/pkg"
-        }
-        let after_slash = &after_at[slash_rel + 1..];
-        let pkg_end_rel = after_slash.find(['@', '/']).unwrap_or(after_slash.len());
-        if pkg_end_rel == 0 {
-            return None; // empty pkg name, e.g. "jsr:@std/"
-        }
-        1 + slash_rel + 1 + pkg_end_rel
-    } else {
-        // Unscoped: exactly one segment.
-        rest.find(['@', '/']).unwrap_or(rest.len())
-    };
-
-    if name_end_in_rest == 0 {
-        return None;
-    }
+    // Scope-aware name/version(/subpath) boundary, shared with `deps-npm`'s `npm:` alias
+    // parsing (issue #654 S3) — see that function's doc for why this lives in `deps-core`.
+    let name_end_in_rest = deps_core::package::npm_style_name_boundary(rest)?;
 
     let name_range = 0..prefix_len + name_end_in_rest;
     let name = value[name_range.clone()].to_string();

--- a/crates/deps-npm/src/catalog.rs
+++ b/crates/deps-npm/src/catalog.rs
@@ -538,9 +538,15 @@ pub fn load(
 /// `version_req` for a resolved one), including when `config` is `None`. See the module's
 /// totality invariant.
 ///
-/// Deliberately does not detect the npm-alias form `"npm:<pkg>@catalog:<name>"` — no user
-/// story covers it and it is not a regression (today's pre-feature behavior is identical); see
-/// `docs/ECOSYSTEM_GUIDE.md`'s pnpm Catalogs "Known limitations".
+/// The base `npm:<pkg>@<version>` alias form (issue #654) is resolved earlier, by
+/// `parser::parse_npm_alias`, before `apply` ever sees the dependency. Deliberately still does
+/// not detect the pnpm-catalog *combination* form `"npm:<pkg>@catalog:<name>"`, though:
+/// `parse_npm_alias` itself declines to resolve it (see that function's doc) precisely so it
+/// reaches `apply` as the original, unaliased literal value — and `CatalogSpecifier::parse`
+/// above only matches a bare `catalog:` prefix, so this combination form still falls through
+/// unresolved here too. No user story covers it and it is not a regression (today's
+/// pre-feature behavior is identical); see `docs/ECOSYSTEM_GUIDE.md`'s pnpm Catalogs "Known
+/// limitations".
 pub fn apply(deps: &mut [NpmDependency], config: Option<&PnpmWorkspaceConfig>) {
     for dep in deps {
         let Some(raw) = dep.version_req.as_ref().map(deps_core::VersionReq::as_str) else {
@@ -585,6 +591,7 @@ mod tests {
             section: NpmDependencySection::Dependencies,
             source: deps_core::parser::DependencySource::Registry,
             catalog: None,
+            package: None,
         }
     }
 

--- a/crates/deps-npm/src/ecosystem.rs
+++ b/crates/deps-npm/src/ecosystem.rs
@@ -388,6 +388,7 @@ mod tests {
             section: crate::types::NpmDependencySection::Dependencies,
             source,
             catalog: None,
+            package: None,
         }
     }
 
@@ -860,6 +861,53 @@ mod tests {
             .await;
 
         assert!(actions.is_empty());
+    }
+
+    /// Critique M3: code actions/lens are deliberately suppressed for an `npm:`-aliased
+    /// dependency, not just untested. `version_range` still spans the whole literal
+    /// (`"npm:react@^17.0.0"`), but `version_requirement()` is only the real range
+    /// (`"^17.0.0"`) — `literal_span_matches` (`deps-core`'s shared code-action guard)
+    /// compares the two, sees a mismatch, and refuses to build a fix/refactor edit. This is
+    /// the safe outcome: a naive edit would write `"my-react": "18.2.0"`, destroying the
+    /// alias. Pinning this here so a future change to `version_literal()`/`version_range`
+    /// doesn't silently re-enable a destructive edit (see `NpmDependency`'s doc and
+    /// `deps_core::lsp_helpers::code_actions::generate_code_actions`'s guard).
+    #[tokio::test]
+    async fn test_generate_code_actions_suppressed_for_npm_alias() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let ecosystem = NpmEcosystem::new(cache);
+        let uri = deps_core::test_util::test_uri("/test/package.json");
+
+        let content = r#"{
+  "dependencies": {
+    "my-react": "npm:react@^17.0.0"
+  }
+}"#;
+        let parse_result = ecosystem.parse_manifest(content, &uri).await.unwrap();
+
+        let mut cached_versions = HashMap::new();
+        cached_versions.insert(
+            pkg("react"),
+            deps_core::lsp_helpers::PackageVersions::latest_only("18.2.0"),
+        );
+        let resolved_versions = HashMap::new();
+
+        // Inside the version literal's text on its line.
+        let position = Position::new(2, 20);
+        let actions = ecosystem
+            .generate_code_actions(
+                parse_result.as_ref(),
+                position,
+                &uri,
+                VersionData::new(&cached_versions, &resolved_versions),
+                content,
+            )
+            .await;
+
+        assert!(
+            actions.is_empty(),
+            "expected no fix/refactor action for an npm: alias, got {actions:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/deps-npm/src/formatter.rs
+++ b/crates/deps-npm/src/formatter.rs
@@ -513,6 +513,7 @@ mod tests {
                 section: NpmDependencySection::Dependencies,
                 source: deps_core::parser::DependencySource::Registry,
                 catalog: None,
+                package: None,
             };
             assert!(
                 !formatter.yanked_diagnostic_applies_to(&dep, &VersionReq::new(requirement)),

--- a/crates/deps-npm/src/lockfile.rs
+++ b/crates/deps-npm/src/lockfile.rs
@@ -83,6 +83,13 @@ struct PackageLockJson {
 /// Individual package entry in the "packages" object.
 #[derive(Debug, Deserialize)]
 struct PackageEntry {
+    /// The package's own name, present when it differs from the lockfile key's physical
+    /// install-path basename — npm writes this whenever a dependency is installed under an
+    /// `npm:` alias (issue #654), so `node_modules/my-react` carries `"name": "react"`. `None`
+    /// for the common case where the two already agree; [`extract_package_name`] is the
+    /// fallback then.
+    name: Option<String>,
+
     /// Package version
     version: Option<String>,
 
@@ -129,8 +136,14 @@ impl LockFileProvider for NpmLockParser {
                     continue;
                 }
 
-                // Extract package name from key (e.g., "node_modules/express" -> "express")
-                let name = extract_package_name(&key);
+                // Prefer the entry's own `name` (npm writes this when it differs from the
+                // physical install path — always the case for an `npm:` alias, issue #654)
+                // over the key-derived basename, so an aliased dependency's lock-file entry
+                // groups under its real registry name, matching `Dependency::name()`.
+                let name = entry
+                    .name
+                    .clone()
+                    .unwrap_or_else(|| extract_package_name(&key).to_string());
 
                 // Version is required for actual dependencies
                 let Some(ref version) = entry.version else {
@@ -145,7 +158,7 @@ impl LockFileProvider for NpmLockParser {
                 let dependencies: Vec<String> = entry.dependencies.keys().cloned().collect();
 
                 packages.insert(ResolvedPackage {
-                    name: name.to_string(),
+                    name,
                     version: version.clone(),
                     source,
                     dependencies,
@@ -287,6 +300,7 @@ mod tests {
     #[test]
     fn test_parse_npm_source_registry() {
         let entry = PackageEntry {
+            name: None,
             version: Some("4.18.2".into()),
             resolved: Some("https://registry.npmjs.org/express/-/express-4.18.2.tgz".into()),
             integrity: Some("sha512-abc123".into()),
@@ -311,6 +325,7 @@ mod tests {
     #[test]
     fn test_parse_npm_source_link() {
         let entry = PackageEntry {
+            name: None,
             version: Some("1.0.0".into()),
             resolved: None,
             integrity: None,
@@ -409,6 +424,48 @@ mod tests {
         let express_pkg = resolved.get("express").unwrap();
         assert_eq!(express_pkg.dependencies.len(), 1);
         assert_eq!(express_pkg.dependencies[0], "body-parser");
+    }
+
+    /// Issue #654 S1: an `npm:` alias installs under `node_modules/<alias>`, but npm records
+    /// the real package name in the entry's own `"name"` field — that must win over the
+    /// key-derived alias basename, so `Dependency::name()` (the real name) finds this entry.
+    #[tokio::test]
+    async fn test_parse_package_lock_with_npm_alias_resolves_real_name() {
+        let lockfile_content = r#"{
+  "name": "my-project",
+  "lockfileVersion": 3,
+  "packages": {
+    "": {
+      "name": "my-project",
+      "dependencies": {
+        "my-react": "npm:react@^18.0.0"
+      }
+    },
+    "node_modules/my-react": {
+      "name": "react",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-abc123"
+    }
+  }
+}"#;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let lockfile_path = temp_dir.path().join("package-lock.json");
+        tokio::fs::write(&lockfile_path, lockfile_content)
+            .await
+            .unwrap();
+
+        let parser = NpmLockParser;
+        let resolved = parser.parse_lockfile(&lockfile_path).await.unwrap();
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved.get_version("react"), Some("18.2.0"));
+        assert_eq!(
+            resolved.get_version("my-react"),
+            None,
+            "the alias key must not shadow the real package name"
+        );
     }
 
     #[tokio::test]

--- a/crates/deps-npm/src/parser.rs
+++ b/crates/deps-npm/src/parser.rs
@@ -172,7 +172,11 @@ pub fn parse_package_json_with_context(
         .unwrap_or_default();
 
     for dep in &mut dependencies {
-        dep.source = npm_config.resolve_source_for(&dep.name);
+        // Route by the real registry package name, not the manifest alias (issue #654 S2):
+        // a `.npmrc` scope entry (`@myorg:registry=...`) matches the package actually being
+        // installed, and routing by the alias instead can send a private scoped package's
+        // name to the public registry, or a public package to a private feed.
+        dep.source = npm_config.resolve_source_for(deps_core::Dependency::name(dep));
     }
 
     // Spec 046 FR-001/NFR-002: cheap fast-path — a non-pnpm manifest pays one string check per
@@ -217,6 +221,11 @@ fn parse_dependency_section(
             .and_then(|s| s.position(name, content, line_table))
             .unwrap_or_default();
 
+        let (package, version_req) = match parse_npm_alias(version_req) {
+            Some(alias) => (Some(alias.package.into()), alias.version_req),
+            None => (None, version_req.to_string()),
+        };
+
         result.push(NpmDependency {
             name: name.into(),
             name_range,
@@ -232,10 +241,110 @@ fn parse_dependency_section(
             // `catalog:` gate fires; `None` here is correct for both a non-pnpm manifest and
             // for this function's own unit tests.
             catalog: None,
+            package,
         });
     }
 
     result
+}
+
+/// The real registry package name and version requirement parsed out of an `npm:` alias value.
+struct NpmAlias {
+    package: String,
+    version_req: String,
+}
+
+/// Parses an `npm:` alias specifier (issue #654): npm/pnpm/yarn let a manifest install a
+/// dependency under a different registry name than its JSON key
+/// (`"my-react": "npm:react@^18.0.0"`) — the key becomes a local import alias, and the value
+/// names the real package to resolve against the registry, with everything after the package
+/// name's own trailing `@` as its version requirement.
+///
+/// Returns `None` when `value` (after trimming surrounding whitespace — `npm`'s own
+/// `npm-package-arg` parser tolerates it, so a manifest author accidentally adding it should
+/// not silently disable the alias) doesn't start with `npm:`, when the parsed package name
+/// is empty (e.g. `"npm:"`, `"npm:@"`, `"npm:@/pkg"`, `"npm:@scope/"`), or for the
+/// pnpm-catalog combination form (`npm:<pkg>@catalog:<name>`, deliberately unhandled — see
+/// below) — the caller then falls back to the original literal value, matching
+/// pre-alias-support behavior.
+///
+/// The name/version boundary is [`deps_core::package::npm_style_name_boundary`] — shared
+/// with `deps-deno`'s `npm:`/`jsr:` specifier grammar so a scoped real package name
+/// (`@scope/pkg`) is bounded identically in both crates (issue #654 S3) rather than
+/// reimplemented here more loosely. A trailing `/` right after the name (that helper's
+/// subpath-boundary behavior, meaningful for Deno's own `npm:` import specifiers) has no
+/// equivalent in a `package.json` dependency value, so it is treated as malformed here, not
+/// silently truncated.
+///
+/// A dist-tag alias (`"npm:react@beta"`, `"npm:foo@latest"`) is legal npm syntax but not a
+/// semver range `NpmFormatter::compile_requirement`'s `node_semver::Range` can parse, which
+/// would otherwise silently match no version at all — treated the same as the
+/// missing-version case below.
+///
+/// The pnpm-catalog combination form is left to the caller's literal-value fallback rather
+/// than resolved here: `catalog.rs`'s `apply` looks up the catalog map by
+/// [`crate::types::NpmDependency::name`] (the JSON key/alias), not the real package this
+/// function would extract, so resolving the alias here would feed the catalog lookup the
+/// wrong key — see `catalog.rs`'s "Known limitations" doc, which this leaves unchanged.
+fn parse_npm_alias(value: &str) -> Option<NpmAlias> {
+    let rest = value.trim().strip_prefix("npm:")?;
+
+    let Some(name_len) = deps_core::package::npm_style_name_boundary(rest) else {
+        tracing::debug!(
+            value,
+            "npm: alias has a malformed package name, using literal value"
+        );
+        return None;
+    };
+    let package = rest[..name_len].trim();
+    if package.is_empty() {
+        tracing::debug!(
+            value,
+            "npm: alias has an empty package name, using literal value"
+        );
+        return None;
+    }
+
+    let after_name = &rest[name_len..];
+    let version_req = match after_name.strip_prefix('@') {
+        Some(v) => v.trim(),
+        // Empty: no version at all (`"npm:react"`). Anything else starts with `/` — Deno's
+        // subpath syntax, not valid here (see this function's doc) — reject rather than
+        // truncate.
+        None if after_name.is_empty() => "",
+        None => {
+            tracing::debug!(
+                value,
+                "npm: alias has a subpath after the package name, using literal value"
+            );
+            return None;
+        }
+    };
+
+    if version_req.starts_with("catalog:") {
+        tracing::debug!(
+            value,
+            "npm: alias is the pnpm-catalog combination form, deferring to catalog.rs"
+        );
+        return None;
+    }
+
+    // No version requirement at all, an empty one (`"npm:react@"`), or one that isn't a
+    // semver range `node_semver::Range` accepts (a dist-tag like `"beta"`/`"latest"`) is a
+    // valid, if unusual, alias: treat it as an existence wildcard rather than fabricating an
+    // invalid semver range or dropping the dependency outright — mirrors the `"*"`
+    // existence-wildcard convention `deps_core::registry::is_existence_wildcard` already
+    // recognizes for every ecosystem's version resolution.
+    let version_req = if version_req.is_empty() || node_semver::Range::parse(version_req).is_err() {
+        "*"
+    } else {
+        version_req
+    };
+
+    Some(NpmAlias {
+        package: package.to_string(),
+        version_req: version_req.to_string(),
+    })
 }
 
 #[cfg(test)]
@@ -563,6 +672,141 @@ mod tests {
         assert!(result.dependencies[0].version_range.is_some());
     }
 
+    /// Issue #654: `"npm:<pkg>@<range>"` resolves the real registry package name while the
+    /// JSON key stays the position anchor.
+    #[test]
+    fn test_parse_npm_alias_resolves_real_package_name() {
+        let json = r#"{
+  "dependencies": {
+    "my-react": "npm:react@^18.0.0"
+  }
+}"#;
+
+        let result = parse_package_json(json, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name, "my-react");
+        assert_eq!(dep.package, Some("react".into()));
+        assert_eq!(
+            deps_core::Dependency::name(dep).as_str(),
+            "react",
+            "registry lookups must use the real package name"
+        );
+        assert_eq!(dep.version_req, Some("^18.0.0".into()));
+    }
+
+    /// Issue #654: a scoped real package name (`@scope/pkg`) must not be split on its own
+    /// leading `@` when locating the name/version boundary.
+    #[test]
+    fn test_parse_npm_alias_resolves_scoped_real_package_name() {
+        let json = r#"{
+  "dependencies": {
+    "my-pkg": "npm:@scope/pkg@^1.0.0"
+  }
+}"#;
+
+        let result = parse_package_json(json, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name, "my-pkg");
+        assert_eq!(dep.package, Some("@scope/pkg".into()));
+        assert_eq!(dep.version_req, Some("^1.0.0".into()));
+    }
+
+    /// Issue #654: no version at all after the real package name falls back to the
+    /// existence-wildcard `"*"` rather than an invalid semver range.
+    #[test]
+    fn test_parse_npm_alias_without_version_falls_back_to_wildcard() {
+        let json = r#"{
+  "dependencies": {
+    "my-react": "npm:react"
+  }
+}"#;
+
+        let result = parse_package_json(json, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.package, Some("react".into()));
+        assert_eq!(dep.version_req, Some("*".into()));
+    }
+
+    /// Issue #654: the pnpm-catalog combination form (`npm:<pkg>@catalog:<name>`) is left as
+    /// the original literal value — resolving the alias here would feed `catalog::apply`'s
+    /// name-keyed lookup the wrong key (see `catalog.rs`'s `apply` doc).
+    #[test]
+    fn test_parse_npm_alias_catalog_combination_form_left_unresolved() {
+        let json = r#"{
+  "dependencies": {
+    "my-pkg": "npm:lodash@catalog:utils"
+  }
+}"#;
+
+        let result = parse_package_json(json, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.package, None);
+        assert_eq!(dep.version_req, Some("npm:lodash@catalog:utils".into()));
+    }
+
+    /// Critique M1: a lone `"npm:@"` (empty scope, no `/pkg`) must be rejected like `"npm:"`
+    /// is, not parsed as a real package literally named `"@"`.
+    #[test]
+    fn test_parse_npm_alias_lone_at_sign_is_rejected() {
+        let json = r#"{"dependencies": {"my-pkg": "npm:@"}}"#;
+        let result = parse_package_json(json, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.package, None);
+        assert_eq!(dep.version_req, Some("npm:@".into()));
+    }
+
+    /// Critique S3: an empty scope (`"npm:@/pkg@^1"`) or empty package segment
+    /// (`"npm:@scope/@1.0"`) must be rejected, matching `deps-deno`'s stricter grammar for
+    /// the same `@scope/pkg` shape.
+    #[test]
+    fn test_parse_npm_alias_malformed_scope_is_rejected() {
+        for value in ["npm:@/pkg@^1", "npm:@scope/@1.0"] {
+            let json = format!(r#"{{"dependencies": {{"my-pkg": "{value}"}}}}"#);
+            let result = parse_package_json(&json, &test_uri()).unwrap();
+            let dep = &result.dependencies[0];
+            assert_eq!(dep.package, None, "{value} should not resolve a package");
+            assert_eq!(dep.version_req, Some(value.into()));
+        }
+    }
+
+    /// Critique M1b/M6: whitespace around the `npm:` prefix, the real package name, or the
+    /// version must not silently produce a garbage package/version.
+    #[test]
+    fn test_parse_npm_alias_trims_whitespace() {
+        let json = r#"{
+  "dependencies": {
+    "leading-space-before-prefix": " npm:react@^18.0.0",
+    "space-after-colon": "npm: react@^18.0.0",
+    "space-before-version-at": "npm:react @^18.0.0"
+  }
+}"#;
+
+        let result = parse_package_json(json, &test_uri()).unwrap();
+        for dep in &result.dependencies {
+            assert_eq!(dep.package, Some("react".into()), "{}", dep.name);
+            assert_eq!(dep.version_req, Some("^18.0.0".into()), "{}", dep.name);
+        }
+    }
+
+    /// Critique M2: a dist-tag alias (`"npm:react@beta"`) is legal npm syntax but not a
+    /// `node_semver::Range` — it must fall back to the existence wildcard rather than
+    /// silently matching no version.
+    #[test]
+    fn test_parse_npm_alias_dist_tag_falls_back_to_wildcard() {
+        let json = r#"{
+  "dependencies": {
+    "my-react": "npm:react@beta"
+  }
+}"#;
+
+        let result = parse_package_json(json, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.package, Some("react".into()));
+        assert_eq!(dep.version_req, Some("*".into()));
+    }
+
     #[test]
     fn test_package_name_in_scripts_not_confused() {
         // Regression test: "vitest" appears in scripts as a value,
@@ -695,6 +939,37 @@ mod tests {
         );
 
         assert_eq!(result.resolved_registries.len(), 2);
+    }
+
+    /// Critique S2: `.npmrc` scoped-registry routing must key off the real registry package
+    /// name, not the manifest alias — otherwise a private scoped package aliased to an
+    /// unscoped local key gets routed to (and queried against) the *public* registry,
+    /// disclosing the private name.
+    #[test]
+    fn test_parse_with_context_npm_alias_routes_by_real_package_name() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(
+            root.path().join(".npmrc"),
+            "@myorg:registry=https://npm.pkg.github.com\n",
+        )
+        .unwrap();
+        let manifest_path = root.path().join("package.json");
+        let uri = Uri::from_file_path(&manifest_path).unwrap();
+
+        let json = r#"{"dependencies": {"my-lib": "npm:@myorg/internal@^1.0.0"}}"#;
+        let result = parse_package_json_with_context(json, &uri, &all_policy()).unwrap();
+
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name, "my-lib");
+        assert_eq!(dep.package, Some("@myorg/internal".into()));
+        assert_eq!(
+            dep.source,
+            deps_core::parser::DependencySource::AlternateRegistry {
+                index: "https://npm.pkg.github.com".to_string(),
+                mirrors_crates_io: false,
+            },
+            "routing must follow the real package's scope, not the unscoped alias key"
+        );
     }
 
     /// FR-006/US-004/SC-004: the npm form of issue #248 — a misconfigured `@scope:registry=`

--- a/crates/deps-npm/src/types.rs
+++ b/crates/deps-npm/src/types.rs
@@ -22,6 +22,7 @@ use crate::catalog::CatalogOrigin;
 ///     section: NpmDependencySection::Dependencies,
 ///     source: deps_core::parser::DependencySource::Registry,
 ///     catalog: None,
+///     package: None,
 /// };
 ///
 /// assert_eq!(dep.name, "express");
@@ -29,6 +30,9 @@ use crate::catalog::CatalogOrigin;
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NpmDependency {
+    /// The JSON key: the local import alias when [`Self::package`] is set (via an `npm:`
+    /// alias value), otherwise the actual registry package name. Always the position anchor
+    /// for [`Self::name_range`], regardless of aliasing.
     pub name: deps_core::PackageName,
     pub name_range: Range,
     pub version_req: Option<deps_core::VersionReq>,
@@ -41,6 +45,19 @@ pub struct NpmDependency {
     /// `catalog:`/`catalog:<name>` specifier (spec `046-pnpm-catalogs`); `None` for every
     /// ordinary literal-range dependency.
     pub catalog: Option<CatalogOrigin>,
+    /// The real registry package name from an
+    /// [`npm:` alias value](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#dependencies)
+    /// (`"my-react": "npm:react@^18.0.0"`), when present. `None` for an ordinary, non-aliased
+    /// dependency, in which case [`Self::name`] is both the local alias and the registry name.
+    ///
+    /// When `Some`, [`Self::version_range`] still spans the *whole* `npm:pkg@range` literal
+    /// (unsplit) while `version_requirement()` (`deps_core::Dependency`'s trait method)
+    /// returns only the real range (`"^18.0.0"`) — this mismatch is deliberate: it makes
+    /// `deps_core::lsp_helpers`'s
+    /// shared `literal_span_matches` code-action guard fail closed, suppressing every
+    /// fix/refactor edit for an aliased dependency rather than writing a version literal
+    /// over the whole alias text and destroying it.
+    pub package: Option<deps_core::PackageName>,
 }
 
 // Implemented by hand rather than via `deps_core::impl_dependency!`: the macro's `source:
@@ -50,8 +67,10 @@ pub struct NpmDependency {
 // `self.source.clone()` cannot be passed through the macro at all. Mirrors `deps-cargo`'s
 // identical direct `impl deps_core::Dependency for ParsedDependency`.
 impl deps_core::Dependency for NpmDependency {
+    /// Returns the registry lookup name: [`Self::package`] when this dependency was
+    /// aliased via an `npm:` value, otherwise the JSON key.
     fn name(&self) -> &deps_core::PackageName {
-        &self.name
+        self.package.as_ref().unwrap_or(&self.name)
     }
 
     fn name_range(&self) -> Range {
@@ -211,6 +230,7 @@ mod tests {
             section: NpmDependencySection::Dependencies,
             source: deps_core::parser::DependencySource::Registry,
             catalog: None,
+            package: None,
         };
 
         assert_eq!(dep.name, "react");

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -172,6 +172,31 @@ setting's own doc above.
   standard `.npmrc` present in the workspace is still honored either way.
   pnpm's own `pnpm-workspace.yaml` catalog extension *is* read — see below.
 
+### npm `npm:` Alias Resolution
+
+npm/pnpm/yarn let a `package.json` dependency install under a different local
+import name than its registry package, via the `npm:` protocol prefix:
+`"my-react": "npm:react@^18.0.0"` — `my-react` is the local key, `react` is the
+real package to resolve, `^18.0.0` is its version requirement. Hover,
+completion, diagnostics, code lens, inlay hints, `.npmrc` scoped-registry
+routing, and OSV vulnerability lookups all resolve against the real package
+name (`react`), while the local alias key stays the position anchor for
+hover/diagnostic ranges in the editor (resolves #654). A scoped real package
+name (`"my-pkg": "npm:@scope/pkg@^1.0.0"`) is supported the same way. A
+dist-tag alias (`"npm:react@beta"`) or one with no version at all
+(`"npm:react"`) resolves as an existence check (equivalent to a bare `"*"`
+requirement) rather than a specific version comparison.
+
+**Code actions/lens are not offered** for an `npm:`-aliased dependency: the
+manifest text at the version position is the whole `npm:pkg@range` literal,
+not just the range, so an automated rewrite would need to preserve the alias
+prefix — not yet implemented. This is a deliberate, safe degradation (no
+version data is lost, only the one-click fix), not a bug.
+
+**Known limitation**: the pnpm-catalog combination form
+(`npm:<pkg>@catalog:<name>`) is not detected — see the pnpm Catalogs section
+below.
+
 ### npm pnpm Catalogs
 
 A `package.json` dependency declared as `"catalog:"` (the default catalog) or
@@ -213,7 +238,10 @@ never per-key-merges the two sections.
   `deps-npm` lockfile support for it yet — see the lock-file column above);
   this is a pre-existing gap shared with every other npm dependency in a pnpm
   workspace, not specific to catalogs.
-- The `npm:<pkg>@catalog:<name>` alias form is not detected.
+- The `npm:<pkg>@catalog:<name>` combination form (an `npm:` alias whose
+  version is itself a catalog reference) is not detected — the base `npm:`
+  alias form (no catalog combination) *is* resolved, see the npm `npm:` Alias
+  Resolution section above.
 - A catalog entry whose value isn't a scalar string (e.g. a nested mapping)
   gets its own distinct "not a version string" message rather than being
   validated against pnpm's own schema further.


### PR DESCRIPTION
## Summary

- `deps-npm` did not handle npm/pnpm/yarn's `npm:<pkg>@<range>` package-alias
  syntax (e.g. `"my-react": "npm:react@^18.0.0"`), so version comparison,
  registry lookups, `.npmrc` scope routing, OSV vulnerability keys, and
  `package-lock.json` in-use-version resolution all operated on the local
  alias name instead of the real package.
- Adds `NpmDependency.package: Option<PackageName>` and resolves it against
  the real package name everywhere `Dependency::name()` is consumed, while
  keeping the alias key's source range for hover/diagnostic anchoring —
  mirrors the pattern already shipped for Cargo's `package = "..."` rename
  (#648, #650, #653).
- `package-lock.json` parsing now prefers a package entry's own `name` field
  (npm writes this for an aliased/renamed install) over the lockfile-key
  -derived name, fixing in-use-version and OSV-target resolution for
  aliased dependencies, and incidentally for npm workspace members too.
- Extracted `deps-deno`'s stricter scope-aware `npm:` specifier splitter
  into a shared `deps_core::package::npm_style_name_boundary` helper reused
  by both `deps-npm` and `deps-deno`, instead of a per-crate reimplementation.
- The pnpm-catalog combination form (`npm:<pkg>@catalog:<name>`) is
  unchanged/unaffected — still resolved via the existing catalog mechanism.

Resolves #654

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4433 passed)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- [x] New unit tests: base alias, scoped alias, missing-version wildcard fallback,
      dist-tag wildcard fallback, malformed/degenerate scope rejection,
      whitespace trimming, catalog-combination-form no-op, package-lock
      `name`-field preference, `.npmrc` scope routing against the real name,
      code-action/lens suppression for aliased deps