### PR TITLE
chore(lints): consolidate restriction lints into [workspace.lints]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-deno**: extracted `deps-deno`'s scope-aware `@scope/pkg` name-boundary parser into a shared `deps_core::package::npm_style_name_boundary` helper, reused by the `deps-npm` alias fix above instead of a per-crate reimplementation (#657)
 
 ### Changed
-- Consolidated the `indexing_slicing`/`unwrap_used`/`expect_used`/`string_slice` clippy restriction lints, previously duplicated as an identical `#![warn(...)]` attribute across all 16 workspace crates, into `[workspace.lints.clippy]`; removed the dead `non_std_lazy_statics` allow (LazyLock has been stable since Rust 1.80, workspace MSRV is 1.98) (resolves #689)
+- Consolidated the `indexing_slicing`/`unwrap_used`/`expect_used`/`string_slice` clippy restriction lints, previously duplicated as an identical `#![warn(...)]` attribute across all 16 workspace crates, into `[workspace.lints.clippy]`; removed the dead `non_std_lazy_statics` allow (LazyLock has been stable since Rust 1.80, workspace MSRV is 1.98) (resolves #689) (#693)
 - **deps-npm**: `package-lock.json` parsing now prefers a package entry's own `name` field (npm writes this when it differs from the physical `node_modules/` path, e.g. for an `npm:` alias) over the lockfile-key-derived name (#657)
 - **deps-core, deps-composer, deps-nuget**: extracted the duplicated lenient string-or-string-array JSON deserializer into a shared `deps_core::json_helpers::deserialize_string_or_string_array` helper (resolves #662) (#665)
 - **deps-core, deps-lsp**: documented NuGet's bare-version pin approximation and added a cross-ecosystem consistency test guarding `bare_requirement_policy` (resolves #669) (#674)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-deno**: extracted `deps-deno`'s scope-aware `@scope/pkg` name-boundary parser into a shared `deps_core::package::npm_style_name_boundary` helper, reused by the `deps-npm` alias fix above instead of a per-crate reimplementation (#657)
 
 ### Changed
+- Consolidated the `indexing_slicing`/`unwrap_used`/`expect_used`/`string_slice` clippy restriction lints, previously duplicated as an identical `#![warn(...)]` attribute across all 16 workspace crates, into `[workspace.lints.clippy]`; removed the dead `non_std_lazy_statics` allow (LazyLock has been stable since Rust 1.80, workspace MSRV is 1.98) (resolves #689)
 - **deps-npm**: `package-lock.json` parsing now prefers a package entry's own `name` field (npm writes this when it differs from the physical `node_modules/` path, e.g. for an `npm:` alias) over the lockfile-key-derived name (#657)
 - **deps-core, deps-composer, deps-nuget**: extracted the duplicated lenient string-or-string-array JSON deserializer into a shared `deps_core::json_helpers::deserialize_string_or_string_array` helper (resolves #662) (#665)
 - **deps-core, deps-lsp**: documented NuGet's bare-version pin approximation and added a cross-ecosystem consistency test guarding `bare_requirement_policy` (resolves #669) (#674)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,13 @@ pedantic = { level = "warn", priority = -1 }
 nursery = { level = "warn", priority = -1 }
 cargo = { level = "warn", priority = -1 }
 
+# Restriction lints - previously duplicated as a per-crate #![warn(...)] source attribute
+# across all 16 workspace crates (#673/#680/#683/#686); consolidated here (#689)
+indexing_slicing = "warn"
+unwrap_used = "warn"
+expect_used = "warn"
+string_slice = "warn"
+
 # Allowed lints - too noisy for this codebase
 module_name_repetitions = "allow"
 similar_names = "allow"
@@ -126,9 +133,6 @@ match_wildcard_for_single_variants = "allow"
 # Function lints - allow for now
 missing_const_for_fn = "allow"
 unnecessary_wraps = "allow"
-
-# LazyLock migration - allow until we can target newer MSRV
-non_std_lazy_statics = "allow"
 
 # HashMap generics - too noisy for internal APIs
 implicit_hasher = "allow"

--- a/crates/deps-bundler/benches/bundler_benchmarks.rs
+++ b/crates/deps-bundler/benches/bundler_benchmarks.rs
@@ -6,6 +6,11 @@
 //! - Parsing large files (100+ deps): < 20ms
 //! - Gemfile.lock parsing: < 10ms for 100 packages
 
+// #689: workspace-level `clippy::unwrap_used` (moved from a per-crate lib.rs attribute)
+// now reaches this bench's separate crate root; benches use `unwrap()` on known-good
+// fixture data, which is idiomatic outside production parsing/registry code.
+#![allow(clippy::unwrap_used)]
+
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use deps_bundler::lockfile::parse_gemfile_lock;
 use deps_bundler::parser::parse_gemfile;

--- a/crates/deps-bundler/src/lib.rs
+++ b/crates/deps-bundler/src/lib.rs
@@ -21,21 +21,6 @@
 //! let _deps: Vec<BundlerDependency> = vec![];
 //! ```
 
-// #680: string slicing on a byte index that isn't a verified char boundary panics; sites
-// confirmed boundary-safe by construction are individually `#[allow]`ed with a justification.
-// #683: the three remaining #673 restriction lints, scoped to this crate only via a source
-// attribute (which overrides this crate's `[lints] workspace = true` Cargo.toml table
-// regardless of that table's level) rather than a duplicated `[lints.clippy]` table — avoids
-// ~90 lines of drift-prone duplication of the workspace allow-list. Deliberately never added
-// to `[workspace.lints.clippy]` itself (must stay opt-in per crate, not workspace-wide).
-// Sites confirmed safe are individually `#[allow]`ed with a one-line justification.
-#![warn(
-    clippy::indexing_slicing,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::string_slice
-)]
-
 pub mod ecosystem;
 pub mod formatter;
 pub mod lockfile;

--- a/crates/deps-cargo/benches/cargo_benchmarks.rs
+++ b/crates/deps-cargo/benches/cargo_benchmarks.rs
@@ -7,6 +7,11 @@
 //! - Registry JSON parsing: < 1ms per package
 //! - Version matching: < 100μs per operation
 
+// #689: workspace-level `clippy::unwrap_used` (moved from a per-crate lib.rs attribute)
+// now reaches this bench's separate crate root; benches use `unwrap()` on known-good
+// fixture data, which is idiomatic outside production parsing/registry code.
+#![allow(clippy::unwrap_used)]
+
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use deps_cargo::parse_cargo_toml;
 use std::hint::black_box;

--- a/crates/deps-cargo/src/lib.rs
+++ b/crates/deps-cargo/src/lib.rs
@@ -20,22 +20,6 @@
 //! let _deps: Vec<ParsedDependency> = vec![];
 //! ```
 
-// #673: restriction lints, scoped to this crate only via a source attribute (overrides
-// this crate's `[lints] workspace = true` Cargo.toml table regardless of that table's
-// level) rather than a duplicated `[lints.clippy]` table — avoids ~90 lines of
-// drift-prone duplication of the workspace allow-list. Deliberately never added to
-// `[workspace.lints.clippy]` itself (must stay opt-in per crate, not workspace-wide).
-// Sites confirmed safe are individually `#[allow]`ed with a one-line justification.
-// #680: `clippy::string_slice` appended to the same restriction-lint attribute for the
-// same reason — string slicing on a byte index that isn't a verified char boundary
-// panics; sites confirmed boundary-safe by construction are individually `#[allow]`ed.
-#![warn(
-    clippy::indexing_slicing,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::string_slice
-)]
-
 pub mod config;
 pub mod ecosystem;
 pub mod formatter;

--- a/crates/deps-cargo/tests/alternate_registry_test.rs
+++ b/crates/deps-cargo/tests/alternate_registry_test.rs
@@ -21,6 +21,13 @@
 //! alternate-index response. [`test_get_latest_matching_from_on_empty_list_routes_to_alternate_index`]
 //! covers exactly that case.
 
+// #689: workspace-level `clippy::unwrap_used` (moved from a per-crate lib.rs attribute)
+// now reaches this integration test's separate crate root. `clippy.toml`'s
+// `allow-unwrap-in-tests` already exempts `#[test]`/`#[tokio::test]` functions, so this
+// covers only the non-`#[test]` helper (`test_index`) calling `unwrap()` on known-good
+// fixture data.
+#![allow(clippy::unwrap_used)]
+
 use deps_cargo::config::{ConfigFileCache, IndexTrust};
 use deps_cargo::{CargoConfig, CargoRegistry, DependencySource};
 use deps_core::freshness::FreshnessSettings;

--- a/crates/deps-cargo/tests/config_test.rs
+++ b/crates/deps-cargo/tests/config_test.rs
@@ -3,6 +3,12 @@
 //! exercised through the crate's public API rather than `config.rs`'s own
 //! module-internal unit tests.
 
+// #689: workspace-level `clippy::unwrap_used` (moved from a per-crate lib.rs attribute)
+// now reaches this integration test's separate crate root. `clippy.toml`'s
+// `allow-unwrap-in-tests` already exempts `#[test]` functions, so this covers only the
+// non-`#[test]` helper (`write_manifest`) calling `unwrap()` on known-good fixture data.
+#![allow(clippy::unwrap_used)]
+
 use deps_cargo::DependencySource;
 use deps_cargo::config::{
     ConfigFileCache, IndexTrust, RegistryIndex, cargo_home_config_path, resolve,

--- a/crates/deps-cargo/tests/source_replace_test.rs
+++ b/crates/deps-cargo/tests/source_replace_test.rs
@@ -9,6 +9,13 @@
 //! pinned occurrences (F1b), and its crates.io hover link was being suppressed (F2) — by
 //! asserting the fixed behavior end to end against a mocked mirror.
 
+// #689: workspace-level `clippy::unwrap_used` (moved from a per-crate lib.rs attribute)
+// now reaches this integration test's separate crate root. `clippy.toml`'s
+// `allow-unwrap-in-tests` already exempts `#[tokio::test]` functions, so this covers
+// only the non-`#[test]` helper (`write_manifest`) calling `unwrap()` on known-good
+// fixture data.
+#![allow(clippy::unwrap_used)]
+
 use deps_cargo::config::ConfigFileCache;
 use deps_cargo::parser::CargoParseContext;
 use deps_cargo::{CargoFormatter, DependencySource};

--- a/crates/deps-composer/src/lib.rs
+++ b/crates/deps-composer/src/lib.rs
@@ -3,21 +3,6 @@
 //! This module provides composer.json parsing and Packagist registry integration
 //! for PHP projects.
 
-// #680: string slicing on a byte index that isn't a verified char boundary panics; sites
-// confirmed boundary-safe by construction are individually `#[allow]`ed with a justification.
-// #683: the three remaining #673 restriction lints, scoped to this crate only via a source
-// attribute (which overrides this crate's `[lints] workspace = true` Cargo.toml table
-// regardless of that table's level) rather than a duplicated `[lints.clippy]` table — avoids
-// ~90 lines of drift-prone duplication of the workspace allow-list. Deliberately never added
-// to `[workspace.lints.clippy]` itself (must stay opt-in per crate, not workspace-wide).
-// Sites confirmed safe are individually `#[allow]`ed with a one-line justification.
-#![warn(
-    clippy::indexing_slicing,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::string_slice
-)]
-
 pub mod ecosystem;
 pub mod formatter;
 pub mod lockfile;

--- a/crates/deps-core/benches/core_benchmarks.rs
+++ b/crates/deps-core/benches/core_benchmarks.rs
@@ -6,6 +6,11 @@
 //! - Cache eviction: < 1ms
 //! - Arc cloning (for response bodies): < 10ns
 
+// #689: workspace-level `clippy::unwrap_used`/`string_slice` (moved from a per-crate
+// lib.rs attribute) now reach this bench's separate crate root; benches slice/unwrap
+// known-good fixture data, which is idiomatic outside production parsing code.
+#![allow(clippy::unwrap_used, clippy::string_slice)]
+
 use bytes::Bytes;
 use criterion::{Criterion, criterion_group, criterion_main};
 use deps_core::cache::{CachedResponse, HttpCache};

--- a/crates/deps-core/src/lib.rs
+++ b/crates/deps-core/src/lib.rs
@@ -21,23 +21,6 @@
     clippy::cast_precision_loss,
     clippy::cast_sign_loss
 )]
-// #673 S5: restriction lints, scoped to this crate only via a source attribute (which
-// overrides the crate's `[lints] workspace = true` Cargo.toml table regardless of that
-// table's level) rather than a duplicated `[lints.clippy]` table in Cargo.toml — avoids
-// ~90 lines of drift-prone duplication of the workspace allow-list. Deliberately never
-// added to `[workspace.lints.clippy]` itself (the three lints must stay opt-in per crate,
-// not workspace-wide — see PR discussion). Sites confirmed safe are individually
-// `#[allow]`ed with a one-line justification, not blanket-allowed.
-// #680: `clippy::string_slice` appended to the same restriction-lint attribute for the
-// same reason — string slicing on a byte index that isn't a verified char boundary
-// panics; sites confirmed boundary-safe by construction are individually `#[allow]`ed.
-#![warn(
-    clippy::indexing_slicing,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::string_slice
-)]
-
 pub mod cache;
 pub mod completion;
 pub mod deps_dev;

--- a/crates/deps-dart/src/lib.rs
+++ b/crates/deps-dart/src/lib.rs
@@ -4,21 +4,6 @@
 //! including pubspec.yaml parsing, dependency extraction, and pub.dev
 //! registry integration.
 
-// #680: string slicing on a byte index that isn't a verified char boundary panics; sites
-// confirmed boundary-safe by construction are individually `#[allow]`ed with a justification.
-// #683: the three remaining #673 restriction lints, scoped to this crate only via a source
-// attribute (which overrides this crate's `[lints] workspace = true` Cargo.toml table
-// regardless of that table's level) rather than a duplicated `[lints.clippy]` table — avoids
-// ~90 lines of drift-prone duplication of the workspace allow-list. Deliberately never added
-// to `[workspace.lints.clippy]` itself (must stay opt-in per crate, not workspace-wide).
-// Sites confirmed safe are individually `#[allow]`ed with a one-line justification.
-#![warn(
-    clippy::indexing_slicing,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::string_slice
-)]
-
 pub mod ecosystem;
 pub mod formatter;
 pub mod lockfile;

--- a/crates/deps-deno/src/lib.rs
+++ b/crates/deps-deno/src/lib.rs
@@ -6,21 +6,6 @@
 //! `deps_core::Registry` facade, [`DenoRegistry`]. See [`crate::registry`]'s module docs
 //! for the full architecture.
 
-// #680: string slicing on a byte index that isn't a verified char boundary panics; sites
-// confirmed boundary-safe by construction are individually `#[allow]`ed with a justification.
-// #683: the three remaining #673 restriction lints, scoped to this crate only via a source
-// attribute (which overrides this crate's `[lints] workspace = true` Cargo.toml table
-// regardless of that table's level) rather than a duplicated `[lints.clippy]` table — avoids
-// ~90 lines of drift-prone duplication of the workspace allow-list. Deliberately never added
-// to `[workspace.lints.clippy]` itself (must stay opt-in per crate, not workspace-wide).
-// Sites confirmed safe are individually `#[allow]`ed with a one-line justification.
-#![warn(
-    clippy::indexing_slicing,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::string_slice
-)]
-
 pub mod ecosystem;
 pub mod formatter;
 pub mod parser;

--- a/crates/deps-github-actions/src/lib.rs
+++ b/crates/deps-github-actions/src/lib.rs
@@ -21,21 +21,6 @@
 //! `./local`/`docker://` — because the referenced workflow's version and the host repo's
 //! release tags are not reliably the same thing (see `parser` module docs).
 
-// #680: string slicing on a byte index that isn't a verified char boundary panics; sites
-// confirmed boundary-safe by construction are individually `#[allow]`ed with a justification.
-// #683: the three remaining #673 restriction lints, scoped to this crate only via a source
-// attribute (which overrides this crate's `[lints] workspace = true` Cargo.toml table
-// regardless of that table's level) rather than a duplicated `[lints.clippy]` table — avoids
-// ~90 lines of drift-prone duplication of the workspace allow-list. Deliberately never added
-// to `[workspace.lints.clippy]` itself (must stay opt-in per crate, not workspace-wide).
-// Sites confirmed safe are individually `#[allow]`ed with a one-line justification.
-#![warn(
-    clippy::indexing_slicing,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::string_slice
-)]
-
 pub mod ecosystem;
 pub mod formatter;
 pub mod parser;

--- a/crates/deps-gitlab-ci/src/lib.rs
+++ b/crates/deps-gitlab-ci/src/lib.rs
@@ -26,21 +26,6 @@
 //! (spec FR-003) — not version-pinnable. `image:`/`services:` Docker tags are out of scope
 //! entirely (spec FR-016) and never parsed.
 
-// #680: string slicing on a byte index that isn't a verified char boundary panics; sites
-// confirmed boundary-safe by construction are individually `#[allow]`ed with a justification.
-// #683: the three remaining #673 restriction lints, scoped to this crate only via a source
-// attribute (which overrides this crate's `[lints] workspace = true` Cargo.toml table
-// regardless of that table's level) rather than a duplicated `[lints.clippy]` table — avoids
-// ~90 lines of drift-prone duplication of the workspace allow-list. Deliberately never added
-// to `[workspace.lints.clippy]` itself (must stay opt-in per crate, not workspace-wide).
-// Sites confirmed safe are individually `#[allow]`ed with a one-line justification.
-#![warn(
-    clippy::indexing_slicing,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::string_slice
-)]
-
 pub mod client;
 pub mod component;
 pub mod ecosystem;

--- a/crates/deps-go/benches/go_benchmarks.rs
+++ b/crates/deps-go/benches/go_benchmarks.rs
@@ -8,6 +8,11 @@
 //! - Version comparison: < 10μs per operation
 //! - Module path escaping: < 1μs per operation
 
+// #689: workspace-level `clippy::unwrap_used` (moved from a per-crate lib.rs attribute)
+// now reaches this bench's separate crate root; benches use `unwrap()` on known-good
+// fixture data, which is idiomatic outside production parsing/registry code.
+#![allow(clippy::unwrap_used)]
+
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use deps_go::lockfile::parse_go_sum;
 use deps_go::parser::parse_go_mod;

--- a/crates/deps-go/src/lib.rs
+++ b/crates/deps-go/src/lib.rs
@@ -28,21 +28,6 @@
 //! assert_eq!(result.dependencies.len(), 1);
 //! ```
 
-// #680: string slicing on a byte index that isn't a verified char boundary panics; sites
-// confirmed boundary-safe by construction are individually `#[allow]`ed with a justification.
-// #683: the three remaining #673 restriction lints, scoped to this crate only via a source
-// attribute (which overrides this crate's `[lints] workspace = true` Cargo.toml table
-// regardless of that table's level) rather than a duplicated `[lints.clippy]` table — avoids
-// ~90 lines of drift-prone duplication of the workspace allow-list. Deliberately never added
-// to `[workspace.lints.clippy]` itself (must stay opt-in per crate, not workspace-wide).
-// Sites confirmed safe are individually `#[allow]`ed with a one-line justification.
-#![warn(
-    clippy::indexing_slicing,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::string_slice
-)]
-
 pub mod config;
 pub mod ecosystem;
 pub mod formatter;

--- a/crates/deps-gradle/src/lib.rs
+++ b/crates/deps-gradle/src/lib.rs
@@ -7,21 +7,6 @@
 //!
 //! Registry integration reuses `deps_maven::MavenCentralRegistry`.
 
-// #680: string slicing on a byte index that isn't a verified char boundary panics; sites
-// confirmed boundary-safe by construction are individually `#[allow]`ed with a justification.
-// #683: the three remaining #673 restriction lints, scoped to this crate only via a source
-// attribute (which overrides this crate's `[lints] workspace = true` Cargo.toml table
-// regardless of that table's level) rather than a duplicated `[lints.clippy]` table — avoids
-// ~90 lines of drift-prone duplication of the workspace allow-list. Deliberately never added
-// to `[workspace.lints.clippy]` itself (must stay opt-in per crate, not workspace-wide).
-// Sites confirmed safe are individually `#[allow]`ed with a one-line justification.
-#![warn(
-    clippy::indexing_slicing,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::string_slice
-)]
-
 pub mod ecosystem;
 pub mod formatter;
 mod license;

--- a/crates/deps-lsp/benches/lsp_handlers.rs
+++ b/crates/deps-lsp/benches/lsp_handlers.rs
@@ -8,6 +8,11 @@
 //!
 //! These benchmarks test user-facing performance - the most critical bottleneck.
 
+// #689: workspace-level `clippy::unwrap_used`/`expect_used` (moved from a per-crate
+// lib.rs/main.rs attribute) now reach this bench's separate crate root; benches
+// unwrap/expect known-good fixture data, which is idiomatic outside production code.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use criterion::{Criterion, criterion_group, criterion_main};
 use deps_core::EcosystemId;
 use deps_lsp::config::DepsConfig;

--- a/crates/deps-lsp/src/lib.rs
+++ b/crates/deps-lsp/src/lib.rs
@@ -1,16 +1,3 @@
-// #676: `clippy::indexing_slicing`/`unwrap_used`/`expect_used` (from #673) don't cover
-// `str` range slicing — that's `clippy::string_slice` — and every #244-class byte/UTF-16
-// offset bug site in this crate is a `str` slice, so add it as a fourth lint. Source
-// attribute (not a `[lints.clippy]` Cargo.toml table) mirrors `deps-core/src/lib.rs`;
-// `main.rs` is a separate crate root and needs the same attribute independently. Sites
-// confirmed safe are individually `#[allow]`ed with a one-line justification.
-#![warn(
-    clippy::indexing_slicing,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::string_slice
-)]
-
 pub mod config;
 pub mod document;
 pub mod file_watcher;

--- a/crates/deps-lsp/src/main.rs
+++ b/crates/deps-lsp/src/main.rs
@@ -1,13 +1,3 @@
-// #676: mirrors `src/lib.rs` — `main.rs` is a separate crate root, so the four
-// restriction lints (indexing_slicing/unwrap_used/expect_used/string_slice) must be
-// warned here independently.
-#![warn(
-    clippy::indexing_slicing,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::string_slice
-)]
-
 use deps_lsp::server::Backend;
 use std::env;
 use tower_lsp_server::{LspService, Server};

--- a/crates/deps-lsp/tests/common/mod.rs
+++ b/crates/deps-lsp/tests/common/mod.rs
@@ -3,6 +3,13 @@
 //! This module provides shared infrastructure for LSP integration tests,
 //! including the `LspClient` for communicating with the server binary.
 
+// #689: workspace-level `clippy::unwrap_used`/`expect_used` (moved from a per-crate
+// lib.rs/main.rs attribute) now reach this integration test module. `clippy.toml`'s
+// allow-*-in-tests exemptions only cover `#[test]` functions, and this module is all
+// non-`#[test]` helpers (`LspClient` and friends) unwrapping/expecting known-good
+// process/protocol state, so the allow is needed here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use serde_json::{Value, json};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::process::{Child, ChildStdout, Command, Stdio};

--- a/crates/deps-maven/src/lib.rs
+++ b/crates/deps-maven/src/lib.rs
@@ -4,21 +4,6 @@
 //! including pom.xml parsing, dependency extraction, and Maven Central
 //! registry integration.
 
-// #680: string slicing on a byte index that isn't a verified char boundary panics; sites
-// confirmed boundary-safe by construction are individually `#[allow]`ed with a justification.
-// #683: the three remaining #673 restriction lints, scoped to this crate only via a source
-// attribute (which overrides this crate's `[lints] workspace = true` Cargo.toml table
-// regardless of that table's level) rather than a duplicated `[lints.clippy]` table — avoids
-// ~90 lines of drift-prone duplication of the workspace allow-list. Deliberately never added
-// to `[workspace.lints.clippy]` itself (must stay opt-in per crate, not workspace-wide).
-// Sites confirmed safe are individually `#[allow]`ed with a one-line justification.
-#![warn(
-    clippy::indexing_slicing,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::string_slice
-)]
-
 pub mod ecosystem;
 pub mod formatter;
 pub mod interval;

--- a/crates/deps-maven/tests/integration_tests.rs
+++ b/crates/deps-maven/tests/integration_tests.rs
@@ -1,5 +1,11 @@
 //! Integration tests using fixture files.
 
+// #689: workspace-level `clippy::unwrap_used` (moved from a per-crate lib.rs attribute)
+// now reaches this integration test's separate crate root. `clippy.toml`'s
+// `allow-unwrap-in-tests` already exempts `#[test]` functions, so this covers only the
+// non-`#[test]` helper (`fixture_uri`) calling `unwrap()` on a known-good path.
+#![allow(clippy::unwrap_used)]
+
 use deps_maven::parse_pom_xml;
 use std::assert_matches;
 use tower_lsp_server::ls_types::Uri;

--- a/crates/deps-npm/benches/npm_benchmarks.rs
+++ b/crates/deps-npm/benches/npm_benchmarks.rs
@@ -7,6 +7,11 @@
 //! - Registry JSON parsing: < 2ms per package
 //! - Version matching with node-semver: < 100μs per operation
 
+// #689: workspace-level `clippy::unwrap_used` (moved from a per-crate lib.rs attribute)
+// now reaches this bench's separate crate root; benches use `unwrap()` on known-good
+// fixture data, which is idiomatic outside production parsing/registry code.
+#![allow(clippy::unwrap_used)]
+
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use deps_npm::parser::parse_package_json;
 use std::hint::black_box;

--- a/crates/deps-npm/src/lib.rs
+++ b/crates/deps-npm/src/lib.rs
@@ -3,22 +3,6 @@
 //! This module provides package.json parsing and npm registry integration
 //! for JavaScript/TypeScript projects.
 
-// #673: restriction lints, scoped to this crate only via a source attribute (overrides
-// this crate's `[lints] workspace = true` Cargo.toml table regardless of that table's
-// level) rather than a duplicated `[lints.clippy]` table — avoids ~90 lines of
-// drift-prone duplication of the workspace allow-list. Deliberately never added to
-// `[workspace.lints.clippy]` itself (must stay opt-in per crate, not workspace-wide).
-// Sites confirmed safe are individually `#[allow]`ed with a one-line justification.
-// #680: `clippy::string_slice` appended to the same restriction-lint attribute for the
-// same reason — string slicing on a byte index that isn't a verified char boundary
-// panics; sites confirmed boundary-safe by construction are individually `#[allow]`ed.
-#![warn(
-    clippy::indexing_slicing,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::string_slice
-)]
-
 pub mod catalog;
 pub mod config;
 pub mod ecosystem;

--- a/crates/deps-nuget/benches/nuget_benchmarks.rs
+++ b/crates/deps-nuget/benches/nuget_benchmarks.rs
@@ -8,6 +8,11 @@
 //! - Range/floating resolution: < 50μs per operation
 //! - Flat-container JSON parsing: < 2ms per response
 
+// #689: workspace-level `clippy::unwrap_used` (moved from a per-crate lib.rs attribute)
+// now reaches this bench's separate crate root; benches use `unwrap()` on known-good
+// fixture data, which is idiomatic outside production parsing/registry code.
+#![allow(clippy::unwrap_used)]
+
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use deps_nuget::parser::{
     parse_directory_packages_props, parse_packages_config, parse_project_file,

--- a/crates/deps-nuget/src/lib.rs
+++ b/crates/deps-nuget/src/lib.rs
@@ -4,21 +4,6 @@
 //! `.csproj`/`.fsproj`/`.vbproj`, `Directory.Packages.props`, and `packages.config`
 //! parsing, `packages.lock.json` lock file support, and NuGet V3 registry integration.
 
-// #680: string slicing on a byte index that isn't a verified char boundary panics; sites
-// confirmed boundary-safe by construction are individually `#[allow]`ed with a justification.
-// #683: the three remaining #673 restriction lints, scoped to this crate only via a source
-// attribute (which overrides this crate's `[lints] workspace = true` Cargo.toml table
-// regardless of that table's level) rather than a duplicated `[lints.clippy]` table — avoids
-// ~90 lines of drift-prone duplication of the workspace allow-list. Deliberately never added
-// to `[workspace.lints.clippy]` itself (must stay opt-in per crate, not workspace-wide).
-// Sites confirmed safe are individually `#[allow]`ed with a one-line justification.
-#![warn(
-    clippy::indexing_slicing,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::string_slice
-)]
-
 pub mod config;
 pub mod ecosystem;
 pub mod formatter;

--- a/crates/deps-nuget/tests/integration_tests.rs
+++ b/crates/deps-nuget/tests/integration_tests.rs
@@ -1,5 +1,11 @@
 //! Integration tests using fixture files.
 
+// #689: workspace-level `clippy::unwrap_used` (moved from a per-crate lib.rs attribute)
+// now reaches this integration test's separate crate root. `clippy.toml`'s
+// `allow-unwrap-in-tests` already exempts `#[test]` functions, so this covers only the
+// non-`#[test]` helper (`fixture_uri`) calling `unwrap()` on a known-good path.
+#![allow(clippy::unwrap_used)]
+
 use deps_core::lockfile::LockFileProvider;
 use deps_nuget::{
     NuGetLockParser, parse_directory_packages_props, parse_packages_config, parse_project_file,

--- a/crates/deps-pypi/benches/pypi_benchmarks.rs
+++ b/crates/deps-pypi/benches/pypi_benchmarks.rs
@@ -7,6 +7,11 @@
 //! - PEP 508 parsing: < 100μs per dependency
 //! - PEP 440 version matching: < 100μs per operation
 
+// #689: workspace-level `clippy::unwrap_used` (moved from a per-crate lib.rs attribute)
+// now reaches this bench's separate crate root; benches use `unwrap()` on known-good
+// fixture data, which is idiomatic outside production parsing/registry code.
+#![allow(clippy::unwrap_used)]
+
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use deps_pypi::parser::PypiParser;
 use std::hint::black_box;

--- a/crates/deps-pypi/src/lib.rs
+++ b/crates/deps-pypi/src/lib.rs
@@ -102,22 +102,6 @@
 //! mypy = "^1.0"
 //! ```
 
-// #673: restriction lints, scoped to this crate only via a source attribute (overrides
-// this crate's `[lints] workspace = true` Cargo.toml table regardless of that table's
-// level) rather than a duplicated `[lints.clippy]` table — avoids ~90 lines of
-// drift-prone duplication of the workspace allow-list. Deliberately never added to
-// `[workspace.lints.clippy]` itself (must stay opt-in per crate, not workspace-wide).
-// Sites confirmed safe are individually `#[allow]`ed with a one-line justification.
-// #680: `clippy::string_slice` appended to the same restriction-lint attribute for the
-// same reason — string slicing on a byte index that isn't a verified char boundary
-// panics; sites confirmed boundary-safe by construction are individually `#[allow]`ed.
-#![warn(
-    clippy::indexing_slicing,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::string_slice
-)]
-
 pub mod config;
 pub mod ecosystem;
 pub mod error;

--- a/crates/deps-swift/src/lib.rs
+++ b/crates/deps-swift/src/lib.rs
@@ -17,21 +17,6 @@
 //! Uses regex-based parsing (no Swift toolchain required) and GitHub API
 //! for package discovery. Compatible with WASM (Zed extension) targets.
 
-// #680: string slicing on a byte index that isn't a verified char boundary panics; sites
-// confirmed boundary-safe by construction are individually `#[allow]`ed with a justification.
-// #683: the three remaining #673 restriction lints, scoped to this crate only via a source
-// attribute (which overrides this crate's `[lints] workspace = true` Cargo.toml table
-// regardless of that table's level) rather than a duplicated `[lints.clippy]` table — avoids
-// ~90 lines of drift-prone duplication of the workspace allow-list. Deliberately never added
-// to `[workspace.lints.clippy]` itself (must stay opt-in per crate, not workspace-wide).
-// Sites confirmed safe are individually `#[allow]`ed with a one-line justification.
-#![warn(
-    clippy::indexing_slicing,
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::string_slice
-)]
-
 pub mod ecosystem;
 pub mod formatter;
 pub mod lockfile;

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -2127,6 +2127,9 @@ Before submitting a PR for a new ecosystem:
 - [ ] Integration tests for registry (can be `#[ignore]`)
 - [ ] Documentation in lib.rs with examples
 - [ ] Added to workspace members in root Cargo.toml
+- [ ] `[lints] workspace = true` in the new crate's Cargo.toml (otherwise it silently gets
+      none of the `indexing_slicing`/`unwrap_used`/`expect_used`/`string_slice` restriction
+      lints consolidated into `[workspace.lints.clippy]` by #689, and CI stays green)
 - [ ] Feature flag added in deps-lsp/Cargo.toml
 - [ ] Re-exports via `ecosystem!()` macro in deps-lsp/src/lib.rs
 - [ ] Registration via `register!()` macro in deps-lsp/src/lib.rs


### PR DESCRIPTION
## Summary

- Moves `indexing_slicing`/`unwrap_used`/`expect_used`/`string_slice` from an identical `#![warn(...)]` source attribute duplicated across all 16 workspace crates into a single `[workspace.lints.clippy]` entry in root `Cargo.toml`. The set had already drifted across three PRs (#673, #684, #686) to converge on what one workspace entry applies atomically; a 15th ecosystem crate added without pasting the block previously got none of these panic-safety lints silently.
- Removes the dead `non_std_lazy_statics = "allow"` entry — its stated rationale (pending LazyLock stabilization) no longer holds: MSRV is 1.98, LazyLock stabilized in 1.80, and the workspace has no `once_cell`/`lazy_static` dependency. Verified dead via a force-warn clippy run before removal (zero hits).
- `crates/deps-zed` (git submodule, outside the workspace) is untouched, keeping its own attribute.

### Side effect: widened test/bench coverage

Moving the lints to workspace scope newly reaches `tests/*.rs` and `benches/*.rs` files (separate crate roots the old per-crate `lib.rs`/`main.rs` attribute never covered) — 14 files across 8 crates. Each gets a narrowly-scoped `#![allow(...)]` with a one-line justification, following the project's existing per-site allow convention. Six of these needed the allow only for non-`#[test]` helper functions, since `clippy.toml` already exempts `#[test]` bodies via `allow-unwrap-in-tests`/etc — those comments explicitly note that.

Also adds a `[lints] workspace = true` checklist note to `docs/ECOSYSTEM_GUIDE.md`'s ecosystem checklist, closing the gap where a new crate added without that line would now silently lose all four panic-safety lints (previously the copy-pasted crate-root attribute made this loud instead of silent).

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean, isolated `CARGO_TARGET_DIR`, 262 units from scratch)
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4627 passed, 0 failed, 54 skipped — matches pre-change baseline)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- [x] Spot-checked 3 of the 14 new test/bench allow additions by removing the allow and running clippy with the specific lint force-warned — every flagged site is fixture/harness code, nothing production-adjacent
- [x] Confirmed all 16 crates carry `[lints] workspace = true`, none missing
- [x] Confirmed no item-level `#[allow(...)]` was removed or widened
- [x] Adversarial critique + independent code review, both findings resolved

Closes #689