### PR TITLE
refactor(deps-core): extract shared lenient string-or-array deserializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **deps-npm**: `package-lock.json` parsing now prefers a package entry's own `name` field (npm writes this when it differs from the physical `node_modules/` path, e.g. for an `npm:` alias) over the lockfile-key-derived name (#657)
+- **deps-core, deps-composer, deps-nuget**: extracted the duplicated lenient string-or-string-array JSON deserializer into a shared `deps_core::json_helpers::deserialize_string_or_string_array` helper (resolves #662)
 
 ### Dependencies
 - Bump `dirs` from 6 to 7.0.0, plus transitive `Cargo.lock` refresh (#659)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **deps-npm**: `package-lock.json` parsing now prefers a package entry's own `name` field (npm writes this when it differs from the physical `node_modules/` path, e.g. for an `npm:` alias) over the lockfile-key-derived name (#657)
-- **deps-core, deps-composer, deps-nuget**: extracted the duplicated lenient string-or-string-array JSON deserializer into a shared `deps_core::json_helpers::deserialize_string_or_string_array` helper (resolves #662)
+- **deps-core, deps-composer, deps-nuget**: extracted the duplicated lenient string-or-string-array JSON deserializer into a shared `deps_core::json_helpers::deserialize_string_or_string_array` helper (resolves #662) (#665)
 
 ### Dependencies
 - Bump `dirs` from 6 to 7.0.0, plus transitive `Cargo.lock` refresh (#659)

--- a/crates/deps-composer/src/registry.rs
+++ b/crates/deps-composer/src/registry.rs
@@ -405,59 +405,26 @@ struct MinifiedVersion {
     time: Option<String>,
     /// SPDX license identifier(s) (issue #204). `None` means "not present on this
     /// minified entry" (inherit from the previous one), distinct from `Some(vec![])`
-    /// ("this release explicitly declares no license").
+    /// ("this release explicitly declares no license") — this is the specific reason
+    /// Composer needs the richer `Option<Vec<String>>` shape rather than collapsing
+    /// straight to `Vec<String>` like `deps-nuget` does: `expand_minified_versions`
+    /// treats `Some(_)` as an explicit override into its inheritance chain, so an
+    /// absent-vs-empty distinction here is load-bearing.
     ///
     /// `composer.json`'s own `license` field is documented as either a single string
-    /// or an array of strings — [`deserialize_license`] accepts both shapes rather
-    /// than only the array form, mirroring [`Self::abandoned`]'s
-    /// `Option<serde_json::Value>` defense-in-depth: an unexpected shape here (a
-    /// bare string, or malformed data of any other JSON type) must degrade to `None`
-    /// rather than fail `serde_json::from_slice` for the *entire* `PackagistResponse`
-    /// — which would otherwise drop every version of the package, not just its
-    /// license (security review S3-2).
-    #[serde(default, deserialize_with = "deserialize_license")]
+    /// or an array of strings —
+    /// [`deps_core::json_helpers::deserialize_string_or_string_array`] accepts both
+    /// shapes (see that function's doc for the full input-shape contract), mirroring
+    /// [`Self::abandoned`]'s `Option<serde_json::Value>` defense-in-depth: an
+    /// unexpected shape here (a bare string, or malformed data of any other JSON
+    /// type) must degrade to `None` rather than fail `serde_json::from_slice` for the
+    /// *entire* `PackagistResponse` — which would otherwise drop every version of the
+    /// package, not just its license (security review S3-2).
+    #[serde(
+        default,
+        deserialize_with = "deps_core::json_helpers::deserialize_string_or_string_array"
+    )]
     license: Option<Vec<String>>,
-}
-
-/// Accepts `composer.json`'s documented `license` shapes — a single string, an array
-/// of strings, or absent/`null` — and normalizes to `Option<Vec<String>>`. Any other
-/// JSON shape (a number, object, bool, or an array containing non-string elements)
-/// degrades to `None`/skips the offending element rather than erroring the whole
-/// response (see [`MinifiedVersion::license`]'s doc).
-fn deserialize_license<'de, D>(
-    deserializer: D,
-) -> std::result::Result<Option<Vec<String>>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = serde_json::Value::deserialize(deserializer)?;
-    Ok(match value {
-        serde_json::Value::String(s) => Some(vec![s]),
-        serde_json::Value::Array(entries) => {
-            // Review round 3 fix: a non-empty raw array whose every element is a
-            // non-string (a malformed `license: [7, 8]`) must degrade to `None`
-            // ("not present on this entry", inherit), not `Some(vec![])` ("this
-            // entry explicitly declares no license"). `expand_minified_versions`
-            // treats `Some(_)` as an override — a stray `Some(vec![])` here would
-            // silently overwrite an earlier real license and then get inherited by
-            // every later entry that omits `license` entirely, corrupting the whole
-            // rest of the inheritance chain from one malformed entry.
-            let had_entries = !entries.is_empty();
-            let strings: Vec<String> = entries
-                .into_iter()
-                .filter_map(|entry| match entry {
-                    serde_json::Value::String(s) => Some(s),
-                    _ => None,
-                })
-                .collect();
-            if had_entries && strings.is_empty() {
-                None
-            } else {
-                Some(strings)
-            }
-        }
-        _ => None,
-    })
 }
 
 /// Expands minified Packagist v2 versions using field inheritance.

--- a/crates/deps-core/src/json_helpers.rs
+++ b/crates/deps-core/src/json_helpers.rs
@@ -1,10 +1,12 @@
-//! Shared `serde_json`-side helpers for parsing a JSON manifest's *semantic* dependency-map
-//! content (#624).
+//! Shared `serde_json`-side helpers for leniently interpreting untrusted JSON value shapes
+//! from a manifest or registry response (#624, #662).
 //!
 //! `deps-npm` and `deps-composer` each parse a dependency section as a raw
 //! `serde_json::Map<String, Value>` and apply the same "is this a valid dependency
-//! declaration" rule to every entry — this module is where that rule lives, so both crates
-//! share one implementation and one set of tests instead of duplicating both.
+//! declaration" rule to every entry; `deps-composer` and `deps-nuget` each accept a field
+//! that may be a bare string or an array of strings — this module is where those rules
+//! live, so every ecosystem crate that needs them shares one implementation and one set of
+//! tests instead of duplicating both.
 //!
 //! This is a different concern from [`crate::json_ast`], which recovers a dependency's
 //! *position* in the source text from a separate jsonc-AST parse of the same content — this
@@ -40,6 +42,88 @@ pub fn string_valued_entries(
     entries
         .iter()
         .filter_map(|(name, value)| Some((name.as_str(), value.as_str()?)))
+}
+
+/// Accepts a JSON value that is either a single string or an array of strings, and
+/// normalizes it to `Option<Vec<String>>` — never erroring on an unexpected shape.
+///
+/// #662, consolidated from `deps-composer`'s `deserialize_license` (#204) and
+/// `deps-nuget`'s `deserialize_type_list` (#523).
+///
+/// Input classes and their result:
+///
+/// - a bare string (`"MIT"`) → `Some(vec!["MIT"])`
+/// - an array of strings (`["MIT", "Apache-2.0"]`) → `Some(vec!["MIT", "Apache-2.0"])`
+/// - an empty array (`[]`) → `Some(vec![])`
+/// - a mixed array with some non-string elements (`["MIT", 7]`) → `Some(vec!["MIT"])`,
+///   dropping only the non-string elements
+/// - a non-empty array whose elements are *all* non-string (`[7, 8]`), or any other JSON
+///   shape (a number, bool, object, `null`, or an absent field) → `None`
+///
+/// The general contract this establishes: `None` means "this value was not meaningfully
+/// present" and `Some(vec![])` means "this value was present and is explicitly empty" — a
+/// caller with no such absent-vs-empty distinction to make can collapse both to an empty
+/// list via `.unwrap_or_default()`. The `[7, 8]` → `None` case (rather than `Some(vec![])`)
+/// exists so that a caller treating `Some(_)` as an explicit override never sees a
+/// fabricated empty override manufactured from malformed input data — see
+/// `deps-composer`'s `MinifiedVersion::license` doc for a concrete case where this
+/// distinction is load-bearing.
+///
+/// # Errors
+///
+/// Returns an error only if the underlying `deserializer` cannot produce a
+/// `serde_json::Value` at all (e.g. malformed input at the transport level) — no JSON
+/// *shape* this function receives is itself treated as an error.
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::json_helpers::deserialize_string_or_string_array;
+/// use serde_json::json;
+///
+/// assert_eq!(
+///     deserialize_string_or_string_array(json!("MIT")).unwrap(),
+///     Some(vec!["MIT".to_string()])
+/// );
+/// assert_eq!(
+///     deserialize_string_or_string_array(json!(["MIT", 7])).unwrap(),
+///     Some(vec!["MIT".to_string()])
+/// );
+/// assert_eq!(deserialize_string_or_string_array(json!([7, 8])).unwrap(), None);
+/// assert_eq!(deserialize_string_or_string_array(json!(null)).unwrap(), None);
+/// ```
+pub fn deserialize_string_or_string_array<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<Vec<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+
+    let value = serde_json::Value::deserialize(deserializer)?;
+    Ok(match value {
+        serde_json::Value::String(s) => Some(vec![s]),
+        serde_json::Value::Array(entries) => {
+            // A non-empty raw array whose every element is a non-string (e.g. `[7, 8]`)
+            // must degrade to `None` ("not meaningfully present"), not `Some(vec![])`
+            // ("explicitly empty") — see this function's doc for why that distinction
+            // matters to a caller like `deps-composer`'s inheritance chain.
+            let had_entries = !entries.is_empty();
+            let strings: Vec<String> = entries
+                .into_iter()
+                .filter_map(|entry| match entry {
+                    serde_json::Value::String(s) => Some(s),
+                    _ => None,
+                })
+                .collect();
+            if had_entries && strings.is_empty() {
+                None
+            } else {
+                Some(strings)
+            }
+        }
+        _ => None,
+    })
 }
 
 #[cfg(test)]
@@ -82,5 +166,65 @@ mod tests {
         let deps = deps.as_object().unwrap();
 
         assert_eq!(string_valued_entries(deps).count(), 0);
+    }
+
+    // --- `deserialize_string_or_string_array` (#662: consolidated from deps-composer's
+    //     `deserialize_license` / #204 and deps-nuget's `deserialize_type_list` / #523) ---
+
+    #[test]
+    fn test_deserialize_string_or_string_array_bare_string() {
+        assert_eq!(
+            deserialize_string_or_string_array(serde_json::json!("MIT")).unwrap(),
+            Some(vec!["MIT".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_deserialize_string_or_string_array_of_strings() {
+        assert_eq!(
+            deserialize_string_or_string_array(serde_json::json!(["MIT", "Apache-2.0"])).unwrap(),
+            Some(vec!["MIT".to_string(), "Apache-2.0".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_deserialize_string_or_string_array_empty_array() {
+        assert_eq!(
+            deserialize_string_or_string_array(serde_json::json!([])).unwrap(),
+            Some(vec![])
+        );
+    }
+
+    #[test]
+    fn test_deserialize_string_or_string_array_mixed_array_keeps_only_strings() {
+        assert_eq!(
+            deserialize_string_or_string_array(serde_json::json!(["MIT", 7, "Apache-2.0"]))
+                .unwrap(),
+            Some(vec!["MIT".to_string(), "Apache-2.0".to_string()])
+        );
+    }
+
+    /// Non-empty array with no string element must degrade to `None` ("not present"), not
+    /// `Some(vec![])` ("explicitly empty") — a caller like `deps-composer`'s minified-entry
+    /// inheritance chain would otherwise treat a malformed array as an explicit override
+    /// that silently wipes out (and then propagates) a real inherited value.
+    #[test]
+    fn test_deserialize_string_or_string_array_all_non_string_array_is_none() {
+        assert_eq!(
+            deserialize_string_or_string_array(serde_json::json!([7, 8])).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_deserialize_string_or_string_array_other_shapes_are_none() {
+        for value in [
+            serde_json::json!(42),
+            serde_json::json!(true),
+            serde_json::json!({"not": "a list"}),
+            serde_json::json!(null),
+        ] {
+            assert_eq!(deserialize_string_or_string_array(value).unwrap(), None);
+        }
     }
 }

--- a/crates/deps-nuget/src/registry.rs
+++ b/crates/deps-nuget/src/registry.rs
@@ -197,25 +197,20 @@ where
 }
 
 /// Lenient `@type` deserializer: accepts a single string, an array of values (keeping only the
-/// string entries), or degrades any other shape (a bare number, `null`, an object) to an empty
-/// list — never an error, so one malformed resource entry cannot fail the whole document. No
-/// existing lenient-deserialization helper exists elsewhere in this workspace to reuse.
+/// string entries), or degrades any other shape (a bare number, `null`, an object, or a
+/// non-empty array with no string element) to an empty list — never an error, so one malformed
+/// resource entry cannot fail the whole document. `@type` has no absent-vs-empty distinction to
+/// preserve (unlike `deps-composer`'s `license`, which does), so both of
+/// [`deps_core::json_helpers::deserialize_string_or_string_array`]'s `None` and `Some(vec![])`
+/// results collapse to the same "matches no type we look for" outcome here.
 fn deserialize_type_list<'de, D>(deserializer: D) -> std::result::Result<Vec<String>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    let value = serde_json::Value::deserialize(deserializer)?;
-    Ok(match value {
-        serde_json::Value::String(s) => vec![s],
-        serde_json::Value::Array(items) => items
-            .into_iter()
-            .filter_map(|v| match v {
-                serde_json::Value::String(s) => Some(s),
-                _ => None,
-            })
-            .collect(),
-        _ => Vec::new(),
-    })
+    Ok(
+        deps_core::json_helpers::deserialize_string_or_string_array(deserializer)?
+            .unwrap_or_default(),
+    )
 }
 
 /// Resolved base URLs from the NuGet service index.
@@ -1585,6 +1580,30 @@ mod tests {
             ]}"#,
         )
         .unwrap();
+        let index =
+            ServiceIndex::resolve(&response, NuGetRegistryTier::Public, &public_policy()).unwrap();
+        assert_eq!(index.package_base_address, "https://flat");
+    }
+
+    /// #662: a `@type` array with no string element at all (the
+    /// [`deps_core::json_helpers::deserialize_string_or_string_array`] `None` row) must still
+    /// degrade to "doesn't match any type we look for" via `unwrap_or_default()`, exactly like
+    /// every other malformed shape — the one truth-table row not otherwise covered by NuGet's
+    /// existing tests.
+    #[test]
+    fn test_service_index_resolve_type_array_of_non_strings_degrades() {
+        let response: ServiceIndexResponse = serde_json::from_str(
+            r#"{"version": "3.0.0", "resources": [
+                {"@id": "https://malformed/", "@type": [7, 8]},
+                {"@id": "https://flat/", "@type": "PackageBaseAddress/3.0.0"},
+                {"@id": "https://search/", "@type": "SearchQueryService"}
+            ]}"#,
+        )
+        .unwrap();
+        // Pins that the malformed resource is *retained* with an empty type list (this
+        // test's intent), not silently dropped by `deserialize_resources`'s per-entry
+        // `.ok()` fallback, which would also leave `package_base_address` resolvable.
+        assert_eq!(response.resources.len(), 3);
         let index =
             ServiceIndex::resolve(&response, NuGetRegistryTier::Public, &public_policy()).unwrap();
         assert_eq!(index.package_base_address, "https://flat");


### PR DESCRIPTION
## Summary
- Extracted the duplicated "lenient string-or-array" JSON deserialization pattern into `deps_core::json_helpers::deserialize_string_or_string_array`, previously implemented independently in `deps-composer::deserialize_license` and `deps-nuget::deserialize_type_list`.
- Pure DRY refactor — no user-visible behavior change. Composer's `Option<Vec<String>>` semantics (including the non-empty all-non-string array degrading to `None`, to avoid corrupting the Packagist minified-entry inheritance chain) are the extracted contract; NuGet collapses it to `Vec<String>` via `.unwrap_or_default()`, which is exhaustively equivalent to its prior behavior across all input shapes.
- Added a new NuGet regression test covering the `[7, 8]` (non-empty, no strings) row, previously untested at that call site.

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4466 passed, 0 failed)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- [x] Composer's existing license tests and NuGet's existing `test_service_index_resolve_type_*` tests pass unchanged, verifying no behavior drift

Resolves #662