### PR TITLE
ci: parallelize check job and decouple downstream jobs from the fmt+check gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,8 @@ jobs:
       - name: Check formatting
         run: cargo +nightly fmt --all -- --check
 
-  check:
-    name: Check
+  clippy:
+    name: Clippy
     needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
@@ -80,11 +80,27 @@ jobs:
       - uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3  # v1
         with:
           components: clippy
+          cache-extra-identifier: clippy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+  doc-and-hygiene:
+    name: Doc + Hygiene
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+
+      - uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3  # v1
+        with:
+          cache-extra-identifier: doc-hygiene
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cargo-machete
         uses: taiki-e/install-action@7b8d4719ee4aaa279bdf55df38dacb9ebfe12a6c  # v2
@@ -139,7 +155,7 @@ jobs:
 
   test:
     name: Test (${{ matrix.os }}${{ matrix.rust != 'stable' && format(' / {0}', matrix.rust) || '' }})
-    needs: [changes, fmt, check]
+    needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -171,7 +187,7 @@ jobs:
 
   cross-check:
     name: Cross-compile Check (${{ matrix.target }})
-    needs: [changes, fmt]
+    needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -213,7 +229,7 @@ jobs:
 
   coverage:
     name: Code Coverage
-    needs: [changes, fmt, check]
+    needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -248,7 +264,7 @@ jobs:
 
   msrv:
     name: Check MSRV
-    needs: [changes, fmt, check]
+    needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -272,7 +288,7 @@ jobs:
 
   wasm:
     name: WASM Build (Zed Extension)
-    needs: [changes, fmt, check]
+    needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -299,7 +315,7 @@ jobs:
 
   benchmark:
     name: Check Benchmarks
-    needs: [changes, fmt, check]
+    needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -315,7 +331,7 @@ jobs:
 
   fuzz:
     name: Fuzz (bounded)
-    needs: [changes, fmt, check]
+    needs: changes
     # Deliberately not in `ci-success`'s `needs` (#673): a bounded regression run, not a
     # merge gate — a flaky/slow nightly toolchain or libFuzzer environment issue here must
     # never block an otherwise-green PR (fuzzing did find a real bug during development —
@@ -456,7 +472,8 @@ jobs:
       [
         changes,
         fmt,
-        check,
+        clippy,
+        doc-and-hygiene,
         security,
         test,
         cross-check,
@@ -487,7 +504,8 @@ jobs:
 
           failed=0
           check_job "${{ needs.fmt.result }}" "fmt" || failed=1
-          check_job "${{ needs.check.result }}" "check" || failed=1
+          check_job "${{ needs.clippy.result }}" "clippy" || failed=1
+          check_job "${{ needs.doc-and-hygiene.result }}" "doc-and-hygiene" || failed=1
           check_job "${{ needs.security.result }}" "security" || failed=1
           check_job "${{ needs.test.result }}" "test" || failed=1
           check_job "${{ needs.cross-check.result }}" "cross-check" || failed=1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,10 +7,6 @@ on:
       - '**/*.rs'
       - '**/Cargo.toml'
       - '.github/workflows/docs.yml'
-  pull_request:
-    paths:
-      - '**/*.rs'
-      - '**/Cargo.toml'
 
 permissions:
   contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-lsp**: documented NuGet's bare-version pin approximation and added a cross-ecosystem consistency test guarding `bare_requirement_policy` (resolves #669) (#674)
 - **workspace**: removed 18 unused dependencies across 11 crates and moved 3 test-only dependencies to `[dev-dependencies]` (touching a 12th crate, `deps-gitlab-ci`); added a `cargo machete` CI gate (resolves #670) (#675)
 - **workspace**: `missing_docs` lint raised from `allow` to `warn` in `[workspace.lints.rust]`; added the ~287 previously-missing `///`/`//!` doc comments across all 14 ecosystem crates plus `deps-core`/`deps-lsp` needed to make the flip clean (resolves #744) (#746)
+- **workspace**: split CI's `check` job into parallel `clippy`/`doc-and-hygiene` jobs, decoupled `test`/`coverage`/`msrv`/`wasm`/`benchmark`/`fuzz`/`cross-check` from the `fmt`+`check` gate so they start immediately, and restricted `docs.yml`'s doc build to `main`-branch pushes since the PR-time rustdoc gate is now covered by `doc-and-hygiene` (resolves #750, #751, #752) (#762)
 
 ### Dependencies
 - Bump `dirs` from 6 to 7.0.0, plus transitive `Cargo.lock` refresh (#659)


### PR DESCRIPTION
## Summary
- Split the `check` job into two parallel jobs: `clippy` (clippy lint) and `doc-and-hygiene` (cargo-machete, rustdoc gate, test-util dependency-tree guard), each with its own cache identifier so they don't thrash a shared cache.
- Decoupled `test`, `coverage`, `msrv`, `wasm`, `benchmark`, `fuzz`, and `cross-check` from `needs: [changes, fmt, check]` down to `needs: changes` — none of them consume fmt's or check's output, and this gate was the single largest contributor to CI wall-clock latency.
- Restricted `docs.yml`'s full-workspace rustdoc build to push-to-`main` only, since PR-time doc-buildability is already validated by `doc-and-hygiene`'s rustdoc gate.
- Updated `ci-success`'s `needs:` list and result-aggregation script accordingly; verified no dangling references to the removed `check` job remain anywhere in `ci.yml`.

## Test plan
- [x] `fy validate` on both modified workflow files
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast`
- [x] Manual read-through of the final job graph for consistency (every `needs:` entry resolves to an existing job)
- [ ] Confirm on this PR's own CI run that the new `clippy`/`doc-and-hygiene` jobs execute in parallel and `ci-success` correctly reflects their pass/fail

Closes #750
Closes #751
Closes #752