### PR TITLE
fix(fuzz): add fuzz targets for YAML-parsing entry points

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,6 +359,12 @@ jobs:
           - maven_parser
           - nuget_parser
           - registry_xml_parser
+          - github_actions_parser
+          - gitlab_ci_parser
+          - dart_parser
+          - dart_lockfile
+          - pnpm_lockfile
+          - pnpm_catalog
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
 
@@ -379,7 +385,25 @@ jobs:
 
       - name: Run ${{ matrix.target }} for 60s
         working-directory: fuzz
-        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=60
+        # `seeds/<target>/` (issue #727), when present, is a tracked, read-only starting
+        # corpus — libFuzzer only ever writes newly-discovered interesting inputs back into
+        # the first CORPUS directory (the auto-managed, gitignored `corpus/<target>/`), never
+        # into later ones, so this cannot mutate the tracked seeds. Targets whose key-driven
+        # YAML dispatch (a whole-string compare on a mapping key, e.g. `value == "uses"`) gives
+        # libFuzzer no per-byte coverage gradient need this to reach the real dependency-
+        # extraction code within the 60s budget, rather than only ever re-deriving syntactically
+        # valid YAML that never contains the right key text.
+        run: |
+          seed_dir="seeds/${{ matrix.target }}"
+          if [ -d "$seed_dir" ]; then
+            # libFuzzer requires the (mutable) main corpus directory to already exist when
+            # any CORPUS argument is passed explicitly — unlike the no-argument default form
+            # below, it won't create it on its own.
+            mkdir -p "corpus/${{ matrix.target }}"
+            cargo +nightly fuzz run ${{ matrix.target }} "corpus/${{ matrix.target }}" "$seed_dir" -- -max_total_time=60
+          else
+            cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=60
+          fi
 
       - name: File or update tracking issue on scheduled failure
         if: failure() && github.event_name == 'schedule'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `fuzz/` workspace: cargo-fuzz targets for the GitHub Actions/GitLab CI/Dart/pnpm YAML-parsing entry points (manifest and lock file), closing a coverage gap versus the existing XML/JSON fuzz targets (resolves #727)
 - **README**: editor setup snippets for Emacs (`eglot`, `lsp-mode`), Sublime Text LSP, Kate, and coc.nvim, each noting the add-on requirement alongside a primary language server (partial work on #712) (#717)
 - **deps-github-actions**: `action.yml`/`action.yaml` composite/Docker/JS action manifests (a repository root or `.github/actions/<name>/`) now get the same hover, diagnostics, SHA-pin quick fix, and code lens as workflow files (resolves #706) (#718)
 - **deps-npm**: `pnpm-lock.yaml` is now read as a lock file for in-use/resolved-version detection, aggregating every pnpm workspace importer, with `package-lock.json` retaining precedence when both are present (resolves #709)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `fuzz/` workspace: cargo-fuzz targets for the GitHub Actions/GitLab CI/Dart/pnpm YAML-parsing entry points (manifest and lock file), closing a coverage gap versus the existing XML/JSON fuzz targets (resolves #727)
+- `fuzz/` workspace: cargo-fuzz targets for the GitHub Actions/GitLab CI/Dart/pnpm YAML-parsing entry points (manifest and lock file), closing a coverage gap versus the existing XML/JSON fuzz targets (resolves #727) (#735)
 - **README**: editor setup snippets for Emacs (`eglot`, `lsp-mode`), Sublime Text LSP, Kate, and coc.nvim, each noting the add-on requirement alongside a primary language server (partial work on #712) (#717)
 - **deps-github-actions**: `action.yml`/`action.yaml` composite/Docker/JS action manifests (a repository root or `.github/actions/<name>/`) now get the same hover, diagnostics, SHA-pin quick fix, and code lens as workflow files (resolves #706) (#718)
 - **deps-npm**: `pnpm-lock.yaml` is now read as a lock file for in-use/resolved-version detection, aggregating every pnpm workspace importer, with `package-lock.json` retaining precedence when both are present (resolves #709)

--- a/crates/deps-github-actions/src/lib.rs
+++ b/crates/deps-github-actions/src/lib.rs
@@ -1,3 +1,11 @@
+// `GithubActionsRegistry::get_versions_with_release_dates`'s boxed-future coercion nests
+// through several layers of `tokio::join!`/`MaybeDone` combinators; rustc's default recursion
+// limit is occasionally insufficient to prove the resulting `Send` bound and downgrades a
+// previously-silent trait-solver retry into `recursion_depth_exceeding_limit`, which the
+// fuzz CI job's `-D warnings` nightly build turns into a hard error (rust-lang/rust#159228).
+// Same fix as deps-swift (#673) and deps-nuget.
+#![recursion_limit = "256"]
+
 //! GitHub Actions ecosystem support for deps-lsp.
 //!
 //! Provides LSP features for `.github/workflows/*.yml`/`*.yaml` workflow files, and for

--- a/crates/deps-gitlab-ci/src/lib.rs
+++ b/crates/deps-gitlab-ci/src/lib.rs
@@ -1,3 +1,11 @@
+// `build_dynamic_component_pin_action`'s boxed-future coercion nests through several layers
+// of `tokio::join!`/`MaybeDone` combinators; rustc's default recursion limit is occasionally
+// insufficient to prove the resulting `Send` bound and downgrades a previously-silent
+// trait-solver retry into `recursion_depth_exceeding_limit`, which the fuzz CI job's
+// `-D warnings` nightly build turns into a hard error (rust-lang/rust#159228). Same fix as
+// deps-swift (#673) and deps-nuget.
+#![recursion_limit = "256"]
+
 //! GitLab CI/CD ecosystem support for deps-lsp.
 //!
 //! Provides LSP features for `.gitlab-ci.yml` and `.gitlab/ci/*.yml`/`*.yaml` files.

--- a/crates/deps-npm/Cargo.toml
+++ b/crates/deps-npm/Cargo.toml
@@ -27,6 +27,13 @@ workspace = true
 # dependency, or a release build of that crate would compile in the http carve-out too.
 test-util = ["deps-core/test-util"]
 
+# Exposes `lockfile::fuzz_parse_pnpm_lock_yaml` and `catalog::fuzz_parse_pnpm_workspace` for
+# the `fuzz/` cargo-fuzz workspace's `pnpm_lockfile`/`pnpm_catalog` targets (#727) — mirrors
+# `deps-gradle`/`deps-maven`'s own `fuzzing` feature (see their Cargo.toml comments). Never
+# enabled by this crate's own default feature set, so these wrappers stay out of the normal
+# public API surface.
+fuzzing = []
+
 [dependencies]
 dashmap = { workspace = true }
 deps-core = { workspace = true }

--- a/crates/deps-npm/src/catalog.rs
+++ b/crates/deps-npm/src/catalog.rs
@@ -213,6 +213,15 @@ fn parse_pnpm_workspace(content: &str) -> PnpmWorkspaceConfig {
     }
 }
 
+/// Fuzz-only entry point for [`parse_pnpm_workspace`], the `pnpm-workspace.yaml` catalog
+/// parser (issue #727). Gated on the `fuzzing` Cargo feature (never enabled by this crate's
+/// own default set) so this stays out of the crate's public API surface in a normal build.
+#[cfg(feature = "fuzzing")]
+#[doc(hidden)]
+pub fn fuzz_parse_pnpm_workspace(content: &str) {
+    let _ = parse_pnpm_workspace(content);
+}
+
 /// Per-path memoization of `pnpm-workspace.yaml` parses, invalidated by mtime.
 ///
 /// The pnpm catalog analogue of [`crate::config::NpmConfigCache`], reusing the same

--- a/crates/deps-npm/src/lib.rs
+++ b/crates/deps-npm/src/lib.rs
@@ -17,6 +17,18 @@ pub use config::{NpmConfig, NpmConfigCache, NpmParseContext, NpmRegistryIndex};
 pub use ecosystem::NpmEcosystem;
 pub use formatter::NpmFormatter;
 pub use lockfile::NpmLockParser;
+// `parse_pnpm_lock_yaml`/`parse_pnpm_workspace` themselves stay private (mirrors
+// `deps-gradle`'s `fuzz_parse_pom_licenses` precedent): only these two wrappers are exposed,
+// and only under the non-default `fuzzing` feature (issue #727, see this crate's Cargo.toml)
+// — `fuzz/`'s `pnpm_lockfile`/`pnpm_catalog` targets reach them as
+// `deps_npm::fuzz_parse_pnpm_lock_yaml`/`deps_npm::fuzz_parse_pnpm_workspace`; the crate's
+// default public API is unaffected.
+#[cfg(feature = "fuzzing")]
+#[doc(hidden)]
+pub use catalog::fuzz_parse_pnpm_workspace;
+#[cfg(feature = "fuzzing")]
+#[doc(hidden)]
+pub use lockfile::fuzz_parse_pnpm_lock_yaml;
 pub use parser::{NpmParseResult, parse_package_json, parse_package_json_with_context};
 pub use registry::{NpmRegistry, package_url};
 pub use types::{NpmDependency, NpmDependencySection, NpmPackage, NpmVersion};

--- a/crates/deps-npm/src/lockfile.rs
+++ b/crates/deps-npm/src/lockfile.rs
@@ -351,6 +351,15 @@ fn parse_pnpm_lock_yaml(content: &str) -> Result<ResolvedPackages> {
     Ok(packages)
 }
 
+/// Fuzz-only entry point for [`parse_pnpm_lock_yaml`], the `pnpm-lock.yaml` CPU-bound parser
+/// (issue #727). Gated on the `fuzzing` Cargo feature (never enabled by this crate's own
+/// default set) so this stays out of the crate's public API surface in a normal build.
+#[cfg(feature = "fuzzing")]
+#[doc(hidden)]
+pub fn fuzz_parse_pnpm_lock_yaml(content: &str) {
+    let _ = parse_pnpm_lock_yaml(content);
+}
+
 /// Resolves one importer dependency entry's real package name and plain version, handling
 /// pnpm's `name@version` alias-resolution form.
 ///

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -45,6 +45,19 @@ path = "../crates/deps-nuget"
 [dependencies.deps-pypi]
 path = "../crates/deps-pypi"
 
+[dependencies.deps-github-actions]
+path = "../crates/deps-github-actions"
+
+[dependencies.deps-gitlab-ci]
+path = "../crates/deps-gitlab-ci"
+
+[dependencies.deps-dart]
+path = "../crates/deps-dart"
+
+[dependencies.deps-npm]
+path = "../crates/deps-npm"
+features = ["fuzzing"]
+
 [profile.release]
 debug = 1
 
@@ -121,6 +134,48 @@ bench = false
 [[bin]]
 name = "registry_xml_parser"
 path = "fuzz_targets/registry_xml_parser.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "github_actions_parser"
+path = "fuzz_targets/github_actions_parser.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "gitlab_ci_parser"
+path = "fuzz_targets/gitlab_ci_parser.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "dart_parser"
+path = "fuzz_targets/dart_parser.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "dart_lockfile"
+path = "fuzz_targets/dart_lockfile.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "pnpm_lockfile"
+path = "fuzz_targets/pnpm_lockfile.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "pnpm_catalog"
+path = "fuzz_targets/pnpm_catalog.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/dart_lockfile.rs
+++ b/fuzz/fuzz_targets/dart_lockfile.rs
@@ -1,0 +1,15 @@
+//! Fuzzes `deps_dart::lockfile::parse_pubspec_lock`, the `pubspec.lock` parser.
+//!
+//! Property under test: never panics for any byte input, valid YAML or not.
+
+#![no_main]
+
+use deps_dart::lockfile::parse_pubspec_lock;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(content) = std::str::from_utf8(data) else {
+        return;
+    };
+    let _ = parse_pubspec_lock(content);
+});

--- a/fuzz/fuzz_targets/dart_parser.rs
+++ b/fuzz/fuzz_targets/dart_parser.rs
@@ -1,0 +1,20 @@
+//! Fuzzes `deps_dart::parse_pubspec_yaml`, the tree-and-text-search `pubspec.yaml` parser.
+//!
+//! Property under test: never panics for any byte input, valid YAML or not.
+
+#![no_main]
+
+use deps_dart::parse_pubspec_yaml;
+use libfuzzer_sys::fuzz_target;
+use std::sync::LazyLock;
+use tower_lsp_server::ls_types::Uri;
+
+static PUBSPEC_URI: LazyLock<Uri> =
+    LazyLock::new(|| Uri::from_file_path("/fuzz/pubspec.yaml").expect("static fixture path"));
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(content) = std::str::from_utf8(data) else {
+        return;
+    };
+    let _ = parse_pubspec_yaml(content, &PUBSPEC_URI);
+});

--- a/fuzz/fuzz_targets/github_actions_parser.rs
+++ b/fuzz/fuzz_targets/github_actions_parser.rs
@@ -1,0 +1,28 @@
+//! Fuzzes `deps_github_actions::parse_workflow_yaml`, the event-driven
+//! (`MarkedEventReceiver`) YAML parser for both of #718's routed manifest shapes:
+//! `.github/workflows/*.yml` workflows and `action.yml`/`action.yaml` composite actions.
+//!
+//! Property under test: never panics for any byte input, valid YAML or not, on either
+//! entry point — including the marker-to-`Range` byte-offset slicing the parser does for
+//! every `uses:` candidate.
+
+#![no_main]
+
+use deps_github_actions::parse_workflow_yaml;
+use libfuzzer_sys::fuzz_target;
+use std::sync::LazyLock;
+use tower_lsp_server::ls_types::Uri;
+
+static WORKFLOW_URI: LazyLock<Uri> = LazyLock::new(|| {
+    Uri::from_file_path("/fuzz/.github/workflows/ci.yml").expect("static fixture path")
+});
+static ACTION_URI: LazyLock<Uri> =
+    LazyLock::new(|| Uri::from_file_path("/fuzz/action.yml").expect("static fixture path"));
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(content) = std::str::from_utf8(data) else {
+        return;
+    };
+    let _ = parse_workflow_yaml(content, &WORKFLOW_URI);
+    let _ = parse_workflow_yaml(content, &ACTION_URI);
+});

--- a/fuzz/fuzz_targets/gitlab_ci_parser.rs
+++ b/fuzz/fuzz_targets/gitlab_ci_parser.rs
@@ -1,0 +1,48 @@
+//! Fuzzes `deps_gitlab_ci::parse_gitlab_ci_yaml`, the `.gitlab-ci.yml` event-driven
+//! (`MarkedEventReceiver`) YAML parser — the same hand-rolled `Vec<Frame>` state-machine
+//! shape as `deps-github-actions`'s workflow parser.
+//!
+//! Property under test: never panics for any byte input, valid YAML or not, including the
+//! marker-to-`Range` byte-offset slicing done for every `include:`/`component:` candidate.
+//! Two disconnected [`GitlabInstanceHost`]s are shared across every call (hoisted to
+//! `LazyLock`s instead of rebuilt per input) — one permanently `Unset` (`raw` stays `None`)
+//! and one permanently `Set` to a fixed, harmless host string, so every input is parsed
+//! against both states of `registries.gitlab_instance_host`. Both are configuration-only,
+//! never derived from fuzz input, so no network access is ever attempted regardless of
+//! input content. Driving only the `Unset` state would leave `resolve_project_host`'s/
+//! `resolve_component_host`'s `Some` branch — including `GitlabHost::parse`'s own
+//! URL-structural-character rejection and policy-gated host validation, per
+//! `crate::parser`'s own `test_component_ci_server_fqdn_resolves_when_instance_host_set`
+//! test — permanently dead to the fuzzer (code-review finding).
+
+#![no_main]
+
+use deps_core::net_policy::RegistryAccessPolicy;
+use deps_gitlab_ci::{GitlabInstanceHost, parse_gitlab_ci_yaml};
+use libfuzzer_sys::fuzz_target;
+use std::sync::{Arc, LazyLock, RwLock};
+use tower_lsp_server::ls_types::Uri;
+
+static FUZZ_URI: LazyLock<Uri> =
+    LazyLock::new(|| Uri::from_file_path("/fuzz/.gitlab-ci.yml").expect("static fixture path"));
+static POLICY: LazyLock<RegistryAccessPolicy> = LazyLock::new(RegistryAccessPolicy::default);
+static INSTANCE_HOST_UNSET: LazyLock<GitlabInstanceHost> = LazyLock::new(|| {
+    GitlabInstanceHost::new(
+        Arc::new(RwLock::new(None)),
+        Arc::new(RegistryAccessPolicy::default()),
+    )
+});
+static INSTANCE_HOST_SET: LazyLock<GitlabInstanceHost> = LazyLock::new(|| {
+    GitlabInstanceHost::new(
+        Arc::new(RwLock::new(Some("gitlab.example.com".to_string()))),
+        Arc::new(RegistryAccessPolicy::default()),
+    )
+});
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(content) = std::str::from_utf8(data) else {
+        return;
+    };
+    let _ = parse_gitlab_ci_yaml(content, &FUZZ_URI, &POLICY, &INSTANCE_HOST_UNSET);
+    let _ = parse_gitlab_ci_yaml(content, &FUZZ_URI, &POLICY, &INSTANCE_HOST_SET);
+});

--- a/fuzz/fuzz_targets/pnpm_catalog.rs
+++ b/fuzz/fuzz_targets/pnpm_catalog.rs
@@ -1,0 +1,16 @@
+//! Fuzzes `deps_npm::fuzz_parse_pnpm_workspace` (feature `fuzzing`), the
+//! `pnpm-workspace.yaml` catalog parser (#719/spec 046).
+//!
+//! Property under test: never panics for any byte input, valid YAML or not.
+
+#![no_main]
+
+use deps_npm::fuzz_parse_pnpm_workspace;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(content) = std::str::from_utf8(data) else {
+        return;
+    };
+    fuzz_parse_pnpm_workspace(content);
+});

--- a/fuzz/fuzz_targets/pnpm_lockfile.rs
+++ b/fuzz/fuzz_targets/pnpm_lockfile.rs
@@ -1,0 +1,17 @@
+//! Fuzzes `deps_npm::fuzz_parse_pnpm_lock_yaml` (feature `fuzzing`), the CPU-bound
+//! `pnpm-lock.yaml` parser (#719): peer-suffix stripping, `name@version` alias splitting,
+//! and `yaml_scalar_string` coercion of unquoted numeric-looking versions.
+//!
+//! Property under test: never panics for any byte input, valid YAML or not.
+
+#![no_main]
+
+use deps_npm::fuzz_parse_pnpm_lock_yaml;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(content) = std::str::from_utf8(data) else {
+        return;
+    };
+    fuzz_parse_pnpm_lock_yaml(content);
+});

--- a/fuzz/seeds/dart_lockfile/pubspec.lock
+++ b/fuzz/seeds/dart_lockfile/pubspec.lock
@@ -1,0 +1,23 @@
+packages:
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
+  my_pkg:
+    dependency: "direct main"
+    description:
+      url: "https://github.com/user/repo.git"
+      resolved-ref: abc123
+    source: git
+    version: "0.1.0"
+  local_pkg:
+    dependency: "direct main"
+    description:
+      path: "../local_pkg"
+    source: path
+    version: "0.1.0"
+sdks:
+  dart: ">=3.0.0 <4.0.0"

--- a/fuzz/seeds/dart_parser/pubspec.yaml
+++ b/fuzz/seeds/dart_parser/pubspec.yaml
@@ -1,0 +1,11 @@
+name: my_app
+description: A sample application
+version: 1.0.0
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+dependencies:
+  http: ^1.2.0
+  provider: ^6.1.2
+dev_dependencies:
+  lints: ^3.0.0
+  test: ^1.24.0

--- a/fuzz/seeds/github_actions_parser/action.yml
+++ b/fuzz/seeds/github_actions_parser/action.yml
@@ -1,0 +1,9 @@
+name: My Action
+description: Does a thing
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4.2.0
+      with:
+        node-version: 20

--- a/fuzz/seeds/github_actions_parser/multibyte_quoted.yml
+++ b/fuzz/seeds/github_actions_parser/multibyte_quoted.yml
@@ -1,0 +1,3 @@
+steps:
+  - uses: "　　actions/checkout@v4"
+  - uses: "　actions/setup-node@a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5"

--- a/fuzz/seeds/github_actions_parser/workflow.yml
+++ b/fuzz/seeds/github_actions_parser/workflow.yml
@@ -1,0 +1,13 @@
+on: push
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.2.0
+        with:
+          node-version: 20
+      - uses: actions/checkout@a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5 # v4.2.0
+      - uses: ./local-action
+      - uses: docker://alpine:3.18
+  call:
+    uses: octo-org/repo/.github/workflows/x.yml@v1

--- a/fuzz/seeds/gitlab_ci_parser/ci_server_fqdn.yml
+++ b/fuzz/seeds/gitlab_ci_parser/ci_server_fqdn.yml
@@ -1,0 +1,4 @@
+include:
+  - component: $CI_SERVER_FQDN/org/proj/comp@1.0
+  - project: org/proj
+    ref: v2.0.0

--- a/fuzz/seeds/gitlab_ci_parser/component.yml
+++ b/fuzz/seeds/gitlab_ci_parser/component.yml
@@ -1,0 +1,5 @@
+include:
+  - component: gitlab.com/org/proj/comp@1.0.0
+  - component: gitlab.com/org/proj/other@~latest
+  - template: Security/SAST.gitlab-ci.yml
+  - remote: https://example.com/ci-template.yml

--- a/fuzz/seeds/gitlab_ci_parser/gitlab-ci.yml
+++ b/fuzz/seeds/gitlab_ci_parser/gitlab-ci.yml
@@ -1,0 +1,7 @@
+include:
+  - project: org/proj
+    ref: v1.2.3
+  - project: org/other
+    ref: a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5a1b2c3d4e5
+  - project: org/branch-tracker
+    ref: main

--- a/fuzz/seeds/gitlab_ci_parser/multibyte.yml
+++ b/fuzz/seeds/gitlab_ci_parser/multibyte.yml
@@ -1,0 +1,6 @@
+include:
+  - project: "　　org/proj"
+    ref: v1.2.3
+  - project: org/proj
+    ref: "　　v1.2.3"
+  - component: gitlab.com/org/prôj/comp@1.0.0

--- a/fuzz/seeds/pnpm_catalog/pnpm-workspace.yaml
+++ b/fuzz/seeds/pnpm_catalog/pnpm-workspace.yaml
@@ -1,0 +1,11 @@
+packages:
+  - packages/*
+catalog:
+  react: ^18.2.0
+  react-dom: ^18.2.0
+catalogs:
+  react17:
+    react: ^17.0.2
+    react-dom: ^17.0.2
+  default:
+    lodash: ^4.17.21

--- a/fuzz/seeds/pnpm_catalog/simple.yaml
+++ b/fuzz/seeds/pnpm_catalog/simple.yaml
@@ -1,0 +1,5 @@
+catalog:
+  react: ^18.2.0
+catalogs:
+  react17:
+    react: ^17.0.2

--- a/fuzz/seeds/pnpm_lockfile/pnpm-lock.yaml
+++ b/fuzz/seeds/pnpm_lockfile/pnpm-lock.yaml
@@ -1,0 +1,23 @@
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+      my-lodash:
+        specifier: npm:lodash@^4.17.0
+        version: lodash@4.17.21
+    devDependencies:
+      typescript:
+        specifier: ^5.4.0
+        version: 5.4.0
+    optionalDependencies:
+      fsevents:
+        specifier: ^2.3.3
+        version: 2.3.3(patch_hash=abc123)
+  packages/local-sibling:
+    dependencies:
+      shared-lib:
+        specifier: workspace:*
+        version: link:../shared-lib


### PR DESCRIPTION
## Summary

None of the 11 existing fuzz targets parsed a YAML document end-to-end — `fuzz/fuzz_targets/parser_checks.rs` only fuzzes the shared pre-pass scanners (`check_yaml_nesting_depth`, `check_yaml_expansion`), not the parsers themselves. That left every YAML-consuming parser of untrusted manifest content (GitHub Actions, GitLab CI, Dart pubspec, the pnpm-lock provider) with no automated panic gate, unlike their XML/JSON equivalents.

Adds 6 fuzz targets mirroring the existing XML/JSON coverage:

- `github_actions_parser` — drives both the composite `action.yml`/`action.yaml` URI and the `.github/workflows/*.yml` URI (these took different branches after #718), plus both the instance-host Set/Unset states are exercised where applicable
- `gitlab_ci_parser` — drives both `registries.gitlab_instance_host` Set and Unset states (a hardcoded, non-fuzzed host string for the Set case, no network reachability risk)
- `dart_parser` / `dart_lockfile` — `pubspec.yaml` / `pubspec.lock`
- `pnpm_lockfile` / `pnpm_catalog` — the pnpm-lock.yaml provider and workspace catalogs added in #719

Each target calls the real production parsing entry point (not just the pre-pass guards), so a panic anywhere in YAML event handling or marker-to-`Range` byte-offset slicing is caught. Tracked seed corpora under `fuzz/seeds/<target>/` give libFuzzer a starting point past the whole-string key-dispatch gradient problem, including multi-byte UTF-8 seeds targeting the non-char-boundary panic class the issue specifically calls out (this repo has hit that exact bug shape before, per `crates/deps-github-actions/src/parser.rs`'s regression test). All 6 targets are registered in `.github/workflows/ci.yml`'s scheduled fuzz matrix.

Adds a `fuzzing` Cargo feature on `deps-npm`, mirroring the existing `deps-gradle`/`deps-maven` precedent, to expose its two private pnpm YAML parsers to their fuzz targets. Confirmed via `cargo tree -p deps-lsp -e features,no-dev` that this feature does not leak into `deps-lsp`'s non-dev dependency tree.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (4659 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- [x] `cargo tree -p deps-lsp -e features,no-dev` confirms no `fuzzing` feature leak
- [x] Each of the 6 new targets run locally (20-25s, 260k-410k execs) with zero crashes, and independently verified to reach past-the-scanner code (corpus entries retain dispatch keys like `uses`, `include`, `CI_SERVER_FQDN`) and multi-byte UTF-8 (byte >= 0x80) input

Closes #727