### PR TITLE
test(deps-core,deps-lsp): guard bare_requirement_policy against cross-ecosystem drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **deps-npm**: `package-lock.json` parsing now prefers a package entry's own `name` field (npm writes this when it differs from the physical `node_modules/` path, e.g. for an `npm:` alias) over the lockfile-key-derived name (#657)
 - **deps-core, deps-composer, deps-nuget**: extracted the duplicated lenient string-or-string-array JSON deserializer into a shared `deps_core::json_helpers::deserialize_string_or_string_array` helper (resolves #662) (#665)
+- **deps-core, deps-lsp**: documented NuGet's bare-version pin approximation and added a cross-ecosystem consistency test guarding `bare_requirement_policy` (resolves #669) (TODO: add PR link)
 
 ### Dependencies
 - Bump `dirs` from 6 to 7.0.0, plus transitive `Cargo.lock` refresh (#659)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **deps-npm**: `package-lock.json` parsing now prefers a package entry's own `name` field (npm writes this when it differs from the physical `node_modules/` path, e.g. for an `npm:` alias) over the lockfile-key-derived name (#657)
 - **deps-core, deps-composer, deps-nuget**: extracted the duplicated lenient string-or-string-array JSON deserializer into a shared `deps_core::json_helpers::deserialize_string_or_string_array` helper (resolves #662) (#665)
-- **deps-core, deps-lsp**: documented NuGet's bare-version pin approximation and added a cross-ecosystem consistency test guarding `bare_requirement_policy` (resolves #669) (TODO: add PR link)
+- **deps-core, deps-lsp**: documented NuGet's bare-version pin approximation and added a cross-ecosystem consistency test guarding `bare_requirement_policy` (resolves #669) (#674)
 
 ### Dependencies
 - Bump `dirs` from 6 to 7.0.0, plus transitive `Cargo.lock` refresh (#659)

--- a/crates/deps-core/src/lsp_helpers/in_use_version.rs
+++ b/crates/deps-core/src/lsp_helpers/in_use_version.rs
@@ -34,10 +34,13 @@ enum BareRequirementPolicy {
 /// Cargo's implicit caret. For these, [`is_concrete_version`] requires an
 /// explicit `=`/`==` (or an exact-bracket wrap) before treating a requirement
 /// as concrete; a bare `"1.2.3"` alone is not enough evidence (critique C2).
-/// Cargo is the sole remaining member of this group: every other ecosystem
-/// with an implicit-range default distinguishes a bare *full* version (a
-/// pin) from a bare *partial* one (a range) instead, so it belongs under
-/// [`BareRequirementPolicy::ConcreteIfFullVersion`] rather than here.
+/// Cargo is the sole member of this group: every other ecosystem with an
+/// implicit-range default distinguishes a bare *full* version (a pin) from a
+/// bare *partial* one (a range) instead, so it belongs under
+/// [`BareRequirementPolicy::ConcreteIfFullVersion`] rather than here — and
+/// NuGet, whose bare form is a range under its own registry-comparator
+/// semantics too, is deliberately kept out of this group anyway; see
+/// [`BareRequirementPolicy::Concrete`]'s doc for why.
 ///
 /// GitHub Actions, GitLab CI, npm, Composer, and Deno all get
 /// [`BareRequirementPolicy::ConcreteIfFullVersion`] instead — see that
@@ -88,12 +91,45 @@ enum BareRequirementPolicy {
 ///   independent, already-correct downstream filter.
 ///
 /// Every remaining ecosystem (Pypi, Go, Bundler, Dart, Maven, Gradle, Swift,
-/// NuGet) gets plain [`BareRequirementPolicy::Concrete`]: none of them has an
-/// implicit-range default the way Cargo does. Gradle in particular: a bare
-/// coordinate version (e.g. `"2.14.1"`) is an exact match under
-/// `GradleFormatter`'s own `version_satisfies_requirement` unless it uses the
-/// `+` dynamic-version suffix, which [`looks_like_a_single_version`] already
-/// rejects via its reject-char set.
+/// NuGet) gets plain [`BareRequirementPolicy::Concrete`]. Gradle in
+/// particular: a bare coordinate version (e.g. `"2.14.1"`) is an exact match
+/// under `GradleFormatter`'s own `version_satisfies_requirement` unless it
+/// uses the `+` dynamic-version suffix, which [`looks_like_a_single_version`]
+/// already rejects via its reject-char set.
+///
+/// NuGet (#669) is the one member of this group that does *not* have "no
+/// implicit-range default" in the strict sense: a bare `Version="1.0.0"`
+/// under `PackageReference`/`PackageVersion` is actually a *minimum-only
+/// floor* — `NuGetFormatter::version_satisfies_requirement`'s
+/// `test_version_satisfies_bare_floor` shows `satisfies("2.5.0", "1.0.0")`
+/// and `satisfies("9.9.9", "1.0.0")` are both `true`, which would put it
+/// under `AlwaysRange` (Cargo's group) by the same reasoning that moved
+/// npm/Composer/Deno to `ConcreteIfFullVersion`. It is deliberately kept
+/// under `Concrete` anyway, as a documented approximation rather than an
+/// oversight: `NuGetFormatter::is_requirement_up_to_date` (this crate's
+/// sibling `deps-nuget`) already treats a bare floor as a pin for the
+/// identical reason — restore resolves a direct `PackageReference` to
+/// *exactly* its floor version unless something else forces a higher one,
+/// so "the floor is the version in practice" is the right default answer for
+/// "what version does this project actually have" even though it is not the
+/// only version the requirement's own comparator would accept. Moving NuGet
+/// to `AlwaysRange` (tried and reverted during #669's implementation) makes
+/// `concrete_pin_version` return `None` for the dominant bare
+/// `Version="12.0.1"` .csproj spelling with no lock file present — verified
+/// live to silently drop OSV vulnerability scanning, hover
+/// Security/Current/License sections, deps.dev trust signals, yanked
+/// checks, and inlay hints for that dependency, since NuGet's
+/// `packages.lock.json` is opt-in (`RestorePackagesWithLockFile`) and rarely
+/// present to rescue it via the lockfile path instead. `Concrete` keeps all
+/// of that working for the common case, at the cost of being wrong in two
+/// narrower situations: the pinned floor version doesn't actually exist on
+/// the feed, or a transitive dependency elsewhere in the graph raises the
+/// effective floor above what this bare requirement alone states — both
+/// already-known limitations of "lowest applicable version" as an
+/// approximation, not new ones introduced by keeping this policy. An
+/// explicit exact-bracket pin (`[1.0.0]`) is unaffected either way — it is
+/// stripped and matched before `bare_requirement_policy` is ever consulted
+/// (see [`concrete_pin_version`]).
 ///
 /// Spelled out as explicit arms rather than a `_` catch-all (impl-critic
 /// #664 review, finding M4): `EcosystemId` is deliberately exhaustive so a
@@ -550,6 +586,26 @@ mod tests {
         ] {
             assert!(is_concrete_version("2.14.1", eco), "{eco:?}");
         }
+    }
+
+    #[test]
+    fn is_concrete_version_nuget_bare_version_is_a_deliberate_pin_approximation() {
+        // #669: a bare NuGet `Version="1.0.0"` is a minimum-only floor under
+        // `PackageReference`/`PackageVersion` semantics — `NuGetFormatter`'s own
+        // `version_satisfies_requirement` accepts any version `>= 1.0.0`, not just
+        // `1.0.0` itself. `deps-core` still treats it as concrete here anyway: this is
+        // a deliberate approximation of "restore resolves a direct reference to its
+        // floor version in practice" (mirrored by `NuGetFormatter::
+        // is_requirement_up_to_date`, which treats the same bare floor as a pin for
+        // outdated-checking), not an oversight — reclassifying NuGet to always-range
+        // was tried and reverted during #669's implementation because it silently
+        // dropped OSV/hover/license resolution for the dominant bare `Version="X"`
+        // spelling with no lock file present. See this module's `Concrete` doc for
+        // the full rationale and known limitations of the approximation.
+        assert!(is_concrete_version("1.0.0", EcosystemId::NuGet));
+        // An explicit exact-bracket pin is unaffected either way — it is stripped
+        // and matched before `bare_requirement_policy` is ever consulted.
+        assert!(is_concrete_version("[1.0.0]", EcosystemId::NuGet));
     }
 
     #[test]
@@ -1224,5 +1280,41 @@ mod tests {
         );
 
         assert_eq!(result, Some("4.17.0".to_string()));
+    }
+
+    /// #669's exact scenario: a `.csproj` `<PackageReference Include="Newtonsoft.Json"
+    /// Version="1.0.0" />` with no lock file present. `NuGetFormatter::
+    /// version_satisfies_requirement` would accept `"2.5.0"`/`"9.9.9"` too (the bare
+    /// requirement is really an unbounded minimum floor), but `in_use_version` still
+    /// resolves this to the pin-approximation `Some("1.0.0")` — restore resolves a
+    /// direct `PackageReference` to exactly its floor version in practice, so this is
+    /// the right default answer for "what version does the project actually have"
+    /// even though it is not the only version the requirement's own comparator would
+    /// accept. Reclassifying NuGet to always-range instead (tried and reverted during
+    /// #669's implementation) made this `None`, which silently dropped OSV scanning
+    /// and hover Security/License sections for the dominant bare `Version="X"`
+    /// spelling — see this module's `Concrete` doc for the full rationale.
+    #[test]
+    fn in_use_version_nuget_bare_floor_resolves_as_pin_approximation() {
+        use crate::VersionReq;
+        use crate::lsp_helpers::test_support::MockDep;
+
+        let dep = MockDep {
+            name: PackageName::new("Newtonsoft.Json"),
+            version_req: VersionReq::new("1.0.0"),
+            version_range: tower_lsp_server::ls_types::Range::default(),
+            name_range: tower_lsp_server::ls_types::Range::default(),
+        };
+
+        let result = in_use_version(
+            &dep,
+            "newtonsoft.json",
+            &HashMap::new(),
+            None,
+            &crate::lsp_helpers::test_support::MockFormatter,
+            EcosystemId::NuGet,
+        );
+
+        assert_eq!(result, Some("1.0.0".to_string()));
     }
 }

--- a/crates/deps-lsp/src/lib.rs
+++ b/crates/deps-lsp/src/lib.rs
@@ -587,6 +587,276 @@ mod tests {
         );
     }
 
+    /// Whether `formatter`'s own comparator (preferring
+    /// [`deps_core::lsp_helpers::RequirementResolution::compile_requirement`], falling back to
+    /// [`deps_core::lsp_helpers::RequirementResolution::version_satisfies_requirement`] when it
+    /// declines to compile) treats a bare `requirement` as an exact pin: it must match
+    /// `requirement` itself but reject both a higher patch (`"1.2.9"`) and a higher
+    /// minor/major (`"9.9.9"`) — the same "matches only this one version" shape
+    /// [`deps_core::lsp_helpers::concrete_pin_version`] asserts. Also correctly says `false`
+    /// for a genuine partial-version range (e.g. `"1.2"`), since that legitimately matches
+    /// more than one candidate.
+    #[cfg(any(
+        feature = "cargo",
+        feature = "npm",
+        feature = "go",
+        feature = "bundler",
+        feature = "dart",
+        feature = "maven",
+        feature = "composer",
+        feature = "gradle",
+        feature = "nuget",
+        feature = "deno",
+        feature = "github-actions",
+        feature = "gitlab-ci",
+        feature = "swift",
+        feature = "pypi"
+    ))]
+    fn formatter_treats_bare_version_as_exact_pin(
+        formatter: &dyn deps_core::lsp_helpers::EcosystemFormatter,
+        bare: &str,
+    ) -> bool {
+        use deps_core::{ConcreteVersion, VersionReq};
+
+        let requirement = VersionReq::new(bare);
+        let matches = |candidate: &str| -> bool {
+            let version = ConcreteVersion::from(candidate);
+            if let Some(matcher) = formatter.compile_requirement(&requirement) {
+                matcher.matches(&version) == Some(true)
+            } else {
+                formatter.version_satisfies_requirement(&version, bare)
+            }
+        };
+
+        matches(bare) && !matches("9.9.9") && !matches("1.2.9")
+    }
+
+    /// How a given ecosystem's bare-version-is-a-pin verdict relates to its own formatter's
+    /// comparator — see [`bare_version_agreement_expectation`].
+    #[cfg(any(
+        feature = "cargo",
+        feature = "npm",
+        feature = "go",
+        feature = "bundler",
+        feature = "dart",
+        feature = "maven",
+        feature = "composer",
+        feature = "gradle",
+        feature = "nuget",
+        feature = "deno",
+        feature = "github-actions",
+        feature = "gitlab-ci",
+        feature = "swift",
+        feature = "pypi"
+    ))]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum BareVersionAgreementExpectation {
+        /// `deps-core`'s `concrete_pin_version` and the ecosystem's own comparator must
+        /// agree on whether a bare full version (`"1.2.3"`) is an exact pin. When `true`,
+        /// also checked against a bare *partial* version (`"1.2"`, impl-critic M1) —
+        /// gated per-ecosystem because a partial-version *requirement* is not a concept
+        /// every `Concrete`-policy ecosystem actually has: Go's own comparator, for
+        /// instance, treats a bare string as a version *prefix* to support pseudo-version
+        /// and `+incompatible`-suffix matching (`go_version_matches`), which makes it
+        /// (correctly, for its real purpose) accept `"1.2"` against a candidate `"1.2.9"`
+        /// — a false "divergence" against `deps-core` if compared as though `"1.2"` were
+        /// a genuine partial-version requirement, which go.mod's `require` directive
+        /// never actually contains (it is always a complete version). Only the
+        /// ecosystems with a real bare-partial-is-a-range grammar (`AlwaysRange`'s Cargo
+        /// caret, `ConcreteIfFullVersion`'s X-range/moving-tag ecosystems) get `true`.
+        Checked { test_partial: bool },
+        /// The ecosystem's own comparator would disagree with `deps-core`'s verdict, but
+        /// the parser can never actually emit a bare requirement in the first place, so the
+        /// divergence never reaches `concrete_pin_version` in practice (Swift, PyPI).
+        LatentOnly,
+        /// `deps-core` deliberately reports a bare requirement as a pin even though the
+        /// ecosystem's own comparator disagrees — a documented approximation, not an
+        /// oversight (NuGet).
+        DeliberateApproximation,
+    }
+
+    /// #669 regression guard: `deps-core`'s `bare_requirement_policy` hand-maintains a
+    /// per-ecosystem model of "is a bare version requirement a pin or a range", but every
+    /// ecosystem's own formatter already has the authoritative answer via
+    /// `compile_requirement`/`version_satisfies_requirement`, and nothing kept the two in
+    /// sync — this already caused two shipped bugs (#664 npm/Composer, #667 Deno). For every
+    /// ecosystem this crate can register, classifies it via [`BareVersionAgreementExpectation`]
+    /// and checks the matching invariant: `Checked` ecosystems must agree on both a bare full
+    /// version (`"1.2.3"`) and a bare partial version (`"1.2"`, impl-critic M1); `LatentOnly`
+    /// and `DeliberateApproximation` ecosystems must instead still exhibit the disagreement
+    /// their exemption relies on (impl-critic M2) — so an alignment on either side (a parser
+    /// change, a comparator change) fails this test instead of silently going stale.
+    ///
+    /// The `match` in [`bare_version_agreement_expectation`] is deliberately exhaustive
+    /// (`.claude/CLAUDE.md`'s bug-class-#118 rule): a future 15th ecosystem must get an
+    /// explicit arm — added to `Checked` or listed as a commented, reviewed exemption —
+    /// rather than silently falling through a wildcard.
+    #[cfg(any(
+        feature = "cargo",
+        feature = "npm",
+        feature = "go",
+        feature = "bundler",
+        feature = "dart",
+        feature = "maven",
+        feature = "composer",
+        feature = "gradle",
+        feature = "nuget",
+        feature = "deno",
+        feature = "github-actions",
+        feature = "gitlab-ci",
+        feature = "swift",
+        feature = "pypi"
+    ))]
+    fn bare_version_agreement_expectation(
+        id: deps_core::EcosystemId,
+    ) -> BareVersionAgreementExpectation {
+        use BareVersionAgreementExpectation::{Checked, DeliberateApproximation, LatentOnly};
+
+        match id {
+            // Cargo (caret), and the `ConcreteIfFullVersion` ecosystems (npm/Composer/Deno's
+            // X-ranges, GitHub Actions'/GitLab CI's moving-major tags): a bare *partial*
+            // version is a real, distinct requirement shape from a bare full version under
+            // these ecosystems' own grammar, so both are worth checking.
+            deps_core::EcosystemId::Cargo
+            | deps_core::EcosystemId::Npm
+            | deps_core::EcosystemId::Composer
+            | deps_core::EcosystemId::Deno
+            | deps_core::EcosystemId::GithubActions
+            | deps_core::EcosystemId::GitlabCi => Checked { test_partial: true },
+            // Go/Bundler/Dart/Maven/Gradle: no partial-version requirement concept exists in
+            // these ecosystems' own manifests (a bare version is always a complete one), so a
+            // synthetic partial input like `"1.2"` isn't a meaningful requirement to compare —
+            // only the full-version case is checked. (Go's own comparator in particular
+            // treats a bare string as a version *prefix*, for pseudo-version/`+incompatible`
+            // matching, not as a partial-version range — comparing it against `"1.2"` as if it
+            // were a partial-range requirement produces a false divergence.)
+            deps_core::EcosystemId::Go
+            | deps_core::EcosystemId::Bundler
+            | deps_core::EcosystemId::Dart
+            | deps_core::EcosystemId::Maven
+            | deps_core::EcosystemId::Gradle => Checked {
+                test_partial: false,
+            },
+            // Swift: `SwiftFormatter::compile_requirement` parses a requirement via
+            // `semver::VersionReq`, whose bare-string default is a caret range — the same
+            // divergence NuGet has — but `deps-swift`'s parser always emits an explicit
+            // range spelling (`">=X, <Y"`) or an exact `"=X"` pin, never a bare `"X.Y.Z"`
+            // string (see `deps-swift/src/parser.rs`'s `upToNextMajor`/`.exact(...)`
+            // handling), so this can't fire today. Re-review if the parser ever changes to
+            // emit a bare form.
+            deps_core::EcosystemId::Swift => LatentOnly,
+            // PyPI: the parser retains the pep440 comparator on every requirement (e.g. an
+            // exact pin parses to `"==1.2.3"`, never bare `"1.2.3"` — see `deps-core`'s
+            // `concrete_pin_version_strips_pep440_double_equals_comparator`), so a bare
+            // requirement never reaches this check either. Re-review if the parser ever
+            // changes to emit a bare form.
+            deps_core::EcosystemId::Pypi => LatentOnly,
+            // NuGet (#669): a bare `Version="X"` is really an unbounded minimum floor under
+            // `NuGetFormatter`'s own comparator, but `deps-core` deliberately still reports
+            // it as a pin — restore resolves a direct `PackageReference` to its floor
+            // version in practice, mirrored by `NuGetFormatter::is_requirement_up_to_date`
+            // treating the same bare floor as a pin for outdated-checking. See
+            // `deps-core`'s `bare_requirement_policy` doc for the full rationale, including
+            // why the alternative (an always-range policy) was tried and reverted.
+            deps_core::EcosystemId::NuGet => DeliberateApproximation,
+        }
+    }
+
+    #[test]
+    fn test_concrete_pin_version_agrees_with_formatter_for_bare_version() {
+        use deps_core::{ConcreteVersion, VersionReq};
+
+        let registry = Arc::new(EcosystemRegistry::new());
+        let cache = Arc::new(HttpCache::new());
+        register_ecosystems(&registry, Arc::clone(&cache), &test_runtime());
+
+        const BARE_FULL_VERSION: &str = "1.2.3";
+        const BARE_PARTIAL_VERSION: &str = "1.2";
+
+        for str_id in registry.ecosystem_ids() {
+            let id: deps_core::EcosystemId = str_id.parse().unwrap_or_else(|_| {
+                panic!("registered ecosystem id {str_id:?} has no matching EcosystemId variant")
+            });
+            let ecosystem = registry
+                .get(str_id)
+                .unwrap_or_else(|| panic!("{str_id:?} just parsed from the registry's own ids"));
+            let formatter = ecosystem.formatter();
+
+            match bare_version_agreement_expectation(id) {
+                BareVersionAgreementExpectation::Checked { test_partial } => {
+                    let bare_inputs: &[&str] = if test_partial {
+                        &[BARE_FULL_VERSION, BARE_PARTIAL_VERSION]
+                    } else {
+                        &[BARE_FULL_VERSION]
+                    };
+                    for &bare in bare_inputs {
+                        let deps_core_says_pin =
+                            deps_core::lsp_helpers::concrete_pin_version(bare, id).is_some();
+                        let formatter_says_pin =
+                            formatter_treats_bare_version_as_exact_pin(formatter, bare);
+
+                        assert_eq!(
+                            deps_core_says_pin, formatter_says_pin,
+                            "{id:?} ({bare:?}): deps-core's concrete_pin_version and the \
+                             ecosystem's own compile_requirement/version_satisfies_requirement \
+                             disagree on whether this bare requirement is an exact pin"
+                        );
+                    }
+                }
+                BareVersionAgreementExpectation::LatentOnly => {
+                    let deps_core_says_pin =
+                        deps_core::lsp_helpers::concrete_pin_version(BARE_FULL_VERSION, id)
+                            .is_some();
+                    let formatter_says_pin =
+                        formatter_treats_bare_version_as_exact_pin(formatter, BARE_FULL_VERSION);
+
+                    assert_ne!(
+                        deps_core_says_pin, formatter_says_pin,
+                        "{id:?}: this ecosystem is exempted as a latent-only mismatch, but its \
+                         comparator no longer disagrees with deps-core's verdict — either the \
+                         parser started emitting a bare requirement (making this a live bug, \
+                         not a latent one) or the comparator changed; re-review this exemption \
+                         in bare_version_agreement_expectation"
+                    );
+                }
+                BareVersionAgreementExpectation::DeliberateApproximation => {
+                    assert!(
+                        deps_core::lsp_helpers::concrete_pin_version(BARE_FULL_VERSION, id)
+                            .is_some(),
+                        "{id:?}: deps-core should still report a bare full version as a pin \
+                         (the deliberate approximation this exemption documents)"
+                    );
+                    assert!(
+                        !formatter_treats_bare_version_as_exact_pin(formatter, BARE_FULL_VERSION),
+                        "{id:?}: the ecosystem's own comparator no longer disagrees with a \
+                         strict pin verdict — re-review whether this exemption (and the \
+                         Concrete-policy approximation it documents) is still needed"
+                    );
+
+                    let requirement = VersionReq::new(BARE_FULL_VERSION);
+                    assert!(
+                        formatter.is_requirement_up_to_date(
+                            &requirement,
+                            &ConcreteVersion::from(BARE_FULL_VERSION)
+                        ),
+                        "{id:?}: is_requirement_up_to_date should treat a bare floor as \
+                         up to date when latest equals the floor — the pin-like precedent \
+                         this exemption relies on"
+                    );
+                    assert!(
+                        !formatter.is_requirement_up_to_date(
+                            &requirement,
+                            &ConcreteVersion::from("9.9.9")
+                        ),
+                        "{id:?}: is_requirement_up_to_date should treat a bare floor as \
+                         outdated once latest moves past it — confirming it is handled as a \
+                         pin, not an auto-following range"
+                    );
+                }
+            }
+        }
+    }
+
     /// #348 regression: `select_latest_matching` must resolve an all-`AdvisoryDeprecated`
     /// version list under a wildcard requirement for every registered ecosystem — an
     /// advisory-only flag (npm `deprecated`, Composer `abandoned`, ...) must never make an


### PR DESCRIPTION
## Summary

- Adds an exhaustive cross-ecosystem consistency test in `deps-lsp` that checks `bare_requirement_policy`'s belief about each ecosystem against that ecosystem's own `compile_requirement`/`version_satisfies_requirement` verdict, following the #118 precedent of an exhaustive `match` on `EcosystemId` rather than a loop a future ecosystem could silently fall through.
- NuGet was the one live divergence #669 reported: `deps-core` treated a bare `Version="X"` as an exact pin, while `NuGetFormatter`'s own comparator treats it as an unbounded floor.
- **#669's proposed fix (move NuGet to match the strict comparator) was investigated and rejected.** It was implemented first, then reverted after a live-verified regression: making `concrete_pin_version` return `None` for the dominant bare-version spelling silently disabled OSV vulnerability scanning and hover Security sections for it (no lock file present, the common case for NuGet since `packages.lock.json` is opt-in).
- NuGet's `Concrete` classification is kept and now documented as a deliberate approximation of "restore picks the lowest applicable version," consistent with the existing precedent in `NuGetFormatter::is_requirement_up_to_date`, which already treats the same bare floor as a pin for outdated-checking. The new test encodes this explicitly as a `DeliberateApproximation` case (alongside Swift/PyPI's `LatentOnly` exemptions, for a bare form neither parser can emit yet), so a future change to either side of the approximation breaks the test instead of drifting unnoticed.

If `bare_requirement_policy`'s NuGet classification is revisited again in the future, see this PR's discussion — the strict-comparator alternative was tried and reverted for the OSV/hover regression described above, not overlooked.

## Test plan

- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4485 passed, 50 skipped)
- [x] `cargo test --workspace --doc --all-features`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo +nightly fmt --all -- --check`
- [x] Strict rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --workspace --no-deps --all-features`)
- [x] Live-verified via debug LSP session: bare `Version="X"` NuGet dependency (no lock file) now again receives OSV scanning and a hover Security advisories section, matching the pre-#669 (and post-revert) behavior

Closes #669