### PR TITLE
docs(workspace): enforce missing_docs and document 287 previously-undocumented public items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-composer, deps-nuget**: extracted the duplicated lenient string-or-string-array JSON deserializer into a shared `deps_core::json_helpers::deserialize_string_or_string_array` helper (resolves #662) (#665)
 - **deps-core, deps-lsp**: documented NuGet's bare-version pin approximation and added a cross-ecosystem consistency test guarding `bare_requirement_policy` (resolves #669) (#674)
 - **workspace**: removed 18 unused dependencies across 11 crates and moved 3 test-only dependencies to `[dev-dependencies]` (touching a 12th crate, `deps-gitlab-ci`); added a `cargo machete` CI gate (resolves #670) (#675)
-- **workspace**: `missing_docs` lint raised from `allow` to `warn` in `[workspace.lints.rust]`; added the ~287 previously-missing `///`/`//!` doc comments across all 14 ecosystem crates plus `deps-core`/`deps-lsp` needed to make the flip clean (resolves #744)
+- **workspace**: `missing_docs` lint raised from `allow` to `warn` in `[workspace.lints.rust]`; added the ~287 previously-missing `///`/`//!` doc comments across all 14 ecosystem crates plus `deps-core`/`deps-lsp` needed to make the flip clean (resolves #744) (#746)
 
 ### Dependencies
 - Bump `dirs` from 6 to 7.0.0, plus transitive `Cargo.lock` refresh (#659)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-composer, deps-nuget**: extracted the duplicated lenient string-or-string-array JSON deserializer into a shared `deps_core::json_helpers::deserialize_string_or_string_array` helper (resolves #662) (#665)
 - **deps-core, deps-lsp**: documented NuGet's bare-version pin approximation and added a cross-ecosystem consistency test guarding `bare_requirement_policy` (resolves #669) (#674)
 - **workspace**: removed 18 unused dependencies across 11 crates and moved 3 test-only dependencies to `[dev-dependencies]` (touching a 12th crate, `deps-gitlab-ci`); added a `cargo machete` CI gate (resolves #670) (#675)
+- **workspace**: `missing_docs` lint raised from `allow` to `warn` in `[workspace.lints.rust]`; added the ~287 previously-missing `///`/`//!` doc comments across all 14 ecosystem crates plus `deps-core`/`deps-lsp` needed to make the flip clean (resolves #744)
 
 ### Dependencies
 - Bump `dirs` from 6 to 7.0.0, plus transitive `Cargo.lock` refresh (#659)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ zeroize = "1.9"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"
-missing_docs = "allow"
+missing_docs = "warn"
 missing_debug_implementations = "allow"
 unreachable_pub = "warn"
 

--- a/crates/deps-bundler/src/parser.rs
+++ b/crates/deps-bundler/src/parser.rs
@@ -14,9 +14,13 @@ use tower_lsp_server::ls_types::{Range, Uri};
 /// Result of parsing a Gemfile.
 #[derive(Debug, Clone)]
 pub struct BundlerParseResult {
+    /// Dependencies found in the `Gemfile`.
     pub dependencies: Vec<BundlerDependency>,
+    /// The `ruby` directive's version constraint, if declared.
     pub ruby_version: Option<String>,
+    /// The top-level `source` URL, if declared.
     pub source_url: Option<String>,
+    /// URI of the manifest this result was parsed from.
     pub uri: Uri,
 }
 

--- a/crates/deps-bundler/src/types.rs
+++ b/crates/deps-bundler/src/types.rs
@@ -6,13 +6,21 @@ use tower_lsp_server::ls_types::Range;
 /// Parsed dependency from Gemfile with position tracking.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BundlerDependency {
+    /// Gem name.
     pub name: deps_core::PackageName,
+    /// Document range of the gem name, for hover/diagnostic positioning.
     pub name_range: Range,
+    /// Version requirement, if the `Gemfile` specifies one.
     pub version_req: Option<deps_core::VersionReq>,
+    /// Document range of the version requirement string.
     pub version_range: Option<Range>,
+    /// Which `Gemfile` group this gem was declared under.
     pub group: DependencyGroup,
+    /// Where this gem resolves from (rubygems, git, path, etc.).
     pub source: DependencySource,
+    /// Platform constraints from a `platforms:` argument, if any.
     pub platforms: Vec<String>,
+    /// The `require:` argument, if the gem specifies a custom require path.
     pub require: Option<String>,
 }
 
@@ -37,8 +45,11 @@ pub enum DependencyGroup {
 /// Version information for a gem from rubygems.org.
 #[derive(Debug, Clone)]
 pub struct BundlerVersion {
+    /// The parsed version number.
     pub number: deps_core::ConcreteVersion,
+    /// Whether rubygems.org marks this version as a prerelease.
     pub prerelease: bool,
+    /// Whether this version has been yanked from rubygems.org.
     pub yanked: bool,
     /// Publish timestamp, parsed eagerly from the API's `created_at` field.
     ///
@@ -46,6 +57,7 @@ pub struct BundlerVersion {
     /// RFC 3339 — degrades gracefully, per
     /// [US-003](https://github.com/bug-ops/deps-lsp/issues/145).
     pub published_at: Option<deps_core::PublishTime>,
+    /// Target platform string (e.g. `"ruby"`, `"x86_64-linux"`).
     pub platform: String,
 }
 
@@ -59,14 +71,23 @@ impl BundlerVersion {
 /// Gem metadata from rubygems.org.
 #[derive(Debug, Clone)]
 pub struct GemInfo {
+    /// Gem name.
     pub name: deps_core::PackageName,
+    /// Short gem description.
     pub info: Option<String>,
+    /// Homepage URL.
     pub homepage_uri: Option<String>,
+    /// Source repository URL.
     pub source_code_uri: Option<String>,
+    /// Documentation URL.
     pub documentation_uri: Option<String>,
+    /// Latest published version.
     pub version: deps_core::ConcreteVersion,
+    /// SPDX license identifiers declared for this gem.
     pub licenses: Vec<String>,
+    /// Author names, as a single comma-separated string.
     pub authors: Option<String>,
+    /// Total download count reported by rubygems.org.
     pub downloads: u64,
 }
 

--- a/crates/deps-cargo/src/formatter.rs
+++ b/crates/deps-cargo/src/formatter.rs
@@ -29,6 +29,7 @@ impl RequirementMatcher for SemverMatcher {
     }
 }
 
+/// [`EcosystemFormatter`](deps_core::lsp_helpers::EcosystemFormatter) implementation for Cargo.
 pub struct CargoFormatter;
 
 impl PackageNaming for CargoFormatter {

--- a/crates/deps-cargo/src/lib.rs
+++ b/crates/deps-cargo/src/lib.rs
@@ -31,11 +31,13 @@
 
 pub mod config;
 pub mod ecosystem;
+/// Version formatting and comparison for Cargo (SemVer caret ranges).
 pub mod formatter;
 pub mod lockfile;
 pub mod parser;
 pub mod registry;
 pub mod sparse;
+/// Domain types for Cargo dependencies (parsed `Cargo.toml` entries, crates.io versions).
 pub mod types;
 
 // Re-export commonly used types

--- a/crates/deps-cargo/src/types.rs
+++ b/crates/deps-cargo/src/types.rs
@@ -38,12 +38,19 @@ pub struct ParsedDependency {
     /// otherwise the actual crate name. Always the position anchor for
     /// [`Self::name_range`], regardless of renaming.
     pub name: deps_core::PackageName,
+    /// Document range of the TOML table key, for hover/diagnostic positioning.
     pub name_range: Range,
+    /// Version requirement, if the manifest specifies one.
     pub version_req: Option<deps_core::VersionReq>,
+    /// Document range of the version requirement string.
     pub version_range: Option<Range>,
+    /// Feature flags requested via `features = [...]`.
     pub features: Vec<String>,
+    /// Document range of the `features` array, if present.
     pub features_range: Option<Range>,
+    /// Where this dependency resolves from (registry, git, path, etc.).
     pub source: DependencySource,
+    /// Which `Cargo.toml` section this dependency was declared under.
     pub section: DependencySection,
     /// The real crate name from an explicit `package = "..."` key
     /// ([renaming dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml)),
@@ -113,8 +120,11 @@ pub enum DependencySection {
 /// ```
 #[derive(Debug, Clone)]
 pub struct CargoVersion {
+    /// The parsed version number.
     pub num: deps_core::ConcreteVersion,
+    /// Whether this version has been yanked from crates.io.
     pub yanked: bool,
+    /// Available feature flags mapped to the other features/deps they enable.
     pub features: HashMap<String, Vec<String>>,
     /// Publish timestamp, parsed from the sparse index's `pubtime` field.
     ///
@@ -146,10 +156,15 @@ pub struct CargoVersion {
 /// ```
 #[derive(Debug, Clone)]
 pub struct CrateInfo {
+    /// Crate name.
     pub name: deps_core::PackageName,
+    /// Short crate description.
     pub description: Option<String>,
+    /// Source repository URL.
     pub repository: Option<String>,
+    /// Documentation URL.
     pub documentation: Option<String>,
+    /// Latest (highest) published version.
     pub max_version: deps_core::ConcreteVersion,
 }
 

--- a/crates/deps-composer/src/lib.rs
+++ b/crates/deps-composer/src/lib.rs
@@ -4,10 +4,12 @@
 //! for PHP projects.
 
 pub mod ecosystem;
+/// Version formatting and comparison for Composer (PHP semver-style ranges).
 pub mod formatter;
 pub mod lockfile;
 pub mod parser;
 pub mod registry;
+/// Domain types for Composer dependencies (parsed `composer.json` entries, Packagist versions).
 pub mod types;
 
 pub use ecosystem::ComposerEcosystem;

--- a/crates/deps-composer/src/parser.rs
+++ b/crates/deps-composer/src/parser.rs
@@ -18,7 +18,9 @@ use tower_lsp_server::ls_types::Uri;
 /// Contains all non-platform dependencies found in the file with their positions.
 #[derive(Debug)]
 pub struct ComposerParseResult {
+    /// Non-platform dependencies found in the manifest.
     pub dependencies: Vec<ComposerDependency>,
+    /// URI of the manifest this result was parsed from.
     pub uri: Uri,
     /// Raw value of the manifest's own top-level `minimum-stability` field (e.g. `"beta"`),
     /// if present — Composer's project-wide default stability floor, one of `dev`, `alpha`,

--- a/crates/deps-composer/src/types.rs
+++ b/crates/deps-composer/src/types.rs
@@ -24,10 +24,15 @@ use tower_lsp_server::ls_types::Range;
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ComposerDependency {
+    /// Package name (`vendor/package`).
     pub name: deps_core::PackageName,
+    /// Document range of the package name, for hover/diagnostic positioning.
     pub name_range: Range,
+    /// Version requirement, if the manifest specifies one.
     pub version_req: Option<deps_core::VersionReq>,
+    /// Document range of the version requirement string.
     pub version_range: Option<Range>,
+    /// Which `composer.json` section this dependency was declared under.
     pub section: ComposerSection,
 }
 
@@ -79,8 +84,11 @@ pub enum ComposerSection {
 /// ```
 #[derive(Debug, Clone)]
 pub struct ComposerVersion {
+    /// The parsed version number.
     pub version: deps_core::ConcreteVersion,
+    /// Packagist's normalized 4-part version string (e.g. `"6.0.0.0"`).
     pub version_normalized: String,
+    /// Whether Packagist marks this package/version as abandoned.
     pub abandoned: bool,
     /// Package-level deprecation payload (issue #205), derived from Packagist's
     /// `abandoned` field. `Some(Deprecation { reason: None, replacement: None })` for a
@@ -256,10 +264,15 @@ deps_core::impl_version!(ComposerVersion {
 /// ```
 #[derive(Debug, Clone)]
 pub struct ComposerPackage {
+    /// Package name (`vendor/package`).
     pub name: deps_core::PackageName,
+    /// Short package description.
     pub description: Option<String>,
+    /// Source repository URL.
     pub repository: Option<String>,
+    /// Homepage URL.
     pub homepage: Option<String>,
+    /// Latest published version.
     pub latest_version: deps_core::ConcreteVersion,
 }
 

--- a/crates/deps-core/src/cache.rs
+++ b/crates/deps-core/src/cache.rs
@@ -1,3 +1,11 @@
+//! HTTP response cache shared by every ecosystem's registry client.
+//!
+//! Wraps outbound registry requests with RFC 7232 conditional-request
+//! validation (`ETag`/`If-None-Match`, `Last-Modified`/`If-Modified-Since`) so
+//! that unchanged registry data is served from a bounded in-memory cache
+//! instead of re-fetched. Entry count and total retained bytes are both
+//! capped to keep memory use predictable under long-running LSP sessions.
+
 use crate::error::{DepsError, Result};
 use crate::net_policy::{RegistryAccessPolicy, WorkspaceRegistryAccess};
 use bytes::{Bytes, BytesMut};
@@ -681,9 +689,13 @@ async fn read_body_capped(url: &str, mut response: Response, limit: BodyLimit) -
 /// ```
 #[derive(Debug, Clone)]
 pub struct CachedResponse {
+    /// Raw response body, shareable across consumers without copying.
     pub body: Bytes,
+    /// `ETag` header from the response, used for `If-None-Match` revalidation.
     pub etag: Option<String>,
+    /// `Last-Modified` header from the response, used for `If-Modified-Since` revalidation.
     pub last_modified: Option<String>,
+    /// Local time the response was fetched, used for TTL expiry checks.
     pub fetched_at: Instant,
 }
 

--- a/crates/deps-core/src/ecosystem.rs
+++ b/crates/deps-core/src/ecosystem.rs
@@ -12,10 +12,18 @@ use crate::{
     registry::Metadata,
 };
 
+/// Sealing mechanism restricting [`Ecosystem`] implementations to this workspace.
 pub mod private {
+    /// Marker trait that only crates inside this workspace can implement.
+    ///
+    /// [`Ecosystem`](super::Ecosystem) requires `Self: Sealed`, which is how the
+    /// trait stays extensible (new default methods can be added without
+    /// breaking downstream implementors) while still forbidding external
+    /// crates from implementing it.
     pub trait Sealed {}
 }
 
+/// A boxed, type-erased future used throughout the [`Ecosystem`] trait's async methods.
 pub type BoxFuture<'a, T> = Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
 
 /// Canonical, exhaustive identifier for every package ecosystem the workspace supports.

--- a/crates/deps-core/src/error.rs
+++ b/crates/deps-core/src/error.rs
@@ -39,20 +39,27 @@ fn http_status_message(status: u16, url: &str) -> String {
 /// ```
 #[derive(Error, Debug)]
 pub enum DepsError {
+    /// A manifest or lockfile failed to parse.
     #[error("failed to parse {file_type}: {source}")]
     ParseError {
+        /// Ecosystem/file kind being parsed (e.g. `"Cargo.toml"`), for the error message.
         file_type: String,
+        /// The underlying parser error.
         #[source]
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
+    /// A registry HTTP request failed at the transport layer.
     #[error("registry request failed for {package}: {source}")]
     RegistryError {
+        /// Name of the package the request was for.
         package: String,
+        /// The underlying `reqwest` error.
         #[source]
         source: reqwest::Error,
     },
 
+    /// The cache layer itself failed (e.g. a poisoned lock), independent of any registry request.
     #[error("cache error: {0}")]
     CacheError(String),
 
@@ -61,27 +68,49 @@ pub enum DepsError {
     /// per-dependency diagnostic (see [`Self::fetch_failure`]) — never build one from a raw
     /// registry error body, which can embed the caller's public IP (`github.rs:332-346`).
     #[error("{message}")]
-    RateLimited { message: String },
+    RateLimited {
+        /// Pre-vetted, IP-free message safe to surface verbatim in a diagnostic.
+        message: String,
+    },
 
+    /// A package name was not found on the given registry.
     #[error("{package} not found on {registry}")]
     PackageNotFound {
+        /// Name of the package that was looked up.
         package: String,
+        /// Name of the registry that reported the package as missing.
         registry: &'static str,
     },
 
+    /// A registry HTTP request returned a non-success status code.
     #[error("{}", http_status_message(*status, url))]
-    HttpStatus { url: String, status: u16 },
+    HttpStatus {
+        /// URL that was requested.
+        url: String,
+        /// HTTP status code returned.
+        status: u16,
+    },
 
+    /// A registry's response body failed to deserialize as JSON.
     #[error("failed to parse {registry} response for {package}: {source}")]
     ApiResponse {
+        /// Name of the package whose response failed to parse.
         package: String,
+        /// Name of the registry the response came from.
         registry: &'static str,
+        /// The underlying JSON deserialization error.
         #[source]
         source: serde_json::Error,
     },
 
+    /// A response body exceeded the configured size cap and was rejected before full download.
     #[error("response body for {url} exceeds {limit} byte limit")]
-    ResponseTooLarge { url: String, limit: usize },
+    ResponseTooLarge {
+        /// URL the oversized response came from.
+        url: String,
+        /// The size cap, in bytes, that was exceeded.
+        limit: usize,
+    },
 
     /// Deliberately shared between two distinct rejection kinds: malformed version-requirement
     /// strings (all ecosystems) and malformed Go module paths (`deps-go`, which has no separate
@@ -91,18 +120,23 @@ pub enum DepsError {
     #[error("invalid version requirement: {0}")]
     InvalidVersionReq(String),
 
+    /// A filesystem I/O operation failed.
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 
+    /// A JSON parsing operation failed outside of a registry response context.
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
 
+    /// The manifest file's ecosystem could not be determined from any registered router.
     #[error("unsupported ecosystem: {0}")]
     UnsupportedEcosystem(String),
 
+    /// More than one ecosystem's routing rules matched the same manifest path.
     #[error("ambiguous ecosystem detection for file: {0}")]
     AmbiguousEcosystem(String),
 
+    /// A URI supplied by the client or a manifest could not be parsed.
     #[error("invalid URI: {0}")]
     InvalidUri(String),
 
@@ -110,7 +144,10 @@ pub enum DepsError {
     /// `network.offline` is set, instead of attempting the request. `url` is the request
     /// that was blocked, for diagnostic/logging purposes.
     #[error("offline: request to {url} was blocked by network.offline")]
-    Offline { url: String },
+    Offline {
+        /// The request URL that was blocked.
+        url: String,
+    },
 
     /// A multi-hop alternate/private-index chain's resolution was halted because a hop
     /// returned a genuine transport error (5xx, timeout, connection failure) rather than a

--- a/crates/deps-core/src/github.rs
+++ b/crates/deps-core/src/github.rs
@@ -326,6 +326,7 @@ impl GithubTagsClient {
 /// GitHub tags API response item.
 #[derive(Debug, Default, Deserialize)]
 pub struct GithubTag {
+    /// The tag name (e.g. `"v1.2.3"`).
     pub name: String,
     /// The tagged commit. Defaults when the field is absent so fixtures that omit it (or
     /// omit `commit.sha` within it) still deserialize — callers that need the SHA (e.g.
@@ -337,6 +338,7 @@ pub struct GithubTag {
 /// The `commit` object nested in a [`GithubTag`].
 #[derive(Debug, Default, Deserialize)]
 pub struct GithubTagCommit {
+    /// The full commit SHA the tag points at.
     #[serde(default)]
     pub sha: String,
 }

--- a/crates/deps-core/src/lib.rs
+++ b/crates/deps-core/src/lib.rs
@@ -21,11 +21,16 @@
     clippy::cast_precision_loss,
     clippy::cast_sign_loss
 )]
+/// HTTP response cache with `ETag`/`Last-Modified` conditional-request validation.
 pub mod cache;
 pub mod completion;
 pub mod deps_dev;
+/// The [`ecosystem::Ecosystem`] trait: the sealed extension point every package
+/// ecosystem crate implements to plug into the LSP server.
 pub mod ecosystem;
+/// Routes a manifest path to its owning [`ecosystem::Ecosystem`] implementation.
 pub mod ecosystem_registry;
+/// Unified error types (`DepsError`, `FetchFailure`) shared across ecosystems.
 pub mod error;
 pub mod fallback_completion;
 pub mod freshness;
@@ -42,7 +47,11 @@ pub mod net_policy;
 pub mod osv;
 pub mod package;
 pub mod pagination;
+/// Shared manifest-parsing helpers: bounded JSON/TOML/YAML nesting checks and
+/// depth-limited parsing used by every ecosystem's manifest parser.
 pub mod parser;
+/// The [`registry::Registry`] trait: version lookup and search that every
+/// ecosystem's registry client implements.
 pub mod registry;
 pub mod secret;
 #[cfg(any(test, feature = "test-util"))]

--- a/crates/deps-core/src/lsp_helpers/hover.rs
+++ b/crates/deps-core/src/lsp_helpers/hover.rs
@@ -63,6 +63,12 @@ const HOVER_FALLBACK_TIMEOUT: std::time::Duration = std::time::Duration::from_se
 /// and risking drift between the two.
 pub const CMD_DOT_FOOTER: &str = "\n---\n⌨️ **Press `Cmd+.` to update version**";
 
+/// Builds the hover response for the dependency under `position`, if any.
+///
+/// Shared by every ecosystem's default [`crate::ecosystem::Ecosystem::generate_hover`]
+/// implementation: locates the dependency whose name or version range contains
+/// `position`, resolves its version data against `registry`, and renders the
+/// result through `formatter`. Returns `None` when no dependency covers the position.
 pub async fn generate_hover<R: Registry + ?Sized>(
     parse_result: &dyn ParseResult,
     position: Position,

--- a/crates/deps-core/src/lsp_helpers/inlay_hints.rs
+++ b/crates/deps-core/src/lsp_helpers/inlay_hints.rs
@@ -4,6 +4,12 @@ use crate::{ConcreteVersion, EcosystemConfig, ParseResult};
 
 use super::{EcosystemFormatter, RequirementStatus, VersionData, in_use_version};
 
+/// Builds inlay hints showing the latest/in-use version next to each dependency's declaration.
+///
+/// Shared by every ecosystem's default
+/// [`crate::ecosystem::Ecosystem::generate_inlay_hints`] implementation: one hint is
+/// emitted per dependency that has a version range, using `versions` and
+/// `loading_state` to decide whether cached data is ready to render yet.
 pub fn generate_inlay_hints(
     parse_result: &dyn ParseResult,
     versions: VersionData<'_>,

--- a/crates/deps-core/src/parser.rs
+++ b/crates/deps-core/src/parser.rs
@@ -921,19 +921,29 @@ pub enum DependencySource {
 
     /// Git repository dependency.
     Git {
+        /// Repository URL.
         url: String,
         /// Git ref: commit SHA, tag, or branch name (ecosystem-specific semantics).
         rev: Option<String>,
     },
 
     /// Local filesystem path dependency.
-    Path { path: String },
+    Path {
+        /// Filesystem path, relative or absolute, as written in the manifest.
+        path: String,
+    },
 
     /// Direct URL to artifact (PyPI wheels, npm tarballs).
-    Url { url: String },
+    Url {
+        /// URL the artifact is fetched from.
+        url: String,
+    },
 
     /// SDK-provided dependency (Dart: `sdk: flutter`).
-    Sdk { sdk: String },
+    Sdk {
+        /// Name of the SDK providing this dependency.
+        sdk: String,
+    },
 
     /// Workspace-inherited dependency (Cargo: `workspace = true`).
     Workspace,
@@ -952,7 +962,10 @@ pub enum DependencySource {
     /// carrying `user:pass@` userinfo that fails to resolve lands here verbatim. Currently
     /// latent — nothing renders `CustomRegistry::url` in hover/diagnostics text today — but a
     /// future caller surfacing it must redact first, matching every logging call site.
-    CustomRegistry { url: String },
+    CustomRegistry {
+        /// Unresolved alias or raw index URL, never redacted (see the variant's own doc).
+        url: String,
+    },
 
     /// A custom/alternative registry resolved to a concrete, fetchable index URL.
     ///

--- a/crates/deps-dart/src/ecosystem.rs
+++ b/crates/deps-dart/src/ecosystem.rs
@@ -12,12 +12,14 @@ use deps_core::{
 use crate::formatter::DartFormatter;
 use crate::registry::PubDevRegistry;
 
+/// [`Ecosystem`] implementation for Dart/Pub (`pubspec.yaml`).
 pub struct DartEcosystem {
     registry: Arc<PubDevRegistry>,
     formatter: DartFormatter,
 }
 
 impl DartEcosystem {
+    /// Creates a Dart ecosystem instance backed by the given shared HTTP cache.
     pub fn new(cache: Arc<deps_core::HttpCache>) -> Self {
         Self {
             registry: Arc::new(PubDevRegistry::new(cache)),

--- a/crates/deps-dart/src/formatter.rs
+++ b/crates/deps-dart/src/formatter.rs
@@ -36,6 +36,7 @@ impl RequirementMatcher for PubDevMatcher {
     }
 }
 
+/// [`EcosystemFormatter`](deps_core::lsp_helpers::EcosystemFormatter) implementation for Dart/Pub.
 pub struct DartFormatter;
 
 impl PackageNaming for DartFormatter {

--- a/crates/deps-dart/src/lockfile.rs
+++ b/crates/deps-dart/src/lockfile.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 use tower_lsp_server::ls_types::Uri;
 use yaml_rust2::{Yaml, YamlLoader};
 
+/// [`LockFileProvider`] implementation for `pubspec.lock`.
 pub struct PubspecLockParser;
 
 impl PubspecLockParser {
@@ -36,6 +37,12 @@ impl LockFileProvider for PubspecLockParser {
     }
 }
 
+/// Parses a `pubspec.lock` file's resolved package versions.
+///
+/// # Errors
+///
+/// Returns [`DepsError::ParseError`] if the YAML nesting depth exceeds the
+/// configured limit or the content is not valid YAML.
 pub fn parse_pubspec_lock(content: &str) -> Result<ResolvedPackages> {
     if let Err(depth) =
         deps_core::check_yaml_nesting_depth(content, deps_core::MAX_YAML_NESTING_DEPTH)

--- a/crates/deps-dart/src/parser.rs
+++ b/crates/deps-dart/src/parser.rs
@@ -7,13 +7,23 @@ use std::any::Any;
 use tower_lsp_server::ls_types::{Range, Uri};
 use yaml_rust2::{Yaml, YamlLoader};
 
+/// Result of parsing a `pubspec.yaml` file.
 #[derive(Debug, Clone)]
 pub struct DartParseResult {
+    /// Dependencies found across all sections.
     pub dependencies: Vec<DartDependency>,
+    /// The `environment: sdk:` constraint string, if declared.
     pub sdk_constraint: Option<String>,
+    /// URI of the manifest this result was parsed from.
     pub uri: Uri,
 }
 
+/// Parses a `pubspec.yaml` document into a [`DartParseResult`].
+///
+/// # Errors
+///
+/// Returns [`DepsError::ParseError`] if the YAML nesting depth or expanded
+/// size exceeds the configured limits, or if the content is not valid YAML.
 pub fn parse_pubspec_yaml(content: &str, doc_uri: &Uri) -> Result<DartParseResult> {
     if let Err(depth) =
         deps_core::check_yaml_nesting_depth(content, deps_core::MAX_YAML_NESTING_DEPTH)

--- a/crates/deps-dart/src/registry.rs
+++ b/crates/deps-dart/src/registry.rs
@@ -54,6 +54,7 @@ fn reject_dot_segment(name: &str) -> Result<()> {
     Ok(())
 }
 
+/// pub.dev registry client implementing [`deps_core::Registry`] for Dart/Pub.
 #[derive(Clone)]
 pub struct PubDevRegistry {
     cache: Arc<HttpCache>,
@@ -64,6 +65,7 @@ pub struct PubDevRegistry {
 }
 
 impl PubDevRegistry {
+    /// Creates a client backed by the given shared HTTP cache, pointed at the real pub.dev API.
     pub fn new(cache: Arc<HttpCache>) -> Self {
         Self {
             cache,
@@ -78,6 +80,12 @@ impl PubDevRegistry {
         Self { cache, base }
     }
 
+    /// Fetches all published versions of a package from pub.dev.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `name` is a dot-segment, the request fails, or the
+    /// response body fails to parse.
     #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_versions(&self, name: &str) -> Result<Vec<DartVersion>> {
         reject_dot_segment(name)?;
@@ -86,6 +94,11 @@ impl PubDevRegistry {
         parse_versions_response(&data)
     }
 
+    /// Returns the newest non-retracted version of `name` matching `req_str`, if any.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if fetching the package's versions fails.
     #[tracing::instrument(skip_all, fields(package = ?name, version = ?req_str), level = "debug")]
     pub async fn get_latest_matching(
         &self,
@@ -98,6 +111,11 @@ impl PubDevRegistry {
         }))
     }
 
+    /// Searches pub.dev for packages matching `query`, returning at most `limit` results.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the search request fails or its response body fails to parse.
     #[tracing::instrument(skip_all, fields(query = ?query), level = "debug")]
     pub async fn search(&self, query: &str, limit: usize) -> Result<Vec<PackageInfo>> {
         let url = format!("{}/search?q={}", self.base, urlencoding::encode(query));
@@ -124,6 +142,12 @@ impl PubDevRegistry {
         Ok(results)
     }
 
+    /// Fetches package metadata (description, homepage, license, etc.) from pub.dev.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `name` is a dot-segment, the request fails, or the
+    /// response body fails to parse.
     #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_package_info(&self, name: &str) -> Result<PackageInfo> {
         reject_dot_segment(name)?;

--- a/crates/deps-dart/src/types.rs
+++ b/crates/deps-dart/src/types.rs
@@ -3,32 +3,46 @@
 use std::any::Any;
 use tower_lsp_server::ls_types::Range;
 
+/// A single dependency declaration parsed from a `pubspec.yaml`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DartDependency {
+    /// Package name.
     pub name: deps_core::PackageName,
+    /// Document range of the package name, for hover/diagnostic positioning.
     pub name_range: Range,
+    /// Version requirement, if the manifest specifies one.
     pub version_req: Option<deps_core::VersionReq>,
+    /// Document range of the version requirement string.
     pub version_range: Option<Range>,
+    /// Which `pubspec.yaml` section this dependency was declared under.
     pub section: DependencySection,
+    /// Where this dependency resolves from (registry, git, path, etc.).
     pub source: DependencySource,
     /// Dart-specific Git sub-path (e.g., `path: packages/pkg` inside a repo).
     /// Only meaningful when `source` is `DependencySource::Git`.
     pub git_path: Option<String>,
 }
 
+/// Which `pubspec.yaml` top-level section a dependency was declared under.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum DependencySection {
+    /// The `dependencies:` section.
     #[default]
     Dependencies,
+    /// The `dev_dependencies:` section.
     DevDependencies,
+    /// The `dependency_overrides:` section.
     DependencyOverrides,
 }
 
 pub use deps_core::parser::DependencySource;
 
+/// A single published version of a Dart/Pub package.
 #[derive(Debug, Clone)]
 pub struct DartVersion {
+    /// The parsed version number.
     pub version: deps_core::ConcreteVersion,
+    /// Whether pub.dev has retracted this version.
     pub retracted: bool,
     /// Publish timestamp, parsed eagerly from the API's `published` field.
     ///
@@ -38,14 +52,22 @@ pub struct DartVersion {
     pub published_at: Option<deps_core::PublishTime>,
 }
 
+/// Package metadata as returned by the pub.dev API.
 #[derive(Debug, Clone)]
 pub struct PackageInfo {
+    /// Package name.
     pub name: deps_core::PackageName,
+    /// Short package description.
     pub description: Option<String>,
+    /// Homepage URL.
     pub homepage: Option<String>,
+    /// Source repository URL.
     pub repository: Option<String>,
+    /// Documentation URL.
     pub documentation: Option<String>,
+    /// Latest published version.
     pub version: deps_core::ConcreteVersion,
+    /// SPDX license identifier, if declared.
     pub license: Option<String>,
 }
 

--- a/crates/deps-gitlab-ci/src/client.rs
+++ b/crates/deps-gitlab-ci/src/client.rs
@@ -98,7 +98,9 @@ pub fn gitlab_rate_limit_error() -> DepsError {
 /// GitLab tags API response item (`GET /projects/:id/repository/tags`).
 #[derive(Debug, Default, Deserialize)]
 pub struct GitlabTag {
+    /// The tag name (e.g. `"v1.2.3"`).
     pub name: String,
+    /// The tagged commit.
     #[serde(default)]
     pub commit: GitlabCommit,
 }
@@ -106,9 +108,12 @@ pub struct GitlabTag {
 /// GitLab releases API response item (`GET /projects/:id/releases`).
 #[derive(Debug, Default, Deserialize)]
 pub struct GitlabRelease {
+    /// The release's associated tag name.
     pub tag_name: String,
+    /// The tagged commit.
     #[serde(default)]
     pub commit: GitlabCommit,
+    /// When the release was published, if GitLab reports it.
     #[serde(default)]
     pub released_at: Option<String>,
 }
@@ -116,6 +121,7 @@ pub struct GitlabRelease {
 /// The `commit` object nested in a [`GitlabTag`]/[`GitlabRelease`].
 #[derive(Debug, Default, Deserialize)]
 pub struct GitlabCommit {
+    /// The full commit SHA the tag/release points at.
     #[serde(default)]
     pub id: String,
 }

--- a/crates/deps-gitlab-ci/src/registry.rs
+++ b/crates/deps-gitlab-ci/src/registry.rs
@@ -77,7 +77,9 @@ impl RateLimitGate {
 /// from the wrong repository.
 #[derive(Debug, Default)]
 pub struct TagIndex {
+    /// Maps a tag/release name to its resolved commit SHA.
     pub tag_to_sha: std::collections::HashMap<String, String>,
+    /// Maps a commit SHA back to the tag/release name that resolved to it.
     pub sha_to_tag: std::collections::HashMap<String, String>,
 }
 

--- a/crates/deps-go/src/lib.rs
+++ b/crates/deps-go/src/lib.rs
@@ -30,6 +30,7 @@
 
 pub mod config;
 pub mod ecosystem;
+/// Version formatting and comparison for Go modules (semver, pseudo-versions, `+incompatible`).
 pub mod formatter;
 pub mod lockfile;
 pub mod parser;

--- a/crates/deps-gradle/src/ecosystem.rs
+++ b/crates/deps-gradle/src/ecosystem.rs
@@ -12,6 +12,8 @@ use deps_maven::MavenCentralRegistry;
 
 use crate::formatter::GradleFormatter;
 
+/// [`Ecosystem`] implementation for Gradle (`build.gradle`/`build.gradle.kts`), reusing
+/// Maven Central resolution via [`MavenCentralRegistry`].
 pub struct GradleEcosystem {
     registry: Arc<MavenCentralRegistry>,
     formatter: GradleFormatter,
@@ -26,6 +28,7 @@ pub struct GradleEcosystem {
 }
 
 impl GradleEcosystem {
+    /// Creates a Gradle ecosystem instance backed by the given shared HTTP cache.
     pub fn new(cache: Arc<deps_core::HttpCache>) -> Self {
         Self {
             registry: Arc::new(MavenCentralRegistry::new(Arc::clone(&cache))),

--- a/crates/deps-gradle/src/formatter.rs
+++ b/crates/deps-gradle/src/formatter.rs
@@ -8,6 +8,7 @@ use deps_core::{
     ConcreteVersion, InvalidPackageName, PackageName, VersionReq, is_safe_maven_coordinate_segment,
 };
 
+/// [`EcosystemFormatter`](deps_core::lsp_helpers::EcosystemFormatter) implementation for Gradle.
 pub struct GradleFormatter;
 
 /// Unresolved Gradle variable reference (`$var`, `${var}`), or an explicit empty

--- a/crates/deps-gradle/src/parser/catalog.rs
+++ b/crates/deps-gradle/src/parser/catalog.rs
@@ -9,6 +9,12 @@ use std::collections::HashMap;
 use toml_span::value::{Table, Value};
 use tower_lsp_server::ls_types::{Range, Uri};
 
+/// Parses a Gradle version catalog (`gradle/libs.versions.toml`) into a [`GradleParseResult`].
+///
+/// # Errors
+///
+/// Returns [`DepsError::ParseError`] if the TOML nesting depth exceeds the
+/// configured limit or the content is not valid TOML.
 pub fn parse_version_catalog(content: &str, uri: &Uri) -> Result<GradleParseResult> {
     if let Err(depth) =
         deps_core::check_toml_nesting_depth(content, deps_core::MAX_TOML_NESTING_DEPTH)

--- a/crates/deps-gradle/src/parser/groovy.rs
+++ b/crates/deps-gradle/src/parser/groovy.rs
@@ -103,6 +103,10 @@ fn extract_matches(
     }
 }
 
+/// Parses a Groovy-DSL `build.gradle` file into a [`GradleParseResult`].
+///
+/// Always succeeds: unrecognized lines are simply skipped. Returns [`Result`]
+/// only to match the shared parser signature every ecosystem implements.
 pub fn parse_groovy_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
     let mut dependencies = Vec::new();
 

--- a/crates/deps-gradle/src/parser/kotlin.rs
+++ b/crates/deps-gradle/src/parser/kotlin.rs
@@ -42,6 +42,10 @@ static RE_PLATFORM_NO_VERSION: LazyLock<Regex> = LazyLock::new(|| {
     .expect("RE_PLATFORM_NO_VERSION")
 });
 
+/// Parses a Kotlin-DSL `build.gradle.kts` file into a [`GradleParseResult`].
+///
+/// Always succeeds: unrecognized lines are simply skipped. Returns [`Result`]
+/// only to match the shared parser signature every ecosystem implements.
 pub fn parse_kotlin_dsl(content: &str, uri: &Uri) -> Result<GradleParseResult> {
     let mut dependencies = Vec::new();
 

--- a/crates/deps-gradle/src/parser/mod.rs
+++ b/crates/deps-gradle/src/parser/mod.rs
@@ -131,9 +131,12 @@ pub(crate) fn build_dependency(
     }
 }
 
+/// Result of parsing a Gradle build script, settings file, or version catalog.
 #[derive(Debug)]
 pub struct GradleParseResult {
+    /// Dependencies found in the file.
     pub dependencies: Vec<GradleDependency>,
+    /// URI of the manifest this result was parsed from.
     pub uri: Uri,
 }
 
@@ -164,6 +167,14 @@ fn resolve_variable_ref(value: &str, properties: &HashMap<String, String>) -> Op
     }
 }
 
+/// Parses a Gradle file, dispatching to the catalog/settings/Kotlin-DSL/Groovy-DSL
+/// parser based on its filename, then resolves `$var`/`${var}` property references
+/// for build files.
+///
+/// # Errors
+///
+/// Returns an error if the file's dedicated parser fails (e.g. malformed TOML for
+/// a version catalog).
 pub fn parse_gradle(content: &str, uri: &Uri) -> Result<GradleParseResult> {
     let path = uri.path().to_string();
     let mut result = if path.ends_with("libs.versions.toml") {

--- a/crates/deps-gradle/src/types.rs
+++ b/crates/deps-gradle/src/types.rs
@@ -5,14 +5,20 @@ use tower_lsp_server::ls_types::Range;
 
 pub use deps_maven::MavenVersion as GradleVersion;
 
+/// A single dependency declaration parsed from a Gradle build script.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GradleDependency {
+    /// Maven `groupId`.
     pub group_id: String,
+    /// Maven `artifactId`.
     pub artifact_id: String,
     /// Canonical identifier: "{groupId}:{artifactId}"
     pub name: deps_core::PackageName,
+    /// Document range of the coordinate, for hover/diagnostic positioning.
     pub name_range: Range,
+    /// Version requirement, if the build script specifies one.
     pub version_req: Option<deps_core::VersionReq>,
+    /// Document range of the version string.
     pub version_range: Option<Range>,
     /// Gradle configuration (e.g. "implementation", "api", "testImplementation")
     pub configuration: String,

--- a/crates/deps-lsp/build.rs
+++ b/crates/deps-lsp/build.rs
@@ -1,3 +1,6 @@
+//! Build script that captures the current git commit hash and build timestamp
+//! as `GIT_HASH`/`BUILD_TIME` environment variables, surfaced by `--version`.
+
 fn main() {
     let hash = std::process::Command::new("git")
         .args(["rev-parse", "--short", "HEAD"])

--- a/crates/deps-lsp/src/config.rs
+++ b/crates/deps-lsp/src/config.rs
@@ -33,26 +33,37 @@ use tower_lsp_server::ls_types::DiagnosticSeverity;
 #[derive(Debug, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct DepsConfig {
+    /// Inline version-annotation settings.
     #[serde(default)]
     pub inlay_hints: InlayHintsConfig,
+    /// Diagnostic severity and behavior settings.
     #[serde(default)]
     pub diagnostics: DiagnosticsConfig,
+    /// HTTP response cache settings.
     #[serde(default)]
     pub cache: CacheConfig,
+    /// Cold-start disk-load behavior settings.
     #[serde(default)]
     pub cold_start: ColdStartConfig,
+    /// Loading-indicator (spinner/progress) settings.
     #[serde(default)]
     pub loading_indicator: LoadingIndicatorConfig,
+    /// Code lens (update-all action) settings.
     #[serde(default)]
     pub code_lens: CodeLensConfig,
+    /// Release-cooldown / freshness-window settings.
     #[serde(default)]
     pub freshness: FreshnessConfig,
+    /// Supply-chain trust signal (Scorecard/SLSA) settings.
     #[serde(default)]
     pub supply_chain: SupplyChainConfig,
+    /// Custom/alternate registry settings.
     #[serde(default)]
     pub registries: RegistriesConfig,
+    /// Network access and offline-mode settings.
     #[serde(default)]
     pub network: NetworkConfig,
+    /// License policy (allow/deny list) settings.
     #[serde(default)]
     pub license_policy: LicensePolicyConfig,
 }
@@ -83,10 +94,13 @@ pub struct DepsConfig {
 /// ```
 #[derive(Debug, Clone, Deserialize)]
 pub struct InlayHintsConfig {
+    /// Whether inlay hints are shown at all.
     #[serde(default = "default_true")]
     pub enabled: bool,
+    /// Text shown when the dependency is already at the latest version.
     #[serde(default = "default_up_to_date")]
     pub up_to_date_text: String,
+    /// Text shown when an update is available; `{}` is replaced with the latest version.
     #[serde(default = "default_needs_update")]
     pub needs_update_text: String,
 }
@@ -137,12 +151,16 @@ impl Default for InlayHintsConfig {
 /// ```
 #[derive(Debug, Clone, Deserialize)]
 pub struct DiagnosticsConfig {
+    /// Severity for a dependency with a newer version available.
     #[serde(default = "default_outdated_severity")]
     pub outdated_severity: DiagnosticSeverity,
+    /// Severity for a dependency not found in the registry.
     #[serde(default = "default_unknown_severity")]
     pub unknown_severity: DiagnosticSeverity,
+    /// Severity for a dependency pinned to a yanked/retracted version.
     #[serde(default = "default_yanked_severity")]
     pub yanked_severity: DiagnosticSeverity,
+    /// Severity for a dependency whose requirement matches zero published versions.
     #[serde(default = "default_unsatisfiable_severity")]
     pub unsatisfiable_severity: DiagnosticSeverity,
     /// Severity for a dependency on a package the registry reports as
@@ -484,8 +502,10 @@ where
 /// ```
 #[derive(Debug, Clone, Deserialize)]
 pub struct ColdStartConfig {
+    /// Whether cold-start disk loading is enabled at all.
     #[serde(default = "default_true")]
     pub enabled: bool,
+    /// Minimum delay in milliseconds between cold-start registry fetches for the same URI.
     #[serde(default = "default_rate_limit_ms")]
     pub rate_limit_ms: u64,
 }
@@ -519,6 +539,7 @@ const fn default_rate_limit_ms() -> u64 {
 /// ```
 #[derive(Debug, Clone, Deserialize)]
 pub struct CodeLensConfig {
+    /// Whether the "Update N outdated dependencies" code lens is shown at all.
     #[serde(default = "default_true")]
     pub enabled: bool,
 }
@@ -558,6 +579,7 @@ impl Default for CodeLensConfig {
 /// ```
 #[derive(Debug, Clone, Deserialize)]
 pub struct FreshnessConfig {
+    /// Whether the release-cooldown freshness signal is enabled at all.
     #[serde(default = "default_true")]
     pub enabled: bool,
     /// Cooldown window in seconds, clamped to 0..=30 days (default: 3 days)
@@ -626,6 +648,7 @@ const fn default_cooldown_secs() -> u64 {
 /// ```
 #[derive(Debug, Clone, Deserialize)]
 pub struct SupplyChainConfig {
+    /// Whether supply-chain trust signals (OpenSSF Scorecard/SLSA provenance) are fetched.
     #[serde(default = "default_true")]
     pub enabled: bool,
 }
@@ -689,6 +712,8 @@ where
 /// ```
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct RegistriesConfig {
+    /// Whether workspace-declared registry hosts (e.g. a manifest's own custom index
+    /// URLs) may be reached at all, or only the default public registry.
     #[serde(default)]
     pub workspace_registries: WorkspaceRegistriesSetting,
     /// Issue #561, FR-006: whether a NuGet user-profile-tier `NuGet.Config` `<add>` with no

--- a/crates/deps-lsp/src/lib.rs
+++ b/crates/deps-lsp/src/lib.rs
@@ -1,8 +1,20 @@
+//! The `deps-lsp` binary crate: wires the 14 ecosystem crates into a running
+//! `tower-lsp-server` [`LanguageServer`](tower_lsp_server::LanguageServer)
+//! implementation.
+//!
+//! [`register_ecosystems`] registers every feature-enabled ecosystem crate
+//! against an [`EcosystemRegistry`], threading live-updatable settings
+//! ([`EcosystemRuntime`]) into the ones that need them. [`server::Backend`]
+//! is the `LanguageServer` implementation itself; `document` holds the
+//! per-document state machine driving hover/completion/diagnostics.
+
+/// Live configuration parsing and the config schema (`deny_unknown_fields`).
 pub mod config;
 pub mod document;
 pub mod file_watcher;
 pub mod handlers;
 pub mod progress;
+/// The `tower-lsp-server` [`LanguageServer`](tower_lsp_server::LanguageServer) implementation.
 pub mod server;
 
 #[cfg(test)]

--- a/crates/deps-lsp/src/main.rs
+++ b/crates/deps-lsp/src/main.rs
@@ -1,3 +1,6 @@
+//! Entry point for the `deps-lsp` binary: parses `--stdio`/`--version` flags,
+//! sets up `tracing` logging, and serves [`Backend`] over stdin/stdout.
+
 use deps_lsp::server::Backend;
 use std::env;
 use tower_lsp_server::{LspService, Server};

--- a/crates/deps-lsp/src/server.rs
+++ b/crates/deps-lsp/src/server.rs
@@ -103,6 +103,10 @@ async fn warn_if_gitlab_instance_host_invalid(
     }
 }
 
+/// The `tower-lsp-server` [`LanguageServer`] implementation for `deps-lsp`.
+///
+/// Holds the LSP client handle, per-document [`ServerState`], the live
+/// [`DepsConfig`], and the client's negotiated capabilities.
 pub struct Backend {
     pub(crate) client: Client,
     state: Arc<ServerState>,
@@ -111,6 +115,7 @@ pub struct Backend {
 }
 
 impl Backend {
+    /// Creates a new backend bound to the given LSP client handle.
     pub fn new(client: Client) -> Self {
         Self {
             client,

--- a/crates/deps-maven/src/ecosystem.rs
+++ b/crates/deps-maven/src/ecosystem.rs
@@ -18,6 +18,7 @@ use crate::formatter::MavenFormatter;
 use crate::registry::MavenCentralRegistry;
 use crate::types::ArtifactInfo;
 
+/// [`Ecosystem`] implementation for Maven (`pom.xml`).
 pub struct MavenEcosystem {
     registry: Arc<MavenCentralRegistry>,
     formatter: MavenFormatter,
@@ -110,6 +111,7 @@ fn build_deduped_field_completions(
 }
 
 impl MavenEcosystem {
+    /// Creates a Maven ecosystem instance backed by the given shared HTTP cache.
     pub fn new(cache: Arc<deps_core::HttpCache>) -> Self {
         Self {
             registry: Arc::new(MavenCentralRegistry::new(cache)),

--- a/crates/deps-maven/src/formatter.rs
+++ b/crates/deps-maven/src/formatter.rs
@@ -8,6 +8,7 @@ use deps_core::{
     ConcreteVersion, InvalidPackageName, PackageName, VersionReq, is_safe_maven_coordinate_segment,
 };
 
+/// [`EcosystemFormatter`](deps_core::lsp_helpers::EcosystemFormatter) implementation for Maven.
 pub struct MavenFormatter;
 
 /// Unexpanded property (missing from `<properties>`).

--- a/crates/deps-maven/src/parser.rs
+++ b/crates/deps-maven/src/parser.rs
@@ -16,10 +16,14 @@ use std::any::Any;
 use std::collections::HashMap;
 use tower_lsp_server::ls_types::{Range, Uri};
 
+/// Result of parsing a `pom.xml` file.
 #[derive(Debug)]
 pub struct MavenParseResult {
+    /// Dependencies found across `<dependencies>` and `<dependencyManagement>`.
     pub dependencies: Vec<MavenDependency>,
+    /// The `<properties>` section, for resolving `${...}` version placeholders.
     pub properties: HashMap<String, String>,
+    /// URI of the manifest this result was parsed from.
     pub uri: Uri,
 }
 
@@ -48,6 +52,11 @@ struct DepAccum {
     scope: Option<String>,
 }
 
+/// Parses a `pom.xml` document into a [`MavenParseResult`].
+///
+/// # Errors
+///
+/// Returns an error if the content is not well-formed XML.
 pub fn parse_pom_xml(content: &str, doc_uri: &Uri) -> Result<MavenParseResult> {
     let line_table = LineOffsetTable::new(content);
     let mut dependencies = Vec::new();

--- a/crates/deps-maven/src/registry.rs
+++ b/crates/deps-maven/src/registry.rs
@@ -259,6 +259,8 @@ fn attach_publish_times(versions: &mut [MavenVersion], times: &HashMap<String, P
     }
 }
 
+/// Registry client implementing [`deps_core::Registry`] for Maven, resolving artifacts
+/// against Maven Central, Google Maven, and the Gradle Plugin Portal in turn.
 #[derive(Clone)]
 pub struct MavenCentralRegistry {
     cache: Arc<HttpCache>,
@@ -275,6 +277,7 @@ pub struct MavenCentralRegistry {
 }
 
 impl MavenCentralRegistry {
+    /// Creates a client backed by the given shared HTTP cache.
     pub fn new(cache: Arc<HttpCache>) -> Self {
         Self {
             cache,
@@ -368,6 +371,12 @@ impl MavenCentralRegistry {
         self.get_versions_typed_with(name, false).await
     }
 
+    /// Returns the version matching `req` exactly, or the latest stable/release version
+    /// when `req` is empty or `"*"`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if fetching or parsing the artifact's metadata fails.
     #[tracing::instrument(skip_all, fields(package = ?name, version = ?req), level = "debug")]
     pub async fn get_latest_matching_typed(
         &self,

--- a/crates/deps-maven/src/types.rs
+++ b/crates/deps-maven/src/types.rs
@@ -3,26 +3,40 @@
 use std::any::Any;
 use tower_lsp_server::ls_types::Range;
 
+/// A single `<dependency>` declaration parsed from a `pom.xml`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MavenDependency {
+    /// Maven `groupId`.
     pub group_id: String,
+    /// Maven `artifactId`.
     pub artifact_id: String,
     /// Canonical identifier: "{groupId}:{artifactId}"
     pub name: deps_core::PackageName,
+    /// Document range of the coordinate, for hover/diagnostic positioning.
     pub name_range: Range,
+    /// Version requirement, if the `pom.xml` specifies one.
     pub version_req: Option<deps_core::VersionReq>,
+    /// Document range of the version string.
     pub version_range: Option<Range>,
+    /// Maven dependency scope (`compile`, `test`, `runtime`, etc.).
     pub scope: MavenScope,
 }
 
+/// Maven dependency scope (the `<scope>` element).
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum MavenScope {
+    /// Default scope: available in all classpaths, propagated to dependents.
     #[default]
     Compile,
+    /// Available only for test compilation and execution.
     Test,
+    /// Required at runtime but not for compilation.
     Runtime,
+    /// Expected to be provided by the JDK or a container at runtime.
     Provided,
+    /// System-path dependency (deprecated by Maven, but still declarable).
     System,
+    /// Imports the dependency management section of another POM (BOM).
     Import,
 }
 
@@ -41,8 +55,10 @@ impl std::str::FromStr for MavenScope {
     }
 }
 
+/// A single published version of a Maven artifact.
 #[derive(Debug, Clone)]
 pub struct MavenVersion {
+    /// The parsed version number.
     pub version: deps_core::ConcreteVersion,
     /// When this version was published, from the `repo1.maven.org` directory listing.
     ///
@@ -52,14 +68,20 @@ pub struct MavenVersion {
     pub published_at: Option<deps_core::PublishTime>,
 }
 
+/// Artifact metadata as returned by Maven Central's search API.
 #[derive(Debug, Clone)]
 pub struct ArtifactInfo {
+    /// Maven `groupId`.
     pub group_id: String,
+    /// Maven `artifactId`.
     pub artifact_id: String,
     /// "{groupId}:{artifactId}"
     pub name: deps_core::PackageName,
+    /// Short artifact description, if available.
     pub description: Option<String>,
+    /// Latest published version.
     pub latest_version: deps_core::ConcreteVersion,
+    /// Source repository URL, if known.
     pub repository: Option<String>,
 }
 

--- a/crates/deps-npm/src/formatter.rs
+++ b/crates/deps-npm/src/formatter.rs
@@ -41,6 +41,7 @@ fn is_url_friendly_segment(segment: &str) -> bool {
     })
 }
 
+/// [`EcosystemFormatter`](deps_core::lsp_helpers::EcosystemFormatter) implementation for npm.
 pub struct NpmFormatter;
 
 impl PackageNaming for NpmFormatter {

--- a/crates/deps-npm/src/lib.rs
+++ b/crates/deps-npm/src/lib.rs
@@ -6,10 +6,12 @@
 pub mod catalog;
 pub mod config;
 pub mod ecosystem;
+/// Version formatting and comparison for npm (node-semver ranges).
 pub mod formatter;
 pub mod lockfile;
 pub mod parser;
 pub mod registry;
+/// Domain types for npm dependencies (parsed `package.json` entries, registry versions).
 pub mod types;
 
 pub use catalog::{CatalogOrigin, CatalogOutcome, PnpmWorkspaceCache};
@@ -33,4 +35,5 @@ pub use parser::{NpmParseResult, parse_package_json, parse_package_json_with_con
 pub use registry::{NpmRegistry, package_url};
 pub use types::{NpmDependency, NpmDependencySection, NpmPackage, NpmVersion};
 
+/// npm's version-requirement range type (a node-semver range, e.g. `"^1.2.0"`).
 pub type NpmVersionReq = node_semver::Range;

--- a/crates/deps-npm/src/parser.rs
+++ b/crates/deps-npm/src/parser.rs
@@ -18,7 +18,9 @@ use tower_lsp_server::ls_types::Uri;
 /// Contains all dependencies found in the file with their positions.
 #[derive(Debug)]
 pub struct NpmParseResult {
+    /// Dependencies found across all `package.json` sections.
     pub dependencies: Vec<NpmDependency>,
+    /// URI of the manifest this result was parsed from.
     pub uri: Uri,
     /// Every `.npmrc`-resolved alternate registry this parse's dependencies reference,
     /// deduplicated (spec FR-002–004) — fed to `NpmRegistry::register_alternate` by

--- a/crates/deps-npm/src/types.rs
+++ b/crates/deps-npm/src/types.rs
@@ -34,9 +34,13 @@ pub struct NpmDependency {
     /// alias value), otherwise the actual registry package name. Always the position anchor
     /// for [`Self::name_range`], regardless of aliasing.
     pub name: deps_core::PackageName,
+    /// Document range of the JSON key, for hover/diagnostic positioning.
     pub name_range: Range,
+    /// Version requirement, if the manifest specifies one.
     pub version_req: Option<deps_core::VersionReq>,
+    /// Document range of the version requirement string.
     pub version_range: Option<Range>,
+    /// Which `package.json` section this dependency was declared under.
     pub section: NpmDependencySection,
     /// Resolved by `.npmrc` lookup (spec `032-npm-npmrc-registry-support`) — `Registry`
     /// (the public default) unless a `registry=`/`@scope:registry=` entry applies.
@@ -143,7 +147,9 @@ pub enum NpmDependencySection {
 /// ```
 #[derive(Debug, Clone)]
 pub struct NpmVersion {
+    /// The parsed version number.
     pub version: deps_core::ConcreteVersion,
+    /// Whether the packument marks this version as deprecated.
     pub deprecated: bool,
     /// Package-level deprecation payload (issue #205), derived from the packument's
     /// `deprecated` free-text field. `None` whenever `deprecated` is absent, `null`, or
@@ -197,10 +203,15 @@ deps_core::impl_version!(NpmVersion {
 /// ```
 #[derive(Debug, Clone)]
 pub struct NpmPackage {
+    /// Package name.
     pub name: deps_core::PackageName,
+    /// Short package description.
     pub description: Option<String>,
+    /// Homepage URL.
     pub homepage: Option<String>,
+    /// Source repository URL.
     pub repository: Option<String>,
+    /// Latest published version.
     pub latest_version: deps_core::ConcreteVersion,
 }
 

--- a/crates/deps-nuget/src/config.rs
+++ b/crates/deps-nuget/src/config.rs
@@ -302,7 +302,9 @@ pub struct InvalidEntry {
 /// every comparison against it goes through `key_candidates`).
 #[derive(Debug, Clone)]
 pub struct PackageSourceEntry {
+    /// The declared `<add key>` name, case preserved.
     pub key: String,
+    /// The resolved feed URL, or why it was rejected.
     pub value: Result<NuGetFeedUrl, InvalidEntry>,
     /// Which tier's file last set [`Self::value`] (issue #561) — diagnostics/gating metadata
     /// only, see [`ConfigTier`]'s doc for the "never a credential gate" invariant.
@@ -321,6 +323,7 @@ pub struct PackageSourceEntry {
 /// disagree with.
 #[derive(Debug, Clone)]
 pub struct ResolvedHop {
+    /// The resolved feed URL for this hop.
     pub url: NuGetFeedUrl,
     /// The lowercased declared `<add key>` that supplied [`Self::auth`], or `None` when this
     /// hop carries no credential. Used (not the credential value) by
@@ -1127,6 +1130,7 @@ fn upsert_source(
 /// the two caches' working-set sizes comparable without inventing a second tuning knob.
 const WARNED_CAPACITY: usize = deps_core::DEFAULT_MAX_CACHED_FILES;
 
+/// Per-`NuGet.Config`-file-path memoization cache (see the module doc above).
 #[derive(Debug)]
 pub struct NuGetConfigCache {
     files: deps_core::MtimeFileCache<RawNuGetConfigFile>,

--- a/crates/deps-nuget/src/ecosystem.rs
+++ b/crates/deps-nuget/src/ecosystem.rs
@@ -51,6 +51,7 @@ pub struct NuGetEcosystem {
 }
 
 impl NuGetEcosystem {
+    /// Creates a NuGet ecosystem instance with a default (unconfigured) parse context.
     pub fn new(cache: Arc<deps_core::HttpCache>) -> Self {
         Self::with_context(
             Arc::new(NuGetRegistry::new(cache)),

--- a/crates/deps-nuget/src/formatter.rs
+++ b/crates/deps-nuget/src/formatter.rs
@@ -46,6 +46,7 @@ impl RequirementMatcher for NuGetMatcher {
     }
 }
 
+/// [`EcosystemFormatter`](deps_core::lsp_helpers::EcosystemFormatter) implementation for NuGet.
 pub struct NuGetFormatter;
 
 impl PackageNaming for NuGetFormatter {

--- a/crates/deps-nuget/src/lockfile.rs
+++ b/crates/deps-nuget/src/lockfile.rs
@@ -31,6 +31,7 @@ use tower_lsp_server::ls_types::Uri;
 /// exact-name search already tried.
 const MAX_WORKSPACE_DEPTH: usize = 5;
 
+/// [`LockFileProvider`] implementation for `packages.lock.json`.
 pub struct NuGetLockParser;
 
 impl NuGetLockParser {

--- a/crates/deps-nuget/src/registry.rs
+++ b/crates/deps-nuget/src/registry.rs
@@ -421,6 +421,8 @@ fn reject_dot_segment(name: &str) -> Result<()> {
     Ok(())
 }
 
+/// Registry client implementing [`deps_core::Registry`] for NuGet, resolving packages
+/// against nuget.org's V3 service index and any workspace-declared alternate feeds.
 #[derive(Clone)]
 pub struct NuGetRegistry {
     cache: Arc<HttpCache>,
@@ -464,6 +466,7 @@ pub struct NuGetRegistry {
 }
 
 impl NuGetRegistry {
+    /// Creates a client backed by the given shared HTTP cache, pointed at nuget.org.
     pub fn new(cache: Arc<HttpCache>) -> Self {
         Self::with_service_index_url(cache, NUGET_ORG_INDEX_URL.to_string())
     }

--- a/crates/deps-nuget/src/types.rs
+++ b/crates/deps-nuget/src/types.rs
@@ -6,12 +6,15 @@ use tower_lsp_server::ls_types::{Range, Uri};
 /// A single `PackageReference` / `PackageVersion` / `package` entry from a manifest.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NuGetDependency {
+    /// Package name.
     pub name: deps_core::PackageName,
+    /// Document range of the package name, for hover/diagnostic positioning.
     pub name_range: Range,
     /// Absent when the manifest omits an explicit version — central package management
     /// entries and unresolvable MSBuild property expressions (`$(...)`) both degrade to
     /// `None` rather than a bogus or unresolved-looking requirement.
     pub version_requirement: Option<deps_core::VersionReq>,
+    /// Document range of the version string.
     pub version_range: Option<Range>,
     /// Resolved against the manifest's `NuGet.Config` `<packageSources>`/
     /// `<packageSourceMapping>` (issue #523) by `NuGetEcosystem::parse_manifest`, after
@@ -53,7 +56,9 @@ impl deps_core::Dependency for NuGetDependency {
 /// `packages.config`).
 #[derive(Debug)]
 pub struct NuGetParseResult {
+    /// Dependencies found in the manifest.
     pub dependencies: Vec<NuGetDependency>,
+    /// URI of the manifest this result was parsed from.
     pub uri: Uri,
     /// Every routing chain this manifest's resolved `NuGet.Config` implies (issue #523) — one
     /// per distinct `<packageSourceMapping>` hop-set, or the single plain accumulated chain
@@ -86,6 +91,7 @@ deps_core::impl_parse_result!(
 /// ecosystems with a structural (non-keyword) prerelease convention.
 #[derive(Debug, Clone)]
 pub struct NuGetVersion {
+    /// The parsed version number.
     pub version: deps_core::ConcreteVersion,
     /// Publish timestamp, populated only when `Registry::get_versions_with` is called with
     /// freshness enabled and the version was covered by the registration-hive walk.
@@ -113,10 +119,15 @@ impl deps_core::Version for NuGetVersion {
 /// Package metadata from a NuGet search result.
 #[derive(Debug, Clone)]
 pub struct PackageInfo {
+    /// Package name.
     pub name: deps_core::PackageName,
+    /// Short package description.
     pub description: Option<String>,
+    /// Source repository URL.
     pub repository: Option<String>,
+    /// Documentation URL.
     pub documentation: Option<String>,
+    /// Latest published version.
     pub latest_version: deps_core::ConcreteVersion,
 }
 

--- a/crates/deps-pypi/src/error.rs
+++ b/crates/deps-pypi/src/error.rs
@@ -16,18 +16,25 @@ use thiserror::Error;
 pub enum PypiError {
     /// Failed to parse pyproject.toml
     #[error("Failed to parse pyproject.toml: {message}")]
-    TomlParseError { message: String },
+    TomlParseError {
+        /// Description of the TOML parse failure.
+        message: String,
+    },
 
     /// Invalid PEP 508 dependency specification
     #[error("Invalid PEP 508 dependency specification: {source}")]
     InvalidDependencySpec {
+        /// The underlying PEP 508 parser error.
         #[source]
         source: pep508_rs::Pep508Error,
     },
 
     /// Unsupported dependency format
     #[error("Unsupported dependency format: {message}")]
-    UnsupportedFormat { message: String },
+    UnsupportedFormat {
+        /// Description of why the format is unsupported.
+        message: String,
+    },
 
     /// PEP 508 requirement string exceeded the length cap protecting against
     /// `pep508_rs`'s O(n²) extras-list parser (see
@@ -37,7 +44,12 @@ pub enum PypiError {
     /// two must be counted differently by heuristics like the
     /// `requirements.txt` "is this really a manifest" signal.
     #[error("requirement string too long: {len} bytes (max {max} bytes)")]
-    RequirementTooLong { len: usize, max: usize },
+    RequirementTooLong {
+        /// Length of the rejected requirement string, in bytes.
+        len: usize,
+        /// The length cap that was exceeded, in bytes.
+        max: usize,
+    },
 }
 
 /// Result type alias for PyPI operations.

--- a/crates/deps-pypi/src/formatter.rs
+++ b/crates/deps-pypi/src/formatter.rs
@@ -22,6 +22,7 @@ impl RequirementMatcher for Pep440Matcher {
     }
 }
 
+/// [`EcosystemFormatter`](deps_core::lsp_helpers::EcosystemFormatter) implementation for PyPI.
 pub struct PypiFormatter;
 
 impl PackageNaming for PypiFormatter {

--- a/crates/deps-pypi/src/lib.rs
+++ b/crates/deps-pypi/src/lib.rs
@@ -104,13 +104,16 @@
 
 pub mod config;
 pub mod ecosystem;
+/// PyPI/pyproject.toml-specific error types.
 pub mod error;
+/// Version formatting and comparison for PyPI (PEP 440 specifiers).
 pub mod formatter;
 pub mod lockfile;
 pub mod name;
 pub mod parser;
 pub mod registry;
 mod search;
+/// Domain types for PyPI dependencies (parsed manifest entries, PyPI JSON API versions).
 pub mod types;
 
 // Re-export commonly used types

--- a/crates/deps-pypi/src/types.rs
+++ b/crates/deps-pypi/src/types.rs
@@ -91,13 +91,22 @@ pub enum PypiDependencySection {
     /// PEP 621 runtime dependencies (`[project.dependencies]`)
     Dependencies,
     /// PEP 621 optional dependency group (`[project.optional-dependencies.{group}]`)
-    OptionalDependencies { group: String },
+    OptionalDependencies {
+        /// Name of the optional-dependency group.
+        group: String,
+    },
     /// PEP 735 dependency group (`[dependency-groups.{group}]`)
-    DependencyGroup { group: String },
+    DependencyGroup {
+        /// Name of the dependency group.
+        group: String,
+    },
     /// Poetry runtime dependencies (`[tool.poetry.dependencies]`)
     PoetryDependencies,
     /// Poetry dependency group (`[tool.poetry.group.{group}.dependencies]`)
-    PoetryGroup { group: String },
+    PoetryGroup {
+        /// Name of the Poetry dependency group.
+        group: String,
+    },
     /// A line in a `requirements.txt`- or `constraints.txt`-format file (pip's
     /// requirements file format). Both file kinds map to this single variant —
     /// nothing downstream distinguishes a constraint from a requirement.

--- a/crates/deps-swift/src/types.rs
+++ b/crates/deps-swift/src/types.rs
@@ -114,7 +114,9 @@ deps_core::impl_metadata!(SwiftPackage {
 /// Result of parsing a Package.swift file.
 #[derive(Debug)]
 pub struct SwiftParseResult {
+    /// Dependencies found in the `Package.swift` manifest.
     pub dependencies: Vec<SwiftDependency>,
+    /// URI of the manifest this result was parsed from.
     pub uri: tower_lsp_server::ls_types::Uri,
 }
 


### PR DESCRIPTION
## Summary
- Flip `missing_docs` from `allow` to `warn` in root `Cargo.toml`'s `[workspace.lints.rust]`, so the CI rustdoc gate (`RUSTFLAGS="-D warnings"`) now enforces the project's own rule that every `pub` item needs a `///`/`//!` doc comment, instead of relying on reviewers to catch drift by hand.
- Add the ~287 previously-missing doc comments this requires across all 14 ecosystem crates plus `deps-core`/`deps-lsp`, including real module-level (`//!`) prose for the six central `deps-core` modules called out in `.claude/CLAUDE.md`'s module map (`cache`, `ecosystem`, `ecosystem_registry`, `error`, `parser`, `registry`) and the `deps-lsp` crate roots (`lib.rs`, `main.rs`, `build.rs`).
- Along the way: fixed two inaccurate `# Errors` doc claims on `deps-gradle`'s Groovy/Kotlin DSL parsers (they never actually error), and a `rustdoc::redundant_explicit_links` warning surfaced by the gate in `deps-nuget/src/lockfile.rs`.
- Verified the issue's "related, one line" item (`Ecosystem::fallback_completion_is_bare` doc parenthetical) is already accurate on `main` — a more recent commit (PR #741) already updated it to list all five current overrides (Maven, NuGet, npm, Composer, PyPI), so no change was needed there.

Closes #744

## Test plan
- [x] `RUSTFLAGS="--force-warn missing_docs" cargo check --workspace --all-features` — 0 warnings
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` — 4789 passed, 55 skipped
- [x] `cargo test --workspace --doc --all-features` — all passed