### PR TITLE
fix(deps-lsp): enforce restriction lints against str-slicing panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: OSV malicious-package advisories (`MAL-*` id or alias) now classify as a distinct `VulnSeverity::Malicious` instead of falling through to "unknown severity" in hover/diagnostics (resolves #646) (#652)
 - `fuzz/` workspace: cargo-fuzz targets for the shared TOML/YAML/JSON depth checkers, JSONC position recovery, and the Bundler/Go/Swift/Gradle/PyPI parsers, plus a bounded (non-blocking) CI job running each nightly-toolchain (resolves #673)
 - **deps-core, deps-cargo, deps-npm, deps-pypi**: clippy restriction lints (`indexing_slicing`/`unwrap_used`/`expect_used`) plus deps-core's re-enabled `cast_*` truncation lints, as a regression gate against panic-DoS bugs in the request-path parsers (resolves #673, deps-lsp follow-up #676)
+- **deps-lsp**: clippy restriction lints (`indexing_slicing`/`unwrap_used`/`expect_used`/`string_slice`) enforced at the crate root (resolves #676; `string_slice` coverage for the rest of the workspace tracked in #680)
 - **deps-core**: property tests (`proptest`) asserting the parser depth/expansion checkers and JSONC position recovery never panic on arbitrary input (#673)
 
 ### Fixed

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -38,6 +38,7 @@ type DepSources = Vec<(PackageName, deps_core::parser::DependencySource)>;
 /// `ecosystem.id()` always originates from a statically registered ecosystem
 /// (see `crate::register_ecosystems`), so parsing it back to `EcosystemId` can
 /// only fail on an internal registration bug, not on user input.
+#[allow(clippy::expect_used)] // safe per the invariant documented above
 fn resolve_ecosystem_id(ecosystem: &dyn Ecosystem) -> EcosystemId {
     ecosystem
         .id()
@@ -1833,6 +1834,9 @@ async fn run_document_open_background_task(
     // progress notifications. `P` is deliberately independent of
     // `cache.max_concurrent_fetches` (that bounds dependencies within one document's
     // fetch; this bounds documents fetching at once).
+    // `state.fetch_permits` is never `.close()`d anywhere in deps-lsp, so `acquire()`
+    // cannot return `Closed`.
+    #[allow(clippy::expect_used)]
     let fetch_permit = state
         .fetch_permits
         .acquire()
@@ -2201,6 +2205,9 @@ pub async fn handle_document_change(
         config,
     )
     .await?;
+    // `CommitGuard::Unconditional` always commits, so `handle_document_change_guarded`
+    // never returns `Ok(None)` for it.
+    #[allow(clippy::expect_used)]
     Ok(task.expect("CommitGuard::Unconditional never skips the commit"))
 }
 
@@ -2430,6 +2437,9 @@ async fn run_document_change_task(
     // before the failure toast / OSV phase B / diagnostics publish — none of those take a
     // permit themselves, and OSV phase A (spawned separately, above) never does either, so
     // there is no permit-holder-awaits-permit-taker deadlock shape here.
+    // `state.fetch_permits` is never `.close()`d anywhere in deps-lsp, so `acquire()`
+    // cannot return `Closed`.
+    #[allow(clippy::expect_used)]
     let fetch_permit = state
         .fetch_permits
         .acquire()

--- a/crates/deps-lsp/src/document/state.rs
+++ b/crates/deps-lsp/src/document/state.rs
@@ -195,7 +195,7 @@ impl ColdStartLimiter {
         if let Some(mut entry) = self.last_attempts.get_mut(uri) {
             let elapsed = now.duration_since(*entry);
             if elapsed < min_interval {
-                let retry_after = min_interval.checked_sub(elapsed).unwrap();
+                let retry_after = min_interval.saturating_sub(elapsed);
                 tracing::warn!(
                     "Cold start rate limited for {:?} (retry after {:?})",
                     uri,

--- a/crates/deps-lsp/src/handlers/code_lens.rs
+++ b/crates/deps-lsp/src/handlers/code_lens.rs
@@ -344,6 +344,9 @@ mod tests {
     /// asserts the *resulting document text is a valid, re-parseable declaration* (not
     /// merely "an edit exists"); every "skipped" fixture asserts no edit is produced at
     /// all, proving the guard — not the absence of a fixture — is what stops it.
+    // `clippy::string_slice` has no `allow-*-in-tests` clippy.toml knob (unlike
+    // indexing_slicing/unwrap_used/expect_used), so it needs an explicit allow here.
+    #[allow(clippy::string_slice)]
     mod cross_ecosystem_tests {
         use super::*;
         use std::collections::HashMap;

--- a/crates/deps-lsp/src/handlers/completion.rs
+++ b/crates/deps-lsp/src/handlers/completion.rs
@@ -302,7 +302,11 @@ async fn fallback_completion(
 fn extract_prefix(line: &str, character: u32, ecosystem_kind: EcosystemId) -> &str {
     let prefix_end =
         deps_core::completion::utf16_to_byte_offset(line, character).unwrap_or(line.len());
-    let prefix = line[..prefix_end].trim();
+    debug_assert!(
+        line.is_char_boundary(prefix_end),
+        "prefix_end must be a char boundary"
+    );
+    let prefix = line.get(..prefix_end).unwrap_or(line).trim();
     if uses_json_quoted_keys(ecosystem_kind) || uses_toml_string_array_values(ecosystem_kind) {
         prefix.trim_matches('"')
     } else if uses_xml_tag_values(ecosystem_kind) {
@@ -356,7 +360,11 @@ const fn uses_xml_tag_values(ecosystem_kind: EcosystemId) -> bool {
 /// `detect_xml_context`'s own "no context" outcome for that position, since its
 /// `between.contains("</")` guard rejects it too).
 fn strip_leading_xml_tag(prefix: &str) -> &str {
-    prefix.rfind('>').map_or(prefix, |gt| &prefix[gt + 1..])
+    // `>` is a single-byte ASCII char, so `gt + 1` is always a valid char boundary.
+    #[allow(clippy::string_slice)]
+    {
+        prefix.rfind('>').map_or(prefix, |gt| &prefix[gt + 1..])
+    }
 }
 
 /// Whether `ecosystem_kind`'s manifest keys are typed as JSON string literals
@@ -616,6 +624,8 @@ fn strip_trailing_toml_comment(line: &str) -> &str {
             Some(quote) if ch == quote => in_string = None,
             Some(_) => {}
             None if ch == '"' || ch == '\'' => in_string = Some(ch),
+            // `idx` comes from `char_indices`, so it is always a char boundary.
+            #[allow(clippy::string_slice)]
             None if ch == '#' => return line[..idx].trim_end(),
             None => {}
         }
@@ -724,6 +734,10 @@ fn is_in_xml_tag_section(content: &str, line_number: usize, tag: &str) -> bool {
 /// Counts real `<{open_prefix}...>` tag occurrences on `line`, i.e. `open_prefix`
 /// followed by `>` or whitespace (an attribute) rather than more tag-name characters
 /// (so `<dependencies` doesn't also match a longer, unrelated tag name).
+// `search_from` starts at 0 and is only ever advanced to `idx + open_prefix.len()`,
+// where `idx` is a `str::find` match start (always a char boundary) and the offset
+// lands exactly at the end of that matched substring (also always a char boundary).
+#[allow(clippy::string_slice)]
 fn count_open_tags(line: &str, open_prefix: &str) -> usize {
     let mut count = 0;
     let mut search_from = 0;

--- a/crates/deps-lsp/src/lib.rs
+++ b/crates/deps-lsp/src/lib.rs
@@ -1,3 +1,16 @@
+// #676: `clippy::indexing_slicing`/`unwrap_used`/`expect_used` (from #673) don't cover
+// `str` range slicing — that's `clippy::string_slice` — and every #244-class byte/UTF-16
+// offset bug site in this crate is a `str` slice, so add it as a fourth lint. Source
+// attribute (not a `[lints.clippy]` Cargo.toml table) mirrors `deps-core/src/lib.rs`;
+// `main.rs` is a separate crate root and needs the same attribute independently. Sites
+// confirmed safe are individually `#[allow]`ed with a one-line justification.
+#![warn(
+    clippy::indexing_slicing,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::string_slice
+)]
+
 pub mod config;
 pub mod document;
 pub mod file_watcher;

--- a/crates/deps-lsp/src/main.rs
+++ b/crates/deps-lsp/src/main.rs
@@ -1,3 +1,13 @@
+// #676: mirrors `src/lib.rs` — `main.rs` is a separate crate root, so the four
+// restriction lints (indexing_slicing/unwrap_used/expect_used/string_slice) must be
+// warned here independently.
+#![warn(
+    clippy::indexing_slicing,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::string_slice
+)]
+
 use deps_lsp::server::Backend;
 use std::env;
 use tower_lsp_server::{LspService, Server};
@@ -55,6 +65,9 @@ fn main() {
         }
     }
 
+    // Startup-time only, before any LSP traffic; a failure here means the process
+    // cannot serve at all, so there is no graceful degradation to fall back to.
+    #[allow(clippy::expect_used)]
     tokio::runtime::Builder::new_multi_thread()
         .thread_stack_size(WORKER_THREAD_STACK_SIZE)
         .enable_all()

--- a/crates/deps-lsp/src/server.rs
+++ b/crates/deps-lsp/src/server.rs
@@ -499,7 +499,10 @@ impl LanguageServer for Backend {
                 .state
                 .gitlab_instance_host
                 .write()
-                .expect("gitlab_instance_host lock poisoned") = gitlab_instance_host;
+                // The write below is a single infallible assignment, so this lock can
+                // never actually be poisoned; recover rather than propagate for
+                // defense in depth.
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = gitlab_instance_host;
             self.state.cache.set_offline(config.network.offline);
             self.state.cache.set_cache_enabled(config.cache.enabled);
             self.state
@@ -694,7 +697,10 @@ impl LanguageServer for Backend {
             .state
             .gitlab_instance_host
             .write()
-            .expect("gitlab_instance_host lock poisoned") = gitlab_instance_host;
+            // The write below is a single infallible assignment, so this lock can
+            // never actually be poisoned; recover rather than propagate for defense
+            // in depth.
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = gitlab_instance_host;
         // Must land before either refresh notification below, or the refresh re-renders
         // diagnostics under the stale flag values (critic M5).
         self.state.cache.set_offline(offline);


### PR DESCRIPTION
## Summary
- Add `clippy::indexing_slicing`/`unwrap_used`/`expect_used`/`string_slice` as crate-root warn lints in deps-lsp (`lib.rs` and `main.rs` independently, both crate roots)
- Fix the 3 sites the new lints flagged: a guarded `checked_sub().unwrap()` replaced with `saturating_sub()`, and two `RwLock` poison-`.expect()` sites replaced with `unwrap_or_else(PoisonError::into_inner)` recovery
- Justify the 8 remaining sites with narrowly-scoped `#[allow]` attributes and a one-line invariant comment each

`clippy::indexing_slicing` does not catch `str` range slicing — `clippy::string_slice` does, and it's the lint that actually covers the #244 bug class (a UTF-16 offset used as a byte offset, panicking on non-ASCII input) that this issue exists to guard against.

Follow-up to #673/#675's deps-core/deps-cargo/deps-npm/deps-pypi restriction-lint work. `string_slice` coverage for the other ecosystem crates is tracked separately in #680.

Closes #676

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4502 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`