### PR TITLE
fix(deps-gradle,deps-core): escape-aware quote parity and fail-closed xml bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: property tests (`proptest`) asserting the parser depth/expansion checkers and JSONC position recovery never panic on arbitrary input (#673)
 
 ### Fixed
-- **deps-gradle**: version catalog/DSL completion no longer miscounts an escaped quote, via a generalized, quote-character-parameterized `deps-core` quote-parity helper (resolves #738)
+- **deps-gradle**: version catalog/DSL completion no longer miscounts an escaped quote, via a generalized, quote-character-parameterized `deps-core` quote-parity helper (resolves #738) (#771)
 - **deps-core**: manifest parsing now runs on the blocking-thread pool instead of the calling tokio worker, no longer stalling the LSP request worker on a large manifest (resolves #743) (#747)
 - **deps-core**: `LineOffsetTable::byte_offset_to_position` no longer rescans an ASCII line from its start on every call, fixing an O(n^2) slowdown on large single-line (minified) manifests (resolves #742) (#747)
 - **deps-pypi**: raw-text fallback completion no longer bare-inserts an unquoted package name into a `pyproject.toml` dependency array when no quote has been typed yet, producing invalid TOML (resolves #737) (#741)
@@ -62,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-deno**: extracted `deps-deno`'s scope-aware `@scope/pkg` name-boundary parser into a shared `deps_core::package::npm_style_name_boundary` helper, reused by the `deps-npm` alias fix above instead of a per-crate reimplementation (#657)
 
 ### Changed
-- **deps-gradle, deps-core**: POM license scan's byte-budget guard now shares a new `deps-core::xml_bounds::exhausted_with` instead of a private lossy `as usize` cast — hardens the fail-closed conversion for a 32-bit target (no behavior change on the 64-bit targets this project builds for) (resolves #725)
+- **deps-gradle, deps-core**: POM license scan's byte-budget guard now shares a new `deps-core::xml_bounds::exhausted_with` instead of a private lossy `as usize` cast — hardens the fail-closed conversion for a 32-bit target (no behavior change on the 64-bit targets this project builds for) (resolves #725) (#771)
 - **deps-lsp**: split the 11k-line `document/lifecycle.rs` god module into `lifecycle.rs`/`fetch.rs`/`osv_scan.rs`/`diff.rs`/`resolved.rs` by responsibility; pure move/re-export, no behavior change (resolves #754) (#764)
 - **deps-core, deps-lsp, deps-cargo, deps-npm, deps-pypi, deps-composer, deps-deno, deps-maven, deps-nuget, deps-go, deps-dart, deps-github-actions, deps-gradle, deps-swift, deps-bundler, deps-gitlab-ci**: raw-text fallback completion (parse-failure path) syntax and package-name completion insert-text are now two `Ecosystem` trait hooks (`fallback_completion_prefix`, `completion_insert_text`) each ecosystem crate implements directly, replacing six non-exhaustive `EcosystemId` match tables previously centralized in `deps-lsp` (resolves #722) (#731)
 - Consolidated the `indexing_slicing`/`unwrap_used`/`expect_used`/`string_slice` clippy restriction lints, previously duplicated as an identical `#![warn(...)]` attribute across all 16 workspace crates, into `[workspace.lints.clippy]`; removed the dead `non_std_lazy_statics` allow (LazyLock has been stable since Rust 1.80, workspace MSRV is 1.98) (resolves #689) (#693)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: property tests (`proptest`) asserting the parser depth/expansion checkers and JSONC position recovery never panic on arbitrary input (#673)
 
 ### Fixed
+- **deps-gradle**: version catalog/DSL completion no longer miscounts an escaped quote, via a generalized, quote-character-parameterized `deps-core` quote-parity helper (resolves #738)
 - **deps-core**: manifest parsing now runs on the blocking-thread pool instead of the calling tokio worker, no longer stalling the LSP request worker on a large manifest (resolves #743) (#747)
 - **deps-core**: `LineOffsetTable::byte_offset_to_position` no longer rescans an ASCII line from its start on every call, fixing an O(n^2) slowdown on large single-line (minified) manifests (resolves #742) (#747)
 - **deps-pypi**: raw-text fallback completion no longer bare-inserts an unquoted package name into a `pyproject.toml` dependency array when no quote has been typed yet, producing invalid TOML (resolves #737) (#741)
@@ -61,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-deno**: extracted `deps-deno`'s scope-aware `@scope/pkg` name-boundary parser into a shared `deps_core::package::npm_style_name_boundary` helper, reused by the `deps-npm` alias fix above instead of a per-crate reimplementation (#657)
 
 ### Changed
+- **deps-gradle, deps-core**: POM license scan's byte-budget guard now shares a new `deps-core::xml_bounds::exhausted_with` instead of a private lossy `as usize` cast — hardens the fail-closed conversion for a 32-bit target (no behavior change on the 64-bit targets this project builds for) (resolves #725)
 - **deps-lsp**: split the 11k-line `document/lifecycle.rs` god module into `lifecycle.rs`/`fetch.rs`/`osv_scan.rs`/`diff.rs`/`resolved.rs` by responsibility; pure move/re-export, no behavior change (resolves #754) (#764)
 - **deps-core, deps-lsp, deps-cargo, deps-npm, deps-pypi, deps-composer, deps-deno, deps-maven, deps-nuget, deps-go, deps-dart, deps-github-actions, deps-gradle, deps-swift, deps-bundler, deps-gitlab-ci**: raw-text fallback completion (parse-failure path) syntax and package-name completion insert-text are now two `Ecosystem` trait hooks (`fallback_completion_prefix`, `completion_insert_text`) each ecosystem crate implements directly, replacing six non-exhaustive `EcosystemId` match tables previously centralized in `deps-lsp` (resolves #722) (#731)
 - Consolidated the `indexing_slicing`/`unwrap_used`/`expect_used`/`string_slice` clippy restriction lints, previously duplicated as an identical `#![warn(...)]` attribute across all 16 workspace crates, into `[workspace.lints.clippy]`; removed the dead `non_std_lazy_statics` allow (LazyLock has been stable since Rust 1.80, workspace MSRV is 1.98) (resolves #689) (#693)

--- a/crates/deps-core/src/fallback_completion.rs
+++ b/crates/deps-core/src/fallback_completion.rs
@@ -333,6 +333,9 @@ pub fn strip_open_xml_attribute_value<'a>(
 /// counting both over-counts, flipping a closed key+value pair to look "open", and
 /// under-counts the inverse, flipping a still-open key to look "closed").
 ///
+/// Thin wrapper around [`count_real_quotes_with`] for `"`, the quote character every
+/// existing caller of this function needs.
+///
 /// # Examples
 ///
 /// ```
@@ -346,23 +349,90 @@ pub fn strip_open_xml_attribute_value<'a>(
 /// ```
 #[must_use]
 pub fn count_real_quotes(segment: &str) -> (usize, Option<usize>) {
-    let mut backslash_run = 0usize;
+    count_real_quotes_with(segment, '"')
+}
+
+/// Same escape-aware counting as [`count_real_quotes`], parameterized over which
+/// character counts as a quote.
+///
+/// Gradle's Kotlin/Groovy DSL accepts either `"..."` or `'...'` string literals (e.g.
+/// `version.ref = "..."` or `version.ref = '...'`), so a single hard-coded `"` check
+/// can't serve it — this lets a caller reuse the same escape-aware parity logic for
+/// whichever quote character its manifest syntax actually uses (#738), instead of
+/// keeping a second, naive (non-escape-aware) counter for `'`.
+///
+/// `quote` must not be `\`: the backslash-run tracking that recognizes an escape
+/// always consumes a `\` character first, so passing `\` itself as `quote` can never
+/// match and this always returns `(0, None)`.
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::fallback_completion::count_real_quotes_with;
+///
+/// // Two plain single quotes, both real: last one is at byte index 7.
+/// assert_eq!(count_real_quotes_with("'pytest'", '\''), (2, Some(7)));
+/// // The middle quote is escaped (one preceding `\`), so it isn't counted.
+/// assert_eq!(count_real_quotes_with("'a\\'b", '\''), (1, Some(0)));
+/// ```
+#[must_use]
+pub fn count_real_quotes_with(segment: &str, quote: char) -> (usize, Option<usize>) {
     let mut count = 0usize;
     let mut last_real_quote = None;
-    for (idx, ch) in segment.char_indices() {
-        match ch {
-            '\\' => backslash_run += 1,
-            '"' => {
-                if backslash_run.is_multiple_of(2) {
-                    count += 1;
-                    last_real_quote = Some(idx);
-                }
-                backslash_run = 0;
-            }
-            _ => backslash_run = 0,
-        }
+    for idx in real_quote_indices(segment, quote) {
+        count += 1;
+        last_real_quote = Some(idx);
     }
     (count, last_real_quote)
+}
+
+/// Finds the byte offset of the first real (escape-aware, see [`count_real_quotes`])
+/// `quote` character in `segment`, scanning forward from the beginning.
+///
+/// The forward-scanning, first-match counterpart to [`count_real_quotes_with`]'s
+/// backward-looking last-match — same escape rule (shared via a private
+/// `real_quote_indices` scan), opposite question. Useful when a string's content is
+/// known to start at byte `0` of `segment` (e.g. the text immediately after an opening
+/// quote), so the first real quote encountered is that string's closing quote.
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::fallback_completion::find_closing_quote;
+///
+/// assert_eq!(find_closing_quote("pytest\" extra", '"'), Some(6));
+/// // The escaped quote is skipped; the real closing quote is found after it.
+/// assert_eq!(find_closing_quote("a\\\"b\"", '"'), Some(4));
+/// assert_eq!(find_closing_quote("no quote here", '"'), None);
+/// ```
+#[must_use]
+pub fn find_closing_quote(segment: &str, quote: char) -> Option<usize> {
+    real_quote_indices(segment, quote).next()
+}
+
+/// Shared escape-aware scan backing both [`count_real_quotes_with`] and
+/// [`find_closing_quote`]: yields the byte offset of every real (non-escaped) `quote`
+/// character in `segment`, in order. See [`count_real_quotes`]'s doc comment for the
+/// escape rule (an odd run of consecutive `\` immediately before `quote` escapes it).
+fn real_quote_indices(segment: &str, quote: char) -> impl Iterator<Item = usize> + '_ {
+    let mut backslash_run = 0usize;
+    segment
+        .char_indices()
+        .filter_map(move |(idx, ch)| match ch {
+            '\\' => {
+                backslash_run += 1;
+                None
+            }
+            ch if ch == quote => {
+                let is_real = backslash_run.is_multiple_of(2);
+                backslash_run = 0;
+                is_real.then_some(idx)
+            }
+            _ => {
+                backslash_run = 0;
+                None
+            }
+        })
 }
 
 /// Classifies whether `prefix` (the trimmed line text up to the cursor) sits inside an
@@ -992,5 +1062,32 @@ tokio
         let (count, last) = count_real_quotes("\"a\\\"b\"");
         assert_eq!(count, 2);
         assert_eq!(last, Some(5));
+    }
+
+    #[test]
+    fn test_count_real_quotes_with_single_quote_skips_escaped_quote() {
+        let (count, last) = count_real_quotes_with("'a\\'b'", '\'');
+        assert_eq!(count, 2);
+        assert_eq!(last, Some(5));
+    }
+
+    #[test]
+    fn test_find_closing_quote_finds_first_real_quote() {
+        assert_eq!(find_closing_quote("pytest\" extra", '"'), Some(6));
+    }
+
+    #[test]
+    fn test_find_closing_quote_skips_escaped_quote() {
+        assert_eq!(find_closing_quote("a\\\"b\"", '"'), Some(4));
+    }
+
+    #[test]
+    fn test_find_closing_quote_no_quote_is_none() {
+        assert_eq!(find_closing_quote("no quote here", '"'), None);
+    }
+
+    #[test]
+    fn test_find_closing_quote_single_quote_variant() {
+        assert_eq!(find_closing_quote("a\\'b'", '\''), Some(4));
     }
 }

--- a/crates/deps-core/src/xml_bounds.rs
+++ b/crates/deps-core/src/xml_bounds.rs
@@ -35,6 +35,11 @@ pub const MAX_METADATA_BYTES_SCANNED: usize = 8 * 1024 * 1024;
 /// document that simply omits the element type a narrower, shape-keyed counter would be
 /// watching for.
 ///
+/// Thin wrapper around [`exhausted_with`] using this module's own
+/// [`MAX_METADATA_VERSIONS`]/[`MAX_METADATA_BYTES_SCANNED`] budget — use `exhausted_with`
+/// directly for a consumer with its own, differently-sized budget (e.g.
+/// `deps-gradle::license`'s POM scan, issue #725).
+///
 /// # Examples
 ///
 /// ```
@@ -45,8 +50,84 @@ pub const MAX_METADATA_BYTES_SCANNED: usize = 8 * 1024 * 1024;
 /// ```
 #[must_use]
 pub fn exhausted(entries: usize, buffer_position: u64) -> bool {
-    entries >= MAX_METADATA_VERSIONS
+    exhausted_with(
+        entries,
+        buffer_position,
+        MAX_METADATA_VERSIONS,
+        MAX_METADATA_BYTES_SCANNED,
+    )
+}
+
+/// Whether a bounded XML scan has exceeded a caller-supplied entry/byte budget.
+///
+/// Same shape-independent check as [`exhausted`], parameterized so a consumer with its
+/// own budget (e.g. a POM's license-entry cap, distinct from a `maven-metadata.xml`
+/// version-list cap) can share this conversion instead of keeping a private, lossy `as
+/// usize` copy of it (issue #725). The `usize::try_from(..).unwrap_or(usize::MAX)`
+/// fail-closed path only differs from a lossy `as usize` cast on a target where `usize`
+/// is narrower than `u64` — i.e. a 32-bit target; every target this workspace's CI
+/// actually builds for (see `.github/workflows/ci.yml`'s `cross-check` matrix) is
+/// 64-bit, where the two are equivalent. This is 32-bit-target hardening and DRY
+/// consolidation of the budget check, not a fix for a bug reachable on a supported
+/// target today.
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::xml_bounds::exhausted_with;
+///
+/// assert!(!exhausted_with(0, 0, 64, 1024));
+/// assert!(exhausted_with(64, 0, 64, 1024));
+/// assert!(exhausted_with(0, 2048, 64, 1024));
+/// ```
+#[must_use]
+pub fn exhausted_with(
+    entries: usize,
+    buffer_position: u64,
+    max_entries: usize,
+    max_bytes: usize,
+) -> bool {
+    entries >= max_entries
         // Fails closed: a `buffer_position` too large to fit `usize` (only possible on a
         // 32-bit target) is treated as exceeding the cap rather than silently wrapping.
-        || usize::try_from(buffer_position).unwrap_or(usize::MAX) >= MAX_METADATA_BYTES_SCANNED
+        || usize::try_from(buffer_position).unwrap_or(usize::MAX) >= max_bytes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MAX_METADATA_BYTES_SCANNED, MAX_METADATA_VERSIONS, exhausted, exhausted_with};
+
+    #[test]
+    fn exhausted_delegates_to_exhausted_with_using_module_constants() {
+        assert!(!exhausted(0, 0));
+        assert!(exhausted(MAX_METADATA_VERSIONS, 0));
+        assert!(exhausted(0, MAX_METADATA_BYTES_SCANNED as u64));
+    }
+
+    #[test]
+    fn exhausted_with_respects_caller_supplied_budget() {
+        assert!(!exhausted_with(0, 0, 64, 1024));
+        assert!(exhausted_with(64, 0, 64, 1024));
+        assert!(exhausted_with(0, 1024, 64, 1024));
+        assert!(!exhausted_with(0, 1023, 64, 1024));
+    }
+
+    /// A `buffer_position` that overflows a 32-bit `usize` must fail closed — treated as
+    /// exceeding the cap — rather than wrapping via a lossy `as usize` cast (the pre-#725
+    /// bug). `u32::MAX + 1` is the smallest such value, and only fails to fit `usize` on
+    /// a genuine 32-bit target, so this test is gated to actually distinguish the fix
+    /// from the bug it replaces — asserting it on 64-bit (where the conversion always
+    /// succeeds and the two implementations agree) would be a vacuous, always-passing
+    /// test that proves nothing about the fix.
+    #[test]
+    #[cfg(target_pointer_width = "32")]
+    fn exhausted_with_fails_closed_on_oversized_buffer_position() {
+        let overflows_32_bit_usize = u64::from(u32::MAX) + 1;
+        assert!(exhausted_with(
+            0,
+            overflows_32_bit_usize,
+            usize::MAX,
+            usize::MAX
+        ));
+    }
 }

--- a/crates/deps-gradle/src/ecosystem.rs
+++ b/crates/deps-gradle/src/ecosystem.rs
@@ -131,14 +131,33 @@ fn byte_range(line: &str, line_idx: u32, start_byte: usize, end_byte: usize) -> 
 /// (e.g. treating a cursor inside `module`'s still-open value as "version" context,
 /// because "version" appears earlier on the line and the combined quote count happens
 /// to be odd).
+// Kept as its own escape-aware loop rather than calling
+// `deps_core::fallback_completion::count_real_quotes`/`find_closing_quote`: this needs
+// an `in_string` toggle interleaved with comma-boundary tracking in a *single* forward
+// pass (a comma's own `!in_string` guard depends on the running parity at that exact
+// position), which the shared helpers — built to answer "count/find real quotes over
+// the whole segment" — don't expose mid-scan. Keeps the same backslash-run escape rule
+// as those helpers (see `count_real_quotes`'s doc comment) so the two can't disagree on
+// a line containing `\"` (#738 follow-up); a future change to that rule must be mirrored
+// here too.
 fn current_field_start(before_cursor: &str) -> usize {
     let mut in_string = false;
+    let mut backslash_run = 0usize;
     let mut field_start = 0;
     for (i, c) in before_cursor.char_indices() {
         match c {
-            '"' => in_string = !in_string,
-            ',' if !in_string => field_start = i + 1,
-            _ => {}
+            '\\' => backslash_run += 1,
+            '"' => {
+                if backslash_run.is_multiple_of(2) {
+                    in_string = !in_string;
+                }
+                backslash_run = 0;
+            }
+            ',' if !in_string => {
+                field_start = i + 1;
+                backslash_run = 0;
+            }
+            _ => backslash_run = 0,
         }
     }
     field_start
@@ -170,13 +189,14 @@ fn detect_catalog_context<'a>(
     if let Some(rel_eq_pos) = field.rfind("version")
         && let after = &field[rel_eq_pos..]
         && after.contains('=')
-        // An odd quote count means the cursor sits inside an unclosed string opened by
-        // the LAST quote in `after` — i.e. `rfind` below is genuinely the opening quote.
+        // An odd, escape-aware (see `count_real_quotes`) quote count means the cursor
+        // sits inside an unclosed string opened by the last *real* quote in `after`.
         // With an even count (string already closed, or no quote at all before cursor)
         // the cursor is past this `version = "..."` entirely (e.g. a trailing comment on
         // the same line), and this is not the right completion context.
-        && after.chars().filter(|&c| c == '"').count() % 2 == 1
-        && let Some(quote_start) = after.rfind('"')
+        && let (quote_count, Some(quote_start)) =
+            deps_core::fallback_completion::count_real_quotes(after)
+        && !quote_count.is_multiple_of(2)
     {
         let value_start = field_start + rel_eq_pos + quote_start + 1;
         if value_start <= cursor {
@@ -188,8 +208,9 @@ fn detect_catalog_context<'a>(
     if let Some(rel_eq_pos) = field.rfind("module")
         && let after = &field[rel_eq_pos..]
         && after.contains('=')
-        && after.chars().filter(|&c| c == '"').count() % 2 == 1
-        && let Some(quote_start) = after.rfind('"')
+        && let (quote_count, Some(quote_start)) =
+            deps_core::fallback_completion::count_real_quotes(after)
+        && !quote_count.is_multiple_of(2)
     {
         let value_start = field_start + rel_eq_pos + quote_start + 1;
         if value_start <= cursor {
@@ -197,10 +218,10 @@ fn detect_catalog_context<'a>(
             // unclosed string doesn't swallow unrelated trailing line content into the
             // replace range (mirrors `MavenEcosystem::detect_xml_context`'s equivalent
             // no-closing-tag fallback).
-            let value_end = line[value_start..]
-                .find('"')
-                .map_or(cursor, |rel| value_start + rel)
-                .max(cursor);
+            let value_end =
+                deps_core::fallback_completion::find_closing_quote(&line[value_start..], '"')
+                    .map_or(cursor, |rel| value_start + rel)
+                    .max(cursor);
             let range = byte_range(line, line_idx, value_start, value_end);
             return ("package", &line[value_start..cursor], range);
         }
@@ -225,26 +246,24 @@ fn detect_dsl_context<'a>(
     line_idx: u32,
 ) -> (&'static str, &'a str, Range) {
     let cursor = col_idx.min(line.len());
-    let in_string = before_cursor
-        .chars()
-        .filter(|&c| c == '"' || c == '\'')
-        .count()
-        % 2
-        == 1;
-    if !in_string {
-        return ("", "", Range::default());
-    }
-
-    let colon_count = before_cursor.chars().filter(|&c| c == ':').count();
     let quote_char = if before_cursor.contains('"') {
         '"'
     } else {
         '\''
     };
-
-    let Some(open_pos) = before_cursor.rfind(quote_char) else {
+    // Escape-aware (see `count_real_quotes_with`) odd-parity check on the chosen quote
+    // character: an even count means the cursor sits past a closed string, or none was
+    // opened at all on this line (#738).
+    let (quote_count, last_real_quote) =
+        deps_core::fallback_completion::count_real_quotes_with(before_cursor, quote_char);
+    if quote_count.is_multiple_of(2) {
+        return ("", "", Range::default());
+    }
+    let Some(open_pos) = last_real_quote else {
         return ("", "", Range::default());
     };
+
+    let colon_count = before_cursor.chars().filter(|&c| c == ':').count();
 
     match colon_count {
         0 | 1 => {
@@ -255,7 +274,8 @@ fn detect_dsl_context<'a>(
             // content (mirrors `MavenEcosystem::detect_xml_context`'s no-closing-tag
             // fallback).
             let rest = &line[open_pos + 1..];
-            let closing_quote_rel = rest.find(quote_char);
+            let closing_quote_rel =
+                deps_core::fallback_completion::find_closing_quote(rest, quote_char);
             let scan_limit_rel = closing_quote_rel.unwrap_or(cursor - (open_pos + 1));
             let end_rel = rest[..scan_limit_rel]
                 .char_indices()
@@ -516,6 +536,44 @@ mod tests {
     }
 
     #[test]
+    fn test_detect_catalog_context_version_closed_value_with_escaped_quote_stays_closed() {
+        // version = "a\"b" | — cursor past a properly closed value that contains an
+        // escaped quote. A naive raw `"` count sees 3 quote characters (odd, "still
+        // open") and wrongly reports a "version" context whose value is the trailing
+        // space; the escape-aware count correctly sees 2 real quotes (even, closed) and
+        // reports no completion context at all (#738 follow-up).
+        let line = "version = \"a\\\"b\" ";
+        let col = line.len();
+        let before = &line[..col];
+        let (t, v, range) = detect_catalog_context(before, line, col, 0);
+        assert_eq!(t, "");
+        assert_eq!(v, "");
+        assert_eq!(range, Range::default());
+    }
+
+    #[test]
+    fn test_detect_catalog_context_module_escaped_quote_does_not_close_string() {
+        // module = "com.example\"extra:lib — an escaped quote inside the still-open
+        // value must not be miscounted as closing the string (#738): a naive raw `"`
+        // count sees 2 quote characters (even, "closed") while the escape-aware count
+        // correctly sees 1 real quote (odd, still open).
+        let line = "module = \"com.example\\\"extra:lib";
+        let col = line.len();
+        let before = &line[..col];
+        let (t, v, range) = detect_catalog_context(before, line, col, 0);
+        assert_eq!(t, "package");
+        let value_start = line.find('"').unwrap() + 1;
+        assert_eq!(v, &line[value_start..col]);
+        assert_eq!(
+            range,
+            Range::new(
+                Position::new(0, value_start as u32),
+                Position::new(0, col as u32)
+            )
+        );
+    }
+
+    #[test]
     fn test_detect_dsl_context_package_cursor_mid() {
         // implementation("junit|:junit:4.13.2")
         let line = r#"implementation("junit:junit:4.13.2")"#;
@@ -549,6 +607,51 @@ mod tests {
             Range::new(Position::new(0, 16), Position::new(0, 21))
         );
         assert_eq!(&line[16..21], "junit");
+    }
+
+    #[test]
+    fn test_detect_dsl_context_escaped_quote_in_earlier_group_does_not_block_completion() {
+        // implementation "a\"b", "com.foo:ba — the escaped quote inside the first,
+        // already-closed string argument must not desync the quote-parity check and
+        // suppress completion on the second, still-open string (#738). A naive raw `"`
+        // count sees 4 quote characters total (even, "no open string") and reports no
+        // completion context at all.
+        let line = "implementation \"a\\\"b\", \"com.foo:ba";
+        let col = line.len();
+        let before = &line[..col];
+        let (t, v, _range) = detect_dsl_context(before, line, col, 0);
+        assert_eq!(t, "package");
+        assert_eq!(v, "com.foo:ba");
+    }
+
+    #[test]
+    fn test_detect_dsl_context_apostrophe_inside_double_quoted_package_name() {
+        // implementation "com.o'reilly:li — an apostrophe inside a double-quoted
+        // string must not be mistaken for a single-quote delimiter (#738).
+        let line = r#"implementation "com.o'reilly:li"#;
+        let col = line.len();
+        let before = &line[..col];
+        let (t, v, _range) = detect_dsl_context(before, line, col, 0);
+        assert_eq!(t, "package");
+        assert_eq!(v, "com.o'reilly:li");
+    }
+
+    #[test]
+    fn test_detect_dsl_context_mixed_quote_types_on_one_line_no_completion() {
+        // exclude module: "x"; implementation 'com.baz:qu — a completed double-quoted
+        // string earlier on the line, followed by a still-open single-quoted string.
+        // `quote_char` picks '"' (the line contains one), whose own parity is even
+        // (closed), so this deliberately reports "no completion context" instead of
+        // guessing at the unrelated single-quoted string — accepted limitation, not a
+        // regression from this fix: a line mixing both quote styles picks one quote
+        // character for the whole line, not per-field.
+        let line = r#"exclude module: "x"; implementation 'com.baz:qu"#;
+        let col = line.len();
+        let before = &line[..col];
+        let (t, v, range) = detect_dsl_context(before, line, col, 0);
+        assert_eq!(t, "");
+        assert_eq!(v, "");
+        assert_eq!(range, Range::default());
     }
 
     #[test]

--- a/crates/deps-gradle/src/license.rs
+++ b/crates/deps-gradle/src/license.rs
@@ -23,6 +23,7 @@
 //! `<licenses>` block is empty, bounded by [`MAX_POM_FETCHES`] so a pathological (or
 //! adversarial) parent chain can't turn one hover request into an unbounded fetch chain.
 
+use deps_core::xml_bounds::exhausted_with;
 use deps_core::{HttpCache, MAX_POM_LICENSE_NAME_RAW_CHARS, is_safe_maven_coordinate_segment};
 use quick_xml::Reader;
 use quick_xml::events::Event;
@@ -238,9 +239,12 @@ fn parse_pom(data: &[u8]) -> PomInfo {
         // counterexamples that each defeated a shape-keyed counter): advances on every
         // event regardless of what it is, so it cannot be starved by a document that
         // simply omits the element type a narrower counter was watching for.
-        if licenses.len() >= MAX_POM_LICENSE_ENTRIES
-            || reader.buffer_position() as usize >= MAX_POM_LICENSE_BYTES_SCANNED
-        {
+        if exhausted_with(
+            licenses.len(),
+            reader.buffer_position(),
+            MAX_POM_LICENSE_ENTRIES,
+            MAX_POM_LICENSE_BYTES_SCANNED,
+        ) {
             break;
         }
         match reader.read_event() {


### PR DESCRIPTION
## Summary

- Generalizes `deps-core::fallback_completion`'s quote-parity counter to take the quote character as a parameter, sharing a single escape-aware scan (`real_quote_indices`) across `count_real_quotes_with` and a new `find_closing_quote`. Migrates all three of `deps-gradle`'s naive, non-escape-aware quote/apostrophe counters in `ecosystem.rs` onto it, fixing miscounted parity on an escaped quote in version-catalog and DSL completion context.
- Generalizes `deps-core::xml_bounds::exhausted` into `exhausted_with`, taking entry/byte budgets as parameters, and migrates `deps-gradle`'s POM license scan (`license.rs`) onto it in place of a private lossy `as usize` cast, hardening the fail-closed conversion for a 32-bit target (no behavior change on the 64-bit targets this project's CI builds for).
- Along the way, fixed an unclaimed related bug: a closed catalog value containing an escaped quote (`version = "a\"b" `) no longer gets misread as still-open by the naive parity count.

## Notable follow-up (not in scope for this PR)

The new `#[cfg(target_pointer_width = "32")]` test for `exhausted_with`'s fail-closed path is never compiled by this project's CI, since the `cross-check` matrix is entirely 64-bit. Worth a separate issue to add an `i686-unknown-linux-musl` leg if 32-bit correctness should have real CI coverage.

Closes #738
Closes #725

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4819 passed)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- [x] New unit tests for escape-aware quote parity (deps-core) and ecosystem-level regression tests (deps-gradle) covering escaped quotes in DSL and catalog entries, mixed-quote-style handling, and the closed-value fix