### PR TITLE
fix(deps-core): correct sealed-trait docs and fix broken intra-doc links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **deps-core, deps-cargo, deps-npm, deps-pypi, deps-go, deps-nuget, deps-maven**: `DepsError`'s `Display`/`Debug` and several ecosystem-crate warn/debug log lines no longer embed a workspace-declared registry URL's raw query string, closing a credential-exfiltration path via `window/showMessage` and `tracing` logs (resolves #767) (#775)
 - **deps-gradle**: version catalog/DSL completion no longer miscounts an escaped quote, via a generalized, quote-character-parameterized `deps-core` quote-parity helper (resolves #738) (#771)
+- **Breaking (pre-1.0, public API)**: **deps-core**: fixed 16 broken rustdoc intra-doc links invisible to the default CI rustdoc gate, renaming the public `in_use_version` function to `resolve_in_use_version` to resolve a function/module name ambiguity (resolves #765) (#772)
+- **deps-core**: corrected the `Ecosystem` sealed-trait docs, which overclaimed that implementation is restricted to this workspace when it is a documented contract, not a compiler-enforced one (resolves #770) (#772)
 - **deps-core**: manifest parsing now runs on the blocking-thread pool instead of the calling tokio worker, no longer stalling the LSP request worker on a large manifest (resolves #743) (#747)
 - **deps-core**: `LineOffsetTable::byte_offset_to_position` no longer rescans an ASCII line from its start on every call, fixing an O(n^2) slowdown on large single-line (minified) manifests (resolves #742) (#747)
 - **deps-pypi**: raw-text fallback completion no longer bare-inserts an unquoted package name into a `pyproject.toml` dependency array when no quote has been typed yet, producing invalid TOML (resolves #737) (#741)

--- a/crates/deps-cargo/tests/source_replace_test.rs
+++ b/crates/deps-cargo/tests/source_replace_test.rs
@@ -277,7 +277,7 @@ fn test_mirror_distinct_pinned_versions_produce_distinct_vulnerability_keys() {
         uri: deps_core::test_util::test_uri("/test/Cargo.toml"),
     };
 
-    // No lockfile-resolved versions; `in_use_version` falls back to the manifest
+    // No lockfile-resolved versions; `resolve_in_use_version` falls back to the manifest
     // requirement, which is already concrete (`=X.Y.Z`) for both occurrences.
     let resolved: HashMap<PackageName, ConcreteVersion> = HashMap::new();
     let formatter = CargoFormatter;

--- a/crates/deps-core/src/cache.rs
+++ b/crates/deps-core/src/cache.rs
@@ -69,7 +69,7 @@ const MAX_RESPONSE_BYTES: usize = 32 * 1024 * 1024;
 /// Ceiling every [`BodyLimit`] is clamped to at construction, so no caller can weaken
 /// the size guard [`read_body_capped`] enforces past this value.
 ///
-/// 128 MiB comfortably covers the largest known caller ([`crate`][deps-pypi]'s PyPI
+/// 128 MiB comfortably covers the largest known caller (`deps-pypi`'s PyPI
 /// Simple API full index, ~43 MB decompressed today, capped at 96 MiB for organic
 /// growth) while still bounding the pathological case.
 const ABSOLUTE_MAX_RESPONSE_BYTES: usize = 128 * 1024 * 1024;

--- a/crates/deps-core/src/deps_dev/mod.rs
+++ b/crates/deps-core/src/deps_dev/mod.rs
@@ -78,7 +78,7 @@ const DEPS_DEV_BODY_LIMIT: usize = 1024 * 1024;
 /// Key for [`DepsDevClient`]'s version-level memo.
 ///
 /// A typed struct, not a `\0`-joined string: `name` comes from a manifest
-/// and `version` from `in_use_version` (whose lockfile `ConcreteVersion`
+/// and `version` from `resolve_in_use_version` (whose lockfile `ConcreteVersion`
 /// branch is never charset-validated), so a joined-string key could let
 /// `("a\0b", "c")` and `("a", "b\0c")` collide and serve another package's
 /// trust signal. A derived `Hash`/`Eq` over four fields cannot collide by

--- a/crates/deps-core/src/ecosystem.rs
+++ b/crates/deps-core/src/ecosystem.rs
@@ -12,14 +12,28 @@ use crate::{
     registry::Metadata,
 };
 
-/// Sealing mechanism restricting [`Ecosystem`] implementations to this workspace.
+/// Soft-sealing mechanism for [`Ecosystem`], shared by every ecosystem crate in this
+/// workspace (`deps-cargo`, `deps-npm`, ...) — each implements [`private::Sealed`] for
+/// its own ecosystem type.
+///
+/// Rust's privacy system has no "visible to this workspace, not beyond" level: `pub(crate)`
+/// would restrict `Sealed` to `deps-core` alone, breaking every sibling ecosystem crate's
+/// `impl Sealed for ...`, since each of those is a separate compilation unit. Making this
+/// module `pub` is therefore required, not a mistake — but it means [`private::Sealed`] is
+/// technically nameable, and implementable, from any crate that depends on `deps-core`, not
+/// only from within this workspace. `#[doc(hidden)]` keeps it out of generated public docs to
+/// avoid inviting that. There is no compiler-enforced wall against it: this is a documented
+/// contract enforced by code review, not a hard guarantee, and [`Ecosystem`]'s default
+/// methods may gain new required behavior without that counting as a breaking change for an
+/// external implementor who ignored this notice.
+#[doc(hidden)]
 pub mod private {
-    /// Marker trait that only crates inside this workspace can implement.
+    /// Marker trait every ecosystem crate in this workspace implements for its own
+    /// ecosystem type, per [`super::private`]'s module doc.
     ///
     /// [`Ecosystem`](super::Ecosystem) requires `Self: Sealed`, which is how the
     /// trait stays extensible (new default methods can be added without
-    /// breaking downstream implementors) while still forbidding external
-    /// crates from implementing it.
+    /// breaking in-workspace implementors).
     pub trait Sealed {}
 }
 
@@ -472,6 +486,18 @@ impl LicenseSource {
 /// This trait uses `Box<dyn Trait>` instead of associated types to allow
 /// runtime polymorphism and dynamic ecosystem registration.
 ///
+/// # Sealing
+///
+/// This trait requires `Self: private::Sealed`, making it sealed in the sense described
+/// on that module's doc: a documented contract enforced by code review, not a
+/// compiler-enforced wall. Every sibling ecosystem crate in this workspace (`deps-cargo`,
+/// `deps-npm`, ...) implements [`private::Sealed`] for its own ecosystem type, which requires
+/// `private` to be `pub`; Rust has no visibility level that admits sibling crates while
+/// excluding a truly external one, so this guarantee cannot be enforced any harder than that
+/// without inverting the crate's whole multi-crate extension-point architecture. See
+/// [`private::Sealed`]'s own doc for the full reasoning, and the `impl private::Sealed`
+/// line in the example below for what implementing it in practice looks like.
+///
 /// # Examples
 ///
 /// ```no_run
@@ -502,6 +528,11 @@ impl LicenseSource {
 ///     formatter: MyFormatter,
 /// }
 ///
+/// // Real in-workspace ecosystem crates implement `Sealed` exactly like this. This line
+/// // compiling here, out-of-crate, is not a bug: as the `# Sealing` section above explains,
+/// // `private::Sealed` is a documented contract, not a compiler-enforced wall — Rust has no
+/// // visibility level that admits sibling workspace crates while excluding a truly external
+/// // one, so any crate that names this path can technically do the same.
 /// impl deps_core::ecosystem::private::Sealed for MyEcosystem {}
 ///
 /// impl Ecosystem for MyEcosystem {

--- a/crates/deps-core/src/lockfile.rs
+++ b/crates/deps-core/src/lockfile.rs
@@ -334,7 +334,7 @@ pub struct ResolvedPackages {
 /// falling back to a lexicographic compare when both (or neither) parse.
 ///
 /// Shared by [`best_package`] and the per-occurrence candidate selection in
-/// [`crate::lsp_helpers::in_use_version`] (issue #649) so a lock file entry with a
+/// [`crate::lsp_helpers::resolve_in_use_version`] (issue #649) so a lock file entry with a
 /// non-semver version string is never ordered by two diverging policies depending on which
 /// caller is asking.
 pub(crate) fn compare_lockfile_versions(a: &str, b: &str) -> std::cmp::Ordering {

--- a/crates/deps-core/src/lsp_helpers/code_actions.rs
+++ b/crates/deps-core/src/lsp_helpers/code_actions.rs
@@ -16,7 +16,7 @@ use super::{
 /// re-parsing the action's title.
 struct VulnerabilityFixAction {
     /// `fix.version`, converted to this ecosystem's namespace via
-    /// [`EcosystemFormatter::osv_version_to_native`].
+    /// [`crate::lsp_helpers::OsvNaming::osv_version_to_native`].
     version_native: String,
     /// The formatted edit text this action's own `TextEdit` writes — the exact
     /// value `action.edit` carries, kept alongside it so callers (the REFACTOR-loop
@@ -84,7 +84,7 @@ fn fix_target_is_verified(
 /// against OSV (#462) — see [`fix_target_is_verified`].
 ///
 /// Registry-independent by construction (FR-007, mirroring the rule already
-/// enforced in [`generate_diagnostics_from_cache`]): computed entirely from
+/// enforced in [`crate::lsp_helpers::generate_diagnostics_from_cache`]): computed entirely from
 /// `versions.vulnerabilities` and `version_req` (the caller's already-fetched
 /// `dep.version_requirement()`), never from a registry fetch — a *registry*
 /// outage still never hides this action. It is not OSV-independent, though:
@@ -249,7 +249,7 @@ struct UnsatisfiableFixAction {
 /// `versions` snapshot and the dependency's declared requirement, before any registry
 /// fetch, so a registry outage never hides it (the same FR-007 rationale). Gated by
 /// [`requirement_is_unsatisfiable`] evaluated against the identical inputs
-/// [`generate_diagnostics_from_cache`] uses, so this action can never appear without —
+/// [`crate::lsp_helpers::generate_diagnostics_from_cache`] uses, so this action can never appear without —
 /// or be missing despite — the diagnostic it resolves.
 ///
 /// Targets `versions.cached[..].latest`, the **cached** value, not a freshly fetched one:
@@ -339,7 +339,7 @@ fn build_unsatisfiable_fix_action(
 }
 
 /// Builds the "Replace with X" package-rename quickfix for `dep` (issue #205), if this
-/// ecosystem opts in via [`EcosystemFormatter::supports_package_rename`] and a
+/// ecosystem opts in via [`crate::lsp_helpers::DiagnosticPolicy::supports_package_rename`] and a
 /// registry-supplied replacement name is on record.
 ///
 /// **Composer-only in Phase 1** — see `EcosystemFormatter::supports_package_rename`'s

--- a/crates/deps-core/src/lsp_helpers/diagnostics.rs
+++ b/crates/deps-core/src/lsp_helpers/diagnostics.rs
@@ -341,7 +341,7 @@ pub fn requirement_is_unsatisfiable(
 /// `None` means `version` is already a stable release, not that it failed to parse — this
 /// is a textual SemVer split, not a validating parse. Callers only rely on it for
 /// strict-SemVer ecosystems (see
-/// [`EcosystemFormatter::strict_semver_prerelease_exclusion`]), whose registries only
+/// [`crate::lsp_helpers::DiagnosticPolicy::strict_semver_prerelease_exclusion`]), whose registries only
 /// publish spec-conformant version strings.
 // `dash` comes from `str::find('-')`, an ASCII byte, so it is always a char boundary.
 #[allow(clippy::string_slice)]
@@ -373,7 +373,7 @@ fn requirement_names_prerelease(requirement: &str) -> bool {
 }
 
 /// For strict-SemVer ecosystems (see
-/// [`EcosystemFormatter::strict_semver_prerelease_exclusion`]), finds the newest published,
+/// [`crate::lsp_helpers::DiagnosticPolicy::strict_semver_prerelease_exclusion`]), finds the newest published,
 /// non-yanked pre-release in `available` whose stable core would satisfy `requirement` —
 /// evidence that `requirement` reads as unsatisfiable only because SemVer's default comparator
 /// excludes pre-releases, not because no compatible version was ever published (#299).
@@ -436,7 +436,7 @@ fn status_for_version(
 /// The aggregate is `Yanked` if any matching entry's status is `Yanked`, else
 /// `AdvisoryDeprecated` (the only other status `yanked` entries carry — see
 /// [`PackageVersions::yanked`]). This lets the caller apply the same D5 gate #263 uses
-/// (see [`VersionData::yanked`]'s docs): suppress the diagnostic for an `AdvisoryDeprecated`
+/// (see [`crate::lsp_helpers::DependencyOutcome::yanked`]'s docs): suppress the diagnostic for an `AdvisoryDeprecated`
 /// aggregate when a package-level deprecation finding co-occurs, but never for a `Yanked`
 /// one, even if one of several matching entries is merely deprecated (#437).
 ///
@@ -946,7 +946,7 @@ fn apply_deprecation_rule(diagnostics: &mut Vec<Diagnostic>, ctx: &RuleContext<'
 /// scope here.
 ///
 /// Reads: `ctx.versions.outcomes.yanked(ctx.normalized_name)` -> `(yanked_version,
-/// status)`; `ctx.versions.ecosystem`; `super::in_use_version(...)`.
+/// status)`; `ctx.versions.ecosystem`; `super::resolve_in_use_version(...)`.
 /// Gate D5 (`deprecation_found`): a package-level deprecation finding suppresses this
 /// check — but only when the underlying yanked finding's status is
 /// `AdvisoryDeprecated`, never when it is `Yanked`. A genuine hard yank ("the exact
@@ -999,7 +999,7 @@ fn apply_in_use_yanked_rule(
         .outcomes
         .and_then(|o| o.yanked(ctx.normalized_name))
         && ctx.versions.ecosystem.is_none_or(|ecosystem| {
-            super::in_use_version(
+            super::resolve_in_use_version(
                 ctx.dep,
                 ctx.normalized_name,
                 ctx.versions.resolved,

--- a/crates/deps-core/src/lsp_helpers/hover.rs
+++ b/crates/deps-core/src/lsp_helpers/hover.rs
@@ -14,7 +14,7 @@ use crate::{
 
 use super::{
     EcosystemFormatter, HOVER_RECENT_VERSIONS, VersionData, escape_markdown, in_use_version,
-    markdown_code_span, position_in_range,
+    markdown_code_span, position_in_range, resolve_in_use_version,
 };
 use crate::github::normalize_tag;
 
@@ -335,21 +335,21 @@ pub async fn generate_hover<R: Registry + ?Sized>(
     // PyPI — the version list itself never carries license for these, live-verified).
     // Latest-version license only ever comes from the native list — deps.dev's
     // version-level call only ever targets the *resolved* version
-    // (`spawn_trust_signal_fetch`'s `in_use_version` argument), so a deps.dev-routed
+    // (`spawn_trust_signal_fetch`'s `resolve_in_use_version` argument), so a deps.dev-routed
     // ecosystem's latest license degrades to "(unavailable)", the graceful-degradation
     // edge case spec 010 §6 explicitly sanctions rather than a second network call.
     //
-    // The native-list lookup keys on `in_use_version` (the same helper
+    // The native-list lookup keys on `resolve_in_use_version` (the same helper
     // `spawn_trust_signal_fetch` already uses above), not the weaker `resolved`
-    // variable the `**Current**`/`**Requirement**` line uses — `in_use_version` adds
+    // variable the `**Current**`/`**Requirement**` line uses — `resolve_in_use_version` adds
     // a `concrete_pin_version` fallback for an exact manifest pin with no lock file
     // (e.g. a `composer.json` `"3.0.0"` dependency with no `composer.lock`), which
     // `resolved` alone doesn't have. Falls back to `resolved` when no ecosystem is
-    // set (`in_use_version` requires one) — a handful of test fixtures only
+    // set (`resolve_in_use_version` requires one) — a handful of test fixtures only
     // (impl-critic review M1: keeps this lookup as least as capable as the
     // deps.dev-routed ecosystems', not just consistent with the Current line).
     let in_use_version_str: Option<String> = versions.ecosystem.and_then(|ecosystem| {
-        in_use_version(
+        resolve_in_use_version(
             dep,
             normalized_name.as_str(),
             versions.resolved,
@@ -543,7 +543,7 @@ fn spawn_trust_signal_fetch(
         if versions.offline || !formatter.source_is_public_registry_content(dep_source) {
             return None;
         }
-        let version = in_use_version(
+        let version = resolve_in_use_version(
             dep,
             normalized_name,
             versions.resolved,
@@ -560,7 +560,7 @@ fn spawn_trust_signal_fetch(
 }
 
 /// Appends the hover header: the dependency name, linked to its registry page when
-/// `url` (from [`EcosystemFormatter::package_url`]) is present.
+/// `url` (from [`crate::lsp_helpers::PackageRendering::package_url`]) is present.
 fn push_header_hover_section(markdown: &mut String, dep: &dyn Dependency, url: Option<&str>) {
     use std::fmt::Write as _;
 
@@ -579,7 +579,7 @@ fn push_header_hover_section(markdown: &mut String, dep: &dyn Dependency, url: O
 
 /// Appends the hover "Current"/"Requirement" line. `resolved` — already selecting
 /// between an ecosystem's resolved manifest requirement and the lockfile-resolved
-/// version, per [`EcosystemFormatter::manifest_requirement_is_resolved_version`] —
+/// version, per [`crate::lsp_helpers::RequirementResolution::manifest_requirement_is_resolved_version`] —
 /// wins over the bare manifest requirement when present.
 fn push_current_or_requirement_hover_section(
     markdown: &mut String,
@@ -1337,7 +1337,7 @@ mod tests {
     /// resolution renders no `**Current**` line (`resolved` stays `None` —
     /// `resolve_occurrence_version` has nothing to match against an empty
     /// `resolved_versions` map), but the license must still be found via the same
-    /// `in_use_version` concrete-pin fallback `spawn_trust_signal_fetch` already
+    /// `resolve_in_use_version` concrete-pin fallback `spawn_trust_signal_fetch` already
     /// uses for the deps.dev path — the native-list lookup must be at least as
     /// capable, not silently weaker just because it reused the `resolved` variable.
     #[tokio::test]
@@ -1712,7 +1712,7 @@ mod tests {
     /// Review round 3 regression: for a deps.dev-routed ecosystem, `available_versions[idx]`
     /// entries never carry license (that trait method's default is empty — only the
     /// native-list ecosystems like Composer override it), so the "latest == resolved"
-    /// shortcut MUST use the same `in_use_version`-derived key the resolved-license
+    /// shortcut MUST use the same `resolve_in_use_version`-derived key the resolved-license
     /// lookup itself used, not the weaker bare `resolved`. An earlier draft compared
     /// the shortcut against `resolved` (which stays `None` here — no lock-file entry
     /// matches an exact `=4.19.2` pin) while the lookup used `in_use_version_str`
@@ -1744,7 +1744,7 @@ mod tests {
         };
         // No lock-file entries: `versions.resolved` stays empty, so the bare
         // `resolved` variable used for the `**Current**` line has no match — only
-        // `in_use_version`'s `concrete_pin_version` fallback resolves the pin.
+        // `resolve_in_use_version`'s `concrete_pin_version` fallback resolves the pin.
         let registry = MockRegistryWithVersions {
             versions: vec![MockVersionWithAge {
                 version: "4.19.2".into(),

--- a/crates/deps-core/src/lsp_helpers/in_use_version.rs
+++ b/crates/deps-core/src/lsp_helpers/in_use_version.rs
@@ -31,7 +31,7 @@ enum BareRequirementPolicy {
 
 /// Ecosystems whose *bare* (no explicit pin marker) version requirement is
 /// unconditionally a range under that ecosystem's own default semantics —
-/// Cargo's implicit caret. For these, [`is_concrete_version`] requires an
+/// Cargo's implicit caret. For these, [`concrete_pin_version`] requires an
 /// explicit `=`/`==` (or an exact-bracket wrap) before treating a requirement
 /// as concrete; a bare `"1.2.3"` alone is not enough evidence (critique C2).
 /// Cargo is the sole member of this group: every other ecosystem with an
@@ -207,7 +207,7 @@ pub fn is_full_semver_shape(s: &str) -> bool {
 /// character, and starting with a digit (after an optional `v`/`V` prefix,
 /// e.g. Go's `v1.9.1`).
 ///
-/// Deliberately conservative — see [`is_concrete_version`]'s doc for why a
+/// Deliberately conservative — see [`concrete_pin_version`]'s doc for why a
 /// false positive here is worse than a false negative.
 fn looks_like_a_single_version(s: &str) -> bool {
     if s.is_empty() {
@@ -303,16 +303,16 @@ fn is_concrete_version(requirement: &str, ecosystem: EcosystemId) -> bool {
 /// Picks the lock-file-resolved candidate that best matches one dependency occurrence's own
 /// version requirement (FR-001/FR-002), among a name's multiple retained lock-file entries.
 ///
-/// Filters `candidates` down to those [`EcosystemFormatter::version_satisfies_requirement`]
+/// Filters `candidates` down to those [`crate::lsp_helpers::RequirementResolution::version_satisfies_requirement`]
 /// accepts, then returns the highest-semver entry among that satisfying subset — falling back
 /// to [`crate::lockfile`]'s lexicographic tiebreak for non-parseable versions
 /// ([`crate::lockfile::compare_lockfile_versions`]), the same ordering a single-candidate
 /// collapse already uses, so this never diverges from it. Returns `None` when nothing
 /// satisfies the requirement (FR-003) — the caller must not then substitute an arbitrary
 /// non-matching entry.
-/// Prefers [`RequirementResolution::compile_requirement`]'s precise, ecosystem-native
+/// Prefers [`crate::lsp_helpers::RequirementResolution::compile_requirement`]'s precise, ecosystem-native
 /// comparator (e.g. `deps-cargo`'s real `semver::VersionReq` range semantics) over
-/// [`RequirementResolution::version_satisfies_requirement`]'s looser heuristic — critical
+/// [`crate::lsp_helpers::RequirementResolution::version_satisfies_requirement`]'s looser heuristic — critical
 /// here specifically because that heuristic's plain/partial-requirement branch requires
 /// *minor-version equality* (`is_same_major_minor`), so a caret-range requirement like
 /// Cargo's `"2.4"` (meaning `>=2.4.0, <3.0.0`) would wrongly reject a `2.9.4` candidate,
@@ -356,7 +356,7 @@ fn best_candidate_for_requirement<'a>(
 /// requirement (FR-003) — that last case intentionally does not substitute the collapsed
 /// value, since it would be an arbitrary, possibly wrong, non-matching entry.
 ///
-/// Shared by [`in_use_version`] and the resolved-version lookups in
+/// Shared by [`resolve_in_use_version`] and the resolved-version lookups in
 /// [`super::hover::generate_hover`] and [`super::inlay_hints::generate_inlay_hints`] so all
 /// three surfaces (hover, inlay hints, OSV target selection) apply the identical
 /// per-occurrence disambiguation policy (US-001/US-002).
@@ -411,7 +411,7 @@ pub(crate) fn resolve_occurrence_version<'a>(
 /// ```
 /// use deps_core::lsp_helpers::{
 ///     DiagnosticMessages, DiagnosticPolicy, OsvNaming, PackageNaming, PackageRendering,
-///     RequirementResolution, SourcePolicy, in_use_version,
+///     RequirementResolution, SourcePolicy, resolve_in_use_version,
 /// };
 /// use deps_core::{ConcreteVersion, Dependency, EcosystemId, PackageName, VersionReq};
 /// use std::any::Any;
@@ -469,11 +469,11 @@ pub(crate) fn resolve_occurrence_version<'a>(
 /// // No lock file, but the requirement is already an exact pin — falls
 /// // back to it, stripped of its `=` marker.
 /// assert_eq!(
-///     in_use_version(&dep, "time", &resolved_versions, None, &SimpleFormatter, EcosystemId::Cargo),
+///     resolve_in_use_version(&dep, "time", &resolved_versions, None, &SimpleFormatter, EcosystemId::Cargo),
 ///     Some("0.1.43".to_string())
 /// );
 /// ```
-pub fn in_use_version(
+pub fn resolve_in_use_version(
     dep: &dyn Dependency,
     normalized_name: &str,
     resolved_versions: &HashMap<PackageName, ConcreteVersion>,
@@ -924,7 +924,7 @@ mod tests {
             ],
         );
 
-        let renamed_result = in_use_version(
+        let renamed_result = resolve_in_use_version(
             &renamed_old_major,
             "serde",
             &resolved_versions,
@@ -932,7 +932,7 @@ mod tests {
             &crate::lsp_helpers::test_support::MockFormatter,
             EcosystemId::Cargo,
         );
-        let plain_result = in_use_version(
+        let plain_result = resolve_in_use_version(
             &plain_current_major,
             "serde",
             &resolved_versions,
@@ -970,7 +970,7 @@ mod tests {
             ],
         );
 
-        let result = in_use_version(
+        let result = resolve_in_use_version(
             &dep,
             "serde",
             &resolved_versions,
@@ -1006,7 +1006,7 @@ mod tests {
             ],
         );
 
-        let result = in_use_version(
+        let result = resolve_in_use_version(
             &dep,
             "serde",
             &resolved_versions,
@@ -1041,7 +1041,7 @@ mod tests {
             vec![ConcreteVersion::from("1.0.219")],
         );
 
-        let with_candidates = in_use_version(
+        let with_candidates = resolve_in_use_version(
             &dep,
             "serde",
             &resolved_versions,
@@ -1049,7 +1049,7 @@ mod tests {
             &crate::lsp_helpers::test_support::MockFormatter,
             EcosystemId::Cargo,
         );
-        let without_candidates = in_use_version(
+        let without_candidates = resolve_in_use_version(
             &dep,
             "serde",
             &resolved_versions,
@@ -1160,7 +1160,7 @@ mod tests {
             ],
         );
 
-        let result = in_use_version(
+        let result = resolve_in_use_version(
             &dep,
             "pkg",
             &resolved_versions,
@@ -1190,7 +1190,7 @@ mod tests {
             name_range: tower_lsp_server::ls_types::Range::default(),
         };
 
-        let result = in_use_version(
+        let result = resolve_in_use_version(
             &dep,
             "express",
             &HashMap::new(),
@@ -1216,7 +1216,7 @@ mod tests {
             name_range: tower_lsp_server::ls_types::Range::default(),
         };
 
-        let result = in_use_version(
+        let result = resolve_in_use_version(
             &dep,
             "monolog/monolog",
             &HashMap::new(),
@@ -1243,7 +1243,7 @@ mod tests {
             name_range: tower_lsp_server::ls_types::Range::default(),
         };
 
-        let result = in_use_version(
+        let result = resolve_in_use_version(
             &dep,
             "serde",
             &HashMap::new(),
@@ -1272,7 +1272,7 @@ mod tests {
             name_range: tower_lsp_server::ls_types::Range::default(),
         };
 
-        let result = in_use_version(
+        let result = resolve_in_use_version(
             &dep,
             "express",
             &HashMap::new(),
@@ -1308,7 +1308,7 @@ mod tests {
             name_range: tower_lsp_server::ls_types::Range::default(),
         };
 
-        let result = in_use_version(
+        let result = resolve_in_use_version(
             &dep,
             "newtonsoft.json",
             &HashMap::new(),

--- a/crates/deps-core/src/lsp_helpers/mod.rs
+++ b/crates/deps-core/src/lsp_helpers/mod.rs
@@ -41,7 +41,7 @@ pub use git_ref::{
     match_v_prefix_style,
 };
 pub use hover::{CMD_DOT_FOOTER, generate_hover};
-pub use in_use_version::{concrete_pin_version, in_use_version, is_full_semver_shape};
+pub use in_use_version::{concrete_pin_version, is_full_semver_shape, resolve_in_use_version};
 pub use inlay_hints::generate_inlay_hints;
 
 /// Maximum number of recent versions hover's "Recent versions" section renders.
@@ -436,7 +436,7 @@ pub struct VersionData<'a> {
     /// Every lock-file-resolved version for a package name, when more than one is retained
     /// (issue #649) — additive alongside [`Self::resolved`], which stays the single
     /// collapsed value for the common case. `None` by default (most call sites have no such
-    /// map); [`crate::lsp_helpers::in_use_version`] and [`crate::osv::vulnerability_keys`]
+    /// map); [`crate::lsp_helpers::resolve_in_use_version`] and [`crate::osv::vulnerability_keys`]
     /// consult it to disambiguate two manifest occurrences of one resolved name (e.g. a
     /// Cargo `package = "..."` rename pinning an older major) by each occurrence's own
     /// `version_requirement()`, falling back to [`Self::resolved`] when a name has at most
@@ -1397,7 +1397,7 @@ pub fn warn_rejected_value(gate: &str, context: &str, value: &str) {
     );
 }
 
-/// Builds a single-entry [`WorkspaceEdit::changes`] map replacing `range` in `uri`
+/// Builds a single-entry [`tower_lsp_server::ls_types::WorkspaceEdit::changes`] map replacing `range` in `uri`
 /// with `new_text`.
 ///
 /// Shared by every quickfix/refactor code action in `code_actions` that edits exactly

--- a/crates/deps-core/src/osv/types.rs
+++ b/crates/deps-core/src/osv/types.rs
@@ -724,7 +724,7 @@ pub fn vulnerability_keys(
     formatter: &dyn crate::lsp_helpers::EcosystemFormatter,
     ecosystem: crate::EcosystemId,
 ) -> HashMap<tower_lsp_server::ls_types::Range, String> {
-    use crate::lsp_helpers::in_use_version;
+    use crate::lsp_helpers::resolve_in_use_version;
 
     let deps = parse_result.dependencies();
 
@@ -744,7 +744,7 @@ pub fn vulnerability_keys(
         .map(|dep| {
             let name = formatter.normalize_package_name(dep.name());
             let signature = if formatter.source_is_public_registry_content(&dep.source()) {
-                match in_use_version(
+                match resolve_in_use_version(
                     *dep,
                     &name,
                     resolved,

--- a/crates/deps-lsp/src/document/osv_scan.rs
+++ b/crates/deps-lsp/src/document/osv_scan.rs
@@ -8,7 +8,7 @@ use deps_core::ConcreteVersion;
 use deps_core::Ecosystem;
 use deps_core::EcosystemId;
 use deps_core::PackageName;
-use deps_core::lsp_helpers::in_use_version;
+use deps_core::lsp_helpers::resolve_in_use_version;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -108,7 +108,7 @@ fn build_scan_targets(
         // to OSV (excludes/replaces fall through to the lockfile lookup below
         // like any other ecosystem, since their `version_requirement()` is
         // not an in-use version — see `manifest_requirement_is_resolved_version`).
-        let version = in_use_version(
+        let version = resolve_in_use_version(
             dep,
             &normalized_name,
             resolved_versions,
@@ -293,7 +293,7 @@ pub(crate) async fn run_osv_scan_phase_a(
 /// all — it reflects pana's detection on whatever pub.dev last scored, not necessarily
 /// the resolved version. Swift's `get_license` calls GitHub's `GET /repos/{owner}/{repo}`,
 /// which reflects the repository's *default branch*, not the resolved version's tag.
-/// `in_use_version` below is still required as a *gate* for all four (no version
+/// `resolve_in_use_version` below is still required as a *gate* for all four (no version
 /// resolved means nothing to look up), but for Dart/Swift it does not pin which
 /// version's license is actually returned.
 ///
@@ -332,7 +332,7 @@ pub(crate) async fn run_license_prefetch(
             .filter(|d| formatter.source_is_public_registry_content(&d.source()))
             .filter_map(|d| {
                 let normalized = formatter.normalize_package_name(d.name());
-                let version = in_use_version(
+                let version = resolve_in_use_version(
                     d,
                     normalized.as_str(),
                     &doc.resolved_versions,
@@ -1339,7 +1339,7 @@ mod tests {
 
         /// #667 follow-up (impl-critic): before this reclassification, a Deno `jsr:`
         /// dependency's bare requirement always failed the version gate under
-        /// `AlwaysRange` (`in_use_version` always `None`), so `DenoFormatter::
+        /// `AlwaysRange` (`resolve_in_use_version` always `None`), so `DenoFormatter::
         /// osv_package_name`'s `_ => None` arm for `jsr:` never actually ran in a live
         /// scan. Now that Deno is `ConcreteIfFullVersion`, a bare-full-version-pinned
         /// `jsr:` dependency passes the version gate and correctness rests entirely on
@@ -1586,7 +1586,7 @@ mod tests {
             );
         }
 
-        // `collect_in_use_versions` (§4.6) reuses the same `in_use_version`
+        // `collect_in_use_versions` (§4.6) reuses the same `resolve_in_use_version`
         // ladder as `build_scan_targets` above, plus its own step-0 filter —
         // these tests exercise that reuse directly.
 

--- a/crates/deps-lsp/src/document/resolved.rs
+++ b/crates/deps-lsp/src/document/resolved.rs
@@ -7,7 +7,7 @@ use deps_core::EcosystemId;
 use deps_core::PackageName;
 use deps_core::PackageVersions;
 use deps_core::VersionReq;
-use deps_core::lsp_helpers::in_use_version;
+use deps_core::lsp_helpers::resolve_in_use_version;
 use std::collections::HashMap;
 use tower_lsp_server::ls_types::Uri;
 
@@ -73,7 +73,7 @@ pub(crate) fn collect_in_use_versions(
         .filter(|dep| formatter.source_is_public_registry_content(&dep.source()))
     {
         let normalized_name = formatter.normalize_package_name(dep.name());
-        if let Some(v) = in_use_version(
+        if let Some(v) = resolve_in_use_version(
             dep,
             &normalized_name,
             resolved_versions,

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -1914,7 +1914,9 @@ impl {Ecosystem}Ecosystem {
     }
 }
 
-// Required sealed trait impl — prevents external implementations
+// Required sealed trait impl — a documented contract (code review, not the compiler)
+// restricting `Ecosystem` implementations to crates in this workspace; see
+// `deps_core::ecosystem::private`'s doc for why Rust cannot enforce this any harder.
 impl deps_core::ecosystem::private::Sealed for {Ecosystem}Ecosystem {}
 
 impl Ecosystem for {Ecosystem}Ecosystem {
@@ -2182,7 +2184,8 @@ Before submitting a PR for a new ecosystem:
 - [ ] Lock file parser implementing `LockFileProvider` trait (`locate_lockfile` + `parse_lockfile`)
 - [ ] Formatter implementing `EcosystemFormatter` trait (`format_version_for_text_edit` + `package_url`)
 - [ ] Registry client implementing `deps_core::Registry` trait with BoxFuture signatures
-- [ ] Ecosystem impl with `impl deps_core::ecosystem::private::Sealed` block
+- [ ] Ecosystem impl with `impl deps_core::ecosystem::private::Sealed` block (the workspace's
+      documented-contract sealing convention, not a compiler-enforced restriction)
 - [ ] `completion_insert_text` implemented (required, no default — issue #722); override
       `fallback_completion_prefix` too if this manifest format has a raw-text
       dependencies-section boundary to detect, reusing `deps_core::fallback_completion`'s


### PR DESCRIPTION
## Summary

- `Ecosystem`'s `private::Sealed` pattern was documented as blocking external implementations, but the seal as shaped cannot actually enforce that while still letting sibling ecosystem crates in this workspace implement it — Rust has no workspace-scoped visibility level, only pub/pub(crate)/pub(super)/pub(in path), scoped strictly to the defining crate. `pub(crate)` on `private` would make `Sealed` unreachable from every sibling ecosystem crate (deps-cargo, deps-npm, ...), breaking their `impl Ecosystem for ...`.
- Corrected the doc comments on `Ecosystem` and `ecosystem::private` to state the real, honest guarantee (a documented contract enforced by code review, not a compiler-enforced wall), added a `# Sealing` section to `Ecosystem`'s own public doc comment, annotated the trait's doctest example (which still does `impl private::Sealed for MyEcosystem` and compiles out-of-crate) explaining it deliberately illustrates the non-enforced contract, added `#[doc(hidden)]` to the `private` module to reduce discoverability, and updated `docs/ECOSYSTEM_GUIDE.md`'s matching overclaim.
- Fixed all 16 broken rustdoc intra-doc links in `deps-core` that are invisible to the default CI rustdoc gate (which does not pass `--document-private-items`), by qualifying paths to their actual owning traits/types (`OsvNaming`, `DiagnosticPolicy`, `PackageRendering`, `RequirementResolution`) and correcting two stale references (`is_concrete_version` → `concrete_pin_version`, `VersionData::yanked` → `DependencyOutcome::yanked`).
- Resolved a `lsp_helpers::in_use_version` function/module name ambiguity (flagged by rustdoc under `--document-private-items`) by renaming the free function to `resolve_in_use_version` across `deps-core` and `deps-lsp` call sites. This is a breaking public-API change (the function was `pub use`d), flagged as such in the changelog since the project is pre-1.0.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4807 passed)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTFLAGS="-D warnings" cargo +nightly rustdoc -p deps-core --all-features -- -Z unstable-options --document-private-items --deny rustdoc::broken_intra_doc_links` (0 errors, was 17)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- [x] Verified generated HTML: `Ecosystem`'s public doc page carries the new `# Sealing` section; the `private` module page is not emitted (doc(hidden) is effective)

Closes #770
Closes #765