### PR TITLE
License hover: SPDX license for 8 ecosystems (PR1 of 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **deps-core, deps-composer**: hover now shows the SPDX license for the resolved and latest version (Cargo, npm, PyPI, Go, Maven, Bundler, NuGet, Composer), flagging a "License changed" when they differ (resolves #204)
+- **deps-core, deps-composer**: hover now shows the SPDX license for the resolved and latest version (Cargo, npm, PyPI, Go, Maven, Bundler, NuGet, Composer), flagging a "License changed" when they differ (resolves #204) (#663)
 - **deps-core**: OSV malicious-package advisories (`MAL-*` id or alias) now classify as a distinct `VulnSeverity::Malicious` instead of falling through to "unknown severity" in hover/diagnostics (resolves #646) (#652)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **deps-core, deps-composer**: hover now shows the SPDX license for the resolved and latest version (Cargo, npm, PyPI, Go, Maven, Bundler, NuGet, Composer), flagging a "License changed" when they differ (resolves #204)
 - **deps-core**: OSV malicious-package advisories (`MAL-*` id or alias) now classify as a distinct `VulnSeverity::Malicious` instead of falling through to "unknown severity" in hover/diagnostics (resolves #646) (#652)
 
 ### Fixed

--- a/crates/deps-composer/src/registry.rs
+++ b/crates/deps-composer/src/registry.rs
@@ -403,6 +403,61 @@ struct MinifiedVersion {
     /// Publish timestamp (RFC 3339, e.g. `"2026-01-02T08:56:05+00:00"`).
     #[serde(default)]
     time: Option<String>,
+    /// SPDX license identifier(s) (issue #204). `None` means "not present on this
+    /// minified entry" (inherit from the previous one), distinct from `Some(vec![])`
+    /// ("this release explicitly declares no license").
+    ///
+    /// `composer.json`'s own `license` field is documented as either a single string
+    /// or an array of strings — [`deserialize_license`] accepts both shapes rather
+    /// than only the array form, mirroring [`Self::abandoned`]'s
+    /// `Option<serde_json::Value>` defense-in-depth: an unexpected shape here (a
+    /// bare string, or malformed data of any other JSON type) must degrade to `None`
+    /// rather than fail `serde_json::from_slice` for the *entire* `PackagistResponse`
+    /// — which would otherwise drop every version of the package, not just its
+    /// license (security review S3-2).
+    #[serde(default, deserialize_with = "deserialize_license")]
+    license: Option<Vec<String>>,
+}
+
+/// Accepts `composer.json`'s documented `license` shapes — a single string, an array
+/// of strings, or absent/`null` — and normalizes to `Option<Vec<String>>`. Any other
+/// JSON shape (a number, object, bool, or an array containing non-string elements)
+/// degrades to `None`/skips the offending element rather than erroring the whole
+/// response (see [`MinifiedVersion::license`]'s doc).
+fn deserialize_license<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<Vec<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    Ok(match value {
+        serde_json::Value::String(s) => Some(vec![s]),
+        serde_json::Value::Array(entries) => {
+            // Review round 3 fix: a non-empty raw array whose every element is a
+            // non-string (a malformed `license: [7, 8]`) must degrade to `None`
+            // ("not present on this entry", inherit), not `Some(vec![])` ("this
+            // entry explicitly declares no license"). `expand_minified_versions`
+            // treats `Some(_)` as an override — a stray `Some(vec![])` here would
+            // silently overwrite an earlier real license and then get inherited by
+            // every later entry that omits `license` entirely, corrupting the whole
+            // rest of the inheritance chain from one malformed entry.
+            let had_entries = !entries.is_empty();
+            let strings: Vec<String> = entries
+                .into_iter()
+                .filter_map(|entry| match entry {
+                    serde_json::Value::String(s) => Some(s),
+                    _ => None,
+                })
+                .collect();
+            if had_entries && strings.is_empty() {
+                None
+            } else {
+                Some(strings)
+            }
+        }
+        _ => None,
+    })
 }
 
 /// Expands minified Packagist v2 versions using field inheritance.
@@ -437,6 +492,9 @@ fn expand_minified_versions(entries: Vec<MinifiedVersion>) -> Vec<ComposerVersio
         if entry.abandoned.is_some() {
             current.abandoned = entry.abandoned;
         }
+        if entry.license.is_some() {
+            current.license = entry.license;
+        }
 
         let Some(ref version) = current.version else {
             continue;
@@ -462,6 +520,7 @@ fn expand_minified_versions(entries: Vec<MinifiedVersion>) -> Vec<ComposerVersio
             abandoned,
             deprecation,
             published_at,
+            license: current.license.clone().unwrap_or_default(),
         });
     }
 
@@ -784,12 +843,14 @@ mod tests {
                 version_normalized: Some("3.0.0.0".into()),
                 abandoned: None,
                 time: None,
+                license: None,
             },
             MinifiedVersion {
                 version: Some("2.0.0".into()),
                 version_normalized: Some("2.0.0.0".into()),
                 abandoned: None,
                 time: None,
+                license: None,
             },
         ];
 
@@ -809,12 +870,14 @@ mod tests {
                 version_normalized: Some("3.0.0.0".into()),
                 abandoned: None,
                 time: None,
+                license: None,
             },
             MinifiedVersion {
                 version: Some("2.9.0".into()),
                 version_normalized: None, // inherited
                 abandoned: None,
                 time: None,
+                license: None,
             },
         ];
 
@@ -822,6 +885,64 @@ mod tests {
         assert_eq!(versions.len(), 2);
         assert_eq!(versions[1].version, "2.9.0");
         assert_eq!(versions[1].version_normalized, "3.0.0.0"); // inherited
+    }
+
+    /// Issue #204: `license` participates in the minified-entry inheritance scheme
+    /// (unlike `time`) — a second entry with no `license` key must inherit the
+    /// first's, mirroring `version_normalized`/`abandoned`.
+    #[test]
+    fn test_expand_minified_versions_license_inherits_like_version_normalized() {
+        let entries = vec![
+            MinifiedVersion {
+                version: Some("3.0.0".into()),
+                version_normalized: Some("3.0.0.0".into()),
+                abandoned: None,
+                time: None,
+                license: Some(vec!["MIT".to_string()]),
+            },
+            MinifiedVersion {
+                version: Some("2.9.0".into()),
+                version_normalized: None,
+                abandoned: None,
+                time: None,
+                license: None, // inherited
+            },
+        ];
+
+        let versions = expand_minified_versions(entries);
+        assert_eq!(versions.len(), 2);
+        assert_eq!(versions[0].license, vec!["MIT".to_string()]);
+        assert_eq!(versions[1].license, vec!["MIT".to_string()]);
+    }
+
+    /// A later entry's own `license` overrides the inherited one, and an entry with
+    /// no `license` ever set (neither its own nor inherited) defaults to empty.
+    #[test]
+    fn test_expand_minified_versions_license_override_and_default_empty() {
+        let entries = vec![
+            MinifiedVersion {
+                version: Some("3.0.0".into()),
+                version_normalized: Some("3.0.0.0".into()),
+                abandoned: None,
+                time: None,
+                license: None,
+            },
+            MinifiedVersion {
+                version: Some("2.0.0".into()),
+                version_normalized: None,
+                abandoned: None,
+                time: None,
+                license: Some(vec!["Apache-2.0".to_string()]),
+            },
+        ];
+
+        let versions = expand_minified_versions(entries);
+        assert_eq!(versions.len(), 2);
+        assert!(
+            versions[0].license.is_empty(),
+            "no license was ever set for the first entry"
+        );
+        assert_eq!(versions[1].license, vec!["Apache-2.0".to_string()]);
     }
 
     #[test]
@@ -832,18 +953,21 @@ mod tests {
                 version_normalized: Some("3.0.0.0".into()),
                 abandoned: None,
                 time: None,
+                license: None,
             },
             MinifiedVersion {
                 version: Some("dev-main".into()),
                 version_normalized: None,
                 abandoned: None,
                 time: None,
+                license: None,
             },
             MinifiedVersion {
                 version: Some("2.0.0-dev".into()),
                 version_normalized: None,
                 abandoned: None,
                 time: None,
+                license: None,
             },
         ];
 
@@ -859,6 +983,7 @@ mod tests {
             version_normalized: Some("3.0.0.0".into()),
             abandoned: Some(serde_json::Value::String("Use other/package".into())),
             time: None,
+            license: None,
         }];
 
         let versions = expand_minified_versions(entries);
@@ -882,6 +1007,7 @@ mod tests {
             version_normalized: Some("3.0.0.0".into()),
             abandoned: Some(serde_json::Value::Bool(true)),
             time: None,
+            license: None,
         }];
 
         let versions = expand_minified_versions(entries);
@@ -903,6 +1029,7 @@ mod tests {
             version_normalized: Some("3.0.0.0".into()),
             abandoned: Some(serde_json::Value::String("   ".into())),
             time: None,
+            license: None,
         }];
 
         let versions = expand_minified_versions(entries);
@@ -923,6 +1050,7 @@ mod tests {
             version_normalized: Some("3.0.0.0".into()),
             abandoned: None,
             time: None,
+            license: None,
         }];
 
         let versions = expand_minified_versions(entries);
@@ -936,6 +1064,7 @@ mod tests {
             version_normalized: Some("3.0.0.0".into()),
             abandoned: None,
             time: Some("2026-01-02T08:56:05+00:00".into()),
+            license: None,
         }];
 
         let versions = expand_minified_versions(entries);
@@ -953,6 +1082,7 @@ mod tests {
             version_normalized: Some("3.0.0.0".into()),
             abandoned: None,
             time: None,
+            license: None,
         }];
 
         let versions = expand_minified_versions(entries);
@@ -967,6 +1097,7 @@ mod tests {
             version_normalized: Some("3.0.0.0".into()),
             abandoned: None,
             time: Some("not-a-timestamp".into()),
+            license: None,
         }];
 
         let versions = expand_minified_versions(entries);
@@ -988,12 +1119,14 @@ mod tests {
                 version_normalized: Some("3.0.0.0".into()),
                 abandoned: None,
                 time: Some("2026-01-02T08:56:05+00:00".into()),
+                license: None,
             },
             MinifiedVersion {
                 version: Some("2.9.0".into()),
                 version_normalized: None, // inherited
                 abandoned: None,
                 time: None, // must NOT inherit the previous entry's time
+                license: None,
             },
         ];
 
@@ -1075,6 +1208,154 @@ mod tests {
         assert_eq!(versions[0].version, "3.0.0");
     }
 
+    /// Issue #204: `license[]` shape live-verified against Packagist's real p2 API
+    /// response — the second entry omits `license` entirely and must inherit the
+    /// first's, matching every other minified field.
+    #[test]
+    fn test_parse_package_metadata_parses_license() {
+        let json = r#"{
+  "packages": {
+    "monolog/monolog": [
+      {
+        "version": "3.0.0",
+        "version_normalized": "3.0.0.0",
+        "abandoned": null,
+        "license": ["MIT"]
+      },
+      {
+        "version": "2.0.0",
+        "version_normalized": "2.0.0.0"
+      }
+    ]
+  }
+}"#;
+
+        let versions = parse_package_metadata("monolog/monolog", json.as_bytes()).unwrap();
+        assert_eq!(versions.len(), 2);
+        assert_eq!(versions[0].license, vec!["MIT".to_string()]);
+        assert_eq!(
+            versions[1].license,
+            vec!["MIT".to_string()],
+            "license inherits like version_normalized/abandoned"
+        );
+    }
+
+    /// Security review S3-2: `composer.json`'s `license` field is documented as
+    /// either a single string or an array of strings — a bare string must parse to
+    /// a one-element `Vec`, not fail the whole `PackagistResponse` deserialization
+    /// (which would otherwise drop every version of the package).
+    #[test]
+    fn test_parse_package_metadata_license_as_bare_string() {
+        let json = r#"{
+  "packages": {
+    "monolog/monolog": [
+      {
+        "version": "3.0.0",
+        "version_normalized": "3.0.0.0",
+        "abandoned": null,
+        "license": "MIT"
+      }
+    ]
+  }
+}"#;
+
+        let versions = parse_package_metadata("monolog/monolog", json.as_bytes()).unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].license, vec!["MIT".to_string()]);
+    }
+
+    /// An unexpected `license` shape (neither string nor array) must degrade to
+    /// "no license" rather than fail the whole response.
+    #[test]
+    fn test_parse_package_metadata_license_unexpected_shape_degrades_gracefully() {
+        let json = r#"{
+  "packages": {
+    "monolog/monolog": [
+      {
+        "version": "3.0.0",
+        "version_normalized": "3.0.0.0",
+        "abandoned": null,
+        "license": 42
+      }
+    ]
+  }
+}"#;
+
+        let versions = parse_package_metadata("monolog/monolog", json.as_bytes()).unwrap();
+        assert_eq!(versions.len(), 1);
+        assert!(versions[0].license.is_empty());
+    }
+
+    /// An array with a mix of string and non-string entries keeps only the string
+    /// entries rather than failing the whole response.
+    #[test]
+    fn test_parse_package_metadata_license_array_skips_non_string_entries() {
+        let json = r#"{
+  "packages": {
+    "monolog/monolog": [
+      {
+        "version": "3.0.0",
+        "version_normalized": "3.0.0.0",
+        "abandoned": null,
+        "license": ["MIT", 7, "Apache-2.0"]
+      }
+    ]
+  }
+}"#;
+
+        let versions = parse_package_metadata("monolog/monolog", json.as_bytes()).unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(
+            versions[0].license,
+            vec!["MIT".to_string(), "Apache-2.0".to_string()]
+        );
+    }
+
+    /// Review round 3 fix: a malformed all-non-string `license` array on a middle
+    /// entry must not corrupt the inheritance chain for every entry after it. Entry 1
+    /// declares a real license, entry 2's `license: [7, 8]` has no usable string
+    /// (must degrade to "not present", not "explicitly empty"), entry 3 omits
+    /// `license` entirely and must still inherit entry 1's real license through
+    /// entry 2 — not entry 2's would-be `Some(vec![])`.
+    #[test]
+    fn test_parse_package_metadata_license_all_non_string_array_does_not_corrupt_inheritance() {
+        let json = r#"{
+  "packages": {
+    "monolog/monolog": [
+      {
+        "version": "3.0.0",
+        "version_normalized": "3.0.0.0",
+        "abandoned": null,
+        "license": ["MIT"]
+      },
+      {
+        "version": "2.9.0",
+        "license": [7, 8]
+      },
+      {
+        "version": "2.8.0"
+      }
+    ]
+  }
+}"#;
+
+        let versions = parse_package_metadata("monolog/monolog", json.as_bytes()).unwrap();
+        assert_eq!(versions.len(), 3);
+        assert_eq!(versions[0].license, vec!["MIT".to_string()]);
+        assert_eq!(
+            versions[1].license,
+            vec!["MIT".to_string()],
+            "an all-non-string license array must inherit the prior entry's real \
+             license rather than overriding it with an empty one"
+        );
+        assert_eq!(
+            versions[2].license,
+            vec!["MIT".to_string()],
+            "the third entry (no license key at all) must still inherit MIT through \
+             the malformed second entry, not lose it"
+        );
+    }
+
     #[test]
     fn test_parse_package_metadata_deeply_nested_json_rejected_before_parse() {
         // #430: a deeply nested `abandoned` value must be rejected by the
@@ -1106,6 +1387,7 @@ mod tests {
                 abandoned: true,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "1.0.0".into(),
@@ -1113,6 +1395,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new("*");
@@ -1135,6 +1418,7 @@ mod tests {
                 abandoned: true,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "1.0.0".into(),
@@ -1142,6 +1426,7 @@ mod tests {
                 abandoned: true,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new("*");
@@ -1197,6 +1482,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "1.5.0".into(),
@@ -1204,6 +1490,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new(">=1.0");
@@ -1226,6 +1513,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "1.5.0".into(),
@@ -1233,6 +1521,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new("2.0.0-beta1");
@@ -1287,6 +1576,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "1.5.0".into(),
@@ -1294,6 +1584,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new("2.0.0-a1");
@@ -1315,6 +1606,7 @@ mod tests {
             abandoned: false,
             deprecation: None,
             published_at: None,
+            license: vec![],
         })];
         let req = VersionReq::new("^1.0.0-a1");
         assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
@@ -1367,6 +1659,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "2.0.0-beta1".into(),
@@ -1374,6 +1667,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new("*");
@@ -1420,6 +1714,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "2.0.0-beta1".into(),
@@ -1427,6 +1722,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "1.5.0".into(),
@@ -1434,6 +1730,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ]
     }
@@ -1553,6 +1850,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "1.0.0".into(),
@@ -1560,6 +1858,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new("^1.0@beta");
@@ -1585,6 +1884,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "1.0.0".into(),
@@ -1592,6 +1892,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new("^1.0@beta");
@@ -1618,6 +1919,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "1.0.0".into(),
@@ -1625,6 +1927,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new("^1.0@stable");
@@ -1647,6 +1950,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "1.4.0-RC1".into(),
@@ -1654,6 +1958,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "1.0.0".into(),
@@ -1661,6 +1966,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new("^1.0@RC");
@@ -1687,6 +1993,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "1.0.0".into(),
@@ -1694,6 +2001,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new("^1.0@alpha");
@@ -1715,6 +2023,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "1.0.0".into(),
@@ -1722,6 +2031,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new("^1.0@dev");
@@ -1745,6 +2055,7 @@ mod tests {
             abandoned: false,
             deprecation: None,
             published_at: None,
+            license: vec![],
         })];
         let req = VersionReq::new("^1.0@beta || ^2.0");
         assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
@@ -1764,6 +2075,7 @@ mod tests {
             abandoned: false,
             deprecation: None,
             published_at: None,
+            license: vec![],
         })];
         let req = VersionReq::new(">=1.0@dev <2.0");
         assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
@@ -1807,6 +2119,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "1.5.0".into(),
@@ -1814,6 +2127,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new(">=1.0");
@@ -1836,6 +2150,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "1.5.0".into(),
@@ -1843,6 +2158,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new("2.0.0a1");
@@ -1863,6 +2179,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "1.5.0".into(),
@@ -1870,6 +2187,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new(">=1.0");
@@ -1895,6 +2213,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "v2.2.8".into(),
@@ -1902,6 +2221,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new("*");
@@ -1928,6 +2248,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "v2.9.0".into(),
@@ -1935,6 +2256,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new(">=2.0");
@@ -1962,6 +2284,7 @@ mod tests {
             abandoned: false,
             deprecation: None,
             published_at: None,
+            license: vec![],
         })];
         let req = VersionReq::new(">=3.0");
         assert_eq!(
@@ -1991,6 +2314,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "1.5.0".into(),
@@ -1998,6 +2322,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new(">=1.0");
@@ -2020,6 +2345,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "1.5.0".into(),
@@ -2027,6 +2353,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new("2.0.0RC1");
@@ -2049,6 +2376,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "2.6.2".into(),
@@ -2056,6 +2384,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new(">=2.0");
@@ -2079,6 +2408,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
             Box::new(ComposerVersion {
                 version: "2.6.2".into(),
@@ -2086,6 +2416,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             }),
         ];
         let req = VersionReq::new("2.6.3.alpha");
@@ -2104,6 +2435,12 @@ mod tests {
             versions
                 .iter()
                 .any(|v| v.version.as_str().starts_with("3."))
+        );
+        // Issue #204: license must be parsed (and inherited across minified
+        // entries) from the real Packagist v2 response, not just the fixture.
+        assert!(
+            versions.iter().any(|v| !v.license.is_empty()),
+            "expected at least one real monolog/monolog version to carry a license"
         );
     }
 

--- a/crates/deps-composer/src/types.rs
+++ b/crates/deps-composer/src/types.rs
@@ -72,6 +72,7 @@ pub enum ComposerSection {
 ///     abandoned: false,
 ///     deprecation: None,
 ///     published_at: None,
+///     license: vec![],
 /// };
 ///
 /// assert!(!version.abandoned);
@@ -93,6 +94,13 @@ pub struct ComposerVersion {
     /// not apply to `time`, since inheriting it would attribute one
     /// release's publish date to another.
     pub published_at: Option<deps_core::PublishTime>,
+    /// SPDX license identifier(s) from the p2 entry's `license` field (issue #204).
+    ///
+    /// Unlike `time`, this *does* participate in the Packagist v2 minified-entry
+    /// inheritance scheme (`expand_minified_versions`) — a release's `composer.json`
+    /// commonly repeats the same `license` as the previous tag, and Packagist only
+    /// sends the field again when it actually changes.
+    pub license: Vec<String>,
 }
 
 /// Whether `s` contains Composer's short `-a`/`-b` stability alias (`-a1`,
@@ -217,6 +225,7 @@ deps_core::impl_version!(ComposerVersion {
             || deps_core::has_default_prerelease_marker(&v.version_normalized)
     },
     deprecation: |v: &ComposerVersion| v.deprecation.as_ref(),
+    license: license,
 });
 
 /// Package metadata from Packagist search.
@@ -292,6 +301,7 @@ mod tests {
             abandoned: true,
             deprecation: None,
             published_at: None,
+            license: vec![],
         };
 
         assert_eq!(version.version_string(), "2.0.0");
@@ -300,6 +310,33 @@ mod tests {
             deps_core::RemovalStatus::AdvisoryDeprecated
         );
         assert!(!version.removal_status().blocks_resolution());
+    }
+
+    /// Issue #204: `Version::license()` reads the dedicated field.
+    #[test]
+    fn test_composer_version_license_accessor() {
+        let with_license = ComposerVersion {
+            version: "2.0.0".into(),
+            version_normalized: "2.0.0.0".into(),
+            abandoned: false,
+            deprecation: None,
+            published_at: None,
+            license: vec!["MIT".to_string(), "Apache-2.0".to_string()],
+        };
+        assert_eq!(
+            with_license.license(),
+            &["MIT".to_string(), "Apache-2.0".to_string()]
+        );
+
+        let without_license = ComposerVersion {
+            version: "1.0.0".into(),
+            version_normalized: "1.0.0.0".into(),
+            abandoned: false,
+            deprecation: None,
+            published_at: None,
+            license: vec![],
+        };
+        assert!(without_license.license().is_empty());
     }
 
     /// #205: `Version::deprecation()` reads the dedicated field, independent of the
@@ -315,6 +352,7 @@ mod tests {
                 replacement: Some("other/package".to_string()),
             }),
             published_at: None,
+            license: vec![],
         };
         assert_eq!(
             with_payload
@@ -329,6 +367,7 @@ mod tests {
             abandoned: false,
             deprecation: None,
             published_at: None,
+            license: vec![],
         };
         assert!(without_payload.deprecation().is_none());
     }
@@ -344,6 +383,7 @@ mod tests {
             abandoned: false,
             deprecation: None,
             published_at: None,
+            license: vec![],
         };
         let beta = ComposerVersion {
             version: "1.0.0-b1".into(),
@@ -351,6 +391,7 @@ mod tests {
             abandoned: false,
             deprecation: None,
             published_at: None,
+            license: vec![],
         };
         assert!(alpha.is_prerelease());
         assert!(beta.is_prerelease());
@@ -378,6 +419,7 @@ mod tests {
                 abandoned: false,
                 deprecation: None,
                 published_at: None,
+                license: vec![],
             };
             assert_eq!(
                 version.is_prerelease(),
@@ -503,6 +545,7 @@ mod tests {
             abandoned: false,
             deprecation: None,
             published_at: None,
+            license: vec![],
         };
         assert!(version.is_prerelease());
     }
@@ -515,6 +558,7 @@ mod tests {
             abandoned: false,
             deprecation: None,
             published_at: None,
+            license: vec![],
         };
         assert!(!version.is_prerelease());
     }

--- a/crates/deps-core/src/deps_dev/mod.rs
+++ b/crates/deps-core/src/deps_dev/mod.rs
@@ -446,12 +446,12 @@ impl DepsDevClient {
             urlencoding::encode(version),
         );
 
-        let (provenance, related_projects) = match self.get(&version_url).await {
+        let (provenance, related_projects, licenses) = match self.get(&version_url).await {
             Ok(bytes) => match crate::parser::parse_json_checked::<DepsDevVersionInfo>(&bytes) {
                 Ok(info) => {
                     let provenance =
                         classify_provenance(&info.slsa_provenances, &info.attestations);
-                    (Some(provenance), info.related_projects)
+                    (Some(provenance), info.related_projects, info.licenses)
                 }
                 Err(e) => {
                     tracing::debug!(error = %e, "deps.dev version response parse failed");
@@ -490,6 +490,7 @@ impl DepsDevClient {
         let signal = SupplyChainTrustSignal {
             scorecard,
             provenance,
+            licenses,
         };
         (Some(signal), DEPS_DEV_SUCCESS_TTL.min(project_ttl))
     }
@@ -690,6 +691,50 @@ mod tests {
         let scorecard = signal.scorecard.expect("scorecard expected");
         assert!((scorecard.overall_score - 9.1).abs() < f32::EPSILON);
         assert!(!scorecard.self_reported);
+    }
+
+    /// Issue #204: `licenses[]` on the same version-call response `provenance` is
+    /// parsed from is threaded into `SupplyChainTrustSignal.licenses`, with no new
+    /// deps.dev endpoint or call.
+    #[tokio::test]
+    async fn trust_signal_parses_licenses_from_version_response() {
+        let (mut server, client) = mock_client().await;
+        let _version = server
+            .mock("GET", "/v3/systems/npm/packages/sigstore/versions/2.3.1")
+            .with_status(200)
+            .with_body(
+                r#"{"slsaProvenances": [], "attestations": [], "relatedProjects": [], "licenses": ["MIT", "Apache-2.0"]}"#,
+            )
+            .create_async()
+            .await;
+
+        let signal = client
+            .trust_signal("npm", "sigstore", "2.3.1")
+            .await
+            .expect("signal expected");
+        assert_eq!(
+            signal.licenses,
+            vec!["MIT".to_string(), "Apache-2.0".to_string()]
+        );
+    }
+
+    /// A version response with no `licenses` key must degrade to an empty `Vec`,
+    /// never a panic or a default `None`-then-unwrap.
+    #[tokio::test]
+    async fn trust_signal_missing_licenses_field_is_empty_vec() {
+        let (mut server, client) = mock_client().await;
+        let _version = server
+            .mock("GET", "/v3/systems/npm/packages/express/versions/4.19.2")
+            .with_status(200)
+            .with_body(EXPRESS_VERSION_NO_PROVENANCE)
+            .create_async()
+            .await;
+
+        let signal = client
+            .trust_signal("npm", "express", "4.19.2")
+            .await
+            .expect("signal expected");
+        assert!(signal.licenses.is_empty());
     }
 
     #[tokio::test]
@@ -1343,6 +1388,24 @@ mod tests {
             client.memo.len() <= MAX_MEMO_ENTRIES,
             "memo must stay bounded at MAX_MEMO_ENTRIES, got {}",
             client.memo.len()
+        );
+    }
+
+    /// Issue #204, live-verified against the real deps.dev API (curl-equivalent
+    /// checks during implementation confirmed `licenses[]` on all 7 covered
+    /// systems): the real npm `express` version response carries a non-empty
+    /// `licenses[]` array, threaded through into `SupplyChainTrustSignal.licenses`.
+    #[tokio::test]
+    #[ignore]
+    async fn trust_signal_real_npm_express_carries_license() {
+        let client = client();
+        let signal = client
+            .trust_signal("npm", "express", "4.19.2")
+            .await
+            .expect("signal expected for a real, well-known package");
+        assert!(
+            !signal.licenses.is_empty(),
+            "expected express@4.19.2 to report a real license"
         );
     }
 

--- a/crates/deps-core/src/deps_dev/types.rs
+++ b/crates/deps-core/src/deps_dev/types.rs
@@ -19,6 +19,11 @@ pub(super) struct DepsDevVersionInfo {
     pub(super) attestations: Vec<ProvenanceEntry>,
     #[serde(default)]
     pub(super) related_projects: Vec<RelatedProject>,
+    /// SPDX license identifier(s) reported for this version (issue #204). Read
+    /// directly from the same version-call response `slsa_provenances`/`attestations`
+    /// come from — no new deps.dev endpoint.
+    #[serde(default)]
+    pub(super) licenses: Vec<String>,
 }
 
 /// One `slsaProvenances[]`/`attestations[]` entry.
@@ -115,4 +120,10 @@ pub struct SupplyChainTrustSignal {
     /// This version's SLSA/attestation provenance status, when the
     /// version-level query itself succeeded (FR-004).
     pub provenance: Option<ProvenanceStatus>,
+    /// SPDX license identifier(s) for this resolved version (issue #204), from the
+    /// same version-level deps.dev call `provenance` is derived from. Empty when the
+    /// version call succeeded but reported no license, or when the call itself never
+    /// succeeded (mirrors [`crate::registry::Version::license`]'s "empty means
+    /// unknown" convention).
+    pub licenses: Vec<String>,
 }

--- a/crates/deps-core/src/lsp_helpers/hover.rs
+++ b/crates/deps-core/src/lsp_helpers/hover.rs
@@ -317,6 +317,85 @@ pub async fn generate_hover<R: Registry + ?Sized>(
     };
     push_trust_signal_hover_section(&mut markdown, trust_signal.as_ref());
 
+    // Issue #204 (spec 010): resolved-version license first tries the already-fetched
+    // `available_versions` list (free for ecosystems whose hot-path version list
+    // carries license per entry, e.g. Composer), then falls back to `trust_signal`'s
+    // `licenses` (deps.dev-covered ecosystems: Cargo, npm, Go, Maven, Bundler, NuGet,
+    // PyPI — the version list itself never carries license for these, live-verified).
+    // Latest-version license only ever comes from the native list — deps.dev's
+    // version-level call only ever targets the *resolved* version
+    // (`spawn_trust_signal_fetch`'s `in_use_version` argument), so a deps.dev-routed
+    // ecosystem's latest license degrades to "(unavailable)", the graceful-degradation
+    // edge case spec 010 §6 explicitly sanctions rather than a second network call.
+    //
+    // The native-list lookup keys on `in_use_version` (the same helper
+    // `spawn_trust_signal_fetch` already uses above), not the weaker `resolved`
+    // variable the `**Current**`/`**Requirement**` line uses — `in_use_version` adds
+    // a `concrete_pin_version` fallback for an exact manifest pin with no lock file
+    // (e.g. a `composer.json` `"3.0.0"` dependency with no `composer.lock`), which
+    // `resolved` alone doesn't have. Falls back to `resolved` when no ecosystem is
+    // set (`in_use_version` requires one) — a handful of test fixtures only
+    // (impl-critic review M1: keeps this lookup as least as capable as the
+    // deps.dev-routed ecosystems', not just consistent with the Current line).
+    let in_use_version_str: Option<String> = versions.ecosystem.and_then(|ecosystem| {
+        in_use_version(
+            dep,
+            normalized_name.as_str(),
+            versions.resolved,
+            versions.resolved_version_candidates,
+            formatter,
+            ecosystem,
+        )
+    });
+    // The single "which concrete version is actually in use" key, shared by the
+    // resolved-license lookup below *and* the latest-license "is this the same
+    // version" shortcut further down — both must agree on the same key, or the
+    // shortcut can miss a version the lookup itself found (review round 3 M1
+    // regression: an earlier draft compared the shortcut against the weaker
+    // `resolved` while the lookup used this stronger key, reintroducing S1's
+    // spurious "unavailable" note for exactly the concrete-pin-no-lockfile case
+    // this key exists to cover).
+    let resolved_key: Option<&str> = in_use_version_str.as_deref().or(resolved);
+    let resolved_license: Vec<String> = resolved_key
+        .and_then(|r| {
+            available_versions
+                .as_ref()
+                .and_then(|versions| versions.iter().find(|v| v.version_string().as_str() == r))
+        })
+        .map(|v| v.license().to_vec())
+        .filter(|l| !l.is_empty())
+        .or_else(|| {
+            trust_signal
+                .as_ref()
+                .map(|s| s.licenses.clone())
+                .filter(|l| !l.is_empty())
+        })
+        .unwrap_or_default();
+    // `None` (no latest version at all — `latest_line` is `None`) is distinct from
+    // `Some(&[])` (a latest version exists but its license is unknown): the former
+    // must render no note at all, the latter renders "(latest version license
+    // unavailable)" (impl-critic S1). When the latest version *is* the resolved
+    // version (up to date), reuse `resolved_license` instead of re-deriving it —
+    // avoids a spurious "unavailable" note on the single most common hover case.
+    // Skipped entirely once `resolved_license` is already empty: nothing to compare
+    // against, and `push_license_hover_section` discards it on its own early return.
+    let latest_license: Option<Vec<String>> = (!resolved_license.is_empty())
+        .then(|| {
+            latest_line.map(|(latest_ver, _)| {
+                if resolved_key == Some(latest_ver) {
+                    resolved_license.clone()
+                } else {
+                    live_latest_idx
+                        .and_then(|idx| available_versions.as_ref().and_then(|v| v.get(idx)))
+                        .map(|v| v.license().to_vec())
+                        .filter(|l| !l.is_empty())
+                        .unwrap_or_default()
+                }
+            })
+        })
+        .flatten();
+    push_license_hover_section(&mut markdown, &resolved_license, latest_license.as_deref());
+
     // `!v.is_empty()`, not just `Some(_)` (#550): a resolvable source's live fetch can
     // succeed with a genuinely empty list — e.g. a real GitHub repository whose only
     // tags don't parse as full semver (`dtolnay/rust-toolchain`'s sole tag `v1`) — and
@@ -834,6 +913,103 @@ fn push_trust_signal_hover_section(markdown: &mut String, signal: Option<&Supply
     markdown.push('\n');
 }
 
+/// Cap on how many license identifiers [`format_license_list`] renders from one
+/// version's license list before collapsing the remainder into "(+N more)" —
+/// defense-in-depth against a malicious/compromised registry response reporting an
+/// excessive number of license entries for a single version (security review S3-1).
+const MAX_LICENSE_ENTRIES_RENDERED: usize = 8;
+
+/// Cap on how many characters of a single license identifier
+/// [`format_license_list`] renders before truncating it — mirrors
+/// `diagnostics::MAX_BLOCKED_REGISTRY_MESSAGE_VALUE_CHARS`'s reasoning for the same
+/// untrusted-registry-string concern (security review S3-1).
+const MAX_LICENSE_ID_CHARS: usize = 128;
+
+/// Formats a license list as comma-separated Markdown code spans, e.g. `` `MIT`, `Apache-2.0` ``.
+/// Each identifier is truncated at [`MAX_LICENSE_ID_CHARS`] and the list itself capped at
+/// [`MAX_LICENSE_ENTRIES_RENDERED`] entries (with a "(+N more)" suffix) — `licenses` is
+/// registry-reported data, not validated or bounded upstream.
+fn format_license_list(licenses: &[String]) -> String {
+    let shown = licenses.len().min(MAX_LICENSE_ENTRIES_RENDERED);
+    let mut rendered: Vec<String> = licenses[..shown]
+        .iter()
+        .map(|l| markdown_code_span(&super::truncate_for_diagnostic(l, MAX_LICENSE_ID_CHARS)))
+        .collect();
+    let remaining = licenses.len() - shown;
+    if remaining > 0 {
+        rendered.push(format!("(+{remaining} more)"));
+    }
+    rendered.join(", ")
+}
+
+/// Order-insensitive, case-insensitive set comparison for two license lists (spec 010
+/// FR-003): a dependency re-declaring the same licenses in a different order or
+/// casing (registry `license[]` fields are author-supplied free text, not a
+/// normalized enum — e.g. `"MIT"` vs `"mit"`) must not be reported as "changed".
+fn license_sets_differ(a: &[String], b: &[String]) -> bool {
+    let a_set: std::collections::BTreeSet<String> = a.iter().map(|l| l.to_lowercase()).collect();
+    let b_set: std::collections::BTreeSet<String> = b.iter().map(|l| l.to_lowercase()).collect();
+    a_set != b_set
+}
+
+/// Appends the hover "License" line (issue #204, spec 010): the resolved version's
+/// SPDX license identifier(s), and — when the latest version's license is also known
+/// and differs (order/case-insensitive) — a "License changed" flag (FR-003).
+///
+/// Renders nothing when `resolved_license` is empty: mirrors
+/// [`push_vulnerability_hover_section`]'s discipline of never rendering a positive
+/// "License: (unknown)" claim for a dependency this feature never actually checked
+/// (no resolved version, an ecosystem/source out of this PR's scope, ...) — spec 010
+/// NFR-003 permits either wording or omission for missing data, and omission avoids
+/// noise on every dependency this PR simply doesn't cover yet.
+///
+/// `latest_license` is three-valued (impl-critic review S1): `None` means no latest
+/// version exists to compare against at all (no `**Latest**` line was rendered
+/// either) — renders no note. `Some(&[])` means a latest version exists but its
+/// license could not be determined — renders the "(unavailable)" note. `Some(licenses)`
+/// with entries renders a "License changed" flag only when the sets actually differ.
+///
+/// The "License changed" line is written as its own Markdown paragraph (blank line
+/// before it, via `\n\n`) rather than a single `\n` — a lone `\n` is a CommonMark soft
+/// break, which strict renderers (e.g. VS Code's hover widget) collapse onto the same
+/// visual line as the License line above it (impl-critic review S3).
+fn push_license_hover_section(
+    markdown: &mut String,
+    resolved_license: &[String],
+    latest_license: Option<&[String]>,
+) {
+    use std::fmt::Write;
+
+    if resolved_license.is_empty() {
+        return;
+    }
+
+    write!(
+        markdown,
+        "**License**: {}",
+        format_license_list(resolved_license)
+    )
+    .unwrap();
+
+    match latest_license {
+        None => {}
+        Some([]) => {
+            markdown.push_str(" *(latest version license unavailable)*");
+        }
+        Some(latest) if license_sets_differ(resolved_license, latest) => {
+            write!(
+                markdown,
+                "\n\n\u{26a0}\u{fe0f} **License changed**: {} \u{2192} {}",
+                format_license_list(resolved_license),
+                format_license_list(latest)
+            )
+            .unwrap();
+        }
+        Some(_) => {}
+    }
+    markdown.push_str("\n\n");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -843,6 +1019,358 @@ mod tests {
 
     use std::collections::HashMap;
     use std::sync::Arc;
+
+    #[test]
+    fn license_sets_differ_is_order_insensitive() {
+        let a = vec!["MIT".to_string(), "Apache-2.0".to_string()];
+        let b = vec!["Apache-2.0".to_string(), "MIT".to_string()];
+        assert!(!license_sets_differ(&a, &b));
+    }
+
+    #[test]
+    fn license_sets_differ_detects_real_change() {
+        let a = vec!["MIT".to_string()];
+        let b = vec!["GPL-3.0".to_string()];
+        assert!(license_sets_differ(&a, &b));
+    }
+
+    /// impl-critic review M2: `license[]` is author-supplied free text, not a
+    /// normalized enum — a casing difference alone must not flag a false change.
+    #[test]
+    fn license_sets_differ_is_case_insensitive() {
+        let a = vec!["MIT".to_string()];
+        let b = vec!["mit".to_string()];
+        assert!(!license_sets_differ(&a, &b));
+    }
+
+    #[test]
+    fn format_license_list_caps_entries_and_labels_the_remainder() {
+        let licenses: Vec<String> = (0..12).map(|i| format!("LICENSE-{i}")).collect();
+        let rendered = format_license_list(&licenses);
+        assert!(rendered.contains("(+4 more)"), "got: {rendered}");
+        assert!(rendered.contains("`LICENSE-0`"));
+        assert!(
+            !rendered.contains("LICENSE-11"),
+            "the 12th entry must not render; got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn format_license_list_truncates_an_overlong_identifier() {
+        let long_id = "A".repeat(500);
+        let rendered = format_license_list(std::slice::from_ref(&long_id));
+        assert!(
+            rendered.len() < long_id.len(),
+            "an untrusted, excessively long license id must be truncated; got len {}",
+            rendered.len()
+        );
+    }
+
+    #[test]
+    fn push_license_hover_section_renders_nothing_when_resolved_unknown() {
+        let mut markdown = String::new();
+        push_license_hover_section(&mut markdown, &[], Some(&["MIT".to_string()]));
+        assert!(markdown.is_empty());
+    }
+
+    /// impl-critic review S1: no latest version exists at all (`None`, distinct from
+    /// `Some(&[])`) — no note should render, since nothing was ever shown to compare
+    /// against.
+    #[test]
+    fn push_license_hover_section_renders_nothing_extra_when_no_latest_version_exists() {
+        let mut markdown = String::new();
+        push_license_hover_section(&mut markdown, &["MIT".to_string()], None);
+        assert!(markdown.contains("**License**: `MIT`"));
+        assert!(!markdown.contains("unavailable"));
+        assert!(!markdown.contains("License changed"));
+    }
+
+    #[test]
+    fn push_license_hover_section_renders_resolved_only_when_latest_unavailable() {
+        let mut markdown = String::new();
+        push_license_hover_section(&mut markdown, &["MIT".to_string()], Some(&[]));
+        assert!(markdown.contains("**License**: `MIT`"));
+        assert!(markdown.contains("latest version license unavailable"));
+        assert!(!markdown.contains("License changed"));
+    }
+
+    #[test]
+    fn push_license_hover_section_flags_change_when_licenses_differ() {
+        let mut markdown = String::new();
+        push_license_hover_section(
+            &mut markdown,
+            &["MIT".to_string()],
+            Some(&["Apache-2.0".to_string()]),
+        );
+        assert!(markdown.contains("**License**: `MIT`"));
+        assert!(markdown.contains("License changed"));
+        assert!(markdown.contains("`MIT` \u{2192} `Apache-2.0`"));
+    }
+
+    /// impl-critic review S3: the "License changed" line must be its own Markdown
+    /// paragraph (blank line before it), not a bare `\n` soft break that a strict
+    /// CommonMark renderer (VS Code's hover widget) would collapse onto the License
+    /// line above it.
+    #[test]
+    fn push_license_hover_section_change_line_is_a_separate_paragraph() {
+        let mut markdown = String::new();
+        push_license_hover_section(
+            &mut markdown,
+            &["MIT".to_string()],
+            Some(&["Apache-2.0".to_string()]),
+        );
+        assert!(
+            markdown.contains("`MIT`\n\n\u{26a0}\u{fe0f} **License changed**"),
+            "expected a blank line (paragraph break) before the License changed line; got: {markdown:?}"
+        );
+    }
+
+    #[test]
+    fn push_license_hover_section_no_flag_when_licenses_equal() {
+        let mut markdown = String::new();
+        push_license_hover_section(
+            &mut markdown,
+            &["MIT".to_string()],
+            Some(&["MIT".to_string()]),
+        );
+        assert!(markdown.contains("**License**: `MIT`"));
+        assert!(!markdown.contains("License changed"));
+        assert!(!markdown.contains("unavailable"));
+    }
+
+    /// Issue #204 end-to-end: a native version-list source (Composer/tier-1 shape,
+    /// via `MockRegistryWithLicensedVersions`) whose resolved and latest versions
+    /// carry different licenses renders both the resolved license and the "License
+    /// changed" flag in the actual hover response.
+    #[tokio::test]
+    async fn test_generate_hover_renders_license_changed_from_native_version_list() {
+        use std::collections::HashMap;
+
+        let registry = MockRegistryWithLicensedVersions {
+            versions: vec![
+                MockVersionWithLicense {
+                    version: "2.0.0".into(),
+                    license: vec!["Apache-2.0".to_string()],
+                },
+                MockVersionWithLicense {
+                    version: "1.0.0".into(),
+                    license: vec!["MIT".to_string()],
+                },
+            ],
+        };
+        let parse_result = freshness_test_parse_result("example");
+        let mut resolved_versions = HashMap::new();
+        resolved_versions.insert("example".into(), "1.0.0".into());
+
+        let hover = generate_hover(
+            &parse_result,
+            Position::new(0, 2),
+            VersionData::new(&HashMap::new(), &resolved_versions),
+            &registry,
+            &MockFormatter,
+            crate::freshness::FreshnessSettings::default(),
+            PublishTime::now(),
+        )
+        .await
+        .expect("hover should be generated for a dependency at the cursor");
+
+        let HoverContents::Markup(content) = hover.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(
+            content.value.contains("**License**: `MIT`"),
+            "got: {}",
+            content.value
+        );
+        assert!(
+            content.value.contains("License changed"),
+            "resolved (1.0.0/MIT) and latest (2.0.0/Apache-2.0) licenses differ; got: {}",
+            content.value
+        );
+    }
+
+    /// impl-critic review S1: when the resolved version *is* the latest version (the
+    /// common up-to-date case), the resolved license must be reused for the latest
+    /// comparison instead of re-deriving it — must render neither a spurious
+    /// "(unavailable)" note nor a self-vs-self "License changed" flag.
+    #[tokio::test]
+    async fn test_generate_hover_up_to_date_dependency_shows_no_spurious_unavailable_note() {
+        use std::collections::HashMap;
+
+        let registry = MockRegistryWithLicensedVersions {
+            versions: vec![MockVersionWithLicense {
+                version: "1.0.0".into(),
+                license: vec!["MIT".to_string()],
+            }],
+        };
+        let parse_result = freshness_test_parse_result("example");
+        let mut resolved_versions = HashMap::new();
+        resolved_versions.insert("example".into(), "1.0.0".into());
+
+        let hover = generate_hover(
+            &parse_result,
+            Position::new(0, 2),
+            VersionData::new(&HashMap::new(), &resolved_versions),
+            &registry,
+            &MockFormatter,
+            crate::freshness::FreshnessSettings::default(),
+            PublishTime::now(),
+        )
+        .await
+        .expect("hover should be generated for a dependency at the cursor");
+
+        let HoverContents::Markup(content) = hover.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(content.value.contains("**License**: `MIT`"));
+        assert!(
+            !content.value.contains("unavailable"),
+            "the resolved version is the latest version, so its already-known license \
+             must be reused rather than reported unavailable; got: {}",
+            content.value
+        );
+        assert!(
+            !content.value.contains("License changed"),
+            "resolved and latest are the same version, so no change flag should fire; got: {}",
+            content.value
+        );
+    }
+
+    /// impl-critic review M1: an exact manifest pin (`=1.0.0`) with no lock-file
+    /// resolution renders no `**Current**` line (`resolved` stays `None` —
+    /// `resolve_occurrence_version` has nothing to match against an empty
+    /// `resolved_versions` map), but the license must still be found via the same
+    /// `in_use_version` concrete-pin fallback `spawn_trust_signal_fetch` already
+    /// uses for the deps.dev path — the native-list lookup must be at least as
+    /// capable, not silently weaker just because it reused the `resolved` variable.
+    #[tokio::test]
+    async fn test_generate_hover_native_list_license_found_via_concrete_pin_fallback() {
+        use std::collections::HashMap;
+
+        let registry = MockRegistryWithLicensedVersions {
+            versions: vec![MockVersionWithLicense {
+                version: "1.0.0".into(),
+                license: vec!["MIT".to_string()],
+            }],
+        };
+        let parse_result = MockParseResult {
+            deps: vec![MockDep {
+                name: "example".into(),
+                version_req: "=1.0.0".into(),
+                version_range: Range::new(Position::new(0, 10), Position::new(0, 20)),
+                name_range: Range::new(Position::new(0, 0), Position::new(0, 7)),
+            }],
+            uri: crate::test_util::test_uri("/test/composer.json"),
+        };
+
+        let hover = generate_hover(
+            &parse_result,
+            Position::new(0, 2),
+            VersionData::new(&HashMap::new(), &HashMap::new())
+                .with_ecosystem(crate::EcosystemId::Composer),
+            &registry,
+            &MockFormatter,
+            crate::freshness::FreshnessSettings::default(),
+            PublishTime::now(),
+        )
+        .await
+        .expect("hover should be generated for a dependency at the cursor");
+
+        let HoverContents::Markup(content) = hover.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(
+            !content.value.contains("**Current**"),
+            "no lock-file resolution exists, so no Current line should render; got: {}",
+            content.value
+        );
+        assert!(
+            content.value.contains("**License**: `MIT`"),
+            "the concrete-pin fallback (=1.0.0) should still resolve a license even \
+             without a lock-file match; got: {}",
+            content.value
+        );
+    }
+
+    /// Review round 3 regression: for a deps.dev-routed ecosystem, `available_versions[idx]`
+    /// entries never carry license (that trait method's default is empty — only the
+    /// native-list ecosystems like Composer override it), so the "latest == resolved"
+    /// shortcut MUST use the same `in_use_version`-derived key the resolved-license
+    /// lookup itself used, not the weaker bare `resolved`. An earlier draft compared
+    /// the shortcut against `resolved` (which stays `None` here — no lock-file entry
+    /// matches an exact `=4.19.2` pin) while the lookup used `in_use_version_str`
+    /// (which resolves the pin via `concrete_pin_version`): the mismatch made the
+    /// shortcut miss, falling through to the empty-by-default native-list branch and
+    /// re-introducing S1's spurious "(latest version license unavailable)" note right
+    /// next to an already-known, unchanged license.
+    #[tokio::test]
+    async fn test_generate_hover_deps_dev_no_lockfile_exact_pin_matching_latest_reuses_license() {
+        let (mut server, deps_dev) = deps_dev_mock_client().await;
+        let _version = server
+            .mock("GET", "/v3/systems/npm/packages/express/versions/4.19.2")
+            .with_status(200)
+            .with_body(
+                r#"{"slsaProvenances": [], "attestations": [], "relatedProjects": [], "licenses": ["MIT"]}"#,
+            )
+            .create_async()
+            .await;
+        let deps_dev = Arc::new(deps_dev);
+
+        let parse_result = MockParseResult {
+            deps: vec![MockDep {
+                name: "express".into(),
+                version_req: "=4.19.2".into(),
+                version_range: Range::new(Position::new(0, 10), Position::new(0, 20)),
+                name_range: Range::new(Position::new(0, 0), Position::new(0, 7)),
+            }],
+            uri: crate::test_util::test_uri("/test/package.json"),
+        };
+        // No lock-file entries: `versions.resolved` stays empty, so the bare
+        // `resolved` variable used for the `**Current**` line has no match — only
+        // `in_use_version`'s `concrete_pin_version` fallback resolves the pin.
+        let registry = MockRegistryWithVersions {
+            versions: vec![MockVersionWithAge {
+                version: "4.19.2".into(),
+                yanked: false,
+                published_at: None,
+            }],
+        };
+
+        let hover = generate_hover(
+            &parse_result,
+            Position::new(0, 2),
+            VersionData::new(&HashMap::new(), &HashMap::new())
+                .with_ecosystem(crate::EcosystemId::Npm)
+                .with_trust(&deps_dev),
+            &registry,
+            &MockFormatter,
+            crate::freshness::FreshnessSettings::default(),
+            PublishTime::now(),
+        )
+        .await
+        .expect("hover should be generated");
+
+        let HoverContents::Markup(content) = hover.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(
+            !content.value.contains("**Current**"),
+            "no lock-file resolution exists, so no Current line should render; got: {}",
+            content.value
+        );
+        assert!(
+            content.value.contains("**License**: `MIT`"),
+            "got: {}",
+            content.value
+        );
+        assert!(
+            !content.value.contains("unavailable"),
+            "the exact pin (4.19.2) equals the only/live-latest version, so the \
+             already-known license must be reused, not reported unavailable; got: {}",
+            content.value
+        );
+        assert!(!content.value.contains("License changed"));
+    }
 
     #[test]
     fn severity_label_for_malicious_is_distinct_from_unknown_and_every_graded_label() {
@@ -3158,6 +3686,59 @@ mod tests {
             .find(|l| l.contains("Supply chain"))
             .unwrap_or_else(|| panic!("expected a Supply chain line, got: {}", content.value));
         insta::assert_snapshot!(line, @"🔐 **Supply chain**: OpenSSF Scorecard `8.5`/10 · Provenance: verified");
+    }
+
+    /// Issue #204 (impl-critic review S2 / tester's independent gap): the deps.dev
+    /// path is the *only* license source for 7 of this PR's 8 ecosystems
+    /// (Cargo/npm/Go/Maven/Bundler/NuGet/PyPI) — only Composer's native-list path had
+    /// an end-to-end `generate_hover` test before this one.
+    #[tokio::test]
+    async fn test_generate_hover_deps_dev_license_renders_license_line() {
+        let (mut server, deps_dev) = deps_dev_mock_client().await;
+        let _version = server
+            .mock("GET", "/v3/systems/npm/packages/express/versions/4.19.2")
+            .with_status(200)
+            .with_body(
+                r#"{"slsaProvenances": [], "attestations": [], "relatedProjects": [], "licenses": ["MIT"]}"#,
+            )
+            .create_async()
+            .await;
+        let deps_dev = Arc::new(deps_dev);
+
+        let (parse_result, resolved_versions) = express_fixture();
+        let registry = MockRegistryWithVersions { versions: vec![] };
+
+        let hover = generate_hover(
+            &parse_result,
+            Position::new(0, 2),
+            VersionData::new(&HashMap::new(), &resolved_versions)
+                .with_ecosystem(crate::EcosystemId::Npm)
+                .with_trust(&deps_dev),
+            &registry,
+            &MockFormatter,
+            crate::freshness::FreshnessSettings::default(),
+            PublishTime::now(),
+        )
+        .await
+        .expect("hover should be generated");
+
+        let HoverContents::Markup(content) = hover.contents else {
+            panic!("expected markup hover contents");
+        };
+        assert!(
+            content.value.contains("**License**: `MIT`"),
+            "expected the deps.dev-sourced license to render; got: {}",
+            content.value
+        );
+        // No live version list was fetched (`MockRegistryWithVersions { versions: vec![] }`),
+        // so no `**Latest**` line exists either — the "(latest version license
+        // unavailable)" note must not render for a dependency with no latest version
+        // at all (impl-critic review S1).
+        assert!(
+            !content.value.contains("unavailable"),
+            "no latest version exists to compare against; got: {}",
+            content.value
+        );
     }
 
     #[tokio::test]

--- a/crates/deps-core/src/lsp_helpers/test_support.rs
+++ b/crates/deps-core/src/lsp_helpers/test_support.rs
@@ -488,6 +488,82 @@ impl crate::Registry for MockRegistryWithVersions {
     }
 }
 
+/// A version carrying an SPDX `license` list (issue #204), used by hover tests that
+/// exercise `push_license_hover_section`'s native-version-list path without touching
+/// every existing [`MockVersionWithAge`] call site.
+pub(crate) struct MockVersionWithLicense {
+    pub(crate) version: ConcreteVersion,
+    pub(crate) license: Vec<String>,
+}
+
+impl crate::Version for MockVersionWithLicense {
+    fn version_string(&self) -> &ConcreteVersion {
+        &self.version
+    }
+
+    fn license(&self) -> &[String] {
+        &self.license
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Registry stub serving [`MockVersionWithLicense`] entries — the license-hover
+/// counterpart of [`MockRegistryWithVersions`].
+pub(crate) struct MockRegistryWithLicensedVersions {
+    pub(crate) versions: Vec<MockVersionWithLicense>,
+}
+
+impl crate::Registry for MockRegistryWithLicensedVersions {
+    fn get_versions<'a>(
+        &'a self,
+        _name: &'a crate::PackageName,
+    ) -> crate::ecosystem::BoxFuture<'a, crate::error::Result<Vec<Box<dyn crate::Version>>>> {
+        let versions = self
+            .versions
+            .iter()
+            .map(|v| {
+                Box::new(MockVersionWithLicense {
+                    version: v.version.clone(),
+                    license: v.license.clone(),
+                }) as Box<dyn crate::Version>
+            })
+            .collect();
+        Box::pin(async move { Ok(versions) })
+    }
+
+    fn get_latest_matching<'a>(
+        &'a self,
+        _name: &'a crate::PackageName,
+        _req: &'a crate::VersionReq,
+    ) -> crate::ecosystem::BoxFuture<'a, crate::error::Result<Option<Box<dyn crate::Version>>>>
+    {
+        Box::pin(async move { Ok(None) })
+    }
+
+    fn search<'a>(
+        &'a self,
+        _query: &'a str,
+        _limit: usize,
+    ) -> crate::ecosystem::BoxFuture<'a, crate::error::Result<Vec<Box<dyn crate::Metadata>>>> {
+        Box::pin(async move { Ok(Vec::new()) })
+    }
+
+    fn select_latest_matching(
+        &self,
+        versions: &[Box<dyn crate::Version>],
+        _req: &crate::VersionReq,
+    ) -> Option<usize> {
+        versions.iter().position(|v| v.is_stable())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
 /// A version carrying an explicit [`RemovalStatus`], used where a test needs
 /// `AdvisoryDeprecated` specifically — `MockVersionWithAge`'s `bool` field can only
 /// express `Available`/`Yanked` via [`RemovalStatus::from_yanked`].

--- a/crates/deps-core/src/macros.rs
+++ b/crates/deps-core/src/macros.rs
@@ -293,6 +293,45 @@ macro_rules! impl_version {
             }
         }
     };
+    ($type:ty {
+        version: $version:ident,
+        status: $status:expr,
+        published_at: $published_at:ident,
+        prerelease: $prerelease:expr,
+        deprecation: $deprecation:expr,
+        license: $license:ident $(,)?
+    }) => {
+        impl $crate::registry::Version for $type {
+            fn version_string(&self) -> &$crate::ConcreteVersion {
+                &self.$version
+            }
+
+            fn removal_status(&self) -> $crate::registry::RemovalStatus {
+                ($status)(self)
+            }
+
+            fn published_at(&self) -> Option<$crate::freshness::PublishTime> {
+                self.$published_at
+            }
+
+            fn is_prerelease(&self) -> bool {
+                ($prerelease)(self)
+            }
+
+            fn deprecation(&self) -> Option<&$crate::registry::Deprecation> {
+                let f: fn(&$type) -> Option<&$crate::registry::Deprecation> = $deprecation;
+                f(self)
+            }
+
+            fn license(&self) -> &[String] {
+                &self.$license
+            }
+
+            fn as_any(&self) -> &dyn ::std::any::Any {
+                self
+            }
+        }
+    };
 }
 
 /// Implement `Metadata` trait for a struct.

--- a/crates/deps-core/src/registry.rs
+++ b/crates/deps-core/src/registry.rs
@@ -600,6 +600,20 @@ pub trait Version: Send + Sync {
     fn published_at(&self) -> Option<crate::freshness::PublishTime> {
         None
     }
+
+    /// SPDX license identifier(s) declared for this version, when the registry's
+    /// already-fetched version-list response carries them.
+    ///
+    /// Default: empty slice — the capability gate for ecosystems whose hot-path
+    /// version fetch doesn't carry license data (issue #204). `Vec<String>`, never
+    /// `Option<String>`, everywhere this is implemented: a package can declare more
+    /// than one license (an SPDX `OR`/dual-license split reported as discrete
+    /// identifiers by the registry), and a single shape avoids an `Option` vs `Vec`
+    /// split across ecosystems (spec 010 plan.md's "License shape" decision). An
+    /// empty slice means "unknown/not reported", never "explicitly no license".
+    fn license(&self) -> &[String] {
+        &[]
+    }
 }
 
 /// Finds the latest stable version from a list of versions.

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -638,6 +638,18 @@ now closed, not accepted risk:
   package name, so this is safe but not feed-aware (mirrors npm's/PyPI's
   identical choice).
 
+### License Hover
+
+Hover shows the SPDX license identifier(s) for the resolved version, and flags a
+"License changed" warning when the latest version's license differs (issue #204).
+Covered for Cargo, npm, PyPI, Go, Maven, Bundler, NuGet (via the deps.dev
+supply-chain call — resolved version only, the "latest" license degrades to
+"unavailable" since no second network call is made) and Composer (via Packagist's
+own version list, which carries license for both the resolved and latest version,
+enabling the "License changed" comparison). Dart, Swift, Gradle, and Deno are not
+yet covered (tracked separately, issue #660). When license data is unavailable for
+a dependency, the section is omitted rather than shown as "unknown".
+
 ### Yanked-Version Diagnostics
 
 `diagnostics.yanked_severity` flags a dependency pinned to a version the registry


### PR DESCRIPTION
## Summary

- Adds a license line to hover for the resolved and latest version across 8 ecosystems: Cargo, npm, PyPI, Go, Maven, Bundler, NuGet, Composer. Flags "License changed: X → Y" when resolved and latest differ.
- Composer parses license natively from its already-fetched Packagist p2 response (with correct minified-entry inheritance handling). The other 7 ecosystems reuse the existing deps.dev `trust_signal()` call — that endpoint already returns `licenses[]` on the same response fetched for Scorecard/provenance data, so no new network call, spawn, or cache entry was introduced for any ecosystem in this PR.
- Live-verified against real registries during planning and implementation: crates.io sparse index, npm registry, PyPI JSON API, Packagist, api.deps.dev.

This is PR1 of a 3-PR rollout documented in `specs/010-license-hover-policy/plan.md` §9:
- **PR1 (this PR)** — Phase 1, tier 1+2 ecosystems (the 8 above).
- **PR2 — #660** — Phase 1, tier 3 ecosystems (Dart, Swift, Gradle, Deno), each needing its own live-verified license source. Intentionally not started here.
- **PR3 — #661** — Phase 2, optional SPDX allow/deny policy diagnostics. Intentionally not started here.

`#662` was filed during review as a DRY follow-up (unifying Composer's lenient string-or-array license deserializer with the structurally similar one already in `deps-nuget`) — judged non-trivial to do safely on top of an already-multi-round fix cycle, deferred rather than forced.

## Review history

Went through the full team-develop validation chain: tester, perf, security, and an adversarial implementation critic (verdict: significant — 3 real findings) in parallel, followed by a correctness-gate pass that caught a regression in the developer's own first fix (a variable-key mismatch reintroducing a spurious "license unavailable" note), then a final independent code review (approved). Every found issue was fixed and verified, not just accepted as a report.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4459 passed, 0 failed, 50 skipped)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- [x] `cargo test --workspace --doc --all-features`
- [x] Live-verified against real crates.io/npm/deps.dev/Packagist responses during implementation (2 `#[ignore]`d live tests added, run once each against the real network)
- [x] New regression tests for both round-3 correctness-gate fixes

Closes #204