### PR TITLE
feat(observability): add tracing spans for document and registry fetch correlation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **deps-lsp, deps-cargo, deps-npm, deps-deno, deps-pypi, deps-go, deps-bundler, deps-dart, deps-maven, deps-gitlab-ci, deps-composer, deps-swift, deps-nuget, deps-github-actions**: `tracing::instrument` spans on document lifecycle handlers, background fetch-task spawning, and every ecosystem registry fetch entry point, correlating log events by document URI, ecosystem, package name, and requested version (resolves #671)
+- **deps-lsp, deps-cargo, deps-npm, deps-deno, deps-pypi, deps-go, deps-bundler, deps-dart, deps-maven, deps-gitlab-ci, deps-composer, deps-swift, deps-nuget, deps-github-actions**: `tracing::instrument` spans on document lifecycle handlers, background fetch-task spawning, and every ecosystem registry fetch entry point, correlating log events by document URI, ecosystem, package name, and requested version (resolves #671) (#677)
 - **deps-core, deps-composer**: hover now shows the SPDX license for the resolved and latest version (Cargo, npm, PyPI, Go, Maven, Bundler, NuGet, Composer), flagging a "License changed" when they differ (resolves #204) (#663)
 - **deps-core**: OSV malicious-package advisories (`MAL-*` id or alias) now classify as a distinct `VulnSeverity::Malicious` instead of falling through to "unknown severity" in hover/diagnostics (resolves #646) (#652)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **deps-lsp, deps-cargo, deps-npm, deps-deno, deps-pypi, deps-go, deps-bundler, deps-dart, deps-maven, deps-gitlab-ci, deps-composer, deps-swift, deps-nuget, deps-github-actions**: `tracing::instrument` spans on document lifecycle handlers, background fetch-task spawning, and every ecosystem registry fetch entry point, correlating log events by document URI, ecosystem, package name, and requested version (resolves #671)
 - **deps-core, deps-composer**: hover now shows the SPDX license for the resolved and latest version (Cargo, npm, PyPI, Go, Maven, Bundler, NuGet, Composer), flagging a "License changed" when they differ (resolves #204) (#663)
 - **deps-core**: OSV malicious-package advisories (`MAL-*` id or alias) now classify as a distinct `VulnSeverity::Malicious` instead of falling through to "unknown severity" in hover/diagnostics (resolves #646) (#652)
 

--- a/crates/deps-bundler/src/registry.rs
+++ b/crates/deps-bundler/src/registry.rs
@@ -56,6 +56,7 @@ impl RubyGemsRegistry {
     }
 
     /// Fetches all versions for a gem.
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_versions(&self, name: &str) -> Result<Vec<BundlerVersion>> {
         let url = versions_url(name);
         let data = self.cache.get_cached(&url).await?;
@@ -63,6 +64,7 @@ impl RubyGemsRegistry {
     }
 
     /// Finds the latest version matching the given requirement.
+    #[tracing::instrument(skip_all, fields(package = ?name, version = ?req_str), level = "debug")]
     pub async fn get_latest_matching(
         &self,
         name: &str,
@@ -75,6 +77,7 @@ impl RubyGemsRegistry {
     }
 
     /// Searches for gems by name/keywords.
+    #[tracing::instrument(skip_all, fields(query = ?query), level = "debug")]
     pub async fn search(&self, query: &str, limit: usize) -> Result<Vec<GemInfo>> {
         let url = format!(
             "{}/search.json?query={}",
@@ -87,6 +90,7 @@ impl RubyGemsRegistry {
     }
 
     /// Gets detailed gem information.
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_gem_info(&self, name: &str) -> Result<GemInfo> {
         let url = gem_info_url(name);
         let data = self.cache.get_cached(&url).await?;

--- a/crates/deps-cargo/src/registry.rs
+++ b/crates/deps-cargo/src/registry.rs
@@ -110,6 +110,7 @@ impl CratesIoRegistry {
     /// drop it if crates.io ever gains its own publish-time enrichment (issue #588 critic
     /// M10) — today this is a pure pass-through, identical to [`Self::get_versions`], since
     /// crates.io's sparse index carries no such enrichment yet.
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_versions_with(
         &self,
         name: &str,
@@ -143,6 +144,7 @@ impl CratesIoRegistry {
     /// assert!(latest.is_some());
     /// # }
     /// ```
+    #[tracing::instrument(skip_all, fields(package = ?name, version = ?req_str), level = "debug")]
     pub async fn get_latest_matching(
         &self,
         name: &str,
@@ -176,6 +178,7 @@ impl CratesIoRegistry {
     /// assert!(!results.is_empty());
     /// # }
     /// ```
+    #[tracing::instrument(skip_all, fields(query = ?query), level = "debug")]
     pub async fn search(&self, query: &str, limit: usize) -> Result<Vec<CrateInfo>> {
         let url = format!(
             "{}/crates?q={}&per_page={}&sort=downloads",

--- a/crates/deps-cargo/src/sparse.rs
+++ b/crates/deps-cargo/src/sparse.rs
@@ -318,6 +318,7 @@ impl SparseIndexClient {
     /// assert!(!versions.is_empty());
     /// # }
     /// ```
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_versions(&self, name: &str) -> Result<Vec<CargoVersion>> {
         reject_unsafe_crate_name(name, self.registry_display_name)?;
         let url = sparse_index_url(&self.base_url, name);
@@ -334,6 +335,7 @@ impl SparseIndexClient {
     /// Returns an error if:
     /// - Version requirement string is invalid semver
     /// - HTTP request fails
+    #[tracing::instrument(skip_all, fields(package = ?name, version = ?req_str), level = "debug")]
     pub async fn get_latest_matching(
         &self,
         name: &str,

--- a/crates/deps-composer/src/registry.rs
+++ b/crates/deps-composer/src/registry.rs
@@ -233,6 +233,7 @@ impl PackagistRegistry {
     /// # Errors
     ///
     /// Returns an error if the HTTP request or JSON parsing fails.
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_versions(&self, name: &str) -> Result<Vec<ComposerVersion>> {
         reject_dot_segment(name)?;
         let url = p2_url(&self.base, name);
@@ -259,6 +260,7 @@ impl PackagistRegistry {
     /// # Errors
     ///
     /// Returns an error if the HTTP request fails.
+    #[tracing::instrument(skip_all, fields(package = ?name, version = ?req_str), level = "debug")]
     pub async fn get_latest_matching(
         &self,
         name: &str,
@@ -279,6 +281,7 @@ impl PackagistRegistry {
     /// # Errors
     ///
     /// Returns an error if the HTTP request fails.
+    #[tracing::instrument(skip_all, fields(package = ?name, version = ?req_str), level = "debug")]
     pub async fn get_latest_matching_for_manifest(
         &self,
         name: &str,
@@ -367,6 +370,7 @@ impl PackagistRegistry {
     /// # Errors
     ///
     /// Returns an error if the HTTP request or JSON parsing fails.
+    #[tracing::instrument(skip_all, fields(query = ?query), level = "debug")]
     pub async fn search(&self, query: &str, limit: usize) -> Result<Vec<ComposerPackage>> {
         let url = format!(
             "{}?q={}&per_page={}",

--- a/crates/deps-dart/src/registry.rs
+++ b/crates/deps-dart/src/registry.rs
@@ -78,6 +78,7 @@ impl PubDevRegistry {
         Self { cache, base }
     }
 
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_versions(&self, name: &str) -> Result<Vec<DartVersion>> {
         reject_dot_segment(name)?;
         let url = package_metadata_url(&self.base, name);
@@ -85,6 +86,7 @@ impl PubDevRegistry {
         parse_versions_response(&data)
     }
 
+    #[tracing::instrument(skip_all, fields(package = ?name, version = ?req_str), level = "debug")]
     pub async fn get_latest_matching(
         &self,
         name: &str,
@@ -96,6 +98,7 @@ impl PubDevRegistry {
         }))
     }
 
+    #[tracing::instrument(skip_all, fields(query = ?query), level = "debug")]
     pub async fn search(&self, query: &str, limit: usize) -> Result<Vec<PackageInfo>> {
         let url = format!("{}/search?q={}", self.base, urlencoding::encode(query));
         let data = self.cache.get_cached(&url).await?;
@@ -121,6 +124,7 @@ impl PubDevRegistry {
         Ok(results)
     }
 
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_package_info(&self, name: &str) -> Result<PackageInfo> {
         reject_dot_segment(name)?;
         let url = package_metadata_url(&self.base, name);

--- a/crates/deps-deno/src/registry.rs
+++ b/crates/deps-deno/src/registry.rs
@@ -205,8 +205,10 @@ impl JsrRegistry {
     /// assert!(!versions.is_empty());
     /// # }
     /// ```
+    #[tracing::instrument(skip_all, fields(package = tracing::field::Empty), level = "debug")]
     pub async fn get_versions(&self, scope: &str, name: &str) -> Result<Vec<JsrVersion>> {
         let full_name = format!("@{scope}/{name}");
+        tracing::Span::current().record("package", tracing::field::debug(&full_name));
         // S-L1: a dot-prefixed segment must be rejected before it ever reaches
         // `meta_json_url` — `url::Url::parse` decodes percent-encoding before dot-segment
         // normalization, so encoding alone cannot prevent `..`/`.` from collapsing the
@@ -260,6 +262,7 @@ impl JsrRegistry {
     /// assert!(!results.is_empty());
     /// # }
     /// ```
+    #[tracing::instrument(skip_all, fields(query = ?query), level = "debug")]
     pub async fn search(&self, query: &str, limit: usize) -> Result<Vec<JsrPackage>> {
         let Some((scope, pkg_prefix)) = split_scope_query(query) else {
             return self.fetch_search(query, limit).await;

--- a/crates/deps-github-actions/src/registry.rs
+++ b/crates/deps-github-actions/src/registry.rs
@@ -305,6 +305,7 @@ impl GithubActionsRegistry {
     /// concurrent callers for the same repository on a cold cache issue one request, not
     /// N (S2) — and short-circuits locally, without touching the network, once the
     /// rate-limit gate has been tripped by an earlier 403 (critic C1).
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_versions(&self, name: &str) -> Result<Vec<GithubActionsVersion>> {
         validate_owner_repo(name)?;
         if self.rate_limit.is_tripped() {
@@ -356,6 +357,7 @@ impl GithubActionsRegistry {
     /// repository, not treated as a workspace-wide outage), so the gate never becomes
     /// tripped while a token is present. Left unfixed rather than adding a check that
     /// would never fire in the tokened case it targets.
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_versions_with_release_dates(
         &self,
         name: &str,
@@ -371,6 +373,7 @@ impl GithubActionsRegistry {
     }
 
     /// Finds the latest version satisfying the given semver requirement.
+    #[tracing::instrument(skip_all, fields(package = ?name, version = ?req_str), level = "debug")]
     pub async fn get_latest_matching(
         &self,
         name: &str,

--- a/crates/deps-gitlab-ci/src/registry.rs
+++ b/crates/deps-gitlab-ci/src/registry.rs
@@ -338,6 +338,7 @@ impl GitlabCiRegistry {
 
     /// Fetches and converts the version list for `name` via `route`, gated by the route's
     /// origin-scoped rate-limit gate.
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     async fn fetch_route(
         &self,
         name: &PackageName,
@@ -431,6 +432,7 @@ impl GitlabCiRegistry {
     /// # Errors
     ///
     /// Propagates the underlying fetch error unchanged (rate limit, not-found, etc).
+    #[tracing::instrument(skip_all, fields(package = ?name, version = ?raw), level = "debug")]
     pub async fn resolve_component_pin(
         &self,
         name: &PackageName,

--- a/crates/deps-go/src/registry.rs
+++ b/crates/deps-go/src/registry.rs
@@ -396,6 +396,7 @@ impl GoRegistry {
     /// `deps-pypi`'s identical FR-005(c) trade-off for the default `,`-separated case:
     /// silently falling through on transport failure risks resolving a module through a
     /// fallback the user did not intend for the reachability state they are actually in.
+    #[tracing::instrument(skip_all, fields(package = ?module_path), level = "debug")]
     async fn get_versions_chained(&self, module_path: &str) -> Result<Vec<GoVersion>> {
         let mut last_miss: Result<Vec<GoVersion>> = Err(DepsError::PackageNotFound {
             package: module_path.to_string(),
@@ -478,6 +479,7 @@ impl GoRegistry {
     /// assert!(!versions.is_empty());
     /// # }
     /// ```
+    #[tracing::instrument(skip_all, fields(package = ?module_path), level = "debug")]
     pub async fn get_versions(&self, module_path: &str) -> Result<Vec<GoVersion>> {
         if self.tier == GoRegistryTier::Terminal {
             return Err(DepsError::PackageNotFound {
@@ -525,6 +527,7 @@ impl GoRegistry {
     /// assert_eq!(info.version, "v1.9.1");
     /// # }
     /// ```
+    #[tracing::instrument(skip_all, fields(package = ?module_path, version = ?version), level = "debug")]
     pub async fn get_version_info(&self, module_path: &str, version: &str) -> Result<GoVersion> {
         if self.tier == GoRegistryTier::Terminal {
             return Err(DepsError::PackageNotFound {
@@ -573,6 +576,7 @@ impl GoRegistry {
     /// assert!(!latest.is_pseudo);
     /// # }
     /// ```
+    #[tracing::instrument(skip_all, fields(package = ?module_path), level = "debug")]
     pub async fn get_latest(&self, module_path: &str) -> Result<GoVersion> {
         if self.tier == GoRegistryTier::Terminal {
             return Err(DepsError::PackageNotFound {
@@ -621,6 +625,7 @@ impl GoRegistry {
     /// assert!(go_mod.contains("module github.com/gin-gonic/gin"));
     /// # }
     /// ```
+    #[tracing::instrument(skip_all, fields(package = ?module_path, version = ?version), level = "debug")]
     pub async fn get_go_mod(&self, module_path: &str, version: &str) -> Result<String> {
         if self.tier == GoRegistryTier::Terminal {
             return Err(DepsError::PackageNotFound {

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -546,6 +546,7 @@ struct OsvScanResult {
 /// Returns `None` only when there is nothing to report at all (no
 /// dependencies reached any of steps 0-3, including the pre-filter skips —
 /// i.e. an empty manifest).
+#[tracing::instrument(skip_all, fields(uri = ?uri, ecosystem = ecosystem.id()))]
 async fn run_osv_scan_phase_a(
     uri: Uri,
     state: Arc<ServerState>,
@@ -1622,6 +1623,10 @@ fn fetch_failure_toast(
 ///
 /// Parses manifest using the ecosystem's parser, creates document state,
 /// and spawns a background task to fetch version information from the registry.
+#[tracing::instrument(
+    skip_all,
+    fields(uri = ?uri, ecosystem = tracing::field::Empty, doc_version = ?version)
+)]
 pub async fn handle_document_open(
     uri: Uri,
     content: String,
@@ -1640,6 +1645,7 @@ pub async fn handle_document_open(
             )));
         }
     };
+    tracing::Span::current().record("ecosystem", ecosystem.id());
 
     check_content_size(&content, &uri)?;
 
@@ -1705,6 +1711,7 @@ pub async fn handle_document_open(
               handle_document_open, so a config struct here would only relocate, not \
               reduce, the parameter list"
 )]
+#[tracing::instrument(skip_all, fields(uri = ?uri, ecosystem = ecosystem.id()))]
 async fn run_document_open_background_task(
     uri: Uri,
     state: Arc<ServerState>,
@@ -2174,6 +2181,7 @@ fn commit_parsed_document(
 ///
 /// Re-parses manifest when document content changes and spawns a debounced
 /// task to update diagnostics and request inlay hint refresh.
+#[tracing::instrument(skip_all, fields(uri = ?uri, doc_version = ?version))]
 pub async fn handle_document_change(
     uri: Uri,
     content: String,
@@ -2222,6 +2230,10 @@ pub async fn handle_document_change(
               independently; bundling them into one struct would only relocate, not reduce, \
               the parameter list"
 )]
+#[tracing::instrument(
+    skip_all,
+    fields(uri = ?uri, ecosystem = tracing::field::Empty, doc_version = ?version)
+)]
 pub(crate) async fn handle_document_change_guarded(
     uri: Uri,
     content: String,
@@ -2242,6 +2254,7 @@ pub(crate) async fn handle_document_change_guarded(
             )));
         }
     };
+    tracing::Span::current().record("ecosystem", ecosystem.id());
 
     check_content_size(&content, &uri)?;
 
@@ -2338,6 +2351,7 @@ struct ChangeTaskConfig {
 /// been committed: reloads lock-file-resolved versions, then runs the OSV rescan
 /// concurrently with any registry fetch the diff calls for, and finally publishes the
 /// resulting diagnostics.
+#[tracing::instrument(skip_all, fields(uri = ?uri, ecosystem = ecosystem.id()))]
 async fn run_document_change_task(
     uri: Uri,
     state: Arc<ServerState>,
@@ -2892,6 +2906,7 @@ async fn load_resolved_versions(
 /// }
 /// # }
 /// ```
+#[tracing::instrument(skip_all, fields(uri = ?uri), level = "debug")]
 pub async fn ensure_document_loaded(
     uri: &Uri,
     state: Arc<ServerState>,

--- a/crates/deps-lsp/src/document/reparse.rs
+++ b/crates/deps-lsp/src/document/reparse.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use tokio::sync::RwLock;
 use tower_lsp_server::Client;
 use tower_lsp_server::ls_types::Uri;
+use tracing::Instrument;
 
 /// Debounce window for coalescing a burst of `workspace/didChangeConfiguration`
 /// notifications (issue #592) into a single reparse — a settings-file save can emit
@@ -83,18 +84,24 @@ pub(crate) async fn reparse_open_documents(
     // that invalidation signal just because nothing needed reparsing *this time*.
     if state.diagnostic_refresh_supported() {
         let client = client.clone();
-        tokio::spawn(async move {
-            match tokio::time::timeout(
-                CLIENT_REFRESH_TIMEOUT,
-                client.workspace_diagnostic_refresh(),
-            )
-            .await
-            {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => tracing::debug!("workspace/diagnostic/refresh failed: {:?}", e),
-                Err(_) => tracing::debug!("workspace/diagnostic/refresh timed out"),
+        // Captured before `tokio::spawn` so this detached refresh's failure/timeout logs
+        // stay correlated with whatever span triggered this reparse.
+        let span = tracing::Span::current();
+        tokio::spawn(
+            async move {
+                match tokio::time::timeout(
+                    CLIENT_REFRESH_TIMEOUT,
+                    client.workspace_diagnostic_refresh(),
+                )
+                .await
+                {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => tracing::debug!("workspace/diagnostic/refresh failed: {:?}", e),
+                    Err(_) => tracing::debug!("workspace/diagnostic/refresh timed out"),
+                }
             }
-        });
+            .instrument(span),
+        );
     }
 
     if affected.is_empty() {

--- a/crates/deps-lsp/src/document/state.rs
+++ b/crates/deps-lsp/src/document/state.rs
@@ -14,6 +14,7 @@ use std::time::{Duration, Instant};
 use tokio::task::JoinHandle;
 use tower_lsp_server::Client;
 use tower_lsp_server::ls_types::Uri;
+use tracing::Instrument;
 
 /// Upper bound on how long a server-to-client request is allowed to wait for a
 /// reply before being abandoned (issue #493). Used both for the detached
@@ -791,30 +792,41 @@ impl ServerState {
     pub fn spawn_refresh_requests(&self, client: &Client) {
         if self.inlay_hint_refresh_supported() {
             let client = client.clone();
-            tokio::spawn(async move {
-                match tokio::time::timeout(CLIENT_REFRESH_TIMEOUT, client.inlay_hint_refresh())
-                    .await
-                {
-                    Ok(Ok(())) => {}
-                    Ok(Err(e)) => tracing::debug!("inlay_hint_refresh failed: {:?}", e),
-                    Err(_) => tracing::debug!(
-                        "inlay_hint_refresh timed out after {CLIENT_REFRESH_TIMEOUT:?}"
-                    ),
+            // Captured before `tokio::spawn` so this detached refresh's failure/timeout
+            // logs stay correlated with whichever document/ecosystem span triggered it.
+            let span = tracing::Span::current();
+            tokio::spawn(
+                async move {
+                    match tokio::time::timeout(CLIENT_REFRESH_TIMEOUT, client.inlay_hint_refresh())
+                        .await
+                    {
+                        Ok(Ok(())) => {}
+                        Ok(Err(e)) => tracing::debug!("inlay_hint_refresh failed: {:?}", e),
+                        Err(_) => tracing::debug!(
+                            "inlay_hint_refresh timed out after {CLIENT_REFRESH_TIMEOUT:?}"
+                        ),
+                    }
                 }
-            });
+                .instrument(span),
+            );
         }
         if self.code_lens_refresh_supported() {
             let client = client.clone();
-            tokio::spawn(async move {
-                match tokio::time::timeout(CLIENT_REFRESH_TIMEOUT, client.code_lens_refresh()).await
-                {
-                    Ok(Ok(())) => {}
-                    Ok(Err(e)) => tracing::debug!("code_lens_refresh failed: {:?}", e),
-                    Err(_) => tracing::debug!(
-                        "code_lens_refresh timed out after {CLIENT_REFRESH_TIMEOUT:?}"
-                    ),
+            let span = tracing::Span::current();
+            tokio::spawn(
+                async move {
+                    match tokio::time::timeout(CLIENT_REFRESH_TIMEOUT, client.code_lens_refresh())
+                        .await
+                    {
+                        Ok(Ok(())) => {}
+                        Ok(Err(e)) => tracing::debug!("code_lens_refresh failed: {:?}", e),
+                        Err(_) => tracing::debug!(
+                            "code_lens_refresh timed out after {CLIENT_REFRESH_TIMEOUT:?}"
+                        ),
+                    }
                 }
-            });
+                .instrument(span),
+            );
         }
     }
 
@@ -907,6 +919,7 @@ impl ServerState {
     /// Removes document state and returns the removed entry.
     ///
     /// Returns `None` if no document exists at the given URI.
+    #[tracing::instrument(skip_all, fields(uri = ?uri))]
     pub fn remove_document(&self, uri: &Uri) -> Option<(Uri, DocumentState)> {
         self.documents.remove(uri)
     }
@@ -932,6 +945,7 @@ impl ServerState {
     /// already panicked (finished, not cancelled) before a newer task was registered for
     /// the same URI must not have its belated supervisor clobber that newer task's
     /// in-flight load.
+    #[tracing::instrument(skip_all, fields(uri = ?uri))]
     pub async fn spawn_background_task(self: &Arc<Self>, uri: Uri, task: JoinHandle<()>) {
         let task_id = task.id();
         let abort_handle = task.abort_handle();
@@ -945,27 +959,34 @@ impl ServerState {
         }
 
         let state = Arc::clone(self);
-        tokio::spawn(async move {
-            if let Err(join_error) = task.await
-                && !join_error.is_cancelled()
-            {
-                if !state.is_current_background_task(&uri, task_id).await {
-                    tracing::debug!(
-                        "background task for {:?} panicked ({}) after being superseded; \
-                         ignoring stale panic",
+        // Captured before `tokio::spawn` (rather than relying on `#[instrument]` on a
+        // supervisor fn) so this detached supervisor's panic/debug logs stay correlated
+        // with the document/ecosystem context of the caller that installed this task.
+        let supervisor_span = tracing::Span::current();
+        tokio::spawn(
+            async move {
+                if let Err(join_error) = task.await
+                    && !join_error.is_cancelled()
+                {
+                    if !state.is_current_background_task(&uri, task_id).await {
+                        tracing::debug!(
+                            "background task for {:?} panicked ({}) after being superseded; \
+                             ignoring stale panic",
+                            uri,
+                            join_error
+                        );
+                        return;
+                    }
+                    tracing::error!(
+                        "background task for {:?} panicked ({}); forcing loading_state to Failed",
                         uri,
                         join_error
                     );
-                    return;
+                    state.force_document_failed_with_not_attempted(&uri);
                 }
-                tracing::error!(
-                    "background task for {:?} panicked ({}); forcing loading_state to Failed",
-                    uri,
-                    join_error
-                );
-                state.force_document_failed_with_not_attempted(&uri);
             }
-        });
+            .instrument(supervisor_span),
+        );
     }
 
     /// Whether `task_id` is still the background task currently registered for `uri`
@@ -1045,6 +1066,7 @@ impl ServerState {
     /// Cancels the background task for a document.
     ///
     /// If no task exists, this is a no-op.
+    #[tracing::instrument(skip_all, fields(uri = ?uri))]
     pub async fn cancel_background_task(&self, uri: &Uri) {
         let mut tasks = self.tasks.write().await;
         if let Some((_, task)) = tasks.remove(uri) {

--- a/crates/deps-maven/src/registry.rs
+++ b/crates/deps-maven/src/registry.rs
@@ -342,6 +342,7 @@ impl MavenCentralRegistry {
     /// caching in [`HttpCache`], so an unconditional fetch would retry forever) and the
     /// Gradle Plugin Portal's listing has no date column (a wasted fetch+parse on every
     /// call). Both degrade to zero extra requests here rather than one doomed one.
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_versions_typed_with(
         &self,
         name: &str,
@@ -365,6 +366,7 @@ impl MavenCentralRegistry {
         self.get_versions_typed_with(name, false).await
     }
 
+    #[tracing::instrument(skip_all, fields(package = ?name, version = ?req), level = "debug")]
     pub async fn get_latest_matching_typed(
         &self,
         name: &str,
@@ -401,6 +403,7 @@ impl MavenCentralRegistry {
     ///
     /// Returns the last error (an HTTP/network error, or a synthesized timeout error)
     /// if every attempt fails and no cached result is available to fall back to.
+    #[tracing::instrument(skip_all, fields(query = ?query), level = "debug")]
     pub async fn search_typed(&self, query: &str, limit: usize) -> Result<Vec<ArtifactInfo>> {
         debug_assert!(
             limit <= SEARCH_CACHE_ROWS,

--- a/crates/deps-npm/src/registry.rs
+++ b/crates/deps-npm/src/registry.rs
@@ -358,6 +358,7 @@ impl NpmRegistry {
     /// assert!(!versions.is_empty());
     /// # }
     /// ```
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_versions(&self, name: &str) -> Result<Vec<NpmVersion>> {
         if has_dot_segment(name) {
             warn_rejected_value("npm_dot_segment_guard", "npm packument request URL", name);
@@ -523,6 +524,7 @@ impl NpmRegistry {
     /// assert!(latest.is_some());
     /// # }
     /// ```
+    #[tracing::instrument(skip_all, fields(package = ?name, version = ?req_str), level = "debug")]
     pub async fn get_latest_matching(
         &self,
         name: &str,
@@ -575,6 +577,7 @@ impl NpmRegistry {
     /// assert!(!results.is_empty());
     /// # }
     /// ```
+    #[tracing::instrument(skip_all, fields(query = ?query), level = "debug")]
     pub async fn search(&self, query: &str, limit: usize) -> Result<Vec<NpmPackage>> {
         // N-M3: an alternate registry never performs a package-*name* search. Today's
         // routing never reaches this on a `WorkspaceDeclared` instance (`complete_package_names`

--- a/crates/deps-nuget/src/registry.rs
+++ b/crates/deps-nuget/src/registry.rs
@@ -689,6 +689,7 @@ impl NuGetRegistry {
     /// [`DepsError::ChainResolutionHalted`] rather than the underlying error unchanged — never
     /// falling back to api.nuget.org or the next configured feed, which would leak the
     /// package's name past a merely-unreachable private feed.
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     async fn get_versions_chained(&self, name: &str) -> Result<Vec<NuGetVersion>> {
         let mut last_miss: Result<Vec<NuGetVersion>> = Err(DepsError::PackageNotFound {
             package: name.to_string(),
@@ -781,6 +782,7 @@ impl NuGetRegistry {
     ///
     /// Returns an error if the service index cannot be resolved or the flat-container
     /// request fails.
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_versions_typed_with(
         &self,
         name: &str,
@@ -917,6 +919,7 @@ impl NuGetRegistry {
     /// Returns an error only if `name` is rejected as a dot-segment or the service index
     /// itself cannot be resolved — both of which also fail the hover response's main
     /// version fetch, so this never surfaces a *distinct* failure mode to the caller.
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn unlisted_versions_for_hover(&self, name: &str) -> Result<HashSet<String>> {
         // Issue #562, FR-012: registration-hive enrichment is no longer skipped for
         // `WorkspaceDeclared`-tier feeds — routed through `Self::fetch` (§3.9) like every
@@ -945,6 +948,7 @@ impl NuGetRegistry {
     ///
     /// Returns an error if the service index cannot be resolved or the flat-container
     /// request fails.
+    #[tracing::instrument(skip_all, fields(package = ?name, version = ?req), level = "debug")]
     pub async fn get_latest_matching_typed(
         &self,
         name: &str,
@@ -959,6 +963,7 @@ impl NuGetRegistry {
     /// # Errors
     ///
     /// Returns an error if the service index cannot be resolved or the search request fails.
+    #[tracing::instrument(skip_all, fields(query = ?query), level = "debug")]
     pub async fn search_typed(&self, query: &str, limit: usize) -> Result<Vec<PackageInfo>> {
         let index = self.service_index().await?;
         // FR-016 (spec 035): a feed may omit `SearchQueryService` entirely (e.g. GitHub

--- a/crates/deps-pypi/src/registry.rs
+++ b/crates/deps-pypi/src/registry.rs
@@ -419,6 +419,7 @@ impl PypiRegistry {
     /// reaches hover/diagnostics text, not just the `tracing::warn!` below (which still logs
     /// the real underlying error for debugging) — this is NFR-003(3)'s required
     /// distinguishable diagnostic.
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     async fn get_versions_chained(&self, name: &str) -> Result<Vec<PypiVersion>> {
         let mut last_miss: Result<Vec<PypiVersion>> = Err(DepsError::PackageNotFound {
             package: name.to_string(),
@@ -486,6 +487,7 @@ impl PypiRegistry {
     /// assert!(!versions.is_empty());
     /// # }
     /// ```
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_versions(&self, name: &str) -> Result<Vec<PypiVersion>> {
         let normalized = crate::name::normalize(name);
         if normalized.is_empty() {
@@ -540,6 +542,7 @@ impl PypiRegistry {
     /// assert!(latest.is_some());
     /// # }
     /// ```
+    #[tracing::instrument(skip_all, fields(package = ?name, version = ?req_str), level = "debug")]
     pub async fn get_latest_matching(
         &self,
         name: &str,
@@ -671,6 +674,7 @@ impl PypiRegistry {
     ///   name to `pypi.org`'s JSON API (`metadata_url` is always built from the hardcoded
     ///   `PYPI_BASE`, never parameterized — see `metadata_url`'s doc) — closed here before
     ///   any such call site exists, not relied on via the call graph
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_package_metadata(&self, name: &str) -> Result<PypiPackage> {
         if self.tier == PypiRegistryTier::WorkspaceDeclared {
             return Err(DepsError::PackageNotFound {

--- a/crates/deps-swift/src/registry.rs
+++ b/crates/deps-swift/src/registry.rs
@@ -46,6 +46,7 @@ impl SwiftRegistry {
     /// Follows GitHub tags pagination up to `MAX_TAG_PAGES` pages, stopping
     /// as soon as a page comes back with fewer than 100 entries (no further
     /// pages exist).
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_versions(&self, name: &str) -> Result<Vec<SwiftVersion>> {
         validate_owner_repo(name)?;
         let tags = paginate_tags("Swift", name, |page| async move {
@@ -75,6 +76,7 @@ impl SwiftRegistry {
     /// so it can never perturb `get_versions`'s error propagation. This removes one
     /// round trip out of the tag-pagination loop's `P+1`, not half the latency (#223
     /// R7), and on a memo hit the join costs nothing at all.
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_versions_with_release_dates(&self, name: &str) -> Result<Vec<SwiftVersion>> {
         let (versions, dates) = tokio::join!(self.get_versions(name), self.release_dates(name));
         let mut versions = versions?;
@@ -92,6 +94,7 @@ impl SwiftRegistry {
     }
 
     /// Finds the latest version satisfying the given semver requirement.
+    #[tracing::instrument(skip_all, fields(package = ?name, version = ?req_str), level = "debug")]
     pub async fn get_latest_matching(
         &self,
         name: &str,
@@ -116,6 +119,7 @@ impl SwiftRegistry {
     ///
     /// Returns up to `limit` results. `latest_version` is left empty to avoid
     /// N+1 API calls per search result.
+    #[tracing::instrument(skip_all, fields(query = ?query), level = "debug")]
     pub async fn search(&self, query: &str, limit: usize) -> Result<Vec<SwiftPackage>> {
         let url = format!(
             "{}/search/repositories?q={}+language:swift&per_page={limit}",


### PR DESCRIPTION
## Summary

- Instrument document lifecycle/state entry points (`crates/deps-lsp/src/document/{lifecycle.rs,state.rs,reparse.rs}`) with `#[tracing::instrument]`, recording document URI/ecosystem/`doc_version` while skipping document content.
- Instrument the outbound-HTTP fetch entry points across all 13 ecosystem `registry.rs` files (bundler, cargo, composer, dart, deno, github-actions, gitlab-ci, go, maven, npm, nuget, pypi, swift; `deps-gradle` delegates to `deps-maven` and has no `registry.rs` of its own) plus `deps-cargo`'s sparse-index client, recording package/version/query fields. All fields are Debug-formatted (`?`) rather than Display (`%`) to avoid log injection from manifest-controlled strings, secrets stay excluded via `skip(self)`/`skip_all`, and registry spans run at `level = "debug"` to match this project's existing per-fetch log verbosity.
- Propagate the parent span into `tokio::spawn`'d background refresh and OSV-scan tasks (`Span::current()` captured before spawn, `.instrument()`'d inside) so background fetch events stay correlated with the document/ecosystem that triggered them.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4485 passed)
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --all-features`)
- [x] Manual call-graph review confirmed every real fetch path is covered, including alternate/private-registry paths and gitlab-ci's actual fetch route (not just its top-level wrapper)
- [x] Log-injection repro confirmed closed: hostile package names no longer forge log lines once fields switched from `%` to `?`

Closes #671