### PR TITLE
fix(deps-pypi): stop fallback completion from bare-inserting into a closed TOML array value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: property tests (`proptest`) asserting the parser depth/expansion checkers and JSONC position recovery never panic on arbitrary input (#673)
 
 ### Fixed
-- **deps-pypi**: raw-text fallback completion no longer bare-inserts a package name right after an already-closed `pyproject.toml` TOML array value, via a shared escape-aware quote-parity check in `deps-core` also consolidated with #732's `strip_open_json_key` — also fixes the same escaped-quote gap in Cargo's `extract_feature_prefix` (resolves #734, #733)
+- **deps-pypi**: raw-text fallback completion no longer bare-inserts a package name right after an already-closed `pyproject.toml` TOML array value, via a shared escape-aware quote-parity check in `deps-core` (now the single implementation backing #732's `strip_open_json_key` too) — also fixes the same escaped-quote gap in Cargo's `extract_feature_prefix` (resolves #734, #733)
 - **deps-core, deps-npm, deps-composer**: npm/Composer raw-text fallback completion no longer inserts a duplicate-quoted key-value pair when the cursor is already inside an open JSON key string (resolves #729) (#732)
 - **deps-core** + all 9 lock-file providers: lock-file parsing now runs on the blocking-thread pool via a shared `read_and_parse_lockfile` helper, no longer stalling the LSP request worker (resolves #723) (#730)
 - **deps-lsp**: NuGet/Maven raw-text fallback completion no longer inserts duplicate markup when the cursor is already inside an open attribute value or tag (resolves #724) (#728)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: property tests (`proptest`) asserting the parser depth/expansion checkers and JSONC position recovery never panic on arbitrary input (#673)
 
 ### Fixed
+- **deps-pypi**: raw-text fallback completion no longer bare-inserts a package name right after an already-closed `pyproject.toml` TOML array value, via a shared escape-aware quote-parity check in `deps-core` also consolidated with #732's `strip_open_json_key` — also fixes the same escaped-quote gap in Cargo's `extract_feature_prefix` (resolves #734, #733)
 - **deps-core, deps-npm, deps-composer**: npm/Composer raw-text fallback completion no longer inserts a duplicate-quoted key-value pair when the cursor is already inside an open JSON key string (resolves #729) (#732)
 - **deps-core** + all 9 lock-file providers: lock-file parsing now runs on the blocking-thread pool via a shared `read_and_parse_lockfile` helper, no longer stalling the LSP request worker (resolves #723) (#730)
 - **deps-lsp**: NuGet/Maven raw-text fallback completion no longer inserts duplicate markup when the cursor is already inside an open attribute value or tag (resolves #724) (#728)

--- a/crates/deps-core/src/completion.rs
+++ b/crates/deps-core/src/completion.rs
@@ -420,7 +420,9 @@ pub fn extract_prefix(content: &str, position: Position, range: Range) -> String
 /// the feature string being typed. Handles both inline and multi-line arrays.
 ///
 /// Returns an empty string when the cursor is not inside a quoted string
-/// (e.g. right after `[` or between `, ` and the next `"`).
+/// (e.g. right after `[` or between `, ` and the next `"`), using
+/// [`crate::fallback_completion::open_quoted_tail`]'s escape-aware quote-parity check
+/// (#733) rather than a naive `"` count, which would miscount an escaped `\"`.
 ///
 /// # Examples
 ///
@@ -436,7 +438,7 @@ pub fn extract_prefix(content: &str, position: Position, range: Range) -> String
 /// assert_eq!(prefix, "ser");
 /// ```
 // `cursor_byte` comes from `utf16_to_byte_offset` (char_indices-based) and is clamped to
-// `line.len()`; `segment_start`/the `rfind('"')` offset are ASCII-char indices (`[`/`"`).
+// `line.len()`; `segment_start` is an ASCII-char (`[`) index.
 #[allow(clippy::string_slice)]
 pub fn extract_feature_prefix(content: &str, position: Position) -> String {
     let line = match content.lines().nth(position.line as usize) {
@@ -457,18 +459,12 @@ pub fn extract_feature_prefix(content: &str, position: Position) -> String {
     let segment_start = before_cursor.rfind('[').map_or(0, |i| i + 1);
     let segment = &before_cursor[segment_start..];
 
-    // Count '"' characters to determine whether the cursor is inside a string.
-    // An odd count means the cursor is inside an open string literal.
-    let quote_count = segment.chars().filter(|&c| c == '"').count();
-    if quote_count % 2 == 0 {
-        return String::new();
-    }
-
-    // Find the last opening quote and return the text after it.
-    match segment.rfind('"') {
-        Some(pos) => segment[pos + 1..].to_string(),
-        None => String::new(),
-    }
+    // Escape-aware quote-parity check (#733): a naive `filter(|&c| c == '"').count()`
+    // miscounts a `\"` escape inside a feature name, desyncing the open/closed check
+    // from the string's real state.
+    crate::fallback_completion::open_quoted_tail(segment)
+        .unwrap_or_default()
+        .to_string()
 }
 
 /// Builds a completion item for a package name.
@@ -3629,6 +3625,26 @@ mod tests {
         };
         let prefix = extract_feature_prefix(content, position);
         assert_eq!(prefix, "");
+    }
+
+    /// #733: a naive `"` count miscounts an escaped `\"` inside a feature name,
+    /// desyncing the open/closed check from the segment's real quote state. Here the
+    /// segment up to the cursor (`"a\"b`) has one real quote (the opening quote; the
+    /// escaped one doesn't count) — an odd count, correctly "open" with tail `a\"b`.
+    /// A naive count sees two `"` characters (even, wrongly "closed") and would
+    /// collapse the prefix to empty; the escape-aware check must still find the
+    /// string open with the correct tail.
+    // A short ASCII test line can never overflow `u32`.
+    #[allow(clippy::cast_possible_truncation)]
+    #[test]
+    fn test_extract_feature_prefix_skips_escaped_quote() {
+        let content = r#"features = ["a\"b"#;
+        let position = Position {
+            line: 0,
+            character: content.chars().count() as u32,
+        };
+        let prefix = extract_feature_prefix(content, position);
+        assert_eq!(prefix, r#"a\"b"#);
     }
 
     // --- Release-freshness signal (issue #145): VersionDisplayItem.published_at,

--- a/crates/deps-core/src/fallback_completion.rs
+++ b/crates/deps-core/src/fallback_completion.rs
@@ -320,23 +320,36 @@ pub fn strip_open_xml_attribute_value<'a>(
     ""
 }
 
-/// Counts the `"` characters in `prefix` that actually open or close a JSON string —
-/// skipping any `\"` escape sequence — and returns that count along with the byte
-/// index of the last such real quote, if any.
+/// Counts the `"` characters in `segment` that actually open or close a string —
+/// skipping any `\"` escape sequence — along with the byte index of the last such
+/// real quote, if any.
 ///
 /// A `"` is escaped, and does not toggle string state, when it is preceded by an *odd*
 /// number of consecutive `\` characters immediately before it (an even count, zero
 /// included, means those backslashes are themselves pairwise-escaped, so the quote is
 /// real) — e.g. in `"a\"b"` the middle `"` is escaped (one preceding `\`), so the
 /// string is `a"b`, not two separate strings. A naive per-`"` count desyncs from real
-/// JSON open/close state on any key or value containing `\"` (#729 code-review: raw
+/// open/close string state on any segment containing `\"` (#729 code-review, #733: raw
 /// counting both over-counts, flipping a closed key+value pair to look "open", and
 /// under-counts the inverse, flipping a still-open key to look "closed").
-fn count_real_json_quotes(prefix: &str) -> (usize, Option<usize>) {
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::fallback_completion::count_real_quotes;
+///
+/// // Two plain quotes, both real: last one is at byte index 7.
+/// assert_eq!(count_real_quotes("\"pytest\""), (2, Some(7)));
+/// // The middle quote is escaped (one preceding `\`), so it isn't counted: only the
+/// // opening quote (index 0) is real.
+/// assert_eq!(count_real_quotes("\"a\\\"b"), (1, Some(0)));
+/// ```
+#[must_use]
+pub fn count_real_quotes(segment: &str) -> (usize, Option<usize>) {
     let mut backslash_run = 0usize;
     let mut count = 0usize;
     let mut last_real_quote = None;
-    for (idx, ch) in prefix.char_indices() {
+    for (idx, ch) in segment.char_indices() {
         match ch {
             '\\' => backslash_run += 1,
             '"' => {
@@ -359,7 +372,7 @@ fn count_real_json_quotes(prefix: &str) -> (usize, Option<usize>) {
 /// `composer.json`'s `require`/`require-dev` entries — distinguishing that from a
 /// closed key, an open value string, or plain unquoted text.
 ///
-/// Uses quote parity — an odd count of real (see `count_real_json_quotes`) `"`
+/// Uses quote parity — an odd count of real (see [`count_real_quotes`]) `"`
 /// characters means the cursor sits inside an open string literal — adapted for a JSON
 /// object key instead of an XML tag/attribute: the text immediately before the open
 /// string's opening quote decides key-vs-value: a `:` right before it
@@ -388,14 +401,14 @@ fn count_real_json_quotes(prefix: &str) -> (usize, Option<usize>) {
 /// there.
 #[must_use]
 pub fn strip_open_json_key(prefix: &str) -> (&str, bool) {
-    let (quote_count, last_quote) = count_real_json_quotes(prefix);
+    let (quote_count, last_quote) = count_real_quotes(prefix);
     if quote_count == 0 {
         return (prefix, false);
     }
     if quote_count.is_multiple_of(2) {
         return ("", false);
     }
-    // `quote_count` odd (so >= 1) guarantees `count_real_json_quotes` found one; `"`
+    // `quote_count` odd (so >= 1) guarantees `count_real_quotes` found one; `"`
     // is a single-byte ASCII char, so `last_quote + 1` is always a char boundary.
     #[allow(clippy::string_slice)]
     let Some(last_quote) = last_quote else {
@@ -408,6 +421,45 @@ pub fn strip_open_json_key(prefix: &str) -> (&str, bool) {
     } else {
         (after_quote, true)
     }
+}
+
+/// Returns the tail of a genuinely still-open quoted string ending at the cursor, or
+/// `None` when there isn't one.
+///
+/// The tail is the text after the last real, escape-aware (see [`count_real_quotes`])
+/// opening `"` in `segment`, returned only when the cursor sits inside a genuinely
+/// still-open quoted string — an odd count of real `"` characters. Returns `None` when
+/// the string is already closed (an even, non-zero count) or no quote has been typed
+/// at all (zero count): in both cases there is no open string to extract a value from.
+///
+/// Shared by ecosystems whose raw-text fallback-completion prefix survives inside a
+/// quoted value (a JSON object key/value, a TOML string-array element) — used instead
+/// of an unconditional `trim_matches('"')`, which cannot distinguish a genuinely open
+/// string from an already-closed one and so cannot tell a caller when a bare insert at
+/// the cursor would corrupt the manifest rather than complete an open value (#734).
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::fallback_completion::open_quoted_tail;
+///
+/// // Still-open string: only the opening quote exists.
+/// assert_eq!(open_quoted_tail("\"flas"), Some("flas"));
+/// // Already-closed string: both quotes exist, nothing left to complete.
+/// assert_eq!(open_quoted_tail("\"pytest\""), None);
+/// // No quote typed yet.
+/// assert_eq!(open_quoted_tail("dependencies = ["), None);
+/// ```
+#[must_use]
+pub fn open_quoted_tail(segment: &str) -> Option<&str> {
+    let (count, last_quote) = count_real_quotes(segment);
+    if count.is_multiple_of(2) {
+        return None;
+    }
+    // `last_quote` is the byte index of a `"` char (from `char_indices`), and `"` is a
+    // single-byte ASCII char, so `last_quote + 1` is always a char boundary.
+    #[allow(clippy::string_slice)]
+    last_quote.map(|pos| &segment[pos + 1..])
 }
 
 #[cfg(test)]
@@ -904,5 +956,41 @@ tokio
         // as still open.
         let prefix = "\"a\\\"b";
         assert_eq!(strip_open_json_key(prefix), ("a\\\"b", true));
+    }
+
+    #[test]
+    fn test_open_quoted_tail_open_string_returns_tail() {
+        assert_eq!(open_quoted_tail("\"flas"), Some("flas"));
+    }
+
+    #[test]
+    fn test_open_quoted_tail_closed_string_is_none() {
+        assert_eq!(open_quoted_tail("\"pytest\""), None);
+    }
+
+    #[test]
+    fn test_open_quoted_tail_no_quote_is_none() {
+        assert_eq!(open_quoted_tail("dependencies = ["), None);
+    }
+
+    /// The escaped `\"` inside the value must not be counted as a real delimiter,
+    /// otherwise this would misclassify as closed (even count) instead of open.
+    #[test]
+    fn test_open_quoted_tail_skips_escaped_quote() {
+        assert_eq!(open_quoted_tail("\"a\\\"b"), Some("a\\\"b"));
+    }
+
+    /// A run of two backslashes before the quote is itself an escaped backslash, so
+    /// the quote after it is real and closes the string.
+    #[test]
+    fn test_open_quoted_tail_even_backslash_run_quote_is_real() {
+        assert_eq!(open_quoted_tail("\"a\\\\\""), None);
+    }
+
+    #[test]
+    fn test_count_real_quotes_skips_escaped_quote() {
+        let (count, last) = count_real_quotes("\"a\\\"b\"");
+        assert_eq!(count, 2);
+        assert_eq!(last, Some(5));
     }
 }

--- a/crates/deps-pypi/src/ecosystem.rs
+++ b/crates/deps-pypi/src/ecosystem.rs
@@ -512,12 +512,40 @@ fn is_dependencies_array_start(trimmed: &str) -> bool {
         .is_some_and(|rest| rest.trim_start().starts_with('['))
 }
 
-/// Extracts the fallback-completion prefix on `line` up to `character`, stripping a
-/// surviving quote on either side — PyPI's dependency entries are TOML string-array
-/// elements (`"pytes`), a different quoting shape from JSON-quoted keys, but still
-/// need the surviving quote stripped before it reaches the registry search.
+/// Extracts the fallback-completion prefix on `line` up to `character` — PyPI's
+/// dependency entries are TOML string-array elements (`"pytes`), a different quoting
+/// shape from JSON-quoted keys.
+///
+/// Returns an empty prefix when the cursor sits right after an already-closed value
+/// (`"pytest"`), rather than unconditionally stripping quotes on either side:
+/// [`PypiEcosystem::completion_insert_text`]'s fallback arm always bare-inserts the
+/// package name, so reporting a prefix for an already-closed value would fire a
+/// registry search and bare-insert the result straight into the manifest text next to
+/// it, producing invalid TOML (`"pytest"pytest-cov`, #734) — the same defect class as
+/// #729 for npm/Composer's JSON keys, just without a key-vs-value split since a TOML
+/// array element has no `:` clause to disambiguate.
+///
+/// Uses [`deps_core::fallback_completion::count_real_quotes`]'s escape-aware
+/// quote-parity check directly rather than
+/// [`deps_core::fallback_completion::open_quoted_tail`]: a *zero* real-quote count
+/// (the opening quote not typed yet — a realistic mid-edit state, since the fallback
+/// path only runs on parse failure) must return `prefix` unchanged, matching this
+/// function's pre-#734 no-op behavior on unquoted text, not the empty string
+/// `open_quoted_tail` returns for that count. Only a non-zero, even count (a genuinely
+/// closed value) suppresses the prefix.
 fn extract_prefix(line: &str, character: u32) -> &str {
-    deps_core::fallback_completion::raw_prefix(line, character).trim_matches('"')
+    let prefix = deps_core::fallback_completion::raw_prefix(line, character);
+    let (count, last_quote) = deps_core::fallback_completion::count_real_quotes(prefix);
+    if count == 0 {
+        return prefix;
+    }
+    if count.is_multiple_of(2) {
+        return "";
+    }
+    // `count` odd (so >= 1) guarantees `count_real_quotes` found a real quote; `"` is
+    // a single-byte ASCII char, so `pos + 1` is always a char boundary.
+    #[allow(clippy::string_slice)]
+    last_quote.map_or("", |pos| &prefix[pos + 1..])
 }
 
 /// Whether `target` is safe to resolve into a clickable `DocumentLink`.
@@ -2018,10 +2046,35 @@ dependencies = []
         assert_eq!(extract_prefix(line, line.len() as u32), "flas");
     }
 
+    /// No quote typed yet at all (zero real-quote count) must return the raw prefix
+    /// unchanged, not empty — a still-reachable mid-edit state (e.g. a bare
+    /// `requests` line under `[project.optional-dependencies]` before the user has
+    /// typed the opening quote), and the pre-#734 no-op behavior on unquoted text.
+    /// Regression guard: routing this case through
+    /// `open_quoted_tail`'s `None` would wrongly collapse it to `""`, suppressing
+    /// completion entirely.
     #[test]
-    fn test_extract_prefix_strips_trailing_quote() {
+    fn test_extract_prefix_no_quote_returns_unchanged() {
+        let line = "    req";
+        assert_eq!(extract_prefix(line, line.len() as u32), "req");
+    }
+
+    /// #734: the cursor sits right after an already-closed value (both quotes
+    /// present) — reporting `"pytest"` here would fire a registry search and
+    /// bare-insert the result right next to it, producing invalid TOML
+    /// (`"pytest"pytest-cov`). Must fall back to an empty prefix instead.
+    #[test]
+    fn test_extract_prefix_closed_value_is_empty() {
         let line = "    \"pytest\"";
-        assert_eq!(extract_prefix(line, line.len() as u32), "pytest");
+        assert_eq!(extract_prefix(line, line.len() as u32), "");
+    }
+
+    /// The escaped `\"` inside the value must not be counted as a real delimiter,
+    /// otherwise this would misclassify a still-open value as closed.
+    #[test]
+    fn test_extract_prefix_skips_escaped_quote() {
+        let line = "    \"py\\\"te";
+        assert_eq!(extract_prefix(line, line.len() as u32), "py\\\"te");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- PyPI's raw-text fallback completion trimmed a surviving quote unconditionally, so a cursor placed right after an already-closed `pyproject.toml` array value (e.g. `"pytest"`) still reported it as an insertable prefix, corrupting the manifest with a bare-inserted registry match (e.g. `"pytest"pytest-cov`)
- Adds a shared escape-aware quote-parity primitive in `deps-core` (`count_real_quotes` / `open_quoted_tail`) and uses it in PyPI's `extract_prefix` to distinguish a genuinely open string from an already-closed one, falling back to an empty prefix (suppressed by the existing `prefix.is_empty()` guard) for a closed value
- The same primitive fixes the identical escaped-quote gap in Cargo's `extract_feature_prefix`, which counted every literal quote including escaped ones instead of tracking real string open/close state
- Consolidated with #732 (merged during this PR's review): `strip_open_json_key` now builds on the same shared `count_real_quotes` instead of keeping its own private near-duplicate copy

## Review history

- impl-critic found and this PR fixes: a regression where the zero-quote case (no opening quote typed yet) was wrongly collapsed to an empty prefix, silently killing completion for a legitimate mid-edit state; an inverted doc-comment describing the wrong quote counts
- Automated correctness review found and this PR fixes: inconsistent backticking of a same-repo issue reference in `CHANGELOG.md`; a missing `# Examples` doctest on `count_real_quotes`
- Two pre-existing, out-of-scope issues noted for follow-up (not fixed here to keep this PR focused): PyPI's fallback completion still bare-inserts an unquoted name when no opening quote exists at all (same old behavior, not a regression); `deps-gradle`'s `ecosystem.rs` still has its own naive, non-escape-aware quote counter

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4777 passed)
- [x] `cargo test --workspace --doc --all-features`
- [x] Strict rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`)
- [x] New regression tests: PyPI closed-value bare-insert corruption, PyPI zero-quote no-op preservation, Cargo `extract_feature_prefix` escaped-quote handling

Closes #734
Closes #733