### PR TITLE
fix(deps-core,deps-lsp): O(1) ASCII line lookup, move manifest parsing off the tokio worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: property tests (`proptest`) asserting the parser depth/expansion checkers and JSONC position recovery never panic on arbitrary input (#673)
 
 ### Fixed
-- **deps-core**: manifest parsing now runs on the blocking-thread pool instead of the calling tokio worker, no longer stalling the LSP request worker on a large manifest (resolves #743)
-- **deps-core**: `LineOffsetTable::byte_offset_to_position` no longer rescans an ASCII line from its start on every call, fixing an O(n^2) slowdown on large single-line (minified) manifests (resolves #742)
+- **deps-core**: manifest parsing now runs on the blocking-thread pool instead of the calling tokio worker, no longer stalling the LSP request worker on a large manifest (resolves #743) (#747)
+- **deps-core**: `LineOffsetTable::byte_offset_to_position` no longer rescans an ASCII line from its start on every call, fixing an O(n^2) slowdown on large single-line (minified) manifests (resolves #742) (#747)
 - **deps-pypi**: raw-text fallback completion no longer bare-inserts an unquoted package name into a `pyproject.toml` dependency array when no quote has been typed yet, producing invalid TOML (resolves #737) (#741)
 - **deps-lsp**: raw-text fallback completion now rejects a prefix longer than 200 characters (previously unbounded), reusing the same `is_valid_completion_prefix_len` guard every primary completion path already uses, and bounds the prefix/query values it logs (resolves #739) (#745)
 - **deps-cargo**: raised `recursion_limit` to fix the nightly `-D warnings` fuzz-job build, which failed proving `Send` for `get_latest_matching_from`'s boxed future (same class of fix as deps-nuget in #696 and deps-swift in #673) (#745)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: property tests (`proptest`) asserting the parser depth/expansion checkers and JSONC position recovery never panic on arbitrary input (#673)
 
 ### Fixed
+- **deps-core**: manifest parsing now runs on the blocking-thread pool instead of the calling tokio worker, no longer stalling the LSP request worker on a large manifest (resolves #743)
+- **deps-core**: `LineOffsetTable::byte_offset_to_position` no longer rescans an ASCII line from its start on every call, fixing an O(n^2) slowdown on large single-line (minified) manifests (resolves #742)
 - **deps-pypi**: raw-text fallback completion no longer bare-inserts an unquoted package name into a `pyproject.toml` dependency array when no quote has been typed yet, producing invalid TOML (resolves #737) (#741)
 - **deps-lsp**: raw-text fallback completion now rejects a prefix longer than 200 characters (previously unbounded), reusing the same `is_valid_completion_prefix_len` guard every primary completion path already uses, and bounds the prefix/query values it logs (resolves #739) (#745)
 - **deps-cargo**: raised `recursion_limit` to fix the nightly `-D warnings` fuzz-job build, which failed proving `Send` for `get_latest_matching_from`'s boxed future (same class of fix as deps-nuget in #696 and deps-swift in #673) (#745)

--- a/crates/deps-core/src/ecosystem.rs
+++ b/crates/deps-core/src/ecosystem.rs
@@ -26,6 +26,71 @@ pub mod private {
 /// A boxed, type-erased future used throughout the [`Ecosystem`] trait's async methods.
 pub type BoxFuture<'a, T> = Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
 
+/// Runs `ecosystem.parse_manifest(content, uri)` on the blocking-thread pool instead of the
+/// calling tokio worker.
+///
+/// Every [`Ecosystem::parse_manifest`] implementation is synchronous work wrapped in an
+/// immediately-ready `async move` block (verified: no implementation contains a real
+/// `.await`). Driving that future to completion via [`tokio::runtime::Handle::block_on`]
+/// from inside [`tokio::task::spawn_blocking`] moves the CPU-bound parse off the tokio
+/// worker without changing the trait's async signature — mirrors
+/// [`crate::lockfile::read_and_parse_lockfile`]'s `spawn_blocking` pattern for the
+/// equivalent lock-file path (#723/#730). This closes #743: a large minified manifest
+/// parsed synchronously on an LSP request's tokio worker would otherwise stall every other
+/// request sharing that worker for the parse's full duration.
+///
+/// `content`/`uri` are cloned internally rather than moved+returned: the caller's own copy
+/// must remain valid (to store into `DocumentState`) even if the blocking task panics, and a
+/// panic here is already an anomalous condition, not a path worth optimizing a clone away
+/// for. Manifest sizes are capped (10MB) and typically far smaller, so the clone's added
+/// *time* cost is negligible next to the parse itself and the thread-pool hop. It does
+/// briefly double transient *peak memory* (both the caller's and the cloned copy live at
+/// once) on exactly the large-manifest path this function targets; a future `Arc<str>`
+/// threaded through the caller would remove that duplication if it ever proves significant.
+///
+/// `Handle::block_on` called from inside a `spawn_blocking` closure is a documented,
+/// supported tokio pattern (distinct from `Runtime::block_on`, which panics if called from
+/// within a runtime). Since the future never actually yields (`Poll::Pending`), `block_on`
+/// resolves on the first poll — negligible overhead beyond the `spawn_blocking` thread-hop
+/// itself.
+///
+/// # Errors
+///
+/// Returns whatever [`Ecosystem::parse_manifest`] returns for a malformed manifest, or a
+/// [`crate::error::DepsError::ParseError`] if the blocking task panics or is cancelled.
+///
+/// # Examples
+///
+/// ```no_run
+/// use deps_core::Ecosystem;
+/// use std::sync::Arc;
+/// use tower_lsp_server::ls_types::Uri;
+///
+/// # async fn example(ecosystem: Arc<dyn Ecosystem>, uri: Uri) -> deps_core::error::Result<()> {
+/// let parsed = deps_core::ecosystem::parse_manifest_blocking(&ecosystem, "content", &uri).await?;
+/// println!("{} dependencies", parsed.dependencies().len());
+/// # Ok(())
+/// # }
+/// ```
+pub async fn parse_manifest_blocking(
+    ecosystem: &Arc<dyn Ecosystem>,
+    content: &str,
+    uri: &Uri,
+) -> crate::error::Result<Box<dyn ParseResult>> {
+    let ecosystem = Arc::clone(ecosystem);
+    let owned_content = content.to_owned();
+    let owned_uri = uri.clone();
+    let handle = tokio::runtime::Handle::current();
+    tokio::task::spawn_blocking(move || {
+        handle.block_on(ecosystem.parse_manifest(&owned_content, &owned_uri))
+    })
+    .await
+    .map_err(|e| crate::error::DepsError::ParseError {
+        file_type: format!("manifest at {uri:?}"),
+        source: Box::new(std::io::Error::other(e)),
+    })?
+}
+
 /// Canonical, exhaustive identifier for every package ecosystem the workspace supports.
 ///
 /// [`Ecosystem::id`] returns a `&'static str` for registry lookups and document
@@ -575,6 +640,14 @@ pub trait Ecosystem: Send + Sync + private::Sealed {
     /// # Errors
     ///
     /// Returns error if manifest cannot be parsed
+    ///
+    /// # Invariant
+    ///
+    /// Implementations must not contain a real `.await` (no network/file I/O, no yielding to
+    /// the scheduler) — the body must be synchronous work wrapped in an immediately-ready
+    /// `async move` block. [`parse_manifest_blocking`] relies on this to drive the future via
+    /// `Handle::block_on` on the blocking-thread pool; violating it doesn't deadlock, but
+    /// silently reintroduces the exact worker-thread stall #743 fixed.
     fn parse_manifest<'a>(
         &'a self,
         content: &'a str,
@@ -1128,5 +1201,138 @@ mod tests {
 
         let dep = MockDep;
         assert_eq!(dep.features(), &[] as &[String]);
+    }
+
+    /// Minimal [`ParseResult`] returned by [`StubEcosystem::parse_manifest`] below —
+    /// only [`parse_manifest_blocking`] tests need it, so it carries nothing beyond a URI.
+    struct StubParseResult {
+        uri: Uri,
+    }
+
+    impl ParseResult for StubParseResult {
+        fn dependencies(&self) -> Vec<&dyn Dependency> {
+            Vec::new()
+        }
+
+        fn workspace_root(&self) -> Option<&std::path::Path> {
+            None
+        }
+
+        fn uri(&self) -> &Uri {
+            &self.uri
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    /// Ecosystem stub for [`parse_manifest_blocking`] tests: `parse_manifest` either
+    /// asserts it runs off `calling_thread` or panics, per `should_panic`.
+    struct StubEcosystem {
+        calling_thread: std::thread::ThreadId,
+        should_panic: bool,
+    }
+
+    impl private::Sealed for StubEcosystem {}
+
+    impl Ecosystem for StubEcosystem {
+        fn id(&self) -> &'static str {
+            "stub"
+        }
+
+        fn display_name(&self) -> &'static str {
+            "Stub"
+        }
+
+        fn manifest_filenames(&self) -> &[&'static str] {
+            &[]
+        }
+
+        fn parse_manifest<'a>(
+            &'a self,
+            _content: &'a str,
+            uri: &'a Uri,
+        ) -> BoxFuture<'a, crate::error::Result<Box<dyn ParseResult>>> {
+            Box::pin(async move {
+                assert!(!self.should_panic, "boom");
+                assert_ne!(
+                    std::thread::current().id(),
+                    self.calling_thread,
+                    "parse must run on the blocking pool, not the calling thread"
+                );
+                Ok(Box::new(StubParseResult { uri: uri.clone() }) as Box<dyn ParseResult>)
+            })
+        }
+
+        fn registry(&self) -> Arc<dyn crate::Registry> {
+            unimplemented!()
+        }
+
+        fn formatter(&self) -> &dyn crate::lsp_helpers::EcosystemFormatter {
+            unimplemented!()
+        }
+
+        fn generate_completions<'a>(
+            &'a self,
+            _parse_result: &'a dyn ParseResult,
+            _position: Position,
+            _content: &'a str,
+            _freshness: crate::FreshnessSettings,
+        ) -> BoxFuture<'a, crate::completion::Completions> {
+            unimplemented!()
+        }
+
+        fn completion_insert_text(&self, _metadata: &dyn crate::Metadata) -> Option<String> {
+            unimplemented!()
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    /// Proves `parse_manifest_blocking` actually runs the parse off the calling (async)
+    /// thread via `spawn_blocking`, mirroring `lockfile.rs`'s
+    /// `test_read_and_parse_lockfile_runs_parse_off_calling_thread`.
+    #[tokio::test]
+    async fn test_parse_manifest_blocking_runs_parse_off_calling_thread() {
+        let ecosystem: Arc<dyn Ecosystem> = Arc::new(StubEcosystem {
+            calling_thread: std::thread::current().id(),
+            should_panic: false,
+        });
+        let uri = crate::test_util::test_uri("/test/manifest.toml");
+
+        let parsed = parse_manifest_blocking(&ecosystem, "content", &uri)
+            .await
+            .unwrap();
+        assert_eq!(parsed.uri(), &uri);
+    }
+
+    /// A panicking `parse_manifest` must surface as `Err(DepsError::ParseError)` with the
+    /// panic message preserved, mirroring `lockfile.rs`'s
+    /// `test_read_and_parse_lockfile_panic_in_parse_becomes_parse_error`.
+    #[tokio::test]
+    async fn test_parse_manifest_blocking_panic_becomes_parse_error() {
+        let ecosystem: Arc<dyn Ecosystem> = Arc::new(StubEcosystem {
+            calling_thread: std::thread::current().id(),
+            should_panic: true,
+        });
+        let uri = crate::test_util::test_uri("/test/manifest.toml");
+
+        let Err(err) = parse_manifest_blocking(&ecosystem, "content", &uri).await else {
+            panic!("expected parse_manifest_blocking to return an error");
+        };
+
+        match err {
+            crate::error::DepsError::ParseError { file_type, source } => {
+                assert!(file_type.contains("manifest at"));
+                assert!(
+                    source.to_string().contains("boom"),
+                    "panic message should be preserved in the error source, got: {source}"
+                );
+            }
+            other => panic!("Expected ParseError, got: {other:?}"),
+        }
     }
 }

--- a/crates/deps-core/src/lib.rs
+++ b/crates/deps-core/src/lib.rs
@@ -64,6 +64,7 @@ pub use cache::{BodyLimit, CachedResponse, HttpCache};
 pub use deps_dev::{DepsDevClient, ProvenanceStatus, ScorecardSummary, SupplyChainTrustSignal};
 pub use ecosystem::{
     Dependency, Ecosystem, EcosystemConfig, EcosystemId, LicenseSource, ParseResult,
+    parse_manifest_blocking,
 };
 pub use ecosystem_registry::EcosystemRegistry;
 pub use error::{DepsError, FetchFailure, Result};

--- a/crates/deps-core/src/lsp_helpers/mod.rs
+++ b/crates/deps-core/src/lsp_helpers/mod.rs
@@ -794,20 +794,47 @@ pub fn position_in_range(pos: Position, range: Range) -> bool {
 /// Precomputes line-start byte offsets once, then maps any byte offset to a
 /// `(line, character)` position. Characters are counted as UTF-16 code units
 /// as required by the LSP specification.
+///
+/// Also precomputes, per line, whether that line is pure ASCII (`line_is_ascii`): for an
+/// ASCII-only line, byte offset and UTF-16 code-unit
+/// offset are always equal, so [`byte_offset_to_position`](Self::byte_offset_to_position)
+/// can skip the `chars().map(char::len_utf16).sum()` scan entirely and compute the
+/// character offset in O(1). This matters because a single minified manifest line (e.g. a
+/// `package.json` with hundreds of dependencies on one line) turns per-offset lookups into
+/// an O(n) scan each, and O(n) lookups across the line's length make the whole document
+/// O(n^2) (#742) — the common case of an ASCII-only line now stays O(1) per lookup; a
+/// non-ASCII line still takes the O(n) scan, unchanged.
 pub struct LineOffsetTable {
     line_starts: Vec<usize>,
+    line_is_ascii: Vec<bool>,
 }
 
 impl LineOffsetTable {
     /// Builds the table for `content`.
     pub fn new(content: &str) -> Self {
         let mut line_starts = vec![0];
+        let mut line_is_ascii = Vec::new();
+        let mut current_ascii = true;
         for (i, c) in content.char_indices() {
+            if !c.is_ascii() {
+                current_ascii = false;
+            }
             if c == '\n' {
                 line_starts.push(i + 1);
+                line_is_ascii.push(current_ascii);
+                current_ascii = true;
             }
         }
-        Self { line_starts }
+        line_is_ascii.push(current_ascii);
+        debug_assert_eq!(
+            line_starts.len(),
+            line_is_ascii.len(),
+            "line_starts and line_is_ascii must stay in lockstep — one entry per line"
+        );
+        Self {
+            line_starts,
+            line_is_ascii,
+        }
     }
 
     /// Absolute byte offset where `line` (0-indexed) starts, or `None` if
@@ -860,13 +887,20 @@ impl LineOffsetTable {
         // text sent directly by the editor, so this saturates rather than assuming an
         // upstream cap that doesn't universally hold (mirrors
         // `completion::byte_to_utf16_offset`'s identical fix).
-        let character = u32::try_from(
-            content[line_start..offset]
-                .chars()
-                .map(char::len_utf16)
-                .sum::<usize>(),
-        )
-        .unwrap_or(u32::MAX);
+        //
+        // #742: an ASCII-only line has 1 UTF-16 unit per byte, so the character offset is
+        // just the byte delta — no need to walk the line's `chars()` to sum `len_utf16`.
+        let character = if self.line_is_ascii.get(line).copied().unwrap_or(false) {
+            u32::try_from(offset - line_start).unwrap_or(u32::MAX)
+        } else {
+            u32::try_from(
+                content[line_start..offset]
+                    .chars()
+                    .map(char::len_utf16)
+                    .sum::<usize>(),
+            )
+            .unwrap_or(u32::MAX)
+        };
         Position::new(u32::try_from(line).unwrap_or(u32::MAX), character)
     }
 
@@ -1596,6 +1630,73 @@ mod tests {
         assert!(!content.is_char_boundary(4));
         let pos = table.byte_offset_to_position(content, 4);
         assert_eq!(pos, table.byte_offset_to_position(content, 3));
+    }
+
+    /// Covers the ASCII/non-ASCII fast-path split introduced for #742: an ASCII-only line
+    /// (line 0), a non-ASCII line mixing a BMP accented character with a surrogate-pair
+    /// emoji (line 1), and a mixed line (line 2) must all still resolve to the same
+    /// `Position`s as the original `chars().map(char::len_utf16).sum()` scan would produce.
+    #[test]
+    fn test_byte_offset_to_position_ascii_and_non_ascii_lines_agree() {
+        let content = "abcde\nhéllo 😀\nab café end";
+        let table = LineOffsetTable::new(content);
+
+        // Line 0 ("abcde"): ASCII fast path, byte offset == UTF-16 character offset.
+        assert_eq!(
+            table.byte_offset_to_position(content, 3),
+            Position::new(0, 3)
+        );
+        assert_eq!(
+            table.byte_offset_to_position(content, 5),
+            Position::new(0, 5)
+        );
+
+        // Line 1 ("héllo 😀"): non-ASCII scan path.
+        // Offset after "h\u{e9}" (1 + 2 bytes into the line): 'h' + 'é' = 2 UTF-16 units.
+        assert_eq!(
+            table.byte_offset_to_position(content, 6 + 3),
+            Position::new(1, 2)
+        );
+        // Offset at the end of the line: "héllo 😀" = 8 UTF-16 units (emoji is a surrogate pair).
+        assert_eq!(
+            table.byte_offset_to_position(content, 6 + 11),
+            Position::new(1, 8)
+        );
+
+        // Line 2 ("ab café end"): mixed line, still takes the non-ASCII scan path.
+        // Offset after "ab café" (8 bytes into the line): 7 UTF-16 units ('é' is 1 BMP unit).
+        assert_eq!(
+            table.byte_offset_to_position(content, 18 + 8),
+            Position::new(2, 7)
+        );
+    }
+
+    /// Regression guard for #742: `byte_offset_to_position` on a large single-line
+    /// (minified) manifest must stay near-instant. The pre-fix implementation rescanned
+    /// the line from its start on every call, making repeated lookups over such a line
+    /// O(n^2) in the line's length (~350ms for 8000 calls on an ~180KB line on the
+    /// reporter's machine); the ASCII fast path makes each call O(1), so this generous
+    /// wall-clock bound leaves wide margin without being flaky.
+    #[test]
+    fn test_byte_offset_to_position_minified_line_stays_fast() {
+        let mut content = String::from("{\"dependencies\":{");
+        for i in 0..8000 {
+            content.push_str(&format!("\"dep{i}\":\"1.0.{i}\","));
+        }
+        content.push_str("}}");
+
+        let table = LineOffsetTable::new(&content);
+        let step = (content.len() / 8000).max(1);
+        let start = std::time::Instant::now();
+        for offset in (0..content.len()).step_by(step) {
+            std::hint::black_box(table.byte_offset_to_position(&content, offset));
+        }
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_millis(100),
+            "8000 byte_offset_to_position calls on a minified line took {elapsed:?}, expected < 100ms"
+        );
     }
 
     #[test]

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -1865,7 +1865,9 @@ pub async fn handle_document_open(
     );
 
     // Try to parse manifest (may fail for incomplete syntax)
-    let parse_result = ecosystem.parse_manifest(&content, &uri).await.ok();
+    let parse_result = deps_core::ecosystem::parse_manifest_blocking(&ecosystem, &content, &uri)
+        .await
+        .ok();
 
     // Create document state (parse_result may be None)
     let mut doc_state = if let Some(pr) = parse_result {
@@ -2239,7 +2241,7 @@ async fn parse_and_diff_manifest(
     uri: &Uri,
     content: &str,
     state: &ServerState,
-    ecosystem: &dyn Ecosystem,
+    ecosystem: &Arc<dyn Ecosystem>,
 ) -> (Option<Box<dyn deps_core::ParseResult>>, DependencyDiff) {
     // Extract old dependency name -> version_requirement map before parsing
     // (for diff computation)
@@ -2251,7 +2253,9 @@ async fn parse_and_diff_manifest(
         });
 
     // Try to parse manifest (may fail for incomplete syntax)
-    let parse_result = ecosystem.parse_manifest(content, uri).await.ok();
+    let parse_result = deps_core::ecosystem::parse_manifest_blocking(ecosystem, content, uri)
+        .await
+        .ok();
 
     // Extract new dependency name -> version_requirement map for diff
     let new_deps: HashMap<PackageName, Vec<Option<VersionReq>>> = parse_result
@@ -2496,8 +2500,7 @@ pub(crate) async fn handle_document_change_guarded(
 
     check_content_size(&content, &uri)?;
 
-    let (parse_result, diff) =
-        parse_and_diff_manifest(&uri, &content, &state, ecosystem.as_ref()).await;
+    let (parse_result, diff) = parse_and_diff_manifest(&uri, &content, &state, &ecosystem).await;
 
     // Captured before `commit_parsed_document` consumes `parse_result` — only needed under
     // `RefetchPolicy::AllDependencies` (issue #592), where the fetch must cover every


### PR DESCRIPTION
## Summary

- `LineOffsetTable::byte_offset_to_position` rescanned each line from its start on every call to compute the UTF-16 column, which degenerates to O(n^2) on a minified/single-line manifest. Lines that are pure ASCII now resolve their column in O(1) (`offset - line_start`, byte-identical result since 1 ASCII byte == 1 UTF-16 unit); non-ASCII lines keep the original scan. Measured: an 8000-dependency minified `package.json` went from 405ms to 17.9us for the same lookup workload, with no output change.
- Every one of the 14 `Ecosystem::parse_manifest` implementations is synchronous work wrapped in an already-ready `async` block, and both `deps-lsp` call sites (`handle_document_open`, `parse_and_diff_manifest`) awaited it directly on the tokio worker inside LSP handler dispatch, burning one of `tower-lsp-server`'s 4 concurrent message slots plus a worker thread for the whole parse — on every `didOpen`/`didChange`. `deps_core::ecosystem::parse_manifest_blocking` now drives that future via `Handle::block_on` inside `spawn_blocking`, mirroring the pattern `lockfile.rs` already uses for lock-file parsing (#723/#730). No ecosystem crate needed changes — confirmed none of the 14 impls contains a real `.await`, and this invariant is now documented on `Ecosystem::parse_manifest`'s own trait doc so a future ecosystem implementer is warned.

Both fixes are on deps-core's shared `LineOffsetTable`/`Ecosystem` machinery, so they apply uniformly across all 14 ecosystems rather than needing per-crate changes.

## Test plan

- [x] Unit test asserting `byte_offset_to_position`'s ASCII fast path and non-ASCII scan path agree on ASCII-only, non-ASCII, and mixed lines, including the column right after a 4-byte UTF-8 character (`len_utf16 == 2`)
- [x] Wall-clock regression test: ~8000-call lookup on a large minified manifest completes well under a generous bound
- [x] New `parse_manifest_blocking` tests mirroring `lockfile.rs`'s thread-id and panic-propagation coverage
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4793 passed)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`

Closes #742
Closes #743