### PR TITLE
fix(deps-core): run lock-file parsing on the blocking pool, not the async worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: property tests (`proptest`) asserting the parser depth/expansion checkers and JSONC position recovery never panic on arbitrary input (#673)
 
 ### Fixed
+- **deps-core** + all 9 lock-file providers: lock-file parsing now runs on the blocking-thread pool via a shared `read_and_parse_lockfile` helper, no longer stalling the LSP request worker (resolves #723)
 - **deps-lsp**: NuGet/Maven raw-text fallback completion no longer inserts duplicate markup when the cursor is already inside an open attribute value or tag (resolves #724) (#728)
 - **deps-lsp**: NuGet raw-text fallback completion now actually fires inside `Include="..."`/`id="..."` on `PackageReference`/`PackageVersion`/`package` elements, instead of being permanently disabled; stale `TODO(#118 follow-up)` markers on the still-disabled Bundler/Swift/Gradle arms were rewritten to plain comments explaining the settled design decision (resolves #699)
 - **deps-core, deps-maven, deps-gradle**: Maven `groupId`/`artifactId` -> URL-path construction is now a single shared `deps_core::maven_coordinate_path` helper, closing a validation gap where an empty `.`-separated group component (e.g. `com..evil`) was rejected by `deps-gradle` but accepted by `deps-maven`, producing an empty path segment (resolves #702) (#715)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: property tests (`proptest`) asserting the parser depth/expansion checkers and JSONC position recovery never panic on arbitrary input (#673)
 
 ### Fixed
-- **deps-core** + all 9 lock-file providers: lock-file parsing now runs on the blocking-thread pool via a shared `read_and_parse_lockfile` helper, no longer stalling the LSP request worker (resolves #723)
+- **deps-core** + all 9 lock-file providers: lock-file parsing now runs on the blocking-thread pool via a shared `read_and_parse_lockfile` helper, no longer stalling the LSP request worker (resolves #723) (#730)
 - **deps-lsp**: NuGet/Maven raw-text fallback completion no longer inserts duplicate markup when the cursor is already inside an open attribute value or tag (resolves #724) (#728)
 - **deps-lsp**: NuGet raw-text fallback completion now actually fires inside `Include="..."`/`id="..."` on `PackageReference`/`PackageVersion`/`package` elements, instead of being permanently disabled; stale `TODO(#118 follow-up)` markers on the still-disabled Bundler/Swift/Gradle arms were rewritten to plain comments explaining the settled design decision (resolves #699)
 - **deps-core, deps-maven, deps-gradle**: Maven `groupId`/`artifactId` -> URL-path construction is now a single shared `deps_core::maven_coordinate_path` helper, closing a validation gap where an empty `.`-separated group component (e.g. `com..evil`) was rejected by `deps-gradle` but accepted by `deps-maven`, producing an empty path segment (resolves #702) (#715)

--- a/crates/deps-bundler/src/lockfile.rs
+++ b/crates/deps-bundler/src/lockfile.rs
@@ -5,7 +5,7 @@
 use deps_core::error::Result;
 use deps_core::lockfile::{
     LockFileProvider, ResolvedPackage, ResolvedPackages, ResolvedSource,
-    locate_lockfile_for_manifest, read_lockfile_content,
+    locate_lockfile_for_manifest, read_and_parse_lockfile,
 };
 use regex::Regex;
 use std::path::{Path, PathBuf};
@@ -51,9 +51,10 @@ impl LockFileProvider for GemfileLockParser {
         Box::pin(async move {
             tracing::debug!("Parsing Gemfile.lock: {}", lockfile_path.display());
 
-            let content = read_lockfile_content(lockfile_path, "Gemfile.lock").await?;
-
-            parse_gemfile_lock(&content)
+            read_and_parse_lockfile(lockfile_path, "Gemfile.lock", |content| {
+                parse_gemfile_lock(&content)
+            })
+            .await
         })
     }
 }

--- a/crates/deps-cargo/src/lockfile.rs
+++ b/crates/deps-cargo/src/lockfile.rs
@@ -25,7 +25,7 @@
 use deps_core::error::{DepsError, Result};
 use deps_core::lockfile::{
     LockFileProvider, ResolvedPackage, ResolvedPackages, ResolvedSource,
-    locate_lockfile_for_manifest, read_lockfile_content,
+    locate_lockfile_for_manifest, read_and_parse_lockfile,
 };
 use std::path::{Path, PathBuf};
 use tower_lsp_server::ls_types::Uri;
@@ -79,71 +79,8 @@ impl LockFileProvider for CargoLockParser {
         Box::pin(async move {
             tracing::debug!("Parsing Cargo.lock: {}", lockfile_path.display());
 
-            let content = read_lockfile_content(lockfile_path, "Cargo.lock").await?;
-
-            if let Err(depth) =
-                deps_core::check_toml_nesting_depth(&content, deps_core::MAX_TOML_NESTING_DEPTH)
-            {
-                return Err(DepsError::ParseError {
-                    file_type: "Cargo.lock".into(),
-                    source: Box::new(std::io::Error::other(format!(
-                        "array/table nesting depth {depth} exceeds maximum of {}",
-                        deps_core::MAX_TOML_NESTING_DEPTH
-                    ))),
-                });
-            }
-
-            let doc = toml_span::parse(&content).map_err(|e| DepsError::ParseError {
-                file_type: "Cargo.lock".into(),
-                source: Box::new(std::io::Error::other(e.to_string())),
-            })?;
-
-            let mut packages = ResolvedPackages::new();
-
-            let Some(root_table) = doc.as_table() else {
-                tracing::warn!("Cargo.lock root is not a table");
-                return Ok(packages);
-            };
-
-            let Some(package_array_val) = root_table.get("package") else {
-                tracing::warn!("Cargo.lock missing [[package]] array of tables");
-                return Ok(packages);
-            };
-
-            let Some(package_array) = package_array_val.as_array() else {
-                tracing::warn!("Cargo.lock [[package]] is not an array");
-                return Ok(packages);
-            };
-
-            for entry in package_array {
-                let Some(table) = entry.as_table() else {
-                    continue;
-                };
-
-                // Extract required fields
-                let Some(name) = table.get("name").and_then(|v| v.as_str()) else {
-                    tracing::warn!("Package missing name field");
-                    continue;
-                };
-
-                let Some(version) = table.get("version").and_then(|v| v.as_str()) else {
-                    tracing::warn!("Package '{}' missing version field", name);
-                    continue;
-                };
-
-                // Parse source (optional for path dependencies)
-                let source = parse_cargo_source(table.get("source").and_then(|v| v.as_str()));
-
-                // Parse dependencies array (optional)
-                let dependencies = parse_cargo_dependencies_from_table(table);
-
-                packages.insert(ResolvedPackage {
-                    name: name.to_string(),
-                    version: version.to_string(),
-                    source,
-                    dependencies,
-                });
-            }
+            let packages =
+                read_and_parse_lockfile(lockfile_path, "Cargo.lock", parse_cargo_lock).await?;
 
             tracing::info!(
                 "Parsed Cargo.lock: {} packages from {}",
@@ -154,6 +91,78 @@ impl LockFileProvider for CargoLockParser {
             Ok(packages)
         })
     }
+}
+
+/// Parses `Cargo.lock` content (already read and size-capped) into resolved packages.
+///
+/// The CPU-bound half of [`CargoLockParser::parse_lockfile`], run inside
+/// [`deps_core::lockfile::read_and_parse_lockfile`]'s `spawn_blocking`.
+fn parse_cargo_lock(content: String) -> Result<ResolvedPackages> {
+    if let Err(depth) =
+        deps_core::check_toml_nesting_depth(&content, deps_core::MAX_TOML_NESTING_DEPTH)
+    {
+        return Err(DepsError::ParseError {
+            file_type: "Cargo.lock".into(),
+            source: Box::new(std::io::Error::other(format!(
+                "array/table nesting depth {depth} exceeds maximum of {}",
+                deps_core::MAX_TOML_NESTING_DEPTH
+            ))),
+        });
+    }
+
+    let doc = toml_span::parse(&content).map_err(|e| DepsError::ParseError {
+        file_type: "Cargo.lock".into(),
+        source: Box::new(std::io::Error::other(e.to_string())),
+    })?;
+
+    let mut packages = ResolvedPackages::new();
+
+    let Some(root_table) = doc.as_table() else {
+        tracing::warn!("Cargo.lock root is not a table");
+        return Ok(packages);
+    };
+
+    let Some(package_array_val) = root_table.get("package") else {
+        tracing::warn!("Cargo.lock missing [[package]] array of tables");
+        return Ok(packages);
+    };
+
+    let Some(package_array) = package_array_val.as_array() else {
+        tracing::warn!("Cargo.lock [[package]] is not an array");
+        return Ok(packages);
+    };
+
+    for entry in package_array {
+        let Some(table) = entry.as_table() else {
+            continue;
+        };
+
+        // Extract required fields
+        let Some(name) = table.get("name").and_then(|v| v.as_str()) else {
+            tracing::warn!("Package missing name field");
+            continue;
+        };
+
+        let Some(version) = table.get("version").and_then(|v| v.as_str()) else {
+            tracing::warn!("Package '{}' missing version field", name);
+            continue;
+        };
+
+        // Parse source (optional for path dependencies)
+        let source = parse_cargo_source(table.get("source").and_then(|v| v.as_str()));
+
+        // Parse dependencies array (optional)
+        let dependencies = parse_cargo_dependencies_from_table(table);
+
+        packages.insert(ResolvedPackage {
+            name: name.to_string(),
+            version: version.to_string(),
+            source,
+            dependencies,
+        });
+    }
+
+    Ok(packages)
 }
 
 /// Parses Cargo source field into ResolvedSource.

--- a/crates/deps-composer/src/lockfile.rs
+++ b/crates/deps-composer/src/lockfile.rs
@@ -6,7 +6,7 @@
 use deps_core::error::{DepsError, Result};
 use deps_core::lockfile::{
     LockFileProvider, ResolvedPackage, ResolvedPackages, ResolvedSource,
-    locate_lockfile_for_manifest, read_lockfile_content,
+    locate_lockfile_for_manifest, read_and_parse_lockfile,
 };
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
@@ -68,42 +68,9 @@ impl LockFileProvider for ComposerLockParser {
         Box::pin(async move {
             tracing::debug!("Parsing composer.lock: {}", lockfile_path.display());
 
-            let content = read_lockfile_content(lockfile_path, "composer.lock").await?;
-
-            let lock_data: ComposerLock = deps_core::parse_json_checked(content.as_bytes())
-                .map_err(|e| DepsError::ParseError {
-                    file_type: "composer.lock".into(),
-                    source: Box::new(e),
-                })?;
-
-            let mut packages = ResolvedPackages::new();
-
-            for pkg in lock_data.packages.into_iter().chain(lock_data.packages_dev) {
-                let source = pkg.source.map_or(
-                    ResolvedSource::Registry {
-                        url: String::new(),
-                        checksum: String::new(),
-                    },
-                    |s| match s.source_type.as_str() {
-                        "git" => ResolvedSource::Git {
-                            url: s.url,
-                            rev: s.reference.unwrap_or_default(),
-                        },
-                        "path" => ResolvedSource::Path { path: s.url },
-                        _ => ResolvedSource::Registry {
-                            url: s.url,
-                            checksum: String::new(),
-                        },
-                    },
-                );
-
-                packages.insert(ResolvedPackage {
-                    name: pkg.name.to_lowercase(),
-                    version: pkg.version,
-                    source,
-                    dependencies: Vec::new(),
-                });
-            }
+            let packages =
+                read_and_parse_lockfile(lockfile_path, "composer.lock", parse_composer_lock)
+                    .await?;
 
             tracing::info!(
                 "Parsed composer.lock: {} packages from {}",
@@ -114,6 +81,49 @@ impl LockFileProvider for ComposerLockParser {
             Ok(packages)
         })
     }
+}
+
+/// Parses `composer.lock` content (already read and size-capped) into resolved packages.
+///
+/// The CPU-bound half of [`ComposerLockParser::parse_lockfile`], run inside
+/// [`deps_core::lockfile::read_and_parse_lockfile`]'s `spawn_blocking`.
+fn parse_composer_lock(content: String) -> Result<ResolvedPackages> {
+    let lock_data: ComposerLock =
+        deps_core::parse_json_checked(content.as_bytes()).map_err(|e| DepsError::ParseError {
+            file_type: "composer.lock".into(),
+            source: Box::new(e),
+        })?;
+
+    let mut packages = ResolvedPackages::new();
+
+    for pkg in lock_data.packages.into_iter().chain(lock_data.packages_dev) {
+        let source = pkg.source.map_or(
+            ResolvedSource::Registry {
+                url: String::new(),
+                checksum: String::new(),
+            },
+            |s| match s.source_type.as_str() {
+                "git" => ResolvedSource::Git {
+                    url: s.url,
+                    rev: s.reference.unwrap_or_default(),
+                },
+                "path" => ResolvedSource::Path { path: s.url },
+                _ => ResolvedSource::Registry {
+                    url: s.url,
+                    checksum: String::new(),
+                },
+            },
+        );
+
+        packages.insert(ResolvedPackage {
+            name: pkg.name.to_lowercase(),
+            version: pkg.version,
+            source,
+            dependencies: Vec::new(),
+        });
+    }
+
+    Ok(packages)
 }
 
 #[cfg(test)]

--- a/crates/deps-core/src/lib.rs
+++ b/crates/deps-core/src/lib.rs
@@ -67,7 +67,8 @@ pub use licenses::{
     evaluate as evaluate_license_policy, resolve_license_entries,
 };
 pub use lockfile::{
-    LockFileProvider, ResolvedPackage, ResolvedPackages, ResolvedSource, read_lockfile_content,
+    LockFileProvider, ResolvedPackage, ResolvedPackages, ResolvedSource, read_and_parse_lockfile,
+    read_lockfile_content,
 };
 pub use lsp_helpers::{
     DependencyOutcome, DependencyOutcomes, DiagnosticMessages, DiagnosticPolicy,

--- a/crates/deps-core/src/lockfile.rs
+++ b/crates/deps-core/src/lockfile.rs
@@ -121,6 +121,55 @@ pub async fn read_lockfile_content(path: &Path, file_type: &str) -> Result<Strin
     }
 }
 
+/// Reads a lock file via [`read_lockfile_content`] and runs `parse` on the blocking-thread
+/// pool, returning the parsed result.
+///
+/// Every `LockFileProvider::parse_lockfile` implementation reads its lock file's content and
+/// then parses it; this shares that second half of the boilerplate too. The parse step is
+/// CPU-bound work over content bounded by the same [`MAX_LOCKFILE_BYTES`] cap as the read
+/// (a `Cargo.lock`/`package-lock.json`/... TOML, JSON, or YAML document up to 32 MiB), so —
+/// like the read itself — it must never run on the calling tokio worker thread: every
+/// `LockFileProvider::parse_lockfile` call site sits on the LSP request path, where a worker
+/// thread blocked on parsing a multi-megabyte document would violate the project's
+/// non-blocking-handler rule.
+///
+/// # Errors
+///
+/// Returns whatever [`read_lockfile_content`] returns for a read failure, whatever `parse`
+/// itself returns for a malformed document, or a [`DepsError::ParseError`] if the blocking
+/// parse task panics or is cancelled.
+///
+/// # Examples
+///
+/// ```no_run
+/// use deps_core::lockfile::{read_and_parse_lockfile, ResolvedPackages};
+/// use std::path::Path;
+///
+/// # async fn example() -> deps_core::error::Result<()> {
+/// let packages: ResolvedPackages = read_and_parse_lockfile(
+///     Path::new("Cargo.lock"),
+///     "Cargo.lock",
+///     |content| Ok(ResolvedPackages::new()), // real parsers inspect `content`
+/// )
+/// .await?;
+/// # Ok(())
+/// # }
+/// ```
+pub async fn read_and_parse_lockfile<T, F>(path: &Path, file_type: &str, parse: F) -> Result<T>
+where
+    F: FnOnce(String) -> Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    let content = read_lockfile_content(path, file_type).await?;
+
+    tokio::task::spawn_blocking(move || parse(content))
+        .await
+        .map_err(|e| DepsError::ParseError {
+            file_type: format!("{file_type} at {}", path.display()),
+            source: Box::new(std::io::Error::other(e)),
+        })?
+}
+
 /// Generic lock file locator.
 ///
 /// Searches for lock files in the following order:
@@ -677,6 +726,61 @@ mod tests {
             }
             other => panic!("Expected ParseError, got: {other:?}"),
         }
+    }
+
+    /// The `spawn_blocking` `JoinError`→`DepsError::ParseError` mapping is issue #723's core
+    /// concern (a panicking/blocking parse must not silently misbehave or unwind the caller),
+    /// but had zero executable coverage — only the `no_run` doctest, which never runs. A
+    /// panicking `parse` closure must surface as `Err(DepsError::ParseError)`, labeled the
+    /// same way as every other `read_and_parse_lockfile` failure (`"{file_type} at {path}"`),
+    /// with the panic message preserved in `source` (tokio's `JoinError: Display` carries it).
+    #[tokio::test]
+    async fn test_read_and_parse_lockfile_panic_in_parse_becomes_parse_error() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let lock_path = temp_dir.path().join("Cargo.lock");
+        std::fs::write(&lock_path, "version = 4").unwrap();
+
+        let err = read_and_parse_lockfile(&lock_path, "Cargo.lock", |_content| -> Result<()> {
+            panic!("boom")
+        })
+        .await
+        .unwrap_err();
+
+        match err {
+            DepsError::ParseError { file_type, source } => {
+                assert_eq!(file_type, format!("Cargo.lock at {}", lock_path.display()));
+                assert!(
+                    source.to_string().contains("boom"),
+                    "panic message should be preserved in the error source, got: {source}"
+                );
+            }
+            other => panic!("Expected ParseError, got: {other:?}"),
+        }
+    }
+
+    /// Proves `parse` actually runs off the calling (async) thread via `spawn_blocking`, not
+    /// merely that the return type happens to line up — the whole point of the fix is that
+    /// CPU-bound parsing no longer executes on the tokio worker driving the LSP request.
+    #[tokio::test]
+    async fn test_read_and_parse_lockfile_runs_parse_off_calling_thread() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let lock_path = temp_dir.path().join("Cargo.lock");
+        std::fs::write(&lock_path, "version = 4").unwrap();
+
+        let calling_thread = std::thread::current().id();
+
+        let content = read_and_parse_lockfile(&lock_path, "Cargo.lock", move |content| {
+            assert_ne!(
+                std::thread::current().id(),
+                calling_thread,
+                "parse must run on the blocking pool, not the calling thread"
+            );
+            Ok(content)
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(content, "version = 4");
     }
 
     #[test]

--- a/crates/deps-dart/src/lockfile.rs
+++ b/crates/deps-dart/src/lockfile.rs
@@ -3,7 +3,7 @@
 use deps_core::error::{DepsError, Result};
 use deps_core::lockfile::{
     LockFileProvider, ResolvedPackage, ResolvedPackages, ResolvedSource,
-    locate_lockfile_for_manifest, read_lockfile_content,
+    locate_lockfile_for_manifest, read_and_parse_lockfile,
 };
 use std::path::{Path, PathBuf};
 use tower_lsp_server::ls_types::Uri;
@@ -28,9 +28,10 @@ impl LockFileProvider for PubspecLockParser {
         Box::pin(async move {
             tracing::debug!("Parsing pubspec.lock: {}", lockfile_path.display());
 
-            let content = read_lockfile_content(lockfile_path, "pubspec.lock").await?;
-
-            parse_pubspec_lock(&content)
+            read_and_parse_lockfile(lockfile_path, "pubspec.lock", |content| {
+                parse_pubspec_lock(&content)
+            })
+            .await
         })
     }
 }

--- a/crates/deps-go/src/lockfile.rs
+++ b/crates/deps-go/src/lockfile.rs
@@ -28,7 +28,7 @@
 use deps_core::error::Result;
 use deps_core::lockfile::{
     LockFileProvider, ResolvedPackage, ResolvedPackages, ResolvedSource,
-    locate_lockfile_for_manifest, read_lockfile_content,
+    locate_lockfile_for_manifest, read_and_parse_lockfile,
 };
 use std::path::{Path, PathBuf};
 use tower_lsp_server::ls_types::Uri;
@@ -80,9 +80,10 @@ impl LockFileProvider for GoSumParser {
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ResolvedPackages>> + Send + 'a>>
     {
         Box::pin(async move {
-            let content = read_lockfile_content(lockfile_path, "go.sum").await?;
-
-            Ok(parse_go_sum(&content))
+            read_and_parse_lockfile(lockfile_path, "go.sum", |content| {
+                Ok(parse_go_sum(&content))
+            })
+            .await
         })
     }
 }

--- a/crates/deps-npm/src/lockfile.rs
+++ b/crates/deps-npm/src/lockfile.rs
@@ -28,7 +28,7 @@
 use deps_core::error::{DepsError, Result};
 use deps_core::lockfile::{
     LockFileProvider, ResolvedPackage, ResolvedPackages, ResolvedSource,
-    locate_lockfile_for_manifest, read_lockfile_content,
+    locate_lockfile_for_manifest, read_and_parse_lockfile,
 };
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -133,8 +133,27 @@ impl LockFileProvider for NpmLockParser {
 async fn parse_package_lock_json(lockfile_path: &Path) -> Result<ResolvedPackages> {
     tracing::debug!("Parsing package-lock.json: {}", lockfile_path.display());
 
-    let content = read_lockfile_content(lockfile_path, "package-lock.json").await?;
+    let packages = read_and_parse_lockfile(
+        lockfile_path,
+        "package-lock.json",
+        parse_package_lock_json_content,
+    )
+    .await?;
 
+    tracing::info!(
+        "Parsed package-lock.json: {} packages from {}",
+        packages.len(),
+        lockfile_path.display()
+    );
+
+    Ok(packages)
+}
+
+/// Parses `package-lock.json` content (already read and size-capped) into resolved packages.
+///
+/// The CPU-bound half of [`parse_package_lock_json`], run inside
+/// [`deps_core::lockfile::read_and_parse_lockfile`]'s `spawn_blocking`.
+fn parse_package_lock_json_content(content: String) -> Result<ResolvedPackages> {
     let lock_data: PackageLockJson =
         deps_core::parse_json_checked(content.as_bytes()).map_err(|e| DepsError::ParseError {
             file_type: "package-lock.json".into(),
@@ -178,12 +197,6 @@ async fn parse_package_lock_json(lockfile_path: &Path) -> Result<ResolvedPackage
         });
     }
 
-    tracing::info!(
-        "Parsed package-lock.json: {} packages from {}",
-        packages.len(),
-        lockfile_path.display()
-    );
-
     Ok(packages)
 }
 
@@ -208,19 +221,15 @@ const MIN_PNPM_LOCKFILE_MAJOR_VERSION: u32 = 6;
 async fn parse_pnpm_lock(lockfile_path: &Path) -> Result<ResolvedPackages> {
     tracing::debug!("Parsing pnpm-lock.yaml: {}", lockfile_path.display());
 
-    let content = read_lockfile_content(lockfile_path, "pnpm-lock.yaml").await?;
-
     // NFR-001: the nesting/expansion guards and the YAML parse itself are CPU-bound work on
-    // already-read, untrusted content — run them on the blocking-thread pool (mirrors
-    // `read_lockfile_content`'s own `spawn_blocking` for the file read) rather than on the
-    // calling tokio worker, so a large `pnpm-lock.yaml` near the 32 MiB cap can't stall the
-    // async executor.
-    let packages = tokio::task::spawn_blocking(move || parse_pnpm_lock_yaml(&content))
-        .await
-        .map_err(|e| DepsError::ParseError {
-            file_type: "pnpm-lock.yaml".into(),
-            source: Box::new(std::io::Error::other(e)),
-        })??;
+    // already-read, untrusted content — `read_and_parse_lockfile` runs `parse_pnpm_lock_yaml`
+    // on the blocking-thread pool (mirrors `read_lockfile_content`'s own `spawn_blocking` for
+    // the file read) rather than on the calling tokio worker, so a large `pnpm-lock.yaml` near
+    // the 32 MiB cap can't stall the async executor.
+    let packages = read_and_parse_lockfile(lockfile_path, "pnpm-lock.yaml", |content| {
+        parse_pnpm_lock_yaml(&content)
+    })
+    .await?;
 
     tracing::info!(
         "Parsed pnpm-lock.yaml: {} packages from {}",
@@ -231,7 +240,8 @@ async fn parse_pnpm_lock(lockfile_path: &Path) -> Result<ResolvedPackages> {
     Ok(packages)
 }
 
-/// The CPU-bound half of [`parse_pnpm_lock`], run inside `spawn_blocking`.
+/// The CPU-bound half of [`parse_pnpm_lock`], run inside
+/// [`deps_core::lockfile::read_and_parse_lockfile`]'s `spawn_blocking`.
 fn parse_pnpm_lock_yaml(content: &str) -> Result<ResolvedPackages> {
     let to_parse_error = |message: String| DepsError::ParseError {
         file_type: "pnpm-lock.yaml".into(),

--- a/crates/deps-nuget/src/lockfile.rs
+++ b/crates/deps-nuget/src/lockfile.rs
@@ -19,7 +19,7 @@
 use deps_core::error::{DepsError, Result};
 use deps_core::lockfile::{
     LockFileProvider, ResolvedPackage, ResolvedPackages, ResolvedSource,
-    locate_lockfile_for_manifest, read_lockfile_content,
+    locate_lockfile_for_manifest, read_and_parse_lockfile,
 };
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -104,56 +104,12 @@ impl LockFileProvider for NuGetLockParser {
         Box::pin(async move {
             tracing::debug!("Parsing packages.lock.json: {}", lockfile_path.display());
 
-            let content = read_lockfile_content(lockfile_path, "packages.lock.json").await?;
-
-            let lock_data: PackagesLock = deps_core::parse_json_checked(content.as_bytes())
-                .map_err(|e| DepsError::ParseError {
-                    file_type: "packages.lock.json".into(),
-                    source: Box::new(e),
-                })?;
-
-            // Collect every TFM's resolved version per package name, then resolve the
-            // cross-TFM tie-break with the crate's own `compare_versions` (S6) instead of
-            // `deps_core::lockfile::best_package`, whose `semver::Version::parse` fallback
-            // always fails on NuGet's 4-component versions and degrades to string
-            // comparison (e.g. "1.10.0" < "1.9.0"). Only the single winner is ever handed
-            // to `ResolvedPackages`, so that broken comparator is never reached.
-            let mut candidates: HashMap<String, Vec<(String, Option<String>)>> = HashMap::new();
-            for packages in lock_data.dependencies.into_values() {
-                for (name, entry) in packages {
-                    // "type": "Project" / "CentralTransitive" entries carry no `resolved`
-                    // at all — skip rather than aborting the whole file (S2).
-                    if let Some(resolved) = entry.resolved {
-                        candidates
-                            .entry(name)
-                            .or_default()
-                            .push((resolved, entry.content_hash));
-                    }
-                }
-            }
-
-            let mut packages = ResolvedPackages::new();
-            for (name, versions) in candidates {
-                let best = versions
-                    .into_iter()
-                    .max_by(|a, b| crate::version::compare_versions(&a.0, &b.0));
-                if let Some((version, content_hash)) = best {
-                    packages.insert(ResolvedPackage {
-                        name,
-                        version,
-                        source: ResolvedSource::Registry {
-                            // Informational only — nothing in `deps-lsp`/`deps-core::lsp_helpers`
-                            // reads `ResolvedSource`, and this path makes no network request, so
-                            // it never routes a lockfile-resolved version against a private feed
-                            // (issue #523's config resolution intentionally stops at
-                            // `NuGetDependency::source`, not `ResolvedPackage::source`).
-                            url: crate::registry::NUGET_ORG_INDEX_URL.into(),
-                            checksum: content_hash.unwrap_or_default(),
-                        },
-                        dependencies: vec![],
-                    });
-                }
-            }
+            let packages = read_and_parse_lockfile(
+                lockfile_path,
+                "packages.lock.json",
+                parse_packages_lock_json,
+            )
+            .await?;
 
             tracing::info!(
                 "Parsed packages.lock.json: {} packages from {}",
@@ -164,6 +120,63 @@ impl LockFileProvider for NuGetLockParser {
             Ok(packages)
         })
     }
+}
+
+/// Parses `packages.lock.json` content (already read and size-capped) into resolved packages.
+///
+/// The CPU-bound half of [`NuGetLockParser::parse_lockfile`], run inside
+/// [`deps_core::lockfile::read_and_parse_lockfile`]'s `spawn_blocking`.
+fn parse_packages_lock_json(content: String) -> Result<ResolvedPackages> {
+    let lock_data: PackagesLock =
+        deps_core::parse_json_checked(content.as_bytes()).map_err(|e| DepsError::ParseError {
+            file_type: "packages.lock.json".into(),
+            source: Box::new(e),
+        })?;
+
+    // Collect every TFM's resolved version per package name, then resolve the
+    // cross-TFM tie-break with the crate's own `compare_versions` (S6) instead of
+    // `deps_core::lockfile::best_package`, whose `semver::Version::parse` fallback
+    // always fails on NuGet's 4-component versions and degrades to string
+    // comparison (e.g. "1.10.0" < "1.9.0"). Only the single winner is ever handed
+    // to `ResolvedPackages`, so that broken comparator is never reached.
+    let mut candidates: HashMap<String, Vec<(String, Option<String>)>> = HashMap::new();
+    for packages in lock_data.dependencies.into_values() {
+        for (name, entry) in packages {
+            // "type": "Project" / "CentralTransitive" entries carry no `resolved`
+            // at all — skip rather than aborting the whole file (S2).
+            if let Some(resolved) = entry.resolved {
+                candidates
+                    .entry(name)
+                    .or_default()
+                    .push((resolved, entry.content_hash));
+            }
+        }
+    }
+
+    let mut packages = ResolvedPackages::new();
+    for (name, versions) in candidates {
+        let best = versions
+            .into_iter()
+            .max_by(|a, b| crate::version::compare_versions(&a.0, &b.0));
+        if let Some((version, content_hash)) = best {
+            packages.insert(ResolvedPackage {
+                name,
+                version,
+                source: ResolvedSource::Registry {
+                    // Informational only — nothing in `deps-lsp`/`deps-core::lsp_helpers`
+                    // reads `ResolvedSource`, and this path makes no network request, so
+                    // it never routes a lockfile-resolved version against a private feed
+                    // (issue #523's config resolution intentionally stops at
+                    // `NuGetDependency::source`, not `ResolvedPackage::source`).
+                    url: crate::registry::NUGET_ORG_INDEX_URL.into(),
+                    checksum: content_hash.unwrap_or_default(),
+                },
+                dependencies: vec![],
+            });
+        }
+    }
+
+    Ok(packages)
 }
 
 #[cfg(test)]

--- a/crates/deps-pypi/src/lockfile.rs
+++ b/crates/deps-pypi/src/lockfile.rs
@@ -41,7 +41,7 @@
 use deps_core::error::{DepsError, Result};
 use deps_core::lockfile::{
     LockFileProvider, ResolvedPackage, ResolvedPackages, ResolvedSource,
-    locate_lockfile_for_manifest, read_lockfile_content,
+    locate_lockfile_for_manifest, read_and_parse_lockfile,
 };
 use std::path::{Path, PathBuf};
 use toml_span::value::Table;
@@ -98,68 +98,8 @@ impl LockFileProvider for PypiLockParser {
         Box::pin(async move {
             tracing::debug!("Parsing lock file: {}", lockfile_path.display());
 
-            let content = read_lockfile_content(lockfile_path, "lock file").await?;
-
-            if let Err(depth) =
-                deps_core::check_toml_nesting_depth(&content, deps_core::MAX_TOML_NESTING_DEPTH)
-            {
-                return Err(DepsError::ParseError {
-                    file_type: "Python lock file".into(),
-                    source: Box::new(std::io::Error::other(format!(
-                        "array/table nesting depth {depth} exceeds maximum of {}",
-                        deps_core::MAX_TOML_NESTING_DEPTH
-                    ))),
-                });
-            }
-
-            let doc = toml_span::parse(&content).map_err(|e| DepsError::ParseError {
-                file_type: "Python lock file".into(),
-                source: Box::new(std::io::Error::other(e.to_string())),
-            })?;
-
-            let mut packages = ResolvedPackages::new();
-
-            // [[package]] in TOML is an array of tables; toml-span represents it as an array of values
-            let Some(package_array) = doc
-                .as_table()
-                .and_then(|t| t.get("package"))
-                .and_then(|v| v.as_array())
-            else {
-                tracing::warn!("Lock file missing [[package]] array of tables");
-                return Ok(packages);
-            };
-
-            for item in package_array {
-                let Some(table) = item.as_table() else {
-                    continue;
-                };
-
-                // Extract required fields
-                let Some(name) = table.get("name").and_then(|v| v.as_str()) else {
-                    tracing::warn!("Package missing name field");
-                    continue;
-                };
-
-                let Some(version) = table.get("version").and_then(|v| v.as_str()) else {
-                    tracing::warn!("Package '{}' missing version field", name);
-                    continue;
-                };
-
-                // Parse source (format varies between poetry and uv)
-                let source = parse_pypi_source(table);
-
-                // Parse dependencies (format varies between poetry and uv)
-                let dependencies = parse_pypi_dependencies(table);
-
-                // Normalize name for consistent lookup (PEP 503: case/`_`/`.`-insensitive)
-                let normalized_name = crate::name::normalize(name);
-                packages.insert(ResolvedPackage {
-                    name: normalized_name,
-                    version: version.to_string(),
-                    source,
-                    dependencies,
-                });
-            }
+            let packages =
+                read_and_parse_lockfile(lockfile_path, "lock file", parse_pypi_lock).await?;
 
             tracing::info!(
                 "Parsed lock file: {} packages from {}",
@@ -170,6 +110,76 @@ impl LockFileProvider for PypiLockParser {
             Ok(packages)
         })
     }
+}
+
+/// Parses `poetry.lock`/`uv.lock` content (already read and size-capped) into resolved
+/// packages.
+///
+/// The CPU-bound half of [`PypiLockParser::parse_lockfile`], run inside
+/// [`deps_core::lockfile::read_and_parse_lockfile`]'s `spawn_blocking`.
+fn parse_pypi_lock(content: String) -> Result<ResolvedPackages> {
+    if let Err(depth) =
+        deps_core::check_toml_nesting_depth(&content, deps_core::MAX_TOML_NESTING_DEPTH)
+    {
+        return Err(DepsError::ParseError {
+            file_type: "Python lock file".into(),
+            source: Box::new(std::io::Error::other(format!(
+                "array/table nesting depth {depth} exceeds maximum of {}",
+                deps_core::MAX_TOML_NESTING_DEPTH
+            ))),
+        });
+    }
+
+    let doc = toml_span::parse(&content).map_err(|e| DepsError::ParseError {
+        file_type: "Python lock file".into(),
+        source: Box::new(std::io::Error::other(e.to_string())),
+    })?;
+
+    let mut packages = ResolvedPackages::new();
+
+    // [[package]] in TOML is an array of tables; toml-span represents it as an array of values
+    let Some(package_array) = doc
+        .as_table()
+        .and_then(|t| t.get("package"))
+        .and_then(|v| v.as_array())
+    else {
+        tracing::warn!("Lock file missing [[package]] array of tables");
+        return Ok(packages);
+    };
+
+    for item in package_array {
+        let Some(table) = item.as_table() else {
+            continue;
+        };
+
+        // Extract required fields
+        let Some(name) = table.get("name").and_then(|v| v.as_str()) else {
+            tracing::warn!("Package missing name field");
+            continue;
+        };
+
+        let Some(version) = table.get("version").and_then(|v| v.as_str()) else {
+            tracing::warn!("Package '{}' missing version field", name);
+            continue;
+        };
+
+        // Parse source (format varies between poetry and uv)
+        let source = parse_pypi_source(table);
+
+        // Parse dependencies (format varies between poetry and uv)
+        let dependencies = parse_pypi_dependencies(table);
+
+        // Normalize name for consistent lookup (PEP 503: case/`_`/`.`-insensitive)
+        let normalized_name = crate::name::normalize(name);
+        packages.insert(ResolvedPackage {
+            name: normalized_name,
+            version: version.to_string(),
+            source,
+            dependencies,
+        });
+    }
+
+    Ok(packages)
 }
 
 /// Parses source information from package table.

--- a/crates/deps-swift/src/lockfile.rs
+++ b/crates/deps-swift/src/lockfile.rs
@@ -11,7 +11,7 @@ use crate::parser::url_to_identity;
 use deps_core::error::{DepsError, Result};
 use deps_core::lockfile::{
     LockFileProvider, ResolvedPackage, ResolvedPackages, ResolvedSource,
-    locate_lockfile_for_manifest, read_lockfile_content,
+    locate_lockfile_for_manifest, read_and_parse_lockfile,
 };
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
@@ -77,81 +77,9 @@ impl LockFileProvider for SwiftLockParser {
         Box::pin(async move {
             tracing::debug!("Parsing Package.resolved: {}", lockfile_path.display());
 
-            let content = read_lockfile_content(lockfile_path, "Package.resolved").await?;
-
-            let lock_data: PackageResolved = deps_core::parse_json_checked(content.as_bytes())
-                .map_err(|e| DepsError::ParseError {
-                    file_type: "Package.resolved".into(),
-                    source: Box::new(e),
-                })?;
-
-            let mut packages = ResolvedPackages::new();
-
-            match lock_data.version {
-                1 => {
-                    let Some(obj) = lock_data.object else {
-                        return Ok(packages);
-                    };
-                    for pin in obj.pins {
-                        let name =
-                            url_to_identity(&pin.repository_url).unwrap_or(pin.package.clone());
-                        if let Some(version) = pin.state.version {
-                            let version = version
-                                .strip_prefix(['v', 'V'])
-                                .unwrap_or(&version)
-                                .to_string();
-                            packages.insert(ResolvedPackage {
-                                name,
-                                version,
-                                source: ResolvedSource::Git {
-                                    url: pin.repository_url,
-                                    rev: pin.state.revision.unwrap_or_default(),
-                                },
-                                dependencies: vec![],
-                            });
-                        }
-                    }
-                }
-                2 | 3 => {
-                    let Some(pins) = lock_data.pins else {
-                        return Ok(packages);
-                    };
-                    for pin in pins {
-                        // For fileSystem pins, location is a local path — use identity as name.
-                        // For remote pins, derive owner/repo from the URL.
-                        let name = if pin.kind == "fileSystem" {
-                            pin.identity.clone()
-                        } else {
-                            url_to_identity(&pin.location).unwrap_or(pin.identity.clone())
-                        };
-                        if let Some(version) = pin.state.version {
-                            let version = version
-                                .strip_prefix(['v', 'V'])
-                                .unwrap_or(&version)
-                                .to_string();
-                            let source = if pin.kind == "fileSystem" {
-                                ResolvedSource::Path {
-                                    path: pin.location.clone(),
-                                }
-                            } else {
-                                ResolvedSource::Git {
-                                    url: pin.location,
-                                    rev: pin.state.revision.unwrap_or_default(),
-                                }
-                            };
-                            packages.insert(ResolvedPackage {
-                                name,
-                                version,
-                                source,
-                                dependencies: vec![],
-                            });
-                        }
-                    }
-                }
-                v => {
-                    tracing::warn!("Unknown Package.resolved version: {}", v);
-                }
-            }
+            let packages =
+                read_and_parse_lockfile(lockfile_path, "Package.resolved", parse_package_resolved)
+                    .await?;
 
             tracing::info!(
                 "Parsed Package.resolved: {} packages from {}",
@@ -162,6 +90,87 @@ impl LockFileProvider for SwiftLockParser {
             Ok(packages)
         })
     }
+}
+
+/// Parses `Package.resolved` content (already read and size-capped) into resolved packages.
+///
+/// The CPU-bound half of [`SwiftLockParser::parse_lockfile`], run inside
+/// [`deps_core::lockfile::read_and_parse_lockfile`]'s `spawn_blocking`.
+fn parse_package_resolved(content: String) -> Result<ResolvedPackages> {
+    let lock_data: PackageResolved =
+        deps_core::parse_json_checked(content.as_bytes()).map_err(|e| DepsError::ParseError {
+            file_type: "Package.resolved".into(),
+            source: Box::new(e),
+        })?;
+
+    let mut packages = ResolvedPackages::new();
+
+    match lock_data.version {
+        1 => {
+            let Some(obj) = lock_data.object else {
+                return Ok(packages);
+            };
+            for pin in obj.pins {
+                let name = url_to_identity(&pin.repository_url).unwrap_or(pin.package.clone());
+                if let Some(version) = pin.state.version {
+                    let version = version
+                        .strip_prefix(['v', 'V'])
+                        .unwrap_or(&version)
+                        .to_string();
+                    packages.insert(ResolvedPackage {
+                        name,
+                        version,
+                        source: ResolvedSource::Git {
+                            url: pin.repository_url,
+                            rev: pin.state.revision.unwrap_or_default(),
+                        },
+                        dependencies: vec![],
+                    });
+                }
+            }
+        }
+        2 | 3 => {
+            let Some(pins) = lock_data.pins else {
+                return Ok(packages);
+            };
+            for pin in pins {
+                // For fileSystem pins, location is a local path — use identity as name.
+                // For remote pins, derive owner/repo from the URL.
+                let name = if pin.kind == "fileSystem" {
+                    pin.identity.clone()
+                } else {
+                    url_to_identity(&pin.location).unwrap_or(pin.identity.clone())
+                };
+                if let Some(version) = pin.state.version {
+                    let version = version
+                        .strip_prefix(['v', 'V'])
+                        .unwrap_or(&version)
+                        .to_string();
+                    let source = if pin.kind == "fileSystem" {
+                        ResolvedSource::Path {
+                            path: pin.location.clone(),
+                        }
+                    } else {
+                        ResolvedSource::Git {
+                            url: pin.location,
+                            rev: pin.state.revision.unwrap_or_default(),
+                        }
+                    };
+                    packages.insert(ResolvedPackage {
+                        name,
+                        version,
+                        source,
+                        dependencies: vec![],
+                    });
+                }
+            }
+        }
+        v => {
+            tracing::warn!("Unknown Package.resolved version: {}", v);
+        }
+    }
+
+    Ok(packages)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- `deps_core::lockfile::read_lockfile_content` already offloaded the capped file read to `spawn_blocking`, but the subsequent parse (equally CPU-bound, capped at 32 MiB) ran inline on the async worker in 9 of 10 `LockFileProvider` implementations; only deps-npm's `pnpm-lock.yaml` path (#719) offloaded it.
- Add `deps_core::lockfile::read_and_parse_lockfile`, which reads via the existing helper and then runs the caller's parse closure via `spawn_blocking`, mapping a `JoinError` to `DepsError::ParseError`.
- Wire all 10 providers (deps-dart, deps-go, deps-bundler, deps-cargo, deps-pypi, deps-composer, deps-swift, deps-nuget, deps-npm's `package-lock.json` and `pnpm-lock.yaml` paths) onto the shared helper, extracting each provider's previously inline parse logic into a plain free function.
- Add executable test coverage for the `JoinError -> ParseError` mapping (panic inside the parse closure) and for the parse actually running off the calling thread.
- Re-export `read_and_parse_lockfile` at the `deps-core` crate root alongside `read_lockfile_content`.

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast`
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`

Closes #723