### PR TITLE
fix(deps-pypi): quote fallback completion inserts when no opening quote exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: property tests (`proptest`) asserting the parser depth/expansion checkers and JSONC position recovery never panic on arbitrary input (#673)
 
 ### Fixed
-- **deps-pypi**: raw-text fallback completion no longer bare-inserts an unquoted package name into a `pyproject.toml` dependency array when no quote has been typed yet, producing invalid TOML (resolves #737)
+- **deps-pypi**: raw-text fallback completion no longer bare-inserts an unquoted package name into a `pyproject.toml` dependency array when no quote has been typed yet, producing invalid TOML (resolves #737) (#741)
 - **deps-pypi**: raw-text fallback completion no longer bare-inserts a package name right after an already-closed `pyproject.toml` TOML array value, via a shared escape-aware quote-parity check in `deps-core` (now the single implementation backing #732's `strip_open_json_key` too) — also fixes the same escaped-quote gap in Cargo's `extract_feature_prefix` (resolves #734, #733)
 - **deps-core, deps-npm, deps-composer**: npm/Composer raw-text fallback completion no longer inserts a duplicate-quoted key-value pair when the cursor is already inside an open JSON key string (resolves #729) (#732)
 - **deps-core** + all 9 lock-file providers: lock-file parsing now runs on the blocking-thread pool via a shared `read_and_parse_lockfile` helper, no longer stalling the LSP request worker (resolves #723) (#730)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: property tests (`proptest`) asserting the parser depth/expansion checkers and JSONC position recovery never panic on arbitrary input (#673)
 
 ### Fixed
+- **deps-pypi**: raw-text fallback completion no longer bare-inserts an unquoted package name into a `pyproject.toml` dependency array when no quote has been typed yet, producing invalid TOML (resolves #737)
 - **deps-pypi**: raw-text fallback completion no longer bare-inserts a package name right after an already-closed `pyproject.toml` TOML array value, via a shared escape-aware quote-parity check in `deps-core` (now the single implementation backing #732's `strip_open_json_key` too) — also fixes the same escaped-quote gap in Cargo's `extract_feature_prefix` (resolves #734, #733)
 - **deps-core, deps-npm, deps-composer**: npm/Composer raw-text fallback completion no longer inserts a duplicate-quoted key-value pair when the cursor is already inside an open JSON key string (resolves #729) (#732)
 - **deps-core** + all 9 lock-file providers: lock-file parsing now runs on the blocking-thread pool via a shared `read_and_parse_lockfile` helper, no longer stalling the LSP request worker (resolves #723) (#730)

--- a/crates/deps-core/src/ecosystem.rs
+++ b/crates/deps-core/src/ecosystem.rs
@@ -848,8 +848,9 @@ pub trait Ecosystem: Send + Sync + private::Sealed {
 
     /// Whether the prefix [`Self::fallback_completion_prefix`] just returned for this
     /// `content`/`position` sits inside manifest markup that can only safely hold the
-    /// bare candidate text — an already-open XML tag or attribute value — rather than
-    /// [`Self::completion_insert_text`]'s normal full snippet.
+    /// bare candidate text — an already-open XML tag/attribute value, JSON object key,
+    /// or TOML quoted string — rather than [`Self::completion_insert_text`]'s normal
+    /// full snippet.
     ///
     /// Inserting the full snippet where markup is already open would nest a duplicate
     /// copy of it (issue #724, the original NuGet report: `Include="Newt` accepting a
@@ -860,11 +861,12 @@ pub trait Ecosystem: Send + Sync + private::Sealed {
     /// when it returns `true`.
     ///
     /// Default `false`: correct for every ecosystem whose manifest syntax has no
-    /// concept of "already open" markup around a fallback-completion cursor (i.e. every
-    /// ecosystem but Maven and NuGet today). Not required, like
-    /// [`Self::fallback_completion_prefix`]: a missing override only means a future
-    /// XML-shaped ecosystem always gets the full-snippet insert, a feature gap rather
-    /// than #118's "silently wrong syntax" failure mode.
+    /// concept of "already open" markup around a fallback-completion cursor. Overridden
+    /// today by Maven/NuGet (XML tag/attribute), npm/Composer (JSON object key), and
+    /// PyPI (TOML quoted string). Not required, like [`Self::fallback_completion_prefix`]:
+    /// a missing override only means a future markup-shaped ecosystem always gets the
+    /// full-snippet insert, a feature gap rather than #118's "silently wrong syntax"
+    /// failure mode.
     fn fallback_completion_is_bare(&self, _content: &str, _position: Position) -> bool {
         false
     }

--- a/crates/deps-pypi/src/ecosystem.rs
+++ b/crates/deps-pypi/src/ecosystem.rs
@@ -400,12 +400,34 @@ impl Ecosystem for PypiEcosystem {
         Some(extract_prefix(line, position.character))
     }
 
+    fn fallback_completion_is_bare(&self, content: &str, position: Position) -> bool {
+        // A genuinely still-open quoted string — an odd, escape-aware real-quote count
+        // via `open_quoted_tail` (the same primitive `extract_prefix` uses below, so
+        // the two methods always agree on the same `content`/`position`) — means the
+        // opening quote already exists in the manifest: the bare package name is the
+        // correct insert there, same as today. Zero real quotes (nothing typed yet, or
+        // only an escaped `\"`) means nothing has opened a quote to insert into: e.g.
+        // `req` alone on its own line under `dependencies = [...]`.
+        // `completion_insert_text` must then supply both quotes itself, or the
+        // fallback insert produces an unquoted, invalid TOML array element (#737). An
+        // already-closed value (an even, non-zero count, e.g. `"pytest"`) also reports
+        // `false` here, but that state is unreachable in practice: `extract_prefix`
+        // already collapses it to an empty prefix, which the caller rejects before
+        // this method is ever invoked.
+        let Some(line) = deps_core::fallback_completion::line_at(content, position) else {
+            return false;
+        };
+        let raw = deps_core::fallback_completion::raw_prefix(line, position.character);
+        deps_core::fallback_completion::open_quoted_tail(raw).is_some()
+    }
+
     fn completion_insert_text(&self, metadata: &dyn deps_core::Metadata) -> Option<String> {
-        // Both real PEP 621 shapes (`dependencies = [...]` and an
-        // `[project.optional-dependencies]` group) are TOML string-array elements, not
-        // a key=value table entry like Cargo's — the surrounding quotes already exist
-        // in the manifest (or the user is still typing them).
-        Some(metadata.name().to_string())
+        // Only reached when `fallback_completion_is_bare` reports no quote typed at
+        // all — see that method. Both real PEP 621 shapes (`dependencies = [...]` and
+        // an `[project.optional-dependencies]` group) are TOML string-array elements,
+        // not a key=value table entry like Cargo's, so the full insert here is the
+        // quoted array element itself rather than a `key = value` pair.
+        Some(format!("\"{}\"", metadata.name()))
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -533,6 +555,12 @@ fn is_dependencies_array_start(trimmed: &str) -> bool {
 /// function's pre-#734 no-op behavior on unquoted text, not the empty string
 /// `open_quoted_tail` returns for that count. Only a non-zero, even count (a genuinely
 /// closed value) suppresses the prefix.
+///
+/// Only tracks `"` (TOML basic strings), not `'` (TOML literal strings, e.g.
+/// `'requests'`) — deliberately out of scope: `crate::name::normalize`'s query never
+/// strips a `'`, so a prefix containing one never matches a real (apostrophe-free)
+/// PyPI project name, and the registry search that would drive a bare/wrapped insert
+/// never returns a result to insert in the first place.
 fn extract_prefix(line: &str, character: u32) -> &str {
     let prefix = deps_core::fallback_completion::raw_prefix(line, character);
     let (count, last_quote) = deps_core::fallback_completion::count_real_quotes(prefix);
@@ -2112,7 +2140,7 @@ dependencies = []
     }
 
     #[test]
-    fn test_completion_insert_text_bare_string() {
+    fn test_completion_insert_text_quotes_the_name() {
         let cache = Arc::new(deps_core::HttpCache::new());
         let ecosystem = PypiEcosystem::new(cache);
         let meta = MockMetadata {
@@ -2121,14 +2149,14 @@ dependencies = []
         };
         assert_eq!(
             ecosystem.completion_insert_text(&meta),
-            Some("requests".to_string())
+            Some("\"requests\"".to_string())
         );
     }
 
     /// A dotted PyPI name (`zope.interface`) has no TOML-key-injection meaning once
-    /// the insert is a bare array-element string, unlike Cargo's key=value shape.
+    /// the insert is a quoted array-element string, unlike Cargo's key=value shape.
     #[test]
-    fn test_completion_insert_text_dotted_name_stays_bare_string() {
+    fn test_completion_insert_text_dotted_name_stays_quoted_string() {
         let cache = Arc::new(deps_core::HttpCache::new());
         let ecosystem = PypiEcosystem::new(cache);
         let meta = MockMetadata {
@@ -2137,7 +2165,119 @@ dependencies = []
         };
         assert_eq!(
             ecosystem.completion_insert_text(&meta),
-            Some("zope.interface".to_string())
+            Some("\"zope.interface\"".to_string())
+        );
+    }
+
+    /// #737: zero quotes typed at all (`req` alone on its own line under
+    /// `dependencies = [...]`) must not be reported as bare — otherwise the fallback
+    /// path bare-inserts the unquoted name straight into the TOML array.
+    #[test]
+    fn test_fallback_completion_is_bare_false_with_no_quote_typed() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = PypiEcosystem::new(cache);
+        let content = "[project]\ndependencies = [\n    \"pytest\",\n    req\n]\n";
+        let line = content.lines().nth(3).unwrap();
+        let position = Position::new(3, line.chars().count() as u32);
+        assert!(!eco.fallback_completion_is_bare(content, position));
+    }
+
+    /// An already-open quote (`"req`, mid-typing) must still route to the bare insert
+    /// — this is the pre-#737 behavior and must not regress.
+    #[test]
+    fn test_fallback_completion_is_bare_true_with_open_quote() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = PypiEcosystem::new(cache);
+        let content = "[project]\ndependencies = [\n    \"req";
+        let line = content.lines().nth(2).unwrap();
+        let position = Position::new(2, line.chars().count() as u32);
+        assert!(eco.fallback_completion_is_bare(content, position));
+    }
+
+    /// Same two states as the primary PEP 621 `dependencies = [...]` array, exercised
+    /// against `[project.optional-dependencies]` instead — coverage gap flagged in
+    /// #737 validation: only the primary array branch was previously tested.
+    #[test]
+    fn test_fallback_completion_is_bare_false_with_no_quote_typed_optional_dependencies() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = PypiEcosystem::new(cache);
+        let content = "[project.optional-dependencies]\ndev = [\n    \"pytest\",\n    req\n]\n";
+        let line = content.lines().nth(3).unwrap();
+        let position = Position::new(3, line.chars().count() as u32);
+        assert!(!eco.fallback_completion_is_bare(content, position));
+    }
+
+    #[test]
+    fn test_fallback_completion_is_bare_true_with_open_quote_optional_dependencies() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = PypiEcosystem::new(cache);
+        let content = "[project.optional-dependencies]\ndev = [\n    \"req";
+        let line = content.lines().nth(2).unwrap();
+        let position = Position::new(2, line.chars().count() as u32);
+        assert!(eco.fallback_completion_is_bare(content, position));
+    }
+
+    /// #737 critic S1: a `\"` preceded by an odd backslash run is an *escaped* quote,
+    /// not a real one — `count_real_quotes`/`open_quoted_tail` correctly report zero
+    /// real quotes here, so this must still route through `completion_insert_text`
+    /// (quoted insert), not the bare path. A naive `.contains('"')` check would
+    /// wrongly report `true` since the literal `"` character is present in the text.
+    #[test]
+    fn test_fallback_completion_is_bare_false_with_only_escaped_quote() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = PypiEcosystem::new(cache);
+        let content = "[project]\ndependencies = [\n    \\\"req";
+        let line = content.lines().nth(2).unwrap();
+        let position = Position::new(2, line.chars().count() as u32);
+        assert!(!eco.fallback_completion_is_bare(content, position));
+    }
+
+    /// #737 validation gap: multiple entries on one line, cursor after a bare trailing
+    /// candidate following an already-CLOSED quoted entry
+    /// (`dependencies = ["pytest", req]`). A naive `.contains('"')` check on the raw
+    /// line prefix would wrongly report `true` — the prior entry's quotes still appear
+    /// in the prefix — routing to bare-insert and reproducing #737's exact corruption
+    /// in a different manifest shape. `open_quoted_tail`'s escape-aware parity check
+    /// correctly reports `false` (an even, non-zero quote count means no string is
+    /// currently open).
+    #[test]
+    fn test_fallback_completion_is_bare_false_with_multiple_deps_same_line() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = PypiEcosystem::new(cache);
+        let content = "[project]\ndependencies = [\"pytest\", req]\n";
+        let cursor = "dependencies = [\"pytest\", req";
+        let position = Position::new(1, cursor.chars().count() as u32);
+        assert!(!eco.fallback_completion_is_bare(content, position));
+    }
+
+    /// Same shape, with an escaped quote inside the prior closed entry — must not
+    /// misclassify the escape as a still-open string either.
+    #[test]
+    fn test_fallback_completion_is_bare_false_with_escaped_quote_in_prior_closed_entry_same_line() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = PypiEcosystem::new(cache);
+        let content = "[project]\ndependencies = [\"a\\\"b\", req]\n";
+        let cursor = "dependencies = [\"a\\\"b\", req";
+        let position = Position::new(1, cursor.chars().count() as u32);
+        assert!(!eco.fallback_completion_is_bare(content, position));
+    }
+
+    /// #737 critic S2: pins the trait default `fallback_bare_insert_text` (bare
+    /// `metadata.name()`) as the correct behavior for PyPI's open-quote case — PyPI has
+    /// no override, unlike Maven's `group:artifact` split, so this must not regress
+    /// silently if a future change adds one. Mirrors npm/Composer's own
+    /// `test_fallback_bare_insert_text_default_is_bare_name` (#729/#732).
+    #[test]
+    fn test_fallback_bare_insert_text_default_is_bare_name() {
+        let cache = Arc::new(deps_core::HttpCache::new());
+        let eco = PypiEcosystem::new(cache);
+        let meta = MockMetadata {
+            name: pkg("requests"),
+            latest_version: "2.31.0".into(),
+        };
+        assert_eq!(
+            eco.fallback_bare_insert_text(&meta),
+            Some("requests".to_string())
         );
     }
 }


### PR DESCRIPTION
## Summary

- Fallback-completion accepting a completion when the cursor sits after text with zero real quotes typed at all (e.g. `req` under `dependencies = [...]` in a `pyproject.toml` with a parse error active elsewhere) previously bare-inserted the package name, producing invalid TOML.
- `completion_insert_text` now wraps the inserted name in quotes by default; a `fallback_completion_is_bare` override routes to the existing bare-insert path only when a quote is already open around the cursor.
- The "already open quote" detection reuses the shared, escape-aware `open_quoted_tail` primitive (introduced in #736) instead of a naive `.contains('"')` check, so it agrees with `extract_prefix`'s own classification and doesn't misfire on closed/escaped quotes earlier in the same line (e.g. a prior dependency entry on the same line).

## Test plan

- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4785 passed)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- [x] `cargo test --workspace --doc --all-features`
- [x] New tests cover: the exact issue repro, the already-open-quote non-regression case, same-line multi-dependency entries, escaped quotes in a prior closed entry, `[project.optional-dependencies]`, and the `fallback_bare_insert_text` trait default.

Closes #737