### PR TITLE
test(ecosystem crates): migrate remaining 13 crates to shared conformance macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: property tests (`proptest`) asserting the parser depth/expansion checkers and JSONC position recovery never panic on arbitrary input (#673)
 - **deps-core**: `EcosystemId::ALL`, generated from the same `macro_rules!` variant list backing `id()`/`FromStr`, so a new ecosystem can no longer be added to some of the three but not all (partial work on #758) (#776)
 - **deps-core**: new `deps_core::conformance` module (behind `test-util`) with 5 macros generating the exact-value per-crate conformance test family every ecosystem crate previously hand-copied; `deps-cargo` migrated as the Wave 1 pilot, with the remaining 13 crates tracked as follow-up work (partial work on #758) (#776)
-- **deps-npm, deps-pypi, deps-go, deps-bundler, deps-dart, deps-maven, deps-composer, deps-gradle, deps-swift, deps-nuget, deps-github-actions, deps-gitlab-ci, deps-deno**: migrated the remaining 13 ecosystem crates to `deps_core::conformance`'s shared macros, completing the trait-conformance test consolidation started in #776 (resolves #758)
+- **deps-npm, deps-pypi, deps-go, deps-bundler, deps-dart, deps-maven, deps-composer, deps-gradle, deps-swift, deps-nuget, deps-github-actions, deps-gitlab-ci, deps-deno**: migrated the remaining 13 ecosystem crates to `deps_core::conformance`'s shared macros, completing the trait-conformance test consolidation started in #776 (resolves #758) (#781)
 
 ### Fixed
 - **deps-core**: corrected a stale doc-comment reference to a nonexistent item in `in_use_version.rs` (resolves #773) (#779)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: property tests (`proptest`) asserting the parser depth/expansion checkers and JSONC position recovery never panic on arbitrary input (#673)
 - **deps-core**: `EcosystemId::ALL`, generated from the same `macro_rules!` variant list backing `id()`/`FromStr`, so a new ecosystem can no longer be added to some of the three but not all (partial work on #758) (#776)
 - **deps-core**: new `deps_core::conformance` module (behind `test-util`) with 5 macros generating the exact-value per-crate conformance test family every ecosystem crate previously hand-copied; `deps-cargo` migrated as the Wave 1 pilot, with the remaining 13 crates tracked as follow-up work (partial work on #758) (#776)
+- **deps-npm, deps-pypi, deps-go, deps-bundler, deps-dart, deps-maven, deps-composer, deps-gradle, deps-swift, deps-nuget, deps-github-actions, deps-gitlab-ci, deps-deno**: migrated the remaining 13 ecosystem crates to `deps_core::conformance`'s shared macros, completing the trait-conformance test consolidation started in #776 (resolves #758)
 
 ### Fixed
 - **deps-core**: corrected a stale doc-comment reference to a nonexistent item in `in_use_version.rs` (resolves #773) (#779)

--- a/crates/deps-bundler/src/ecosystem.rs
+++ b/crates/deps-bundler/src/ecosystem.rs
@@ -148,40 +148,37 @@ impl Ecosystem for BundlerEcosystem {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_ecosystem_id() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = BundlerEcosystem::new(cache);
-        assert_eq!(ecosystem.id(), "bundler");
+    // #758: exact-value `Ecosystem` conformance, replacing the hand-written
+    // test_ecosystem_id/test_ecosystem_display_name/test_ecosystem_manifest_filenames/
+    // test_ecosystem_lockfile_filenames/test_as_any family.
+    deps_core::ecosystem_conformance! {
+        mod bundler_ecosystem_conformance;
+        build: BundlerEcosystem::new(Arc::new(deps_core::HttpCache::new()));
+        ty: BundlerEcosystem;
+        id: "bundler";
+        display_name: "Bundler (Ruby)";
+        manifest_filenames: &["Gemfile"];
+        lockfile_filenames: &["Gemfile.lock"];
     }
 
-    #[test]
-    fn test_ecosystem_display_name() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = BundlerEcosystem::new(cache);
-        assert_eq!(ecosystem.display_name(), "Bundler (Ruby)");
-    }
-
-    #[test]
-    fn test_ecosystem_manifest_filenames() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = BundlerEcosystem::new(cache);
-        assert_eq!(ecosystem.manifest_filenames(), &["Gemfile"]);
-    }
-
-    #[test]
-    fn test_ecosystem_lockfile_filenames() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = BundlerEcosystem::new(cache);
-        assert_eq!(ecosystem.lockfile_filenames(), &["Gemfile.lock"]);
-    }
-
-    #[test]
-    fn test_as_any() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = BundlerEcosystem::new(cache);
-        let any = ecosystem.as_any();
-        assert!(any.is::<BundlerEcosystem>());
+    // #758: the shared completion-prefix-length guard
+    // (`deps_core::completion::complete_package_names_generic`), replacing
+    // test_complete_package_names_minimum_prefix/test_complete_package_names_max_length.
+    deps_core::completion_guard_conformance! {
+        mod bundler_completion_guard_conformance;
+        complete: |registry: &dyn deps_core::Registry, prefix: String| -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Vec<tower_lsp_server::ls_types::CompletionItem>> + Send + '_>,
+        > {
+            Box::pin(async move {
+                deps_core::completion::complete_package_names_generic(
+                    registry,
+                    &prefix,
+                    20,
+                    Range::default(),
+                )
+                .await
+            })
+        };
     }
 
     #[tokio::test]
@@ -210,35 +207,6 @@ mod tests {
             }
             other => panic!("Expected PackageName context, got {other:?}"),
         }
-    }
-
-    #[tokio::test]
-    async fn test_complete_package_names_minimum_prefix() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = BundlerEcosystem::new(cache);
-
-        // Less than 2 characters should return empty
-        let results = ecosystem
-            .complete_package_names("r", Range::default())
-            .await;
-        assert!(results.is_empty());
-
-        // Empty prefix should return empty
-        let results = ecosystem.complete_package_names("", Range::default()).await;
-        assert!(results.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_complete_package_names_max_length() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = BundlerEcosystem::new(cache);
-
-        // Prefix longer than 200 chars should return empty
-        let long_prefix = "a".repeat(201);
-        let results = ecosystem
-            .complete_package_names(&long_prefix, Range::default())
-            .await;
-        assert!(results.is_empty());
     }
 
     #[tokio::test]

--- a/crates/deps-bundler/src/formatter.rs
+++ b/crates/deps-bundler/src/formatter.rs
@@ -236,82 +236,42 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_package_url() {
-        let formatter = BundlerFormatter;
-        assert_eq!(
-            formatter.package_url(&PackageName::new("rails")),
-            "https://rubygems.org/gems/rails"
-        );
-        assert_eq!(
-            formatter.package_url(&PackageName::new("nokogiri")),
-            "https://rubygems.org/gems/nokogiri"
-        );
-    }
-
-    #[test]
-    fn test_pessimistic_operator() {
-        let formatter = BundlerFormatter;
-
-        // ~> 7.0 means >= 7.0, < 8.0
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("7.0.8"), "~> 7.0"));
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("7.0.0"), "~> 7.0"));
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("7.9.9"), "~> 7.0"));
-        assert!(!formatter.version_satisfies_requirement(&ConcreteVersion::new("8.0.0"), "~> 7.0"));
-        assert!(!formatter.version_satisfies_requirement(&ConcreteVersion::new("6.9.9"), "~> 7.0"));
-
-        // ~> 1.0.5 means >= 1.0.5, < 1.1.0
-        assert!(
-            formatter.version_satisfies_requirement(&ConcreteVersion::new("1.0.5"), "~> 1.0.5")
-        );
-        assert!(
-            formatter.version_satisfies_requirement(&ConcreteVersion::new("1.0.9"), "~> 1.0.5")
-        );
-        assert!(
-            !formatter.version_satisfies_requirement(&ConcreteVersion::new("1.1.0"), "~> 1.0.5")
-        );
-        assert!(
-            !formatter.version_satisfies_requirement(&ConcreteVersion::new("1.0.4"), "~> 1.0.5")
-        );
-    }
-
-    #[test]
-    fn test_comparison_operators() {
-        let formatter = BundlerFormatter;
-
-        // >= operator
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("1.5.0"), ">= 1.1"));
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("1.1.0"), ">= 1.1"));
-        assert!(!formatter.version_satisfies_requirement(&ConcreteVersion::new("1.0.0"), ">= 1.1"));
-
-        // > operator
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("2.0.0"), "> 1.0"));
-        assert!(!formatter.version_satisfies_requirement(&ConcreteVersion::new("1.0.0"), "> 1.0"));
-
-        // <= operator
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("1.0.0"), "<= 1.0"));
-        assert!(!formatter.version_satisfies_requirement(&ConcreteVersion::new("1.1.0"), "<= 1.0"));
-
-        // < operator
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("0.9.0"), "< 1.0"));
-        assert!(!formatter.version_satisfies_requirement(&ConcreteVersion::new("1.0.0"), "< 1.0"));
-    }
-
-    #[test]
-    fn test_exact_match() {
-        let formatter = BundlerFormatter;
-
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("1.0.0"), "= 1.0.0"));
-        assert!(
-            !formatter.version_satisfies_requirement(&ConcreteVersion::new("1.0.1"), "= 1.0.0")
-        );
-
-        assert!(
-            formatter.version_satisfies_requirement(&ConcreteVersion::new("1.0.1"), "!= 1.0.0")
-        );
-        assert!(
-            !formatter.version_satisfies_requirement(&ConcreteVersion::new("1.0.0"), "!= 1.0.0")
-        );
+    // #758: exact-value `EcosystemFormatter` conformance, replacing test_package_url,
+    // test_validate_package_name_accepts_valid_names, test_validate_package_name_rejects_invalid_names,
+    // test_pessimistic_operator, test_comparison_operators, and test_exact_match.
+    deps_core::formatter_conformance! {
+        mod bundler_formatter_conformance;
+        build: BundlerFormatter;
+        package_url: {
+            "rails" => "https://rubygems.org/gems/rails",
+            "nokogiri" => "https://rubygems.org/gems/nokogiri",
+        };
+        accepts: ["rails", "rspec-rails", "nokogiri", "activesupport.rb"];
+        rejects: ["", "123", "rails util", "rails/util", "日本語"];
+        version_roundtrip: [
+            "7.0.8", "~> 7.0" => true,
+            "7.0.0", "~> 7.0" => true,
+            "7.9.9", "~> 7.0" => true,
+            "8.0.0", "~> 7.0" => false,
+            "6.9.9", "~> 7.0" => false,
+            "1.0.5", "~> 1.0.5" => true,
+            "1.0.9", "~> 1.0.5" => true,
+            "1.1.0", "~> 1.0.5" => false,
+            "1.0.4", "~> 1.0.5" => false,
+            "1.5.0", ">= 1.1" => true,
+            "1.1.0", ">= 1.1" => true,
+            "1.0.0", ">= 1.1" => false,
+            "2.0.0", "> 1.0" => true,
+            "1.0.0", "> 1.0" => false,
+            "1.0.0", "<= 1.0" => true,
+            "1.1.0", "<= 1.0" => false,
+            "0.9.0", "< 1.0" => true,
+            "1.0.0", "< 1.0" => false,
+            "1.0.0", "= 1.0.0" => true,
+            "1.0.1", "= 1.0.0" => false,
+            "1.0.1", "!= 1.0.0" => true,
+            "1.0.0", "!= 1.0.0" => false
+        ];
     }
 
     #[test]
@@ -575,30 +535,6 @@ mod tests {
             &VersionReq::new("7.2.0"),
             &available,
         ));
-    }
-
-    #[test]
-    fn test_validate_package_name_accepts_valid_names() {
-        let formatter = BundlerFormatter;
-        for name in ["rails", "rspec-rails", "nokogiri", "activesupport.rb"] {
-            assert!(
-                formatter.validate_package_name(name).is_ok(),
-                "expected {name:?} to be accepted"
-            );
-        }
-    }
-
-    /// #402: a structurally invalid gem name must be reported as an invalid package name, not
-    /// forwarded to the registry lookup that produces the misleading generic diagnostic.
-    #[test]
-    fn test_validate_package_name_rejects_invalid_names() {
-        let formatter = BundlerFormatter;
-        for name in ["", "123", "rails util", "rails/util", "日本語"] {
-            assert!(
-                formatter.validate_package_name(name).is_err(),
-                "expected {name:?} to be rejected"
-            );
-        }
     }
 
     /// #402 critique M4: a name that fails both checks (no ASCII letter at all, and a

--- a/crates/deps-bundler/src/lockfile.rs
+++ b/crates/deps-bundler/src/lockfile.rs
@@ -272,34 +272,16 @@ BUNDLED WITH
         assert!(packages.is_empty());
     }
 
-    #[test]
-    fn test_locate_lockfile_same_directory() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("Gemfile");
-        let lock_path = temp_dir.path().join("Gemfile.lock");
-
-        std::fs::write(&manifest_path, "source 'https://rubygems.org'").unwrap();
-        std::fs::write(&lock_path, "GEM\n  specs:\n").unwrap();
-
-        let manifest_uri = Uri::from_file_path(&manifest_path).unwrap();
-        let parser = GemfileLockParser;
-
-        let located = parser.locate_lockfile(&manifest_uri);
-        assert!(located.is_some());
-        assert_eq!(located.unwrap(), lock_path);
-    }
-
-    #[test]
-    fn test_locate_lockfile_not_found() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("Gemfile");
-        std::fs::write(&manifest_path, "source 'https://rubygems.org'").unwrap();
-
-        let manifest_uri = Uri::from_file_path(&manifest_path).unwrap();
-        let parser = GemfileLockParser;
-
-        let located = parser.locate_lockfile(&manifest_uri);
-        assert!(located.is_none());
+    // #758: shared `LockFileProvider` conformance, replacing test_locate_lockfile_same_directory,
+    // test_locate_lockfile_not_found, and test_is_lockfile_stale_not_modified/_modified.
+    deps_core::lockfile_conformance! {
+        mod bundler_lockfile_conformance;
+        build: GemfileLockParser;
+        manifest: "Gemfile" => "source 'https://rubygems.org'";
+        lockfiles: [
+            "Gemfile.lock" => "GEM\n  remote: https://rubygems.org/\n  specs:\n    rails (7.0.8)\n",
+        ];
+        malformed: "not a valid gemfile.lock !!!";
     }
 
     #[tokio::test]
@@ -325,38 +307,5 @@ BUNDLED WITH
 
         assert_eq!(packages.len(), 1);
         assert_eq!(packages.get_version("rails"), Some("7.0.8"));
-    }
-
-    #[test]
-    fn test_is_lockfile_stale_not_modified() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let lockfile_path = temp_dir.path().join("Gemfile.lock");
-        std::fs::write(&lockfile_path, "GEM\n  specs:\n").unwrap();
-
-        let mtime = std::fs::metadata(&lockfile_path)
-            .unwrap()
-            .modified()
-            .unwrap();
-        let parser = GemfileLockParser;
-
-        assert!(
-            !parser.is_lockfile_stale(&lockfile_path, mtime),
-            "Lock file should not be stale when mtime matches"
-        );
-    }
-
-    #[test]
-    fn test_is_lockfile_stale_modified() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let lockfile_path = temp_dir.path().join("Gemfile.lock");
-        std::fs::write(&lockfile_path, "GEM\n  specs:\n").unwrap();
-
-        let old_time = std::time::UNIX_EPOCH;
-        let parser = GemfileLockParser;
-
-        assert!(
-            parser.is_lockfile_stale(&lockfile_path, old_time),
-            "Lock file should be stale when last_modified is old"
-        );
     }
 }

--- a/crates/deps-bundler/src/registry.rs
+++ b/crates/deps-bundler/src/registry.rs
@@ -395,14 +395,10 @@ mod tests {
         assert!(!url.contains(']'));
     }
 
-    #[test]
-    fn test_gem_url_encodes_newline_autolink_and_percent() {
-        let url = gem_url("evil\n<https://evil%zz.example>");
-        assert!(!url.contains('\n'));
-        assert!(!url.contains('<'));
-        assert!(!url.contains('>'));
-        assert!(url.contains("%25"));
-    }
+    // #758: this hostile newline/autolink/percent payload case is now covered universally by
+    // deps-lsp's `test_registered_ecosystems_universal_invariants` (Layer 1), via
+    // `deps_core::conformance::HOSTILE_DISPLAY_LINK_PAYLOAD` — this crate's own copy is
+    // redundant and has been removed.
 
     #[test]
     fn test_gem_url_empty_name() {
@@ -638,6 +634,17 @@ mod tests {
         let json = r"[]";
         let results = parse_search_response(json.as_bytes()).unwrap();
         assert!(results.is_empty());
+    }
+
+    // #758: the shared JSON-nesting-depth cap — deps-bundler had no prior nesting-depth test.
+    // Targets `parse_gem_info` (a single JSON object response) rather than
+    // `parse_search_response` (a top-level array): wrapping a nested fragment inside an array
+    // element would add an extra array-nesting level ahead of the fragment itself, shifting
+    // the accept/reject boundary by one relative to every other crate's identical macro call.
+    deps_core::json_depth_conformance! {
+        mod bundler_json_depth_conformance;
+        parse: |bytes: &[u8]| parse_gem_info(bytes);
+        wrap: |nested: &str| format!(r#"{{"name": "test", "version": "1.0.0", "extra": {nested}}}"#);
     }
 
     #[test]

--- a/crates/deps-composer/src/ecosystem.rs
+++ b/crates/deps-composer/src/ecosystem.rs
@@ -213,25 +213,37 @@ mod tests {
     use deps_core::{EcosystemConfig, VersionData};
     use std::collections::HashMap;
 
-    #[test]
-    fn test_ecosystem_id() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = ComposerEcosystem::new(cache);
-        assert_eq!(ecosystem.id(), "composer");
+    // #758: exact-value `Ecosystem` conformance, replacing test_ecosystem_id,
+    // test_ecosystem_manifest_filenames, and test_ecosystem_lockfile_filenames. Also closes
+    // a real gap: this crate had no `test_as_any`/registry-smoke-test equivalent before.
+    deps_core::ecosystem_conformance! {
+        mod composer_ecosystem_conformance;
+        build: ComposerEcosystem::new(Arc::new(deps_core::HttpCache::new()));
+        ty: ComposerEcosystem;
+        id: "composer";
+        display_name: "Composer (PHP)";
+        manifest_filenames: &["composer.json"];
+        lockfile_filenames: &["composer.lock"];
     }
 
-    #[test]
-    fn test_ecosystem_manifest_filenames() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = ComposerEcosystem::new(cache);
-        assert_eq!(ecosystem.manifest_filenames(), &["composer.json"]);
-    }
-
-    #[test]
-    fn test_ecosystem_lockfile_filenames() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = ComposerEcosystem::new(cache);
-        assert_eq!(ecosystem.lockfile_filenames(), &["composer.lock"]);
+    // #758: the shared completion-prefix-length guard
+    // (`deps_core::completion::complete_package_names_generic`), replacing
+    // test_complete_package_names_short_prefix — also closes the missing max-length case.
+    deps_core::completion_guard_conformance! {
+        mod composer_completion_guard_conformance;
+        complete: |registry: &dyn deps_core::Registry, prefix: String| -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Vec<tower_lsp_server::ls_types::CompletionItem>> + Send + '_>,
+        > {
+            Box::pin(async move {
+                deps_core::completion::complete_package_names_generic(
+                    registry,
+                    &prefix,
+                    20,
+                    Range::default(),
+                )
+                .await
+            })
+        };
     }
 
     #[test]
@@ -291,17 +303,6 @@ mod tests {
             }
             other => panic!("Expected PackageName context, got {other:?}"),
         }
-    }
-
-    #[tokio::test]
-    async fn test_complete_package_names_short_prefix() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = ComposerEcosystem::new(cache);
-
-        let results = ecosystem
-            .complete_package_names("s", Range::default())
-            .await;
-        assert!(results.is_empty());
     }
 
     #[tokio::test]

--- a/crates/deps-composer/src/formatter.rs
+++ b/crates/deps-composer/src/formatter.rs
@@ -592,13 +592,29 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_package_url() {
-        let f = ComposerFormatter;
-        assert_eq!(
-            f.package_url(&PackageName::new("symfony/console")),
-            "https://packagist.org/packages/symfony/console"
-        );
+    // #758: exact-value `package_url`/`validate_package_name` conformance, replacing
+    // test_package_url, test_validate_package_name_accepts_valid_names, and
+    // test_validate_package_name_rejects_invalid_names. `version_satisfies_requirement`'s
+    // own tests stay hand-written below: Composer's tilde/caret/range/OR/`v`-prefix
+    // semantics are extensively documented, historically-regression-driven behavior (#424,
+    // #534, ...), not simple redundant literal lists.
+    deps_core::formatter_conformance! {
+        mod composer_formatter_conformance;
+        build: ComposerFormatter;
+        package_url: {
+            "symfony/console" => "https://packagist.org/packages/symfony/console",
+        };
+        accepts: ["symfony/console", "vendor.name/pkg-name", "a/b"];
+        rejects: [
+            "",
+            "symfony",
+            "symfony/console/extra",
+            "/console",
+            "symfony/",
+            "-vendor/pkg",
+            "vendor/-pkg",
+            "vendor name/pkg"
+        ];
     }
 
     #[test]
@@ -1082,40 +1098,6 @@ mod tests {
                 .is_none()
         );
         assert!(f.compile_requirement(&VersionReq::new("2.0@dev")).is_none());
-    }
-
-    #[test]
-    fn test_validate_package_name_accepts_valid_names() {
-        let f = ComposerFormatter;
-        for name in ["symfony/console", "vendor.name/pkg-name", "a/b"] {
-            assert!(
-                f.validate_package_name(name).is_ok(),
-                "expected {name:?} to be accepted"
-            );
-        }
-    }
-
-    /// #402: a structurally invalid Composer coordinate must be reported as an invalid
-    /// package name, not forwarded to the registry lookup that produces the misleading
-    /// generic diagnostic.
-    #[test]
-    fn test_validate_package_name_rejects_invalid_names() {
-        let f = ComposerFormatter;
-        for name in [
-            "",
-            "symfony",
-            "symfony/console/extra",
-            "/console",
-            "symfony/",
-            "-vendor/pkg",
-            "vendor/-pkg",
-            "vendor name/pkg",
-        ] {
-            assert!(
-                f.validate_package_name(name).is_err(),
-                "expected {name:?} to be rejected"
-            );
-        }
     }
 
     // --- #205 package-level deprecation ---

--- a/crates/deps-composer/src/lockfile.rs
+++ b/crates/deps-composer/src/lockfile.rs
@@ -197,63 +197,25 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_parse_malformed_lock() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let lock_path = temp_dir.path().join("composer.lock");
-        tokio::fs::write(&lock_path, "not json").await.unwrap();
-
-        let parser = ComposerLockParser;
-        let result = parser.parse_lockfile(&lock_path).await;
-        assert!(result.is_err());
+    // #758: shared `LockFileProvider` conformance, replacing test_locate_lockfile and
+    // test_parse_malformed_lock — also closes a real gap: this crate had no
+    // is_lockfile_stale_* coverage at all before.
+    deps_core::lockfile_conformance! {
+        mod composer_lockfile_conformance;
+        build: ComposerLockParser;
+        manifest: "composer.json" => r#"{"name": "test/project"}"#;
+        lockfiles: [
+            "composer.lock" => r#"{"packages": [], "packages-dev": []}"#,
+        ];
+        malformed: "not json";
     }
 
-    #[tokio::test]
-    async fn test_nesting_at_max_depth_accepted() {
-        let depth = deps_core::MAX_JSON_NESTING_DEPTH;
-        let content = format!(
-            r#"{{"packages": [], "extra": {}1{}}}"#,
-            "[".repeat(depth - 1),
-            "]".repeat(depth - 1)
-        );
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("composer.lock");
-        tokio::fs::write(&path, &content).await.unwrap();
-
-        let parser = ComposerLockParser;
-        assert!(parser.parse_lockfile(&path).await.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_nesting_over_max_depth_rejected() {
-        let depth = deps_core::MAX_JSON_NESTING_DEPTH + 1;
-        let content = format!(
-            r#"{{"packages": [], "extra": {}1{}}}"#,
-            "[".repeat(depth),
-            "]".repeat(depth)
-        );
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("composer.lock");
-        tokio::fs::write(&path, &content).await.unwrap();
-
-        let parser = ComposerLockParser;
-        assert!(parser.parse_lockfile(&path).await.is_err());
-    }
-
-    #[test]
-    fn test_locate_lockfile() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("composer.json");
-        let lock_path = temp_dir.path().join("composer.lock");
-
-        std::fs::write(&manifest_path, r#"{"name": "test/project"}"#).unwrap();
-        std::fs::write(&lock_path, r#"{"packages": [], "packages-dev": []}"#).unwrap();
-
-        let manifest_uri = Uri::from_file_path(&manifest_path).unwrap();
-        let parser = ComposerLockParser;
-
-        let located = parser.locate_lockfile(&manifest_uri);
-        assert!(located.is_some());
-        assert_eq!(located.unwrap(), lock_path);
+    // #758: the shared JSON-nesting-depth cap, replacing test_nesting_at_max_depth_accepted/
+    // test_nesting_over_max_depth_rejected — `parse_composer_lock` takes an owned `String`,
+    // not `&[u8]`, so the closure re-owns the bytes via `String::from_utf8_lossy` first.
+    deps_core::json_depth_conformance! {
+        mod composer_lockfile_json_depth_conformance;
+        parse: |bytes: &[u8]| parse_composer_lock(String::from_utf8_lossy(bytes).into_owned());
+        wrap: |nested: &str| format!(r#"{{"packages": [], "extra": {nested}}}"#);
     }
 }

--- a/crates/deps-composer/src/registry.rs
+++ b/crates/deps-composer/src/registry.rs
@@ -712,14 +712,15 @@ mod tests {
         assert!(!url.contains(']'));
     }
 
-    #[test]
-    fn test_package_url_encodes_newline_autolink_and_percent() {
-        let url = package_url("evil\n<%>/pkg");
-        assert!(!url.contains('\n'));
-        assert!(!url.contains('<'));
-        assert!(!url.contains('>'));
-        assert!(url.contains("%25"));
-    }
+    // #758: the generic newline/autolink/percent hostile-payload check this test used to
+    // provide is now covered for every ecosystem by Layer 1 (`deps-lsp`'s
+    // `test_registered_ecosystems_universal_invariants`), which calls this exact function
+    // through `ComposerFormatter::package_url`. `test_package_url_encodes_malicious_segments`
+    // above stays hand-written: the shared hostile fixture also contains a `/` (from its
+    // embedded `https://`), so it exercises this function's `vendor/package` split branch
+    // too — the hand-written test just asserts general bracket-safety properties rather
+    // than pinning an exact encoded string, which is why it stays separate from
+    // `formatter_conformance!`'s literal `package_url` pair list.
 
     #[test]
     fn test_package_url_empty_name() {
@@ -1134,26 +1135,12 @@ mod tests {
         assert_eq!(pkg.latest_version, "6.0.0");
     }
 
-    #[test]
-    fn test_parse_search_response_nesting_at_max_depth_accepted() {
-        let depth = deps_core::MAX_JSON_NESTING_DEPTH;
-        let json = format!(
-            r#"{{"results": [], "extra": {}1{}}}"#,
-            "[".repeat(depth - 1),
-            "]".repeat(depth - 1)
-        );
-        assert!(parse_search_response(json.as_bytes()).is_ok());
-    }
-
-    #[test]
-    fn test_parse_search_response_nesting_over_max_depth_rejected() {
-        let depth = deps_core::MAX_JSON_NESTING_DEPTH + 1;
-        let json = format!(
-            r#"{{"results": [], "extra": {}1{}}}"#,
-            "[".repeat(depth),
-            "]".repeat(depth)
-        );
-        assert!(parse_search_response(json.as_bytes()).is_err());
+    // #758: the shared JSON-nesting-depth cap, replacing
+    // test_parse_search_response_nesting_at_max_depth_accepted/_over_max_depth_rejected.
+    deps_core::json_depth_conformance! {
+        mod composer_json_depth_conformance;
+        parse: |bytes: &[u8]| parse_search_response(bytes);
+        wrap: |nested: &str| format!(r#"{{"results": [], "extra": {nested}}}"#);
     }
 
     #[test]

--- a/crates/deps-dart/src/ecosystem.rs
+++ b/crates/deps-dart/src/ecosystem.rs
@@ -214,39 +214,37 @@ fn extract_prefix(line: &str, character: u32) -> &str {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_ecosystem_id() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = DartEcosystem::new(cache);
-        assert_eq!(eco.id(), "dart");
+    // #758: exact-value `Ecosystem` conformance, replacing the hand-written
+    // test_ecosystem_id/test_ecosystem_display_name/test_ecosystem_manifest_filenames/
+    // test_ecosystem_lockfile_filenames/test_as_any family.
+    deps_core::ecosystem_conformance! {
+        mod dart_ecosystem_conformance;
+        build: DartEcosystem::new(Arc::new(deps_core::HttpCache::new()));
+        ty: DartEcosystem;
+        id: "dart";
+        display_name: "Dart (Pub)";
+        manifest_filenames: &["pubspec.yaml"];
+        lockfile_filenames: &["pubspec.lock"];
     }
 
-    #[test]
-    fn test_ecosystem_display_name() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = DartEcosystem::new(cache);
-        assert_eq!(eco.display_name(), "Dart (Pub)");
-    }
-
-    #[test]
-    fn test_ecosystem_manifest_filenames() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = DartEcosystem::new(cache);
-        assert_eq!(eco.manifest_filenames(), &["pubspec.yaml"]);
-    }
-
-    #[test]
-    fn test_ecosystem_lockfile_filenames() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = DartEcosystem::new(cache);
-        assert_eq!(eco.lockfile_filenames(), &["pubspec.lock"]);
-    }
-
-    #[test]
-    fn test_as_any() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = DartEcosystem::new(cache);
-        assert!(eco.as_any().is::<DartEcosystem>());
+    // #758: the shared completion-prefix-length guard
+    // (`deps_core::completion::complete_package_names_generic`), replacing
+    // test_complete_package_names_min_prefix/test_complete_package_names_max_length.
+    deps_core::completion_guard_conformance! {
+        mod dart_completion_guard_conformance;
+        complete: |registry: &dyn deps_core::Registry, prefix: String| -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Vec<tower_lsp_server::ls_types::CompletionItem>> + Send + '_>,
+        > {
+            Box::pin(async move {
+                deps_core::completion::complete_package_names_generic(
+                    registry,
+                    &prefix,
+                    20,
+                    Range::default(),
+                )
+                .await
+            })
+        };
     }
 
     #[tokio::test]
@@ -275,34 +273,6 @@ mod tests {
             }
             other => panic!("Expected PackageName context, got {other:?}"),
         }
-    }
-
-    #[tokio::test]
-    async fn test_complete_package_names_min_prefix() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = DartEcosystem::new(cache);
-        assert!(
-            eco.complete_package_names("h", Range::default())
-                .await
-                .is_empty()
-        );
-        assert!(
-            eco.complete_package_names("", Range::default())
-                .await
-                .is_empty()
-        );
-    }
-
-    #[tokio::test]
-    async fn test_complete_package_names_max_length() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = DartEcosystem::new(cache);
-        let long = "a".repeat(201);
-        assert!(
-            eco.complete_package_names(&long, Range::default())
-                .await
-                .is_empty()
-        );
     }
 
     #[tokio::test]

--- a/crates/deps-dart/src/formatter.rs
+++ b/crates/deps-dart/src/formatter.rs
@@ -114,20 +114,21 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_package_url() {
-        let f = DartFormatter;
-        assert_eq!(
-            f.package_url(&PackageName::new("provider")),
-            "https://pub.dev/packages/provider"
-        );
-    }
-
-    #[test]
-    fn test_version_satisfies() {
-        let f = DartFormatter;
-        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("1.5.0"), "^1.0.0"));
-        assert!(!f.version_satisfies_requirement(&ConcreteVersion::new("2.0.0"), "^1.0.0"));
+    // #758: exact-value `EcosystemFormatter` conformance, replacing test_package_url,
+    // test_validate_package_name_accepts_valid_names, test_validate_package_name_rejects_invalid_names,
+    // and test_version_satisfies.
+    deps_core::formatter_conformance! {
+        mod dart_formatter_conformance;
+        build: DartFormatter;
+        package_url: {
+            "provider" => "https://pub.dev/packages/provider",
+        };
+        accepts: ["provider", "flutter_bloc", "_private", "path9"];
+        rejects: ["", "9path", "my-package", "my package", "日本語"];
+        version_roundtrip: [
+            "1.5.0", "^1.0.0" => true,
+            "2.0.0", "^1.0.0" => false
+        ];
     }
 
     #[test]
@@ -162,30 +163,5 @@ mod tests {
             matcher.matches(&ConcreteVersion::new("1.14.0")),
             Some(false)
         );
-    }
-
-    #[test]
-    fn test_validate_package_name_accepts_valid_names() {
-        let f = DartFormatter;
-        for name in ["provider", "flutter_bloc", "_private", "path9"] {
-            assert!(
-                f.validate_package_name(name).is_ok(),
-                "expected {name:?} to be accepted"
-            );
-        }
-    }
-
-    /// #402: a structurally invalid Dart package name must be reported as an invalid package
-    /// name, not forwarded to the registry lookup that produces the misleading generic
-    /// diagnostic.
-    #[test]
-    fn test_validate_package_name_rejects_invalid_names() {
-        let f = DartFormatter;
-        for name in ["", "9path", "my-package", "my package", "日本語"] {
-            assert!(
-                f.validate_package_name(name).is_err(),
-                "expected {name:?} to be rejected"
-            );
-        }
     }
 }

--- a/crates/deps-dart/src/lockfile.rs
+++ b/crates/deps-dart/src/lockfile.rs
@@ -320,33 +320,17 @@ packages:
         assert_eq!(packages.get_version("http"), Some("1.2.0"));
     }
 
-    #[test]
-    fn test_locate_lockfile() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("pubspec.yaml");
-        let lock_path = temp_dir.path().join("pubspec.lock");
-
-        std::fs::write(&manifest_path, "name: test").unwrap();
-        std::fs::write(&lock_path, "packages:\n").unwrap();
-
-        let manifest_uri = Uri::from_file_path(&manifest_path).unwrap();
-        let parser = PubspecLockParser;
-
-        let located = parser.locate_lockfile(&manifest_uri);
-        assert!(located.is_some());
-        assert_eq!(located.unwrap(), lock_path);
-    }
-
-    #[test]
-    fn test_locate_lockfile_not_found() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("pubspec.yaml");
-        std::fs::write(&manifest_path, "name: test").unwrap();
-
-        let manifest_uri = Uri::from_file_path(&manifest_path).unwrap();
-        let parser = PubspecLockParser;
-
-        assert!(parser.locate_lockfile(&manifest_uri).is_none());
+    // #758: shared `LockFileProvider` conformance, replacing test_locate_lockfile and
+    // test_locate_lockfile_not_found — deps-dart had no prior `is_lockfile_stale` coverage at
+    // all, so this also adds that.
+    deps_core::lockfile_conformance! {
+        mod dart_lockfile_conformance;
+        build: PubspecLockParser;
+        manifest: "pubspec.yaml" => "name: test";
+        lockfiles: [
+            "pubspec.lock" => "packages:\n",
+        ];
+        malformed: "not valid yaml: [[[";
     }
 
     #[tokio::test]

--- a/crates/deps-dart/src/registry.rs
+++ b/crates/deps-dart/src/registry.rs
@@ -477,14 +477,10 @@ mod tests {
         assert!(!url.contains(']'));
     }
 
-    #[test]
-    fn test_package_url_encodes_newline_autolink_and_percent() {
-        let url = package_url("evil\n<https://evil%zz.example>");
-        assert!(!url.contains('\n'));
-        assert!(!url.contains('<'));
-        assert!(!url.contains('>'));
-        assert!(url.contains("%25"));
-    }
+    // #758: this hostile newline/autolink/percent payload case is now covered universally by
+    // deps-lsp's `test_registered_ecosystems_universal_invariants` (Layer 1), via
+    // `deps_core::conformance::HOSTILE_DISPLAY_LINK_PAYLOAD` — this crate's own copy is
+    // redundant and has been removed.
 
     #[test]
     fn test_package_url_empty_name() {
@@ -612,6 +608,13 @@ mod tests {
         assert_eq!(info.name, "minimal");
         assert_eq!(info.version, "0.1.0");
         assert!(info.description.is_none());
+    }
+
+    // #758: the shared JSON-nesting-depth cap — deps-dart had no prior nesting-depth test.
+    deps_core::json_depth_conformance! {
+        mod dart_json_depth_conformance;
+        parse: |bytes: &[u8]| parse_package_info(bytes);
+        wrap: |nested: &str| format!(r#"{{"name": "test", "latest": {{"version": "0.1.0"}}, "versions": [], "extra": {nested}}}"#);
     }
 
     #[test]

--- a/crates/deps-deno/src/ecosystem.rs
+++ b/crates/deps-deno/src/ecosystem.rs
@@ -247,25 +247,38 @@ fn extract_prefix(line: &str, character: u32) -> &str {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_ecosystem_id() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = DenoEcosystem::new(cache);
-        assert_eq!(ecosystem.id(), "deno");
+    // #758: exact-value `Ecosystem` conformance, replacing test_ecosystem_id/
+    // test_ecosystem_display_name/test_ecosystem_manifest_filenames/test_as_any.
+    // `lockfile_filenames` is omitted — deno.lock resolved-version parsing is a documented
+    // MVP gap (D9), not yet a `LockFileProvider` impl in this crate; that specific
+    // absence-of-both-halves invariant stays covered by test_ecosystem_no_lockfile_support
+    // below, which the macro doesn't replace.
+    deps_core::ecosystem_conformance! {
+        mod deno_ecosystem_conformance;
+        build: DenoEcosystem::new(Arc::new(deps_core::HttpCache::new()));
+        ty: DenoEcosystem;
+        id: "deno";
+        display_name: "Deno (JSR/npm)";
+        manifest_filenames: &["deno.json", "deno.jsonc"];
     }
 
-    #[test]
-    fn test_ecosystem_display_name() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = DenoEcosystem::new(cache);
-        assert_eq!(ecosystem.display_name(), "Deno (JSR/npm)");
-    }
-
-    #[test]
-    fn test_ecosystem_manifest_filenames() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = DenoEcosystem::new(cache);
-        assert_eq!(ecosystem.manifest_filenames(), &["deno.json", "deno.jsonc"]);
+    // #758: the shared completion-prefix-length guard, replacing
+    // test_complete_package_names_minimum_prefix (which only checked a 1-character prefix).
+    deps_core::completion_guard_conformance! {
+        mod deno_completion_guard_conformance;
+        complete: |registry: &dyn deps_core::Registry, prefix: String| -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Vec<tower_lsp_server::ls_types::CompletionItem>> + Send + '_>,
+        > {
+            Box::pin(async move {
+                deps_core::completion::complete_package_names_generic(
+                    registry,
+                    &prefix,
+                    20,
+                    Range::default(),
+                )
+                .await
+            })
+        };
     }
 
     #[test]
@@ -274,13 +287,6 @@ mod tests {
         let ecosystem = DenoEcosystem::new(cache);
         assert!(ecosystem.lockfile_filenames().is_empty());
         assert!(ecosystem.lockfile_provider().is_none());
-    }
-
-    #[test]
-    fn test_as_any() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = DenoEcosystem::new(cache);
-        assert!(ecosystem.as_any().is::<DenoEcosystem>());
     }
 
     #[tokio::test]
@@ -307,14 +313,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_registry_returns_arc() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = DenoEcosystem::new(cache);
-        let registry = ecosystem.registry();
-        assert!(Arc::strong_count(&registry) >= 1);
-    }
-
-    #[tokio::test]
     async fn test_generate_completions_no_context() {
         let cache = Arc::new(deps_core::HttpCache::new());
         let ecosystem = DenoEcosystem::new(cache);
@@ -334,17 +332,6 @@ mod tests {
             .await;
 
         assert!(completions.items.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_complete_package_names_minimum_prefix() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = DenoEcosystem::new(cache);
-
-        let results = ecosystem
-            .complete_package_names("j", Range::default())
-            .await;
-        assert!(results.is_empty());
     }
 
     #[tokio::test]

--- a/crates/deps-deno/src/formatter.rs
+++ b/crates/deps-deno/src/formatter.rs
@@ -198,44 +198,33 @@ mod tests {
 
     use deps_core::test_util::capture_tracing_output;
 
-    #[test]
-    fn test_package_url_jsr() {
-        let formatter = DenoFormatter;
-        assert_eq!(
-            formatter.package_url(&PackageName::new("jsr:@std/fs")),
-            "https://jsr.io/@std/fs"
-        );
-    }
-
-    #[test]
-    fn test_package_url_npm() {
-        let formatter = DenoFormatter;
-        assert_eq!(
-            formatter.package_url(&PackageName::new("npm:react")),
-            "https://www.npmjs.com/package/react"
-        );
-    }
-
-    #[test]
-    fn test_package_url_npm_scoped() {
-        let formatter = DenoFormatter;
-        assert_eq!(
-            formatter.package_url(&PackageName::new("npm:@types/node")),
-            "https://www.npmjs.com/package/@types/node"
-        );
-    }
-
-    #[test]
-    fn test_package_url_unroutable_scheme_is_empty() {
-        let formatter = DenoFormatter;
-        assert_eq!(formatter.package_url(&PackageName::new("unknown:x")), "");
-    }
-
-    #[test]
-    fn test_package_url_jsr_unscoped_is_empty() {
-        // `split_scoped` fails for a `jsr:` specifier missing the `@scope/` prefix.
-        let formatter = DenoFormatter;
-        assert_eq!(formatter.package_url(&PackageName::new("jsr:std")), "");
+    // #758: exact-value `EcosystemFormatter` conformance, replacing test_package_url_jsr/
+    // test_package_url_npm/test_package_url_npm_scoped/
+    // test_package_url_unroutable_scheme_is_empty/test_package_url_jsr_unscoped_is_empty
+    // and the accepts/rejects halves of test_validate_package_name_jsr_requires_scope/
+    // test_validate_package_name_jsr_rejects_dot_segments/
+    // test_validate_package_name_npm_delegates_to_npm_rules/
+    // test_validate_package_name_rejects_unknown_scheme. Does not replace the
+    // capture_tracing_output-based warn-log tests below (different assertion surface), or
+    // the non-literal test_validate_package_name_jsr_rejects_overlong_segment (`.repeat`
+    // boundary), both of which stay hand-written. No `version_roundtrip` — this formatter
+    // has no `version_satisfies_requirement` override, only `compile_requirement`, whose
+    // matcher is exercised directly by the hand-written tests below.
+    deps_core::formatter_conformance! {
+        mod deno_formatter_conformance;
+        build: DenoFormatter;
+        package_url: {
+            "jsr:@std/fs" => "https://jsr.io/@std/fs",
+            "npm:react" => "https://www.npmjs.com/package/react",
+            "npm:@types/node" => "https://www.npmjs.com/package/@types/node",
+            "unknown:x" => "",
+            "jsr:std" => "",
+        };
+        accepts: [ "jsr:@std/fs", "npm:react", "npm:@types/node" ];
+        rejects: [
+            "jsr:std", "jsr:@std", "jsr:@a/..", "jsr:@../x", "jsr:@./x", "jsr:@a/.hidden",
+            "npm:node_modules", "https://example.com",
+        ];
     }
 
     #[test]
@@ -283,25 +272,6 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_package_name_jsr_requires_scope() {
-        let formatter = DenoFormatter;
-        assert!(formatter.validate_package_name("jsr:@std/fs").is_ok());
-        assert!(formatter.validate_package_name("jsr:std").is_err());
-        assert!(formatter.validate_package_name("jsr:@std").is_err());
-    }
-
-    #[test]
-    fn test_validate_package_name_jsr_rejects_dot_segments() {
-        // S-L1: without this, `jsr:@a/..` builds a URL that path-normalizes away from
-        // `jsr.io`'s intended `/@scope/pkg` shape.
-        let formatter = DenoFormatter;
-        assert!(formatter.validate_package_name("jsr:@a/..").is_err());
-        assert!(formatter.validate_package_name("jsr:@../x").is_err());
-        assert!(formatter.validate_package_name("jsr:@./x").is_err());
-        assert!(formatter.validate_package_name("jsr:@a/.hidden").is_err());
-    }
-
-    #[test]
     fn test_validate_package_name_jsr_rejects_overlong_segment() {
         let formatter = DenoFormatter;
         let too_long = "a".repeat(65);
@@ -320,25 +290,6 @@ mod tests {
             formatter
                 .validate_package_name(&format!("jsr:@{max_len}/pkg"))
                 .is_ok()
-        );
-    }
-
-    #[test]
-    fn test_validate_package_name_npm_delegates_to_npm_rules() {
-        let formatter = DenoFormatter;
-        assert!(formatter.validate_package_name("npm:react").is_ok());
-        assert!(formatter.validate_package_name("npm:@types/node").is_ok());
-        // npm rejects a reserved name.
-        assert!(formatter.validate_package_name("npm:node_modules").is_err());
-    }
-
-    #[test]
-    fn test_validate_package_name_rejects_unknown_scheme() {
-        let formatter = DenoFormatter;
-        assert!(
-            formatter
-                .validate_package_name("https://example.com")
-                .is_err()
         );
     }
 

--- a/crates/deps-deno/src/registry.rs
+++ b/crates/deps-deno/src/registry.rs
@@ -742,26 +742,13 @@ mod tests {
         assert_eq!(versions[0].version, "1.0.0");
     }
 
-    #[test]
-    fn test_parse_meta_json_nesting_at_max_depth_accepted() {
-        let depth = deps_core::MAX_JSON_NESTING_DEPTH;
-        let json = format!(
-            r#"{{"versions": {{}}, "extra": {}1{}}}"#,
-            "[".repeat(depth - 1),
-            "]".repeat(depth - 1)
-        );
-        assert!(parse_meta_json(json.as_bytes()).is_ok());
-    }
-
-    #[test]
-    fn test_parse_meta_json_nesting_over_max_depth_rejected() {
-        let depth = deps_core::MAX_JSON_NESTING_DEPTH + 1;
-        let json = format!(
-            r#"{{"versions": {{}}, "extra": {}1{}}}"#,
-            "[".repeat(depth),
-            "]".repeat(depth)
-        );
-        assert!(parse_meta_json(json.as_bytes()).is_err());
+    // #758: the shared JSON-nesting-depth cap, replacing
+    // test_parse_meta_json_nesting_at_max_depth_accepted/
+    // test_parse_meta_json_nesting_over_max_depth_rejected.
+    deps_core::json_depth_conformance! {
+        mod deno_meta_json_depth_conformance;
+        parse: |bytes: &[u8]| parse_meta_json(bytes);
+        wrap: |nested: &str| format!(r#"{{"versions": {{}}, "extra": {nested}}}"#);
     }
 
     #[test]
@@ -792,26 +779,13 @@ mod tests {
         assert_eq!(packages[0].latest_version, "1.0.24");
     }
 
-    #[test]
-    fn test_parse_search_response_nesting_at_max_depth_accepted() {
-        let depth = deps_core::MAX_JSON_NESTING_DEPTH;
-        let json = format!(
-            r#"{{"items": [], "extra": {}1{}}}"#,
-            "[".repeat(depth - 1),
-            "]".repeat(depth - 1)
-        );
-        assert!(parse_search_response(json.as_bytes()).is_ok());
-    }
-
-    #[test]
-    fn test_parse_search_response_nesting_over_max_depth_rejected() {
-        let depth = deps_core::MAX_JSON_NESTING_DEPTH + 1;
-        let json = format!(
-            r#"{{"items": [], "extra": {}1{}}}"#,
-            "[".repeat(depth),
-            "]".repeat(depth)
-        );
-        assert!(parse_search_response(json.as_bytes()).is_err());
+    // #758: the shared JSON-nesting-depth cap, replacing
+    // test_parse_search_response_nesting_at_max_depth_accepted/
+    // test_parse_search_response_nesting_over_max_depth_rejected.
+    deps_core::json_depth_conformance! {
+        mod deno_search_response_json_depth_conformance;
+        parse: |bytes: &[u8]| parse_search_response(bytes);
+        wrap: |nested: &str| format!(r#"{{"items": [], "extra": {nested}}}"#);
     }
 
     #[test]

--- a/crates/deps-github-actions/src/ecosystem.rs
+++ b/crates/deps-github-actions/src/ecosystem.rs
@@ -1188,19 +1188,31 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_ecosystem_id_and_display_name() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = GithubActionsEcosystem::new(cache);
-        assert_eq!(eco.id(), "github-actions");
-        assert_eq!(eco.display_name(), "GitHub Actions");
+    // #758: exact-value `Ecosystem` conformance, replacing
+    // test_ecosystem_id_and_display_name and test_as_any. `lockfile_filenames()` is
+    // omitted — GHA workflows have no lock file concept (no `LockFileProvider` impl in
+    // this crate). No `completion_guard_conformance!`/`json_depth_conformance!` for this
+    // crate: GHA never performs package-name search completion
+    // (`CompletionContext::PackageName` always yields `Completions::default()` — versions
+    // resolve via the tags API only), and its tags-response parsing goes through the
+    // shared, already depth-capped `deps_core::github::parse_tags_page`, which fails open
+    // to `Ok(vec![])` rather than `Err` on excess nesting (a deliberate malformed-page
+    // tolerance) — `json_depth_conformance!`'s over-depth-rejected assertion does not hold
+    // for that call site, and the underlying cap itself is already covered by deps-core's
+    // own `parser`/`github` test suites.
+    deps_core::ecosystem_conformance! {
+        mod github_actions_ecosystem_conformance;
+        build: GithubActionsEcosystem::new(Arc::new(deps_core::HttpCache::new()));
+        ty: GithubActionsEcosystem;
+        id: "github-actions";
+        display_name: "GitHub Actions";
+        manifest_filenames: &["action.yml", "action.yaml"];
     }
 
     #[test]
     fn test_manifest_routing_filenames_and_directory_patterns() {
         let cache = Arc::new(deps_core::HttpCache::new());
         let eco = GithubActionsEcosystem::new(cache);
-        assert_eq!(eco.manifest_filenames(), &["action.yml", "action.yaml"]);
         assert!(eco.manifest_patterns().is_empty());
         assert!(eco.manifest_extensions().is_empty());
         assert_eq!(
@@ -1236,13 +1248,6 @@ mod tests {
                 .unwrap_or_else(|| panic!("expected {path} to route to an ecosystem"));
             assert_eq!(eco.id(), "github-actions", "{path}");
         }
-    }
-
-    #[test]
-    fn test_as_any() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = GithubActionsEcosystem::new(cache);
-        assert!(eco.as_any().is::<GithubActionsEcosystem>());
     }
 
     #[tokio::test]

--- a/crates/deps-github-actions/src/formatter.rs
+++ b/crates/deps-github-actions/src/formatter.rs
@@ -633,17 +633,6 @@ mod tests {
     }
 
     #[test]
-    fn test_package_url_valid_and_invalid() {
-        let fmt = formatter();
-        assert_eq!(
-            fmt.package_url(&PackageName::new("actions/checkout")),
-            "https://github.com/actions/checkout"
-        );
-        assert_eq!(fmt.package_url(&PackageName::new("no-slash")), "");
-        assert_eq!(fmt.package_url(&PackageName::new("owner/..")), "");
-    }
-
-    #[test]
     fn test_normalize_package_name() {
         let fmt = formatter();
         assert_eq!(
@@ -652,53 +641,29 @@ mod tests {
         );
     }
 
-    // --- #544: validate_package_name override ---
-
-    #[test]
-    fn test_validate_package_name_accepts_owner_repo() {
-        let fmt = formatter();
-        assert!(fmt.validate_package_name("actions/checkout").is_ok());
-    }
-
-    /// A local composite action's `name` is its raw `./`-prefixed `uses:` value
-    /// (`crate::parser`'s `ParsedUses::Path` arm), never an `owner/repo` coordinate — it
-    /// must not be flagged as an invalid package name.
-    #[test]
-    fn test_validate_package_name_accepts_local_path_action() {
-        let fmt = formatter();
-        assert!(fmt.validate_package_name("./local-action").is_ok());
-        assert!(fmt.validate_package_name("./nested/local-action").is_ok());
-    }
-
-    /// A Docker image reference's `name` is its raw `docker://`-prefixed `uses:` value
-    /// (`crate::parser`'s `ParsedUses::Docker` arm) — same rationale as the local-path
-    /// case above.
-    #[test]
-    fn test_validate_package_name_accepts_docker_ref() {
-        let fmt = formatter();
-        assert!(fmt.validate_package_name("docker://alpine:3.18").is_ok());
-    }
-
-    /// A structurally invalid GitHub Actions reference must be reported as an invalid
-    /// package name, not forwarded to the registry lookup that produces the misleading
-    /// generic "Registry lookup failed" diagnostic.
-    #[test]
-    fn test_validate_package_name_rejects_malformed_names() {
-        let fmt = formatter();
-        for name in [
-            "",
-            ".",
-            "..",
-            "no-slash",
-            "owner/repo/extra",
-            "../../etc/passwd",
-            "owner/..",
-        ] {
-            assert!(
-                fmt.validate_package_name(name).is_err(),
-                "expected {name:?} to be rejected"
-            );
-        }
+    // #758: exact-value `EcosystemFormatter` conformance, replacing
+    // test_package_url_valid_and_invalid, test_validate_package_name_accepts_owner_repo,
+    // test_validate_package_name_accepts_local_path_action,
+    // test_validate_package_name_accepts_docker_ref, and
+    // test_validate_package_name_rejects_malformed_names (#544/#722). No
+    // `version_roundtrip` — this formatter has no `version_satisfies_requirement`
+    // override, only `is_requirement_up_to_date`/`requirement_is_unresolved`, which stay
+    // hand-written below.
+    deps_core::formatter_conformance! {
+        mod github_actions_formatter_conformance;
+        build: formatter();
+        package_url: {
+            "actions/checkout" => "https://github.com/actions/checkout",
+            "no-slash" => "",
+            "owner/.." => "",
+        };
+        accepts: [
+            "actions/checkout", "./local-action", "./nested/local-action",
+            "docker://alpine:3.18",
+        ];
+        rejects: [
+            "", ".", "..", "no-slash", "owner/repo/extra", "../../etc/passwd", "owner/..",
+        ];
     }
 
     #[test]

--- a/crates/deps-gitlab-ci/src/ecosystem.rs
+++ b/crates/deps-gitlab-ci/src/ecosystem.rs
@@ -1027,32 +1027,37 @@ mod tests {
     use crate::types::EndpointKind;
     use dashmap::DashMap;
 
-    #[test]
-    fn test_ecosystem_id_and_display_name() {
-        let cache = Arc::new(HttpCache::new());
-        let eco = GitlabCiEcosystem::new(cache);
-        assert_eq!(eco.id(), "gitlab-ci");
-        assert_eq!(eco.display_name(), "GitLab CI/CD");
+    // #758: exact-value `Ecosystem` conformance, replacing test_ecosystem_id_and_display_name
+    // and test_as_any. `lockfile_filenames()` is omitted — GitLab CI pipelines have no lock
+    // file concept (no `LockFileProvider` impl in this crate). No
+    // `completion_guard_conformance!`/`json_depth_conformance!` for this crate:
+    // `generate_completions` above only ever handles `CompletionContext::Version` (no
+    // package-name search endpoint, spec NFR-002), and `client::parse_gitlab_page`
+    // (backing both tags and releases parsing) is already depth-capped via
+    // `deps_core::parser::parse_json_checked`, but fails open to `Ok(vec![])` rather than
+    // `Err` on excess nesting (mirrors `deps_github_actions::parse_tags_page`'s identical,
+    // deliberate malformed-page tolerance) — `json_depth_conformance!`'s
+    // over-depth-rejected assertion does not hold for that call site, and the underlying
+    // cap itself is already covered by deps-core's own `parser` test suite.
+    deps_core::ecosystem_conformance! {
+        mod gitlab_ci_ecosystem_conformance;
+        build: GitlabCiEcosystem::new(Arc::new(HttpCache::new()));
+        ty: GitlabCiEcosystem;
+        id: "gitlab-ci";
+        display_name: "GitLab CI/CD";
+        manifest_filenames: &[".gitlab-ci.yml"];
     }
 
     #[test]
     fn test_manifest_routing() {
         let cache = Arc::new(HttpCache::new());
         let eco = GitlabCiEcosystem::new(cache);
-        assert_eq!(eco.manifest_filenames(), &[".gitlab-ci.yml"]);
         assert_eq!(
             eco.manifest_directory_patterns(),
             &[(".gitlab/ci", ".yml"), (".gitlab/ci", ".yaml")]
         );
         assert!(eco.manifest_patterns().is_empty());
         assert!(eco.manifest_extensions().is_empty());
-    }
-
-    #[test]
-    fn test_as_any() {
-        let cache = Arc::new(HttpCache::new());
-        let eco = GitlabCiEcosystem::new(cache);
-        assert!(eco.as_any().is::<GitlabCiEcosystem>());
     }
 
     #[tokio::test]

--- a/crates/deps-gitlab-ci/src/formatter.rs
+++ b/crates/deps-gitlab-ci/src/formatter.rs
@@ -344,25 +344,20 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_validate_package_name_accepts_bare_and_host_qualified() {
-        let fmt = formatter();
-        assert!(fmt.validate_package_name("org/proj").is_ok());
-        assert!(
-            fmt.validate_package_name("gitlab.com/org/proj/comp")
-                .is_ok()
-        );
-        assert!(fmt.validate_package_name("no-slash").is_err());
-    }
-
-    #[test]
-    fn test_package_url() {
-        let fmt = formatter();
-        assert_eq!(
-            fmt.package_url(&PackageName::new("gitlab.com/org/proj")),
-            "https://gitlab.com/org/proj"
-        );
-        assert_eq!(fmt.package_url(&PackageName::new("no-slash")), "");
+    // #758: exact-value `EcosystemFormatter` conformance, replacing
+    // test_validate_package_name_accepts_bare_and_host_qualified and test_package_url. No
+    // `version_roundtrip` — this formatter has no `version_satisfies_requirement`
+    // override, only `is_requirement_up_to_date`/`requirement_status_for`, which stay
+    // hand-written below.
+    deps_core::formatter_conformance! {
+        mod gitlab_ci_formatter_conformance;
+        build: formatter();
+        package_url: {
+            "gitlab.com/org/proj" => "https://gitlab.com/org/proj",
+            "no-slash" => "",
+        };
+        accepts: [ "org/proj", "gitlab.com/org/proj/comp" ];
+        rejects: [ "no-slash" ];
     }
 
     #[test]

--- a/crates/deps-go/src/ecosystem.rs
+++ b/crates/deps-go/src/ecosystem.rs
@@ -336,32 +336,19 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_ecosystem_id() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = GoEcosystem::new(cache);
-        assert_eq!(ecosystem.id(), "go");
-    }
-
-    #[test]
-    fn test_ecosystem_display_name() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = GoEcosystem::new(cache);
-        assert_eq!(ecosystem.display_name(), "Go Modules");
-    }
-
-    #[test]
-    fn test_ecosystem_manifest_filenames() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = GoEcosystem::new(cache);
-        assert_eq!(ecosystem.manifest_filenames(), &["go.mod"]);
-    }
-
-    #[test]
-    fn test_ecosystem_lockfile_filenames() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = GoEcosystem::new(cache);
-        assert_eq!(ecosystem.lockfile_filenames(), &["go.sum"]);
+    // #758: exact-value `Ecosystem` conformance, replacing the hand-written
+    // test_ecosystem_id/test_ecosystem_display_name/test_ecosystem_manifest_filenames/
+    // test_ecosystem_lockfile_filenames/test_as_any family. test_registry_returns_trait_object
+    // stays hand-written below: it also asserts the concrete `GoRegistry` downcast, stronger
+    // than the macro's plain smoke check.
+    deps_core::ecosystem_conformance! {
+        mod go_ecosystem_conformance;
+        build: GoEcosystem::new(Arc::new(deps_core::HttpCache::new()));
+        ty: GoEcosystem;
+        id: "go";
+        display_name: "Go Modules";
+        manifest_filenames: &["go.mod"];
+        lockfile_filenames: &["go.sum"];
     }
 
     #[test]
@@ -509,16 +496,6 @@ mod tests {
         ));
 
         assert_eq!(hints.len(), 0);
-    }
-
-    #[test]
-    fn test_as_any() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = GoEcosystem::new(cache);
-
-        // Verify we can downcast
-        let any = ecosystem.as_any();
-        assert!(any.is::<GoEcosystem>());
     }
 
     #[tokio::test]

--- a/crates/deps-go/src/formatter.rs
+++ b/crates/deps-go/src/formatter.rs
@@ -254,123 +254,44 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_package_url() {
-        let formatter = GoFormatter;
-
-        // Standard package
-        assert_eq!(
-            formatter.package_url(&PackageName::new("github.com/gin-gonic/gin")),
-            "https://pkg.go.dev/github.com/gin-gonic/gin"
-        );
-
-        // Package with version path
-        assert_eq!(
-            formatter.package_url(&PackageName::new("github.com/go-redis/redis/v8")),
-            "https://pkg.go.dev/github.com/go-redis/redis/v8"
-        );
-
-        // Standard library package
-        assert_eq!(
-            formatter.package_url(&PackageName::new("fmt")),
-            "https://pkg.go.dev/fmt"
-        );
-
-        // Package with @ character (should be URL encoded)
-        assert_eq!(
-            formatter.package_url(&PackageName::new("github.com/user@org/package")),
-            "https://pkg.go.dev/github.com/user%40org/package"
-        );
-
-        // Package with space (should be URL encoded)
-        assert_eq!(
-            formatter.package_url(&PackageName::new("github.com/user/pkg name")),
-            "https://pkg.go.dev/github.com/user/pkg%20name"
-        );
-    }
-
-    #[test]
-    fn test_version_satisfies_requirement_exact_match() {
-        let formatter = GoFormatter;
-
-        // Exact version match
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("v1.2.3"), "v1.2.3"));
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("v0.1.0"), "v0.1.0"));
-    }
-
-    #[test]
-    fn test_version_satisfies_requirement_pseudo_version() {
-        let formatter = GoFormatter;
-
-        // Pseudo-version prefix match
-        assert!(formatter.version_satisfies_requirement(
-            &ConcreteVersion::new("v0.0.0-20191109021931-daa7c04131f5"),
-            "v0.0.0"
-        ));
-
-        // Full pseudo-version match
-        assert!(formatter.version_satisfies_requirement(
-            &ConcreteVersion::new("v0.0.0-20191109021931-daa7c04131f5"),
-            "v0.0.0-20191109021931-daa7c04131f5"
-        ));
-    }
-
-    #[test]
-    fn test_version_satisfies_requirement_incompatible() {
-        let formatter = GoFormatter;
-
-        // +incompatible suffix handling
-        assert!(
-            formatter.version_satisfies_requirement(
-                &ConcreteVersion::new("v2.0.0+incompatible"),
-                "v2.0.0"
-            )
-        );
-
-        // Exact match with +incompatible
-        assert!(formatter.version_satisfies_requirement(
-            &ConcreteVersion::new("v2.0.0+incompatible"),
-            "v2.0.0+incompatible"
-        ));
-    }
-
-    #[test]
-    fn test_version_does_not_satisfy_requirement() {
-        let formatter = GoFormatter;
-
-        // Different versions
-        assert!(
-            !formatter.version_satisfies_requirement(&ConcreteVersion::new("v1.2.3"), "v1.2.4")
-        );
-        assert!(
-            !formatter.version_satisfies_requirement(&ConcreteVersion::new("v2.0.0"), "v1.0.0")
-        );
-
-        // Partial match that doesn't start with requirement
-        assert!(
-            !formatter.version_satisfies_requirement(&ConcreteVersion::new("v1.2.3"), "v1.2.3.4")
-        );
-    }
-
-    #[test]
-    fn test_version_satisfies_requirement_prefix_scenarios() {
-        let formatter = GoFormatter;
-
-        // Version is prefix of requirement (should NOT match)
-        assert!(!formatter.version_satisfies_requirement(&ConcreteVersion::new("v1.2"), "v1.2.3"));
-
-        // Requirement is prefix of version with dot boundary (should match)
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("v1.2.3"), "v1.2"));
-
-        // False positive prevention: v1.2.30 should NOT match v1.2.3
-        assert!(
-            !formatter.version_satisfies_requirement(&ConcreteVersion::new("v1.2.30"), "v1.2.3")
-        );
-
-        // But v1.2.3.1 SHOULD match v1.2.3 (if it has dot boundary)
-        assert!(
-            formatter.version_satisfies_requirement(&ConcreteVersion::new("v1.2.3.1"), "v1.2.3")
-        );
+    // #758: exact-value `EcosystemFormatter` conformance, replacing test_package_url,
+    // test_validate_package_name_accepts_valid_module_path, test_validate_package_name_rejects_empty,
+    // test_validate_package_name_rejects_dot_segment, test_version_satisfies_requirement_exact_match,
+    // test_version_satisfies_requirement_pseudo_version, test_version_satisfies_requirement_incompatible,
+    // test_version_does_not_satisfy_requirement, and test_version_satisfies_requirement_prefix_scenarios.
+    // test_validate_package_name_rejects_too_long below stays hand-written: it asserts on a
+    // computed (`.repeat(n)`) length, which doesn't fit the macro's `literal`-only list.
+    deps_core::formatter_conformance! {
+        mod go_formatter_conformance;
+        build: GoFormatter;
+        package_url: {
+            "github.com/gin-gonic/gin" => "https://pkg.go.dev/github.com/gin-gonic/gin",
+            "github.com/go-redis/redis/v8" => "https://pkg.go.dev/github.com/go-redis/redis/v8",
+            "fmt" => "https://pkg.go.dev/fmt",
+            "github.com/user@org/package" => "https://pkg.go.dev/github.com/user%40org/package",
+            "github.com/user/pkg name" => "https://pkg.go.dev/github.com/user/pkg%20name",
+        };
+        accepts: [
+            "github.com/gin-gonic/gin", "golang.org/x/mod"
+        ];
+        rejects: [
+            "", "github.com/user/..", "./evil"
+        ];
+        version_roundtrip: [
+            "v1.2.3", "v1.2.3" => true,
+            "v0.1.0", "v0.1.0" => true,
+            "v0.0.0-20191109021931-daa7c04131f5", "v0.0.0" => true,
+            "v0.0.0-20191109021931-daa7c04131f5", "v0.0.0-20191109021931-daa7c04131f5" => true,
+            "v2.0.0+incompatible", "v2.0.0" => true,
+            "v2.0.0+incompatible", "v2.0.0+incompatible" => true,
+            "v1.2.3", "v1.2.4" => false,
+            "v2.0.0", "v1.0.0" => false,
+            "v1.2.3", "v1.2.3.4" => false,
+            "v1.2", "v1.2.3" => false,
+            "v1.2.3", "v1.2" => true,
+            "v1.2.30", "v1.2.3" => false,
+            "v1.2.3.1", "v1.2.3" => true
+        ];
     }
 
     #[test]
@@ -459,36 +380,6 @@ mod tests {
             matcher.matches(&ConcreteVersion::new("v2.0.0+incompatible")),
             Some(true)
         );
-    }
-
-    #[test]
-    fn test_validate_package_name_accepts_valid_module_path() {
-        let formatter = GoFormatter;
-        assert!(
-            formatter
-                .validate_package_name("github.com/gin-gonic/gin")
-                .is_ok()
-        );
-        assert!(formatter.validate_package_name("golang.org/x/mod").is_ok());
-    }
-
-    #[test]
-    fn test_validate_package_name_rejects_empty() {
-        let formatter = GoFormatter;
-        assert!(formatter.validate_package_name("").is_err());
-    }
-
-    /// #402: a `.`/`..` module path segment must be reported as an invalid package name,
-    /// not forwarded to the registry lookup that produces the misleading generic diagnostic.
-    #[test]
-    fn test_validate_package_name_rejects_dot_segment() {
-        let formatter = GoFormatter;
-        assert!(
-            formatter
-                .validate_package_name("github.com/user/..")
-                .is_err()
-        );
-        assert!(formatter.validate_package_name("./evil").is_err());
     }
 
     /// FR-012 (spec 034): `can_resolve_source` accepts `Registry`/`AlternateRegistry`,

--- a/crates/deps-go/src/lockfile.rs
+++ b/crates/deps-go/src/lockfile.rs
@@ -337,21 +337,18 @@ golang.org/x/sync v0.5.0/go.mod h1:RxMgew5V=
         assert!(result.is_err());
     }
 
-    #[test]
-    fn test_locate_lockfile_same_directory() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("go.mod");
-        let lock_path = temp_dir.path().join("go.sum");
-
-        std::fs::write(&manifest_path, "module test").unwrap();
-        std::fs::write(&lock_path, "").unwrap();
-
-        let manifest_uri = Uri::from_file_path(&manifest_path).unwrap();
-        let parser = GoSumParser;
-
-        let located = parser.locate_lockfile(&manifest_uri);
-        assert!(located.is_some());
-        assert_eq!(located.unwrap(), lock_path);
+    // #758: shared `LockFileProvider` conformance, replacing test_locate_lockfile_same_directory,
+    // test_locate_lockfile_not_found, and test_is_lockfile_stale_not_modified/_modified/_deleted/
+    // _future_time. test_locate_lockfile_workspace_root stays hand-written: it exercises the
+    // ancestor-directory search, a scenario this macro doesn't cover.
+    deps_core::lockfile_conformance! {
+        mod go_lockfile_conformance;
+        build: GoSumParser;
+        manifest: "go.mod" => "module test";
+        lockfiles: [
+            "go.sum" => "github.com/gin-gonic/gin v1.9.1 h1:hash=",
+        ];
+        malformed: "not valid go.sum content !!!";
     }
 
     #[test]
@@ -371,79 +368,6 @@ golang.org/x/sync v0.5.0/go.mod h1:RxMgew5V=
         let located = parser.locate_lockfile(&manifest_uri);
         assert!(located.is_some());
         assert_eq!(located.unwrap(), workspace_lock);
-    }
-
-    #[test]
-    fn test_locate_lockfile_not_found() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("go.mod");
-        std::fs::write(&manifest_path, "module test").unwrap();
-
-        let manifest_uri = Uri::from_file_path(&manifest_path).unwrap();
-        let parser = GoSumParser;
-
-        let located = parser.locate_lockfile(&manifest_uri);
-        assert!(located.is_none());
-    }
-
-    #[test]
-    fn test_is_lockfile_stale_not_modified() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let lockfile_path = temp_dir.path().join("go.sum");
-        std::fs::write(&lockfile_path, "").unwrap();
-
-        let mtime = std::fs::metadata(&lockfile_path)
-            .unwrap()
-            .modified()
-            .unwrap();
-        let parser = GoSumParser;
-
-        assert!(
-            !parser.is_lockfile_stale(&lockfile_path, mtime),
-            "Lock file should not be stale when mtime matches"
-        );
-    }
-
-    #[test]
-    fn test_is_lockfile_stale_modified() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let lockfile_path = temp_dir.path().join("go.sum");
-        std::fs::write(&lockfile_path, "").unwrap();
-
-        let old_time = std::time::UNIX_EPOCH;
-        let parser = GoSumParser;
-
-        assert!(
-            parser.is_lockfile_stale(&lockfile_path, old_time),
-            "Lock file should be stale when last_modified is old"
-        );
-    }
-
-    #[test]
-    fn test_is_lockfile_stale_deleted() {
-        let parser = GoSumParser;
-        let non_existent = std::path::Path::new("/nonexistent/go.sum");
-
-        assert!(
-            parser.is_lockfile_stale(non_existent, std::time::SystemTime::now()),
-            "Non-existent lock file should be considered stale"
-        );
-    }
-
-    #[test]
-    fn test_is_lockfile_stale_future_time() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let lockfile_path = temp_dir.path().join("go.sum");
-        std::fs::write(&lockfile_path, "").unwrap();
-
-        // Use a time far in the future
-        let future_time = std::time::SystemTime::now() + std::time::Duration::from_hours(24);
-        let parser = GoSumParser;
-
-        assert!(
-            !parser.is_lockfile_stale(&lockfile_path, future_time),
-            "Lock file should not be stale when last_modified is in the future"
-        );
     }
 
     #[test]

--- a/crates/deps-go/src/registry.rs
+++ b/crates/deps-go/src/registry.rs
@@ -981,26 +981,12 @@ mod tests {
         assert!(result.is_err());
     }
 
-    #[test]
-    fn test_parse_version_info_nesting_at_max_depth_accepted() {
-        let depth = deps_core::MAX_JSON_NESTING_DEPTH;
-        let json = format!(
-            r#"{{"Version": "v1.0.0", "Time": "2024-01-01T00:00:00Z", "extra": {}1{}}}"#,
-            "[".repeat(depth - 1),
-            "]".repeat(depth - 1)
-        );
-        assert!(parse_version_info("github.com/gin-gonic/gin", json.as_bytes()).is_ok());
-    }
-
-    #[test]
-    fn test_parse_version_info_nesting_over_max_depth_rejected() {
-        let depth = deps_core::MAX_JSON_NESTING_DEPTH + 1;
-        let json = format!(
-            r#"{{"Version": "v1.0.0", "Time": "2024-01-01T00:00:00Z", "extra": {}1{}}}"#,
-            "[".repeat(depth),
-            "]".repeat(depth)
-        );
-        assert!(parse_version_info("github.com/gin-gonic/gin", json.as_bytes()).is_err());
+    // #758: the shared JSON-nesting-depth cap, replacing
+    // test_parse_version_info_nesting_at_max_depth_accepted/_over_max_depth_rejected.
+    deps_core::json_depth_conformance! {
+        mod go_json_depth_conformance;
+        parse: |bytes: &[u8]| parse_version_info("github.com/gin-gonic/gin", bytes);
+        wrap: |nested: &str| format!(r#"{{"Version": "v1.0.0", "Time": "2024-01-01T00:00:00Z", "extra": {nested}}}"#);
     }
 
     #[test]
@@ -1068,14 +1054,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_package_url_encodes_newline_autolink_and_percent() {
-        let url = package_url("github.com/evil\n<https://evil%zz.example>");
-        assert!(!url.contains('\n'));
-        assert!(!url.contains('<'));
-        assert!(!url.contains('>'));
-        assert!(url.contains("%25"));
-    }
+    // #758: this hostile newline/autolink/percent payload case is now covered universally by
+    // deps-lsp's `test_registered_ecosystems_universal_invariants` (Layer 1), via
+    // `deps_core::conformance::HOSTILE_DISPLAY_LINK_PAYLOAD` — this crate's own copy is
+    // redundant and has been removed.
 
     #[test]
     fn test_package_url_empty_module_path() {

--- a/crates/deps-gradle/src/ecosystem.rs
+++ b/crates/deps-gradle/src/ecosystem.rs
@@ -417,26 +417,23 @@ mod tests {
         Arc::new(deps_core::HttpCache::new())
     }
 
-    #[test]
-    fn test_ecosystem_id() {
-        let eco = GradleEcosystem::new(make_cache());
-        assert_eq!(eco.id(), "gradle");
-    }
-
-    #[test]
-    fn test_ecosystem_display_name() {
-        let eco = GradleEcosystem::new(make_cache());
-        assert_eq!(eco.display_name(), "Gradle (JVM)");
-    }
-
-    #[test]
-    fn test_manifest_filenames() {
-        let eco = GradleEcosystem::new(make_cache());
-        assert!(eco.manifest_filenames().contains(&"libs.versions.toml"));
-        assert!(eco.manifest_filenames().contains(&"build.gradle.kts"));
-        assert!(eco.manifest_filenames().contains(&"build.gradle"));
-        assert!(eco.manifest_filenames().contains(&"settings.gradle.kts"));
-        assert!(eco.manifest_filenames().contains(&"settings.gradle"));
+    // #758: exact-value `Ecosystem` conformance, replacing test_ecosystem_id,
+    // test_ecosystem_display_name, test_manifest_filenames, and test_as_any. Gradle has no
+    // lock file format, so `lockfile_filenames` is omitted here; `test_lockfile_filenames_empty`/
+    // `test_lockfile_provider_none` below stay hand-written to pin that contract explicitly.
+    deps_core::ecosystem_conformance! {
+        mod gradle_ecosystem_conformance;
+        build: GradleEcosystem::new(make_cache());
+        ty: GradleEcosystem;
+        id: "gradle";
+        display_name: "Gradle (JVM)";
+        manifest_filenames: &[
+            "libs.versions.toml",
+            "build.gradle.kts",
+            "build.gradle",
+            "settings.gradle.kts",
+            "settings.gradle",
+        ];
     }
 
     #[test]
@@ -451,25 +448,25 @@ mod tests {
         assert!(eco.lockfile_provider().is_none());
     }
 
-    #[test]
-    fn test_as_any() {
-        let eco = GradleEcosystem::new(make_cache());
-        assert!(eco.as_any().is::<GradleEcosystem>());
-    }
-
-    #[tokio::test]
-    async fn test_complete_package_names_short_prefix() {
-        let eco = GradleEcosystem::new(make_cache());
-        assert!(
-            eco.complete_package_names("a", Range::default())
+    // #758: the shared completion-prefix-length guard
+    // (`deps_core::completion::complete_package_names_generic`), replacing
+    // test_complete_package_names_short_prefix — also closes the missing max-length case
+    // (issue #758 named deps-gradle as missing this).
+    deps_core::completion_guard_conformance! {
+        mod gradle_completion_guard_conformance;
+        complete: |registry: &dyn deps_core::Registry, prefix: String| -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Vec<CompletionItem>> + Send + '_>,
+        > {
+            Box::pin(async move {
+                deps_core::completion::complete_package_names_generic(
+                    registry,
+                    &prefix,
+                    20,
+                    Range::default(),
+                )
                 .await
-                .is_empty()
-        );
-        assert!(
-            eco.complete_package_names("", Range::default())
-                .await
-                .is_empty()
-        );
+            })
+        };
     }
 
     #[tokio::test]

--- a/crates/deps-gradle/src/formatter.rs
+++ b/crates/deps-gradle/src/formatter.rs
@@ -364,23 +364,35 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_package_url() {
-        let f = GradleFormatter;
-        assert_eq!(
-            f.package_url(&PackageName::new(
-                "org.springframework.boot:spring-boot-starter"
-            )),
-            "https://central.sonatype.com/artifact/org.springframework.boot/spring-boot-starter"
-        );
-    }
-
-    #[test]
-    fn test_version_satisfies() {
-        let f = GradleFormatter;
-        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("3.2.0"), "3.2.0"));
-        assert!(!f.version_satisfies_requirement(&ConcreteVersion::new("3.2.0"), "3.1.0"));
-        assert!(!f.version_satisfies_requirement(&ConcreteVersion::new("3.2.0"), "3.2.1"));
+    // #758: exact-value `EcosystemFormatter` conformance, replacing test_package_url,
+    // test_version_satisfies, test_validate_package_name_accepts_valid_coordinate,
+    // test_validate_package_name_rejects_missing_colon, test_validate_package_name_rejects_invalid_group,
+    // test_validate_package_name_rejects_invalid_artifact, and
+    // test_validate_package_name_accepts_unresolved_variable. Every other
+    // version_satisfies_requirement/compile_requirement test below stays hand-written:
+    // Gradle's dynamic-prefix/range/strict-marker/snapshot rich-version semantics are
+    // extensively documented, regression-driven behavior, not simple redundant literal lists.
+    deps_core::formatter_conformance! {
+        mod gradle_formatter_conformance;
+        build: GradleFormatter;
+        package_url: {
+            "org.springframework.boot:spring-boot-starter" => "https://central.sonatype.com/artifact/org.springframework.boot/spring-boot-starter",
+        };
+        accepts: [
+            "com.google.guava:guava",
+            "$group:guava",
+            "com.google.guava:${name}",
+        ];
+        rejects: [
+            "com.google.guava",
+            "com</group>:guava",
+            "com.google.guava:..",
+        ];
+        version_roundtrip: [
+            "3.2.0", "3.2.0" => true,
+            "3.2.0", "3.1.0" => false,
+            "3.2.0", "3.2.1" => false
+        ];
     }
 
     #[test]
@@ -497,40 +509,6 @@ mod tests {
     fn test_version_satisfies_unresolved_compound_variable() {
         let f = GradleFormatter;
         assert!(f.version_satisfies_requirement(&ConcreteVersion::new("3.14.0"), "1.0.0-$suffix"));
-    }
-
-    #[test]
-    fn test_validate_package_name_accepts_valid_coordinate() {
-        let f = GradleFormatter;
-        assert!(f.validate_package_name("com.google.guava:guava").is_ok());
-    }
-
-    #[test]
-    fn test_validate_package_name_rejects_missing_colon() {
-        let f = GradleFormatter;
-        assert!(f.validate_package_name("com.google.guava").is_err());
-    }
-
-    #[test]
-    fn test_validate_package_name_rejects_invalid_group() {
-        let f = GradleFormatter;
-        assert!(f.validate_package_name("com</group>:guava").is_err());
-    }
-
-    #[test]
-    fn test_validate_package_name_rejects_invalid_artifact() {
-        let f = GradleFormatter;
-        assert!(f.validate_package_name("com.google.guava:..").is_err());
-    }
-
-    /// Gradle's own `is_unresolved` (unresolved `$var`/`${var}` or catalog-alias
-    /// placeholder) is valid Gradle syntax, not a malformed coordinate — must be
-    /// accepted, mirroring Maven's `${property}` treatment.
-    #[test]
-    fn test_validate_package_name_accepts_unresolved_variable() {
-        let f = GradleFormatter;
-        assert!(f.validate_package_name("$group:guava").is_ok());
-        assert!(f.validate_package_name("com.google.guava:${name}").is_ok());
     }
 
     #[test]

--- a/crates/deps-maven/src/ecosystem.rs
+++ b/crates/deps-maven/src/ecosystem.rs
@@ -432,25 +432,18 @@ fn extract_prefix(line: &str, character: u32) -> (&str, Option<&str>) {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_ecosystem_id() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = MavenEcosystem::new(cache);
-        assert_eq!(eco.id(), "maven");
-    }
-
-    #[test]
-    fn test_ecosystem_display_name() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = MavenEcosystem::new(cache);
-        assert_eq!(eco.display_name(), "Maven (JVM)");
-    }
-
-    #[test]
-    fn test_manifest_filenames() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = MavenEcosystem::new(cache);
-        assert_eq!(eco.manifest_filenames(), &["pom.xml"]);
+    // #758: exact-value `Ecosystem` conformance, replacing the hand-written
+    // test_ecosystem_id/test_ecosystem_display_name/test_manifest_filenames/test_as_any
+    // family. Maven has no lock file format, so `lockfile_filenames` is omitted here;
+    // `test_lockfile_filenames`/`test_lockfile_provider_none` below stay hand-written to
+    // pin that "no lock file support" contract explicitly.
+    deps_core::ecosystem_conformance! {
+        mod maven_ecosystem_conformance;
+        build: MavenEcosystem::new(Arc::new(deps_core::HttpCache::new()));
+        ty: MavenEcosystem;
+        id: "maven";
+        display_name: "Maven (JVM)";
+        manifest_filenames: &["pom.xml"];
     }
 
     #[test]
@@ -465,13 +458,6 @@ mod tests {
         let cache = Arc::new(deps_core::HttpCache::new());
         let eco = MavenEcosystem::new(cache);
         assert!(eco.lockfile_provider().is_none());
-    }
-
-    #[test]
-    fn test_as_any() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = MavenEcosystem::new(cache);
-        assert!(eco.as_any().is::<MavenEcosystem>());
     }
 
     struct NoopParseResult;

--- a/crates/deps-maven/src/formatter.rs
+++ b/crates/deps-maven/src/formatter.rs
@@ -243,90 +243,64 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_package_url() {
-        let f = MavenFormatter;
-        assert_eq!(
-            f.package_url(&PackageName::new("org.apache.commons:commons-lang3")),
-            "https://central.sonatype.com/artifact/org.apache.commons/commons-lang3"
-        );
+    // #758: exact-value `EcosystemFormatter` conformance, replacing test_package_url,
+    // test_version_satisfies, test_version_satisfies_range, test_version_satisfies_maven_property,
+    // test_validate_package_name_accepts_valid_coordinate,
+    // test_validate_package_name_rejects_invalid_group_id,
+    // test_validate_package_name_rejects_invalid_artifact_id,
+    // test_validate_package_name_rejects_missing_colon, and
+    // test_validate_package_name_accepts_unresolved_property. The unresolved-`${property}`
+    // acceptance (impl-critic S2: valid Maven, not a malformed coordinate) and the
+    // `${property}`-requirement always-satisfied cases both fit this macro's literal lists.
+    deps_core::formatter_conformance! {
+        mod maven_formatter_conformance;
+        build: MavenFormatter;
+        package_url: {
+            "org.apache.commons:commons-lang3" => "https://central.sonatype.com/artifact/org.apache.commons/commons-lang3",
+        };
+        accepts: [
+            "org.apache.commons:commons-lang3",
+            "${project.groupId}:my-module",
+            "org.example:${artifact.name}",
+        ];
+        rejects: [
+            "commons</artifactId><parent>:commons-lang3",
+            "org.apache.commons:..",
+            "org.apache.commons",
+        ];
+        version_roundtrip: [
+            "3.14.0", "3.14.0" => true,
+            "3.14.0", "3.13.0" => false,
+            "3.14.0", "3.14.1" => false,
+            "1.5.0", "[1.0,2.0)" => true,
+            "2.0.0", "[1.0,2.0)" => false,
+            "1.0.0", "[1.0.0]" => true,
+            "1.0.1", "[1.0.0]" => false,
+            "7.1.1", "${woodstoxVersion}" => true,
+            "2.0.17", "${slf4j.version}" => true,
+            "1.0.0", "${project.version}" => true
+        ];
     }
 
+    /// #758: `package_url`'s hostile-input safety is generically covered for every
+    /// ecosystem by Layer 1 (`deps-lsp`'s `test_registered_ecosystems_universal_invariants`,
+    /// which calls `formatter().package_url()` with this exact fixture) — this per-crate
+    /// test exists only so a regression here is caught by `cargo nextest run -p deps-maven`
+    /// alone, without needing the whole-workspace `deps-lsp` suite.
     #[test]
-    fn test_version_satisfies() {
+    fn test_package_url_hostile_display_link_payload_is_safe() {
         let f = MavenFormatter;
-        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("3.14.0"), "3.14.0"));
-        assert!(!f.version_satisfies_requirement(&ConcreteVersion::new("3.14.0"), "3.13.0"));
-        assert!(!f.version_satisfies_requirement(&ConcreteVersion::new("3.14.0"), "3.14.1"));
-    }
-
-    #[test]
-    fn test_version_satisfies_range() {
-        let f = MavenFormatter;
-        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("1.5.0"), "[1.0,2.0)"));
-        assert!(!f.version_satisfies_requirement(&ConcreteVersion::new("2.0.0"), "[1.0,2.0)"));
-        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("1.0.0"), "[1.0.0]"));
-        assert!(!f.version_satisfies_requirement(&ConcreteVersion::new("1.0.1"), "[1.0.0]"));
-    }
-
-    #[test]
-    fn test_version_satisfies_maven_property() {
-        let f = MavenFormatter;
+        let url = f.package_url(&PackageName::new(
+            deps_core::conformance::HOSTILE_DISPLAY_LINK_PAYLOAD,
+        ));
+        for hazard in ['\n', '<', '>', '(', ')', '[', ']', '`'] {
+            assert!(!url.contains(hazard), "leaked {hazard:?} in {url:?}");
+        }
         assert!(
-            f.version_satisfies_requirement(&ConcreteVersion::new("7.1.1"), "${woodstoxVersion}")
+            !url.chars().any(char::is_control),
+            "leaked control char in {url:?}"
         );
-        assert!(
-            f.version_satisfies_requirement(&ConcreteVersion::new("2.0.17"), "${slf4j.version}")
-        );
-        assert!(
-            f.version_satisfies_requirement(&ConcreteVersion::new("1.0.0"), "${project.version}")
-        );
-    }
-
-    #[test]
-    fn test_validate_package_name_accepts_valid_coordinate() {
-        let f = MavenFormatter;
-        assert!(
-            f.validate_package_name("org.apache.commons:commons-lang3")
-                .is_ok()
-        );
-    }
-
-    #[test]
-    fn test_validate_package_name_rejects_invalid_group_id() {
-        let f = MavenFormatter;
-        assert!(
-            f.validate_package_name("commons</artifactId><parent>:commons-lang3")
-                .is_err()
-        );
-    }
-
-    #[test]
-    fn test_validate_package_name_rejects_invalid_artifact_id() {
-        let f = MavenFormatter;
-        assert!(f.validate_package_name("org.apache.commons:..").is_err());
-    }
-
-    #[test]
-    fn test_validate_package_name_rejects_missing_colon() {
-        let f = MavenFormatter;
-        assert!(f.validate_package_name("org.apache.commons").is_err());
-    }
-
-    /// Impl-critic S2: an unresolved `${property}` groupId/artifactId (e.g. a
-    /// multi-module POM's `<groupId>${project.groupId}</groupId>`) is valid Maven, not a
-    /// malformed coordinate — must be treated as undecidable (`Ok`), not rejected.
-    #[test]
-    fn test_validate_package_name_accepts_unresolved_property() {
-        let f = MavenFormatter;
-        assert!(
-            f.validate_package_name("${project.groupId}:my-module")
-                .is_ok()
-        );
-        assert!(
-            f.validate_package_name("org.example:${artifact.name}")
-                .is_ok()
-        );
+        assert!(!url.contains('\u{202e}'), "leaked RTL override in {url:?}");
     }
 
     #[test]

--- a/crates/deps-maven/src/registry.rs
+++ b/crates/deps-maven/src/registry.rs
@@ -1072,14 +1072,19 @@ mod tests {
         assert!(!url.contains(']'));
     }
 
-    #[test]
-    fn test_package_url_encodes_newline_autolink_and_percent() {
-        let url = package_url("evil\n<%:pkg>");
-        assert!(!url.contains('\n'));
-        assert!(!url.contains('<'));
-        assert!(!url.contains('>'));
-        assert!(url.contains("%25"));
-    }
+    // #758: the generic newline/autolink/percent hostile-payload check this test used to
+    // provide is now covered for every ecosystem by Layer 1 (`deps-lsp`'s
+    // `test_registered_ecosystems_universal_invariants`) and, at the per-crate level, by
+    // `formatter.rs`'s `test_package_url_hostile_display_link_payload_is_safe` (which
+    // exercises this exact `package_url` function through `MavenFormatter::package_url`).
+    // `test_package_url_encodes_malicious_group_and_artifact`/`_google_...` above stay
+    // hand-written: the shared hostile fixture does contain a `:` (from its embedded
+    // `https://`), so it exercises this function's `groupId:artifactId` split branch too —
+    // but its `groupId` half never matches a `GOOGLE_PREFIXES` entry, so it never reaches
+    // the Google-routing branch `_google_encodes_malicious_group_and_artifact` covers. Both
+    // hand-written tests also assert general bracket-safety properties rather than pinning
+    // an exact encoded string, which is why they stay separate from
+    // `formatter_conformance!`'s literal `package_url` pair list.
 
     #[test]
     fn test_metadata_urls_central_has_two_urls() {
@@ -1398,26 +1403,12 @@ mod tests {
         assert_eq!(results[0].latest_version, "3.14.0");
     }
 
-    #[test]
-    fn test_parse_search_response_nesting_at_max_depth_accepted() {
-        let depth = deps_core::MAX_JSON_NESTING_DEPTH;
-        let json = format!(
-            r#"{{"response": {{"docs": []}}, "extra": {}1{}}}"#,
-            "[".repeat(depth - 1),
-            "]".repeat(depth - 1)
-        );
-        assert!(parse_search_response(json.as_bytes(), 10).is_ok());
-    }
-
-    #[test]
-    fn test_parse_search_response_nesting_over_max_depth_rejected() {
-        let depth = deps_core::MAX_JSON_NESTING_DEPTH + 1;
-        let json = format!(
-            r#"{{"response": {{"docs": []}}, "extra": {}1{}}}"#,
-            "[".repeat(depth),
-            "]".repeat(depth)
-        );
-        assert!(parse_search_response(json.as_bytes(), 10).is_err());
+    // #758: the shared JSON-nesting-depth cap, replacing
+    // test_parse_search_response_nesting_at_max_depth_accepted/_over_max_depth_rejected.
+    deps_core::json_depth_conformance! {
+        mod maven_json_depth_conformance;
+        parse: |bytes: &[u8]| parse_search_response(bytes, 10);
+        wrap: |nested: &str| format!(r#"{{"response": {{"docs": []}}, "extra": {nested}}}"#);
     }
 
     /// Manual live probe against the real endpoint (#274) — NOT deterministic

--- a/crates/deps-npm/src/ecosystem.rs
+++ b/crates/deps-npm/src/ecosystem.rs
@@ -463,35 +463,37 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_ecosystem_id() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = NpmEcosystem::new(cache);
-        assert_eq!(ecosystem.id(), "npm");
+    // #758: exact-value `Ecosystem` conformance, replacing the hand-written
+    // test_ecosystem_id/test_ecosystem_display_name/test_ecosystem_manifest_filenames/
+    // test_ecosystem_lockfile_filenames/test_as_any/test_registry_returns_arc family.
+    deps_core::ecosystem_conformance! {
+        mod npm_ecosystem_conformance;
+        build: NpmEcosystem::new(Arc::new(deps_core::HttpCache::new()));
+        ty: NpmEcosystem;
+        id: "npm";
+        display_name: "npm (JavaScript)";
+        manifest_filenames: &["package.json"];
+        lockfile_filenames: &["package-lock.json", "pnpm-lock.yaml"];
     }
 
-    #[test]
-    fn test_ecosystem_display_name() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = NpmEcosystem::new(cache);
-        assert_eq!(ecosystem.display_name(), "npm (JavaScript)");
-    }
-
-    #[test]
-    fn test_ecosystem_manifest_filenames() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = NpmEcosystem::new(cache);
-        assert_eq!(ecosystem.manifest_filenames(), &["package.json"]);
-    }
-
-    #[test]
-    fn test_ecosystem_lockfile_filenames() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = NpmEcosystem::new(cache);
-        assert_eq!(
-            ecosystem.lockfile_filenames(),
-            &["package-lock.json", "pnpm-lock.yaml"]
-        );
+    // #758: the shared completion-prefix-length guard
+    // (`deps_core::completion::complete_package_names_generic`), replacing
+    // test_complete_package_names_minimum_prefix/test_complete_package_names_max_length.
+    deps_core::completion_guard_conformance! {
+        mod npm_completion_guard_conformance;
+        complete: |registry: &dyn deps_core::Registry, prefix: String| -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Vec<tower_lsp_server::ls_types::CompletionItem>> + Send + '_>,
+        > {
+            Box::pin(async move {
+                deps_core::completion::complete_package_names_generic(
+                    registry,
+                    &prefix,
+                    20,
+                    Range::default(),
+                )
+                .await
+            })
+        };
     }
 
     #[test]
@@ -502,15 +504,6 @@ mod tests {
             ecosystem.watched_config_filenames(),
             &["pnpm-workspace.yaml", ".npmrc"]
         );
-    }
-
-    #[test]
-    fn test_as_any() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = NpmEcosystem::new(cache);
-
-        let any = ecosystem.as_any();
-        assert!(any.is::<NpmEcosystem>());
     }
 
     #[tokio::test]
@@ -569,22 +562,6 @@ mod tests {
                  name's own span and the range must not be widened to reach it), got {range:?}"
             );
         }
-    }
-
-    #[tokio::test]
-    async fn test_complete_package_names_minimum_prefix() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = NpmEcosystem::new(cache);
-
-        // Less than 2 characters should return empty
-        let results = ecosystem
-            .complete_package_names("e", Range::default())
-            .await;
-        assert!(results.is_empty());
-
-        // Empty prefix should return empty
-        let results = ecosystem.complete_package_names("", Range::default()).await;
-        assert!(results.is_empty());
     }
 
     #[tokio::test]
@@ -686,27 +663,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_complete_package_names_max_length() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = NpmEcosystem::new(cache);
-
-        // Prefix longer than 200 chars should return empty (security)
-        let long_prefix = "a".repeat(201);
-        let results = ecosystem
-            .complete_package_names(&long_prefix, Range::default())
-            .await;
-        assert!(results.is_empty());
-
-        // Exactly 100 chars should work
-        let max_prefix = "a".repeat(100);
-        let results = ecosystem
-            .complete_package_names(&max_prefix, Range::default())
-            .await;
-        // Should not panic, but may return empty (no matches)
-        assert!(results.is_empty() || !results.is_empty());
-    }
-
-    #[tokio::test]
     #[ignore] // Requires network access
     async fn test_complete_versions_limit_20() {
         let cache = Arc::new(deps_core::HttpCache::new());
@@ -782,15 +738,6 @@ mod tests {
 
         let parse_result = result.unwrap();
         assert!(parse_result.dependencies().is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_registry_returns_arc() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = NpmEcosystem::new(cache);
-
-        let registry = ecosystem.registry();
-        assert!(Arc::strong_count(&registry) >= 1);
     }
 
     #[tokio::test]

--- a/crates/deps-npm/src/formatter.rs
+++ b/crates/deps-npm/src/formatter.rs
@@ -238,87 +238,63 @@ mod tests {
         assert_eq!(f.deprecated_label(), "*(deprecated)*");
     }
 
-    #[test]
-    fn test_validate_package_name_accepts_hostile_but_legitimate_names() {
-        let formatter = NpmFormatter;
-        let long_but_valid = "a".repeat(214);
-
-        for name in [
-            "@types/node",
-            "@scope/_private",
-            "@scope/.config",
-            "lodash.debounce",
-            "c8",
-            "-",
-            "a",
-            long_but_valid.as_str(),
+    // #758: exact-value `EcosystemFormatter` conformance, replacing test_package_url,
+    // test_validate_package_name_accepts_hostile_but_legitimate_names,
+    // test_validate_package_name_rejects_invalid_names, test_validate_package_name_does_not_reject_star,
+    // test_validate_package_name_rejects_disallowed_char_inside_scope,
+    // test_validate_package_name_rejects_disallowed_char_inside_name_with_valid_scope, and
+    // test_version_satisfies_requirement. test_validate_package_name_length_boundary below stays
+    // hand-written: it asserts on a computed (`.repeat(n)`) boundary-length name, which doesn't
+    // fit the macro's `literal`-only accepts/rejects lists.
+    deps_core::formatter_conformance! {
+        mod npm_formatter_conformance;
+        build: NpmFormatter;
+        package_url: {
+            "react" => "https://www.npmjs.com/package/react",
+            "@types/node" => "https://www.npmjs.com/package/@types/node",
+        };
+        accepts: [
+            "@types/node", "@scope/_private", "@scope/.config", "lodash.debounce", "c8", "-", "a",
             "MyLegacyPackage",
-        ] {
-            assert!(
-                formatter.validate_package_name(name).is_ok(),
-                "expected {name:?} to be accepted"
-            );
-        }
+            // npm's encodeURIComponent leaves `!'()*-._~` untouched, so `*` is a legitimate
+            // (if unusual) character in a package name.
+            "weird*name"
+        ];
+        rejects: [
+            "", "node_modules", "NODE_MODULES", "favicon.ico", "foo/bar", "a\\b", ".hidden",
+            "_private", "@scope", "@/pkg", "@scope/", "@scope/pkg/extra",
+            // Structurally well-formed `@scope/name` (single '/', both segments non-empty),
+            // but the scope segment itself contains a space, outside npm's unreserved set.
+            "@sco pe/valid-pkg",
+            // Same, but the disallowed character is in the name segment while the scope is
+            // well-formed — the asymmetric case in the other direction.
+            "@valid-scope/pkg name"
+        ];
+        version_roundtrip: [
+            "1.2.3", "1.2.3" => true,
+            "1.2.3", "1" => true,
+            "1.2.3", "1.2" => true,
+            "1.2.3", "^1.2" => true,
+            "1.2.3", "^1.0" => true,
+            "1.5.0", "^1.2.3" => true,
+            "10.1.3", "^10.1.3" => true,
+            "10.2.0", "^10.1.3" => true,
+            "1.2.3", "~1.2" => true,
+            "1.2.5", "~1.2" => true,
+            "1.2.3", "2.0.0" => false,
+            "1.2.3", "1.3" => false,
+            "2.0.0", "^1.2.3" => false
+        ];
     }
 
+    /// Boundary pair for `MAX_NAME_LENGTH`: exactly 214 chars accepted, 215 rejected.
+    /// Computed (`.repeat(n)`) lengths, so this doesn't fit `formatter_conformance!`'s
+    /// `literal`-only accepts/rejects lists above.
     #[test]
-    fn test_validate_package_name_rejects_invalid_names() {
+    fn test_validate_package_name_length_boundary() {
         let formatter = NpmFormatter;
-        let too_long = "a".repeat(215);
-
-        for name in [
-            "",
-            "node_modules",
-            "NODE_MODULES",
-            "favicon.ico",
-            "foo/bar",
-            "a\\b",
-            ".hidden",
-            "_private",
-            too_long.as_str(),
-            "@scope",
-            "@/pkg",
-            "@scope/",
-            "@scope/pkg/extra",
-        ] {
-            assert!(
-                formatter.validate_package_name(name).is_err(),
-                "expected {name:?} to be rejected"
-            );
-        }
-    }
-
-    #[test]
-    fn test_validate_package_name_does_not_reject_star() {
-        // npm's encodeURIComponent leaves `!'()*-._~` untouched, so `*` is a
-        // legitimate (if unusual) character in a package name.
-        let formatter = NpmFormatter;
-        assert!(formatter.validate_package_name("weird*name").is_ok());
-    }
-
-    #[test]
-    fn test_validate_package_name_rejects_disallowed_char_inside_scope() {
-        // Structurally well-formed `@scope/name` (single '/', both segments
-        // non-empty), but the scope segment itself contains a space, which is
-        // outside npm's unreserved character set.
-        let formatter = NpmFormatter;
-        assert!(
-            formatter
-                .validate_package_name("@sco pe/valid-pkg")
-                .is_err()
-        );
-    }
-
-    #[test]
-    fn test_validate_package_name_rejects_disallowed_char_inside_name_with_valid_scope() {
-        // Same, but the disallowed character is in the name segment while the
-        // scope is well-formed — the asymmetric case in the other direction.
-        let formatter = NpmFormatter;
-        assert!(
-            formatter
-                .validate_package_name("@valid-scope/pkg name")
-                .is_err()
-        );
+        assert!(formatter.validate_package_name(&"a".repeat(214)).is_ok());
+        assert!(formatter.validate_package_name(&"a".repeat(215)).is_err());
     }
 
     /// FR-009 (M7): `can_resolve_source` accepts `Registry` and `AlternateRegistry`, rejects
@@ -373,19 +349,6 @@ mod tests {
     }
 
     #[test]
-    fn test_package_url() {
-        let formatter = NpmFormatter;
-        assert_eq!(
-            formatter.package_url(&PackageName::new("react")),
-            "https://www.npmjs.com/package/react"
-        );
-        assert_eq!(
-            formatter.package_url(&PackageName::new("@types/node")),
-            "https://www.npmjs.com/package/@types/node"
-        );
-    }
-
-    #[test]
     fn test_default_normalize_is_identity() {
         let formatter = NpmFormatter;
         assert_eq!(
@@ -403,38 +366,6 @@ mod tests {
         let formatter = NpmFormatter;
         assert_eq!(formatter.yanked_message(), "This version is deprecated");
         assert_eq!(formatter.yanked_label(), "*(deprecated)*");
-    }
-
-    #[test]
-    fn test_version_satisfies_requirement() {
-        let formatter = NpmFormatter;
-
-        // Exact match
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("1.2.3"), "1.2.3"));
-
-        // Partial versions
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("1.2.3"), "1"));
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("1.2.3"), "1.2"));
-
-        // Caret - allows any version with same major (for major > 0)
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("1.2.3"), "^1.2"));
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("1.2.3"), "^1.0"));
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("1.5.0"), "^1.2.3"));
-        assert!(
-            formatter.version_satisfies_requirement(&ConcreteVersion::new("10.1.3"), "^10.1.3")
-        ); // Same version
-        assert!(
-            formatter.version_satisfies_requirement(&ConcreteVersion::new("10.2.0"), "^10.1.3")
-        ); // Higher minor
-
-        // Tilde - allows patch changes
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("1.2.3"), "~1.2"));
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("1.2.5"), "~1.2"));
-
-        // Should not match
-        assert!(!formatter.version_satisfies_requirement(&ConcreteVersion::new("1.2.3"), "2.0.0"));
-        assert!(!formatter.version_satisfies_requirement(&ConcreteVersion::new("1.2.3"), "1.3"));
-        assert!(!formatter.version_satisfies_requirement(&ConcreteVersion::new("2.0.0"), "^1.2.3")); // Different major
     }
 
     #[test]

--- a/crates/deps-npm/src/lockfile.rs
+++ b/crates/deps-npm/src/lockfile.rs
@@ -779,22 +779,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_parse_malformed_package_lock() {
-        let lockfile_content = "not valid json {{{";
-
-        let temp_dir = tempfile::tempdir().unwrap();
-        let lockfile_path = temp_dir.path().join("package-lock.json");
-        tokio::fs::write(&lockfile_path, lockfile_content)
-            .await
-            .unwrap();
-
-        let parser = NpmLockParser;
-        let result = parser.parse_lockfile(&lockfile_path).await;
-
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
     async fn test_nesting_at_max_depth_accepted() {
         let depth = deps_core::MAX_JSON_NESTING_DEPTH;
         let content = format!(
@@ -826,21 +810,24 @@ mod tests {
         assert!(parser.parse_lockfile(&lockfile_path).await.is_err());
     }
 
-    #[test]
-    fn test_locate_lockfile_same_directory() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("package.json");
-        let lock_path = temp_dir.path().join("package-lock.json");
-
-        std::fs::write(&manifest_path, r#"{"name": "test"}"#).unwrap();
-        std::fs::write(&lock_path, r#"{"lockfileVersion": 3}"#).unwrap();
-
-        let manifest_uri = Uri::from_file_path(&manifest_path).unwrap();
-        let parser = NpmLockParser;
-
-        let located = parser.locate_lockfile(&manifest_uri);
-        assert!(located.is_some());
-        assert_eq!(located.unwrap(), lock_path);
+    // #758: shared `LockFileProvider` conformance, replacing test_locate_lockfile_same_directory,
+    // test_locate_lockfile_not_found, test_is_lockfile_stale_not_modified/_modified/_deleted/
+    // _future_time, and test_parse_malformed_package_lock. test_locate_lockfile_workspace_root,
+    // test_locate_lockfile_prefers_package_lock_json_over_pnpm,
+    // test_locate_lockfile_falls_back_to_pnpm_when_no_package_lock, and
+    // test_parse_pnpm_lock_malformed_yaml_is_parse_error stay hand-written: the macro's
+    // malformed-content check only exercises LOCKFILES[0] (package-lock.json's JSON parser), so
+    // pnpm-lock.yaml's own (YAML) malformed-parsing path needs its own test, and the
+    // multi-lockfile precedence/ancestor-search scenarios aren't covered by the macro either.
+    deps_core::lockfile_conformance! {
+        mod npm_lockfile_conformance;
+        build: NpmLockParser;
+        manifest: "package.json" => "{\"name\": \"test\"}";
+        lockfiles: [
+            "package-lock.json" => "{\"lockfileVersion\": 3}",
+            "pnpm-lock.yaml" => "lockfileVersion: '9.0'\n",
+        ];
+        malformed: "not valid json {{{";
     }
 
     #[test]
@@ -860,79 +847,6 @@ mod tests {
         let located = parser.locate_lockfile(&manifest_uri);
         assert!(located.is_some());
         assert_eq!(located.unwrap(), workspace_lock);
-    }
-
-    #[test]
-    fn test_locate_lockfile_not_found() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("package.json");
-        std::fs::write(&manifest_path, r#"{"name": "test"}"#).unwrap();
-
-        let manifest_uri = Uri::from_file_path(&manifest_path).unwrap();
-        let parser = NpmLockParser;
-
-        let located = parser.locate_lockfile(&manifest_uri);
-        assert!(located.is_none());
-    }
-
-    #[test]
-    fn test_is_lockfile_stale_not_modified() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let lockfile_path = temp_dir.path().join("package-lock.json");
-        std::fs::write(&lockfile_path, r#"{"lockfileVersion": 3}"#).unwrap();
-
-        let mtime = std::fs::metadata(&lockfile_path)
-            .unwrap()
-            .modified()
-            .unwrap();
-        let parser = NpmLockParser;
-
-        assert!(
-            !parser.is_lockfile_stale(&lockfile_path, mtime),
-            "Lock file should not be stale when mtime matches"
-        );
-    }
-
-    #[test]
-    fn test_is_lockfile_stale_modified() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let lockfile_path = temp_dir.path().join("package-lock.json");
-        std::fs::write(&lockfile_path, r#"{"lockfileVersion": 3}"#).unwrap();
-
-        let old_time = std::time::UNIX_EPOCH;
-        let parser = NpmLockParser;
-
-        assert!(
-            parser.is_lockfile_stale(&lockfile_path, old_time),
-            "Lock file should be stale when last_modified is old"
-        );
-    }
-
-    #[test]
-    fn test_is_lockfile_stale_deleted() {
-        let parser = NpmLockParser;
-        let non_existent = std::path::Path::new("/nonexistent/package-lock.json");
-
-        assert!(
-            parser.is_lockfile_stale(non_existent, std::time::SystemTime::now()),
-            "Non-existent lock file should be considered stale"
-        );
-    }
-
-    #[test]
-    fn test_is_lockfile_stale_future_time() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let lockfile_path = temp_dir.path().join("package-lock.json");
-        std::fs::write(&lockfile_path, r#"{"lockfileVersion": 3}"#).unwrap();
-
-        // Use a time far in the future
-        let future_time = std::time::SystemTime::now() + std::time::Duration::from_hours(24);
-        let parser = NpmLockParser;
-
-        assert!(
-            !parser.is_lockfile_stale(&lockfile_path, future_time),
-            "Lock file should not be stale when last_modified is in the future"
-        );
     }
 
     // --- pnpm-lock.yaml (spec 052) ---

--- a/crates/deps-npm/src/registry.rs
+++ b/crates/deps-npm/src/registry.rs
@@ -995,15 +995,11 @@ mod tests {
         assert!(!url.contains(']'));
     }
 
-    #[test]
-    fn test_package_url_encodes_newline_autolink_and_percent() {
-        let url = package_url("evil\n<https://evil%zz.example>");
-        assert!(!url.contains('\n'));
-        assert!(!url.contains('<'));
-        assert!(!url.contains('>'));
-        assert!(url.contains("%25"));
-    }
-
+    // #758: the plain (unscoped) newline/autolink/percent hostile-payload case is now covered
+    // universally by deps-lsp's `test_registered_ecosystems_universal_invariants` (Layer 1),
+    // via `deps_core::conformance::HOSTILE_DISPLAY_LINK_PAYLOAD` — this crate's own copy of
+    // that case is redundant. The scoped-name variant below stays: Layer 1 only exercises a
+    // plain name, not `@scope/pkg`'s split-and-reassemble path.
     #[test]
     fn test_package_url_scoped_encodes_newline_and_percent() {
         let url = package_url("@evil\n<%/pkg");
@@ -1245,26 +1241,12 @@ mod tests {
         assert_eq!(packages[0].description, None);
     }
 
-    #[test]
-    fn test_parse_search_response_nesting_at_max_depth_accepted() {
-        let depth = deps_core::MAX_JSON_NESTING_DEPTH;
-        let json = format!(
-            r#"{{"objects": [], "extra": {}1{}}}"#,
-            "[".repeat(depth - 1),
-            "]".repeat(depth - 1)
-        );
-        assert!(parse_search_response(json.as_bytes()).is_ok());
-    }
-
-    #[test]
-    fn test_parse_search_response_nesting_over_max_depth_rejected() {
-        let depth = deps_core::MAX_JSON_NESTING_DEPTH + 1;
-        let json = format!(
-            r#"{{"objects": [], "extra": {}1{}}}"#,
-            "[".repeat(depth),
-            "]".repeat(depth)
-        );
-        assert!(parse_search_response(json.as_bytes()).is_err());
+    // #758: the shared JSON-nesting-depth cap, replacing
+    // test_parse_search_response_nesting_at_max_depth_accepted/_over_max_depth_rejected.
+    deps_core::json_depth_conformance! {
+        mod npm_json_depth_conformance;
+        parse: |bytes: &[u8]| parse_search_response(bytes);
+        wrap: |nested: &str| format!(r#"{{"objects": [], "extra": {nested}}}"#);
     }
 
     #[test]

--- a/crates/deps-nuget/src/ecosystem.rs
+++ b/crates/deps-nuget/src/ecosystem.rs
@@ -469,41 +469,48 @@ mod tests {
     use super::*;
     use crate::types::NuGetDependency;
 
-    #[test]
-    fn test_ecosystem_id() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = NuGetEcosystem::new(cache);
-        assert_eq!(eco.id(), "nuget");
+    // #758: exact-value `Ecosystem` conformance, replacing the hand-written
+    // test_ecosystem_id/test_ecosystem_display_name/test_lockfile_filenames/test_as_any
+    // family. `manifest_extensions()` (csproj/fsproj/vbproj) has no macro parameter, so it
+    // stays covered by `test_manifest_extensions` below. Does not replace
+    // `test_lockfile_provider_some`, which asserts `lockfile_provider()` specifically, not
+    // anything `ecosystem_conformance!` covers.
+    deps_core::ecosystem_conformance! {
+        mod nuget_ecosystem_conformance;
+        build: NuGetEcosystem::new(Arc::new(deps_core::HttpCache::new()));
+        ty: NuGetEcosystem;
+        id: "nuget";
+        display_name: "NuGet (.NET)";
+        manifest_filenames: &["Directory.Packages.props", "packages.config"];
+        lockfile_filenames: &["packages.lock.json", "packages.*.lock.json"];
+    }
+
+    // #758: the shared completion-prefix-length guard, replacing
+    // test_complete_package_names_min_prefix (which only checked the empty-prefix case).
+    deps_core::completion_guard_conformance! {
+        mod nuget_completion_guard_conformance;
+        complete: |registry: &dyn deps_core::Registry, prefix: String| -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Vec<tower_lsp_server::ls_types::CompletionItem>> + Send + '_>,
+        > {
+            Box::pin(async move {
+                deps_core::completion::complete_package_names_generic(
+                    registry,
+                    &prefix,
+                    20,
+                    Range::default(),
+                )
+                .await
+            })
+        };
     }
 
     #[test]
-    fn test_ecosystem_display_name() {
+    fn test_manifest_extensions() {
         let cache = Arc::new(deps_core::HttpCache::new());
         let eco = NuGetEcosystem::new(cache);
-        assert_eq!(eco.display_name(), "NuGet (.NET)");
-    }
-
-    #[test]
-    fn test_manifest_filenames_and_extensions() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = NuGetEcosystem::new(cache);
-        assert_eq!(
-            eco.manifest_filenames(),
-            &["Directory.Packages.props", "packages.config"]
-        );
         assert_eq!(
             eco.manifest_extensions(),
             &[".csproj", ".fsproj", ".vbproj"]
-        );
-    }
-
-    #[test]
-    fn test_lockfile_filenames() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = NuGetEcosystem::new(cache);
-        assert_eq!(
-            eco.lockfile_filenames(),
-            &["packages.lock.json", "packages.*.lock.json"]
         );
     }
 
@@ -512,13 +519,6 @@ mod tests {
         let cache = Arc::new(deps_core::HttpCache::new());
         let eco = NuGetEcosystem::new(cache);
         assert!(eco.lockfile_provider().is_some());
-    }
-
-    #[test]
-    fn test_as_any() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = NuGetEcosystem::new(cache);
-        assert!(eco.as_any().is::<NuGetEcosystem>());
     }
 
     #[tokio::test]
@@ -605,17 +605,6 @@ mod tests {
 
         let result = eco.parse_manifest(content, &uri).await;
         assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn test_complete_package_names_min_prefix() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = NuGetEcosystem::new(cache);
-        assert!(
-            eco.complete_package_names("", Range::default())
-                .await
-                .is_empty()
-        );
     }
 
     // --- complete_versions: position-based dependency lookup + can_resolve_source gate (issue #593) ---

--- a/crates/deps-nuget/src/formatter.rs
+++ b/crates/deps-nuget/src/formatter.rs
@@ -236,34 +236,32 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_package_url() {
-        let f = NuGetFormatter;
-        assert_eq!(
-            f.package_url(&PackageName::new("Newtonsoft.Json")),
-            "https://www.nuget.org/packages/Newtonsoft.Json"
-        );
-    }
-
-    #[test]
-    fn test_version_satisfies_exact_pin() {
-        let f = NuGetFormatter;
-        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("1.0.0"), "[1.0.0]"));
-        assert!(!f.version_satisfies_requirement(&ConcreteVersion::new("1.0.1"), "[1.0.0]"));
-    }
-
-    #[test]
-    fn test_version_satisfies_bare_floor() {
-        let f = NuGetFormatter;
-        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("2.0.0"), "1.0.0"));
-        assert!(!f.version_satisfies_requirement(&ConcreteVersion::new("0.9.0"), "1.0.0"));
-    }
-
-    #[test]
-    fn test_version_satisfies_floating() {
-        let f = NuGetFormatter;
-        assert!(f.version_satisfies_requirement(&ConcreteVersion::new("1.1.5"), "1.1.*"));
-        assert!(!f.version_satisfies_requirement(&ConcreteVersion::new("1.2.0"), "1.1.*"));
+    // #758: exact-value `EcosystemFormatter` conformance, replacing
+    // test_package_url/test_version_satisfies_exact_pin/test_version_satisfies_bare_floor/
+    // test_version_satisfies_floating and the accepts/rejects halves of
+    // test_validate_package_name_accepts_valid_names/
+    // test_validate_package_name_accepts_underscore_as_word_character/
+    // test_validate_package_name_accepts_unresolved_msbuild_property/
+    // test_validate_package_name_rejects_invalid_names. Does not cover
+    // `is_requirement_up_to_date` (a distinct method from `version_satisfies_requirement`) or
+    // the non-literal `test_validate_package_name_rejects_too_long`, which stay hand-written.
+    deps_core::formatter_conformance! {
+        mod nuget_formatter_conformance;
+        build: NuGetFormatter;
+        package_url: { "Newtonsoft.Json" => "https://www.nuget.org/packages/Newtonsoft.Json" };
+        accepts: [
+            "Newtonsoft.Json", "Microsoft.Extensions.Logging", "moq",
+            "_foo", "foo__bar", "_", "foo_bar", "$(MyPackageId)",
+        ];
+        rejects: [ "", ".Json", "Json.", "New..Json", "New Json", "日本語" ];
+        version_roundtrip: [
+            "1.0.0", "[1.0.0]" => true,
+            "1.0.1", "[1.0.0]" => false,
+            "2.0.0", "1.0.0" => true,
+            "0.9.0", "1.0.0" => false,
+            "1.1.5", "1.1.*" => true,
+            "1.2.0", "1.1.*" => false
+        ];
     }
 
     #[test]
@@ -490,54 +488,6 @@ mod tests {
         let f = NuGetFormatter;
         assert!(!f.requirement_is_unresolved(&VersionReq::new("13.0.3")));
         assert!(!f.requirement_is_unresolved(&VersionReq::new("[1.0,2.0)")));
-    }
-
-    #[test]
-    fn test_validate_package_name_accepts_valid_names() {
-        let f = NuGetFormatter;
-        for name in ["Newtonsoft.Json", "Microsoft.Extensions.Logging", "moq"] {
-            assert!(
-                f.validate_package_name(name).is_ok(),
-                "expected {name:?} to be accepted"
-            );
-        }
-    }
-
-    /// #402: a structurally invalid NuGet package ID must be reported as an invalid package
-    /// name, not forwarded to the registry lookup that produces the misleading generic
-    /// diagnostic.
-    #[test]
-    fn test_validate_package_name_rejects_invalid_names() {
-        let f = NuGetFormatter;
-        for name in ["", ".Json", "Json.", "New..Json", "New Json", "日本語"] {
-            assert!(
-                f.validate_package_name(name).is_err(),
-                "expected {name:?} to be rejected"
-            );
-        }
-    }
-
-    /// #402 critique M1: `_` is a `\w` character in NuGet's real `PackageIdValidator.IdRegex`,
-    /// not a separator, so a leading/doubled/bare underscore is accepted (confirmed live:
-    /// nuget.org publishes a package with id `_`).
-    #[test]
-    fn test_validate_package_name_accepts_underscore_as_word_character() {
-        let f = NuGetFormatter;
-        for name in ["_foo", "foo__bar", "_", "foo_bar"] {
-            assert!(
-                f.validate_package_name(name).is_ok(),
-                "expected {name:?} to be accepted"
-            );
-        }
-    }
-
-    /// #402 critique M2: an unexpanded MSBuild property reference in `Include` (e.g.
-    /// `<PackageReference Include="$(MyPackageId)" />`) is not yet a concrete package id and
-    /// must not be flagged as an invalid package name.
-    #[test]
-    fn test_validate_package_name_accepts_unresolved_msbuild_property() {
-        let f = NuGetFormatter;
-        assert!(f.validate_package_name("$(MyPackageId)").is_ok());
     }
 
     #[test]

--- a/crates/deps-nuget/src/lockfile.rs
+++ b/crates/deps-nuget/src/lockfile.rs
@@ -327,18 +327,17 @@ mod tests {
         assert_eq!(resolved.len(), 0);
     }
 
-    #[test]
-    fn test_locate_lockfile() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("App.csproj");
-        let lock_path = temp_dir.path().join("packages.lock.json");
-        std::fs::write(&manifest_path, "<Project></Project>").unwrap();
-        std::fs::write(&lock_path, "{}").unwrap();
-
-        let manifest_uri = Uri::from_file_path(&manifest_path).unwrap();
-        let parser = NuGetLockParser;
-        let located = parser.locate_lockfile(&manifest_uri);
-        assert_eq!(located, Some(lock_path));
+    // #758: `LockFileProvider` conformance — exact-name location/staleness/malformed-parse
+    // behavior, replacing test_locate_lockfile and adding the previously-missing
+    // is_lockfile_stale_* family (NuGetLockParser has no stale override, only the shared
+    // default). Does not cover the multi-project (`packages.<project>.lock.json`) fallback
+    // below, which is unique to this crate.
+    deps_core::lockfile_conformance! {
+        mod nuget_lockfile_conformance;
+        build: NuGetLockParser;
+        manifest: "App.csproj" => "<Project></Project>";
+        lockfiles: [ "packages.lock.json" => "{}" ];
+        malformed: "not valid json";
     }
 
     // --- locate_lockfile: multi-project fallback (D3, #451) ---
@@ -426,17 +425,6 @@ mod tests {
         let manifest_uri = Uri::from_file_path(&manifest_path).unwrap();
         let parser = NuGetLockParser;
         assert_eq!(parser.locate_lockfile(&manifest_uri), Some(lock_path));
-    }
-
-    #[test]
-    fn test_locate_lockfile_no_match_returns_none() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("MyApp.csproj");
-        std::fs::write(&manifest_path, "<Project></Project>").unwrap();
-
-        let manifest_uri = Uri::from_file_path(&manifest_path).unwrap();
-        let parser = NuGetLockParser;
-        assert_eq!(parser.locate_lockfile(&manifest_uri), None);
     }
 
     #[test]

--- a/crates/deps-nuget/src/registry.rs
+++ b/crates/deps-nuget/src/registry.rs
@@ -1392,14 +1392,14 @@ mod tests {
         assert!(!url.contains(']'));
     }
 
-    #[test]
-    fn test_package_url_encodes_newline_autolink_and_percent() {
-        let url = package_url("evil\n<https://evil%zz.example>");
-        assert!(!url.contains('\n'));
-        assert!(!url.contains('<'));
-        assert!(!url.contains('>'));
-        assert!(url.contains("%25"));
-    }
+    // #758: `test_package_url_encodes_newline_autolink_and_percent` (narrower
+    // newline/autolink/percent subset) was removed here — `NuGetFormatter::package_url`
+    // delegates straight to this crate's own `package_url`, so it's already exercised with
+    // the full `deps_core::conformance::HOSTILE_DISPLAY_LINK_PAYLOAD` by `deps-lsp`'s
+    // Layer-1 `EcosystemId::ALL` loop (`crates/deps-lsp/src/lib.rs`), unlike
+    // `deps-deno`'s same-named test (kept — see that crate's handoff note: deno's
+    // `jsr_package_url` two-arg function is not reachable through
+    // `Ecosystem::formatter().package_url()`, so Layer-1 never exercises it).
 
     #[test]
     fn test_package_url_empty_name() {
@@ -1732,6 +1732,15 @@ mod tests {
         let results = parse_search_response(data, 1).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].name, "A");
+    }
+
+    // #758: the shared JSON-nesting-depth cap, replacing the missing
+    // test_search_response_nesting_at/over_max_depth family for NuGet's SearchQueryService
+    // response parsing.
+    deps_core::json_depth_conformance! {
+        mod nuget_search_response_json_depth_conformance;
+        parse: |bytes: &[u8]| parse_search_response(bytes, 20);
+        wrap: |nested: &str| format!(r#"{{"data": [], "extra": {nested}}}"#);
     }
 
     fn v(s: &str) -> NuGetVersion {

--- a/crates/deps-pypi/src/ecosystem.rs
+++ b/crates/deps-pypi/src/ecosystem.rs
@@ -615,11 +615,39 @@ mod tests {
         deps_core::PackageName::new(s)
     }
 
-    #[test]
-    fn test_ecosystem_id() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = PypiEcosystem::new(cache);
-        assert_eq!(ecosystem.id(), "pypi");
+    // #758: exact-value `Ecosystem` conformance, replacing the hand-written
+    // test_ecosystem_id/test_ecosystem_display_name/test_ecosystem_manifest_filenames/
+    // test_ecosystem_lockfile_filenames/test_as_any/test_registry_returns_arc family.
+    // test_ecosystem_manifest_patterns below stays hand-written: `manifest_patterns()` isn't
+    // part of the macro's exact-value set.
+    deps_core::ecosystem_conformance! {
+        mod pypi_ecosystem_conformance;
+        build: PypiEcosystem::new(Arc::new(deps_core::HttpCache::new()));
+        ty: PypiEcosystem;
+        id: "pypi";
+        display_name: "PyPI (Python)";
+        manifest_filenames: &["pyproject.toml"];
+        lockfile_filenames: &["poetry.lock", "uv.lock"];
+    }
+
+    // #758: the shared completion-prefix-length guard
+    // (`deps_core::completion::complete_package_names_generic`), replacing
+    // test_complete_package_names_minimum_prefix/test_complete_package_names_max_length.
+    deps_core::completion_guard_conformance! {
+        mod pypi_completion_guard_conformance;
+        complete: |registry: &dyn deps_core::Registry, prefix: String| -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Vec<tower_lsp_server::ls_types::CompletionItem>> + Send + '_>,
+        > {
+            Box::pin(async move {
+                deps_core::completion::complete_package_names_generic(
+                    registry,
+                    &prefix,
+                    20,
+                    Range::default(),
+                )
+                .await
+            })
+        };
     }
 
     #[test]
@@ -807,36 +835,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_ecosystem_display_name() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = PypiEcosystem::new(cache);
-        assert_eq!(ecosystem.display_name(), "PyPI (Python)");
-    }
-
-    #[test]
-    fn test_ecosystem_manifest_filenames() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = PypiEcosystem::new(cache);
-        assert_eq!(ecosystem.manifest_filenames(), &["pyproject.toml"]);
-    }
-
-    #[test]
-    fn test_ecosystem_lockfile_filenames() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = PypiEcosystem::new(cache);
-        assert_eq!(ecosystem.lockfile_filenames(), &["poetry.lock", "uv.lock"]);
-    }
-
-    #[test]
-    fn test_as_any() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = PypiEcosystem::new(cache);
-
-        let any = ecosystem.as_any();
-        assert!(any.is::<PypiEcosystem>());
-    }
-
     #[tokio::test]
     async fn test_package_name_completion_context_has_real_range() {
         // Regression test for #232: the textEdit range for a package-name completion
@@ -897,22 +895,6 @@ mod tests {
             "PackageName context must report is_incomplete: true, even with zero \
              items on a cold-start index"
         );
-    }
-
-    #[tokio::test]
-    async fn test_complete_package_names_minimum_prefix() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = PypiEcosystem::new(cache);
-
-        // Less than 2 characters should return empty
-        let results = ecosystem
-            .complete_package_names("d", Range::default())
-            .await;
-        assert!(results.is_empty());
-
-        // Empty prefix should return empty
-        let results = ecosystem.complete_package_names("", Range::default()).await;
-        assert!(results.is_empty());
     }
 
     /// Builds a `PypiEcosystem` whose registry's search index is pointed at a
@@ -1368,27 +1350,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_complete_package_names_max_length() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = PypiEcosystem::new(cache);
-
-        // Prefix longer than 200 chars should return empty (security)
-        let long_prefix = "a".repeat(201);
-        let results = ecosystem
-            .complete_package_names(&long_prefix, Range::default())
-            .await;
-        assert!(results.is_empty());
-
-        // Exactly 100 chars should work
-        let max_prefix = "a".repeat(100);
-        let results = ecosystem
-            .complete_package_names(&max_prefix, Range::default())
-            .await;
-        // Should not panic, but may return empty (no matches)
-        assert!(results.is_empty() || !results.is_empty());
-    }
-
-    #[tokio::test]
     #[ignore] // Requires network access
     async fn test_complete_versions_limit_20() {
         let cache = Arc::new(deps_core::HttpCache::new());
@@ -1466,15 +1427,6 @@ dependencies = []
 
         let parse_result = result.unwrap();
         assert!(parse_result.dependencies().is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_registry_returns_arc() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let ecosystem = PypiEcosystem::new(cache);
-
-        let registry = ecosystem.registry();
-        assert!(Arc::strong_count(&registry) >= 1);
     }
 
     #[tokio::test]

--- a/crates/deps-pypi/src/formatter.rs
+++ b/crates/deps-pypi/src/formatter.rs
@@ -337,52 +337,29 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_package_url() {
-        let formatter = PypiFormatter;
-        assert_eq!(
-            formatter.package_url(&PackageName::new("requests")),
-            "https://pypi.org/project/requests"
-        );
-        assert_eq!(
-            formatter.package_url(&PackageName::new("django")),
-            "https://pypi.org/project/django"
-        );
-    }
-
-    #[test]
-    fn test_version_satisfies_pep440() {
-        let formatter = PypiFormatter;
-
-        assert!(
-            formatter.version_satisfies_requirement(&ConcreteVersion::new("1.2.3"), ">=1.0,<2")
-        );
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("2.28.0"), ">=2.0"));
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("1.0.0"), "==1.0.0"));
-        assert!(formatter.version_satisfies_requirement(&ConcreteVersion::new("1.2.0"), "~=1.2.0"));
-
-        assert!(
-            !formatter.version_satisfies_requirement(&ConcreteVersion::new("2.0.0"), ">=1.0,<2")
-        );
-        assert!(!formatter.version_satisfies_requirement(&ConcreteVersion::new("0.9.0"), ">=1.0"));
-    }
-
-    #[test]
-    fn test_version_satisfies_invalid_version() {
-        let formatter = PypiFormatter;
-        assert!(
-            !formatter
-                .version_satisfies_requirement(&ConcreteVersion::new("not-a-version"), ">=1.0")
-        );
-    }
-
-    #[test]
-    fn test_version_satisfies_invalid_specifier() {
-        let formatter = PypiFormatter;
-        assert!(
-            !formatter
-                .version_satisfies_requirement(&ConcreteVersion::new("1.0.0"), "not-a-specifier")
-        );
+    // #758: exact-value `EcosystemFormatter` conformance, replacing test_package_url,
+    // test_validate_package_name_accepts_valid_names, test_validate_package_name_rejects_invalid_names,
+    // test_version_satisfies_pep440, test_version_satisfies_invalid_version, and
+    // test_version_satisfies_invalid_specifier.
+    deps_core::formatter_conformance! {
+        mod pypi_formatter_conformance;
+        build: PypiFormatter;
+        package_url: {
+            "requests" => "https://pypi.org/project/requests",
+            "django" => "https://pypi.org/project/django",
+        };
+        accepts: ["zope.interface", "Django", "a", "my-package_1.0"];
+        rejects: ["---", "-x", "x-", "a b", ""];
+        version_roundtrip: [
+            "1.2.3", ">=1.0,<2" => true,
+            "2.28.0", ">=2.0" => true,
+            "1.0.0", "==1.0.0" => true,
+            "1.2.0", "~=1.2.0" => true,
+            "2.0.0", ">=1.0,<2" => false,
+            "0.9.0", ">=1.0" => false,
+            "not-a-version", ">=1.0" => false,
+            "1.0.0", "not-a-specifier" => false
+        ];
     }
 
     #[test]
@@ -486,25 +463,6 @@ mod tests {
             formatter.normalize_package_name(&PackageName::new("numpy")),
             "numpy"
         );
-    }
-
-    #[test]
-    fn test_validate_package_name_accepts_valid_names() {
-        let formatter = PypiFormatter;
-        assert!(formatter.validate_package_name("zope.interface").is_ok());
-        assert!(formatter.validate_package_name("Django").is_ok());
-        assert!(formatter.validate_package_name("a").is_ok());
-        assert!(formatter.validate_package_name("my-package_1.0").is_ok());
-    }
-
-    #[test]
-    fn test_validate_package_name_rejects_invalid_names() {
-        let formatter = PypiFormatter;
-        assert!(formatter.validate_package_name("---").is_err());
-        assert!(formatter.validate_package_name("-x").is_err());
-        assert!(formatter.validate_package_name("x-").is_err());
-        assert!(formatter.validate_package_name("a b").is_err());
-        assert!(formatter.validate_package_name("").is_err());
     }
 
     #[test]

--- a/crates/deps-pypi/src/lockfile.rs
+++ b/crates/deps-pypi/src/lockfile.rs
@@ -591,20 +591,6 @@ version = 1
         assert!(resolved.is_empty());
     }
 
-    #[tokio::test]
-    async fn test_parse_malformed_toml() {
-        let lockfile_content = "not valid toml {{{";
-
-        let temp_dir = tempfile::tempdir().unwrap();
-        let lockfile_path = temp_dir.path().join("poetry.lock");
-        std::fs::write(&lockfile_path, lockfile_content).unwrap();
-
-        let parser = PypiLockParser;
-        let result = parser.parse_lockfile(&lockfile_path).await;
-
-        assert!(result.is_err());
-    }
-
     #[test]
     fn test_locate_lockfile_poetry_priority() {
         let temp_dir = tempfile::tempdir().unwrap();
@@ -645,17 +631,20 @@ version = 1
         assert_eq!(located.unwrap(), uv_lock);
     }
 
-    #[test]
-    fn test_locate_lockfile_not_found() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("pyproject.toml");
-        std::fs::write(&manifest_path, "[project]\nname = \"test\"").unwrap();
-
-        let manifest_uri = Uri::from_file_path(&manifest_path).unwrap();
-        let parser = PypiLockParser;
-
-        let located = parser.locate_lockfile(&manifest_uri);
-        assert!(located.is_none());
+    // #758: shared `LockFileProvider` conformance, replacing test_locate_lockfile_not_found,
+    // test_is_lockfile_stale_not_modified/_modified/_deleted, and test_parse_malformed_toml.
+    // test_locate_lockfile_poetry_priority/test_locate_lockfile_uv_fallback stay hand-written:
+    // they exercise the poetry-over-uv precedence when both lock files coexist, a scenario the
+    // macro's per-filename loop doesn't cover.
+    deps_core::lockfile_conformance! {
+        mod pypi_lockfile_conformance;
+        build: PypiLockParser;
+        manifest: "pyproject.toml" => "[project]\nname = \"test\"";
+        lockfiles: [
+            "poetry.lock" => "# poetry.lock",
+            "uv.lock" => "# uv.lock",
+        ];
+        malformed: "not valid toml {{{";
     }
 
     #[tokio::test]
@@ -685,49 +674,5 @@ name = "missing-version"
         assert_eq!(resolved.len(), 1);
         assert_eq!(resolved.get_version("valid-package"), Some("1.0.0"));
         assert!(resolved.get("missing-version").is_none());
-    }
-
-    #[test]
-    fn test_is_lockfile_stale_not_modified() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let lockfile_path = temp_dir.path().join("poetry.lock");
-        std::fs::write(&lockfile_path, "version = 1").unwrap();
-
-        let mtime = std::fs::metadata(&lockfile_path)
-            .unwrap()
-            .modified()
-            .unwrap();
-        let parser = PypiLockParser;
-
-        assert!(
-            !parser.is_lockfile_stale(&lockfile_path, mtime),
-            "Lock file should not be stale when mtime matches"
-        );
-    }
-
-    #[test]
-    fn test_is_lockfile_stale_modified() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let lockfile_path = temp_dir.path().join("poetry.lock");
-        std::fs::write(&lockfile_path, "version = 1").unwrap();
-
-        let old_time = std::time::UNIX_EPOCH;
-        let parser = PypiLockParser;
-
-        assert!(
-            parser.is_lockfile_stale(&lockfile_path, old_time),
-            "Lock file should be stale when last_modified is old"
-        );
-    }
-
-    #[test]
-    fn test_is_lockfile_stale_deleted() {
-        let parser = PypiLockParser;
-        let non_existent = std::path::Path::new("/nonexistent/poetry.lock");
-
-        assert!(
-            parser.is_lockfile_stale(non_existent, std::time::SystemTime::now()),
-            "Non-existent lock file should be considered stale"
-        );
     }
 }

--- a/crates/deps-pypi/src/registry.rs
+++ b/crates/deps-pypi/src/registry.rs
@@ -1170,16 +1170,10 @@ mod tests {
         assert!(!url.contains(']'));
     }
 
-    #[test]
-    fn test_package_url_encodes_newline_autolink_and_percent() {
-        let url = package_url("evil\n<https://evil%zz.example>");
-        assert!(!url.contains('\n'));
-        assert!(!url.contains('<'));
-        assert!(!url.contains('>'));
-        // The literal '%' from the payload must itself be encoded (to %25), or a
-        // browser/renderer double-decode could smuggle a raw byte back in.
-        assert!(url.contains("%25"));
-    }
+    // #758: this hostile newline/autolink/percent payload case is now covered universally by
+    // deps-lsp's `test_registered_ecosystems_universal_invariants` (Layer 1), via
+    // `deps_core::conformance::HOSTILE_DISPLAY_LINK_PAYLOAD` — this crate's own copy is
+    // redundant and has been removed.
 
     #[test]
     fn test_package_url_empty_name() {
@@ -1225,26 +1219,12 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_parse_simple_api_response_nesting_at_max_depth_accepted() {
-        let depth = deps_core::MAX_JSON_NESTING_DEPTH;
-        let json = format!(
-            r#"{{"versions": [], "files": [], "extra": {}1{}}}"#,
-            "[".repeat(depth - 1),
-            "]".repeat(depth - 1)
-        );
-        assert!(parse_simple_api_response("pkg", json.as_bytes()).is_ok());
-    }
-
-    #[test]
-    fn test_parse_simple_api_response_nesting_over_max_depth_rejected() {
-        let depth = deps_core::MAX_JSON_NESTING_DEPTH + 1;
-        let json = format!(
-            r#"{{"versions": [], "files": [], "extra": {}1{}}}"#,
-            "[".repeat(depth),
-            "]".repeat(depth)
-        );
-        assert!(parse_simple_api_response("pkg", json.as_bytes()).is_err());
+    // #758: the shared JSON-nesting-depth cap, replacing
+    // test_parse_simple_api_response_nesting_at_max_depth_accepted/_over_max_depth_rejected.
+    deps_core::json_depth_conformance! {
+        mod pypi_simple_api_json_depth_conformance;
+        parse: |bytes: &[u8]| parse_simple_api_response("pkg", bytes);
+        wrap: |nested: &str| format!(r#"{{"versions": [], "files": [], "extra": {nested}}}"#);
     }
 
     #[test]
@@ -1700,26 +1680,12 @@ mod tests {
         assert_eq!(pkg.project_urls.len(), 2);
     }
 
-    #[test]
-    fn test_parse_package_info_nesting_at_max_depth_accepted() {
-        let depth = deps_core::MAX_JSON_NESTING_DEPTH;
-        let json = format!(
-            r#"{{"info": {{"name": "pkg", "version": "1.0.0"}}, "extra": {}1{}}}"#,
-            "[".repeat(depth - 1),
-            "]".repeat(depth - 1)
-        );
-        assert!(parse_package_info("pkg", json.as_bytes()).is_ok());
-    }
-
-    #[test]
-    fn test_parse_package_info_nesting_over_max_depth_rejected() {
-        let depth = deps_core::MAX_JSON_NESTING_DEPTH + 1;
-        let json = format!(
-            r#"{{"info": {{"name": "pkg", "version": "1.0.0"}}, "extra": {}1{}}}"#,
-            "[".repeat(depth),
-            "]".repeat(depth)
-        );
-        assert!(parse_package_info("pkg", json.as_bytes()).is_err());
+    // #758: the shared JSON-nesting-depth cap, replacing
+    // test_parse_package_info_nesting_at_max_depth_accepted/_over_max_depth_rejected.
+    deps_core::json_depth_conformance! {
+        mod pypi_package_info_json_depth_conformance;
+        parse: |bytes: &[u8]| parse_package_info("pkg", bytes);
+        wrap: |nested: &str| format!(r#"{{"info": {{"name": "pkg", "version": "1.0.0"}}, "extra": {nested}}}"#);
     }
 
     #[test]

--- a/crates/deps-swift/src/ecosystem.rs
+++ b/crates/deps-swift/src/ecosystem.rs
@@ -402,33 +402,16 @@ mod tests {
         assert_eq!(strip_github_prefix("htt"), "htt");
     }
 
-    #[test]
-    fn test_ecosystem_id() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = SwiftEcosystem::new(cache);
-        assert_eq!(eco.id(), "swift");
-    }
-
-    #[test]
-    fn test_ecosystem_display_name() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = SwiftEcosystem::new(cache);
-        assert_eq!(eco.display_name(), "Swift (SPM)");
-    }
-
-    #[test]
-    fn test_manifest_filenames() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = SwiftEcosystem::new(cache);
-        assert_eq!(eco.manifest_filenames(), &["Package.swift"]);
-        assert_eq!(eco.lockfile_filenames(), &["Package.resolved"]);
-    }
-
-    #[test]
-    fn test_as_any() {
-        let cache = Arc::new(deps_core::HttpCache::new());
-        let eco = SwiftEcosystem::new(cache);
-        assert!(eco.as_any().is::<SwiftEcosystem>());
+    // #758: exact-value `Ecosystem` conformance, replacing test_ecosystem_id,
+    // test_ecosystem_display_name, test_manifest_filenames, and test_as_any.
+    deps_core::ecosystem_conformance! {
+        mod swift_ecosystem_conformance;
+        build: SwiftEcosystem::new(Arc::new(deps_core::HttpCache::new()));
+        ty: SwiftEcosystem;
+        id: "swift";
+        display_name: "Swift (SPM)";
+        manifest_filenames: &["Package.swift"];
+        lockfile_filenames: &["Package.resolved"];
     }
 
     #[test]

--- a/crates/deps-swift/src/formatter.rs
+++ b/crates/deps-swift/src/formatter.rs
@@ -176,21 +176,54 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_package_url() {
-        let fmt = SwiftFormatter;
-        assert_eq!(
-            fmt.package_url(&PackageName::new("apple/swift-nio")),
-            "https://github.com/apple/swift-nio"
-        );
+    // #758: exact-value `EcosystemFormatter` conformance, replacing test_package_url,
+    // test_package_url_invalid_returns_empty, test_package_url_rejects_dot_segment,
+    // test_validate_package_name_accepts_owner_repo,
+    // test_validate_package_name_accepts_bare_name_for_path_dependencies,
+    // test_validate_package_name_rejects_malformed_names, test_version_satisfies,
+    // test_version_satisfies_invalid_version_returns_false, and
+    // test_version_satisfies_invalid_requirement_returns_false. `test_version_satisfies_up_to_next_major_range`/
+    // `_minor_range`/`_closed_range`/`_prerelease` stay hand-written: they document SPM's
+    // `upToNextMajor`/`upToNextMinor`/closed-range syntax translation, not simple literal
+    // roundtrips.
+    deps_core::formatter_conformance! {
+        mod swift_formatter_conformance;
+        build: SwiftFormatter;
+        package_url: {
+            "apple/swift-nio" => "https://github.com/apple/swift-nio",
+            "../../etc/passwd" => "",
+            "no-slash" => "",
+            "owner/repo/extra" => "",
+            "apple/.." => "",
+            "apple/." => "",
+            "../repo" => "",
+        };
+        accepts: ["apple/swift-nio", "MyLib", "my-package", "LocalPackage", "no-slash"];
+        rejects: ["", ".", "..", "owner/repo/extra", "../../etc/passwd", "apple/.."];
+        version_roundtrip: [
+            "2.62.0", ">=2.0.0, <3.0.0" => true,
+            "3.0.0", ">=2.0.0, <3.0.0" => false,
+            "1.4.2", "=1.4.2" => true,
+            "1.4.3", "=1.4.2" => false,
+            "not-a-version", ">=1.0.0" => false,
+            "1.0.0", "not-a-req" => false
+        ];
     }
 
+    /// #758: `package_url`'s hostile-input safety is generically covered for every
+    /// ecosystem by Layer 1 (`deps-lsp`'s `test_registered_ecosystems_universal_invariants`,
+    /// which calls `formatter().package_url()` with this exact fixture) — this per-crate
+    /// test pins Swift's specific fail-closed-to-empty-string behavior for the same input,
+    /// catchable by `cargo nextest run -p deps-swift` alone.
     #[test]
-    fn test_package_url_invalid_returns_empty() {
+    fn test_package_url_hostile_display_link_payload_returns_empty() {
         let fmt = SwiftFormatter;
-        assert_eq!(fmt.package_url(&PackageName::new("../../etc/passwd")), "");
-        assert_eq!(fmt.package_url(&PackageName::new("no-slash")), "");
-        assert_eq!(fmt.package_url(&PackageName::new("owner/repo/extra")), "");
+        assert_eq!(
+            fmt.package_url(&PackageName::new(
+                deps_core::conformance::HOSTILE_DISPLAY_LINK_PAYLOAD
+            )),
+            ""
+        );
     }
 
     #[test]
@@ -225,37 +258,12 @@ mod tests {
     }
 
     #[test]
-    fn test_package_url_rejects_dot_segment() {
-        // Regression for #357 M1: `is_valid_owner_repo` now shares
-        // `crate::is_valid_github_identity` with `registry::validate_owner_repo`, so a
-        // `..`/`.` repo or owner segment is rejected here too, not just on the
-        // credential-bearing fetch path.
-        let fmt = SwiftFormatter;
-        assert_eq!(fmt.package_url(&PackageName::new("apple/..")), "");
-        assert_eq!(fmt.package_url(&PackageName::new("apple/.")), "");
-        assert_eq!(fmt.package_url(&PackageName::new("../repo")), "");
-    }
-
-    #[test]
     fn test_normalize_package_name() {
         let fmt = SwiftFormatter;
         assert_eq!(
             fmt.normalize_package_name(&PackageName::new("Apple/Swift-NIO")),
             "apple/swift-nio"
         );
-    }
-
-    #[test]
-    fn test_version_satisfies() {
-        let fmt = SwiftFormatter;
-        assert!(
-            fmt.version_satisfies_requirement(&ConcreteVersion::new("2.62.0"), ">=2.0.0, <3.0.0")
-        );
-        assert!(
-            !fmt.version_satisfies_requirement(&ConcreteVersion::new("3.0.0"), ">=2.0.0, <3.0.0")
-        );
-        assert!(fmt.version_satisfies_requirement(&ConcreteVersion::new("1.4.2"), "=1.4.2"));
-        assert!(!fmt.version_satisfies_requirement(&ConcreteVersion::new("1.4.3"), "=1.4.2"));
     }
 
     #[test]
@@ -308,20 +316,6 @@ mod tests {
         assert!(
             !fmt.version_satisfies_requirement(&ConcreteVersion::new("2.0.0"), ">=1.0.0, <=1.9.9")
         );
-    }
-
-    #[test]
-    fn test_version_satisfies_invalid_version_returns_false() {
-        let fmt = SwiftFormatter;
-        assert!(
-            !fmt.version_satisfies_requirement(&ConcreteVersion::new("not-a-version"), ">=1.0.0")
-        );
-    }
-
-    #[test]
-    fn test_version_satisfies_invalid_requirement_returns_false() {
-        let fmt = SwiftFormatter;
-        assert!(!fmt.version_satisfies_requirement(&ConcreteVersion::new("1.0.0"), "not-a-req"));
     }
 
     fn dep_with_url(name: &str, url: &str) -> SwiftDependency {
@@ -454,48 +448,5 @@ mod tests {
             matcher.matches(&ConcreteVersion::new("not-a-version")),
             None
         );
-    }
-
-    #[test]
-    fn test_validate_package_name_accepts_owner_repo() {
-        let fmt = SwiftFormatter;
-        assert!(fmt.validate_package_name("apple/swift-nio").is_ok());
-    }
-
-    /// #402 critique C1: a `.package(path:)` dependency's name is the target directory's
-    /// basename (see `deps_swift::parser`'s `RE_PATH` arm), never an `owner/repo` GitHub
-    /// coordinate — it must not be flagged as an invalid package name.
-    #[test]
-    fn test_validate_package_name_accepts_bare_name_for_path_dependencies() {
-        let fmt = SwiftFormatter;
-        for name in ["MyLib", "my-package", "LocalPackage", "no-slash"] {
-            assert!(
-                fmt.validate_package_name(name).is_ok(),
-                "expected {name:?} to be accepted"
-            );
-        }
-    }
-
-    /// #402: a structurally invalid Swift package name must be reported as an invalid
-    /// package name, not forwarded to the registry lookup that produces the misleading
-    /// generic "Registry lookup failed" diagnostic. Only multi-segment shapes are still
-    /// checked against `owner/repo` — a bare name has no `/` to validate the shape of (see
-    /// `test_validate_package_name_accepts_bare_name_for_path_dependencies`).
-    #[test]
-    fn test_validate_package_name_rejects_malformed_names() {
-        let fmt = SwiftFormatter;
-        for name in [
-            "",
-            ".",
-            "..",
-            "owner/repo/extra",
-            "../../etc/passwd",
-            "apple/..",
-        ] {
-            assert!(
-                fmt.validate_package_name(name).is_err(),
-                "expected {name:?} to be rejected"
-            );
-        }
     }
 }

--- a/crates/deps-swift/src/lockfile.rs
+++ b/crates/deps-swift/src/lockfile.rs
@@ -280,47 +280,26 @@ mod tests {
         assert_matches!(pkg.source, ResolvedSource::Path { .. });
     }
 
-    #[tokio::test]
-    async fn test_invalid_json_returns_error() {
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("Package.resolved");
-        tokio::fs::write(&path, b"not valid json").await.unwrap();
-
-        let parser = SwiftLockParser;
-        let result = parser.parse_lockfile(&path).await;
-        assert!(result.is_err());
+    // #758: shared `LockFileProvider` conformance, replacing test_invalid_json_returns_error
+    // — also closes a real gap: this crate had no `locate_lockfile`/`is_lockfile_stale_*`
+    // coverage at all before.
+    deps_core::lockfile_conformance! {
+        mod swift_lockfile_conformance;
+        build: SwiftLockParser;
+        manifest: "Package.swift" => "// empty";
+        lockfiles: [
+            "Package.resolved" => r#"{"version": 2, "pins": []}"#,
+        ];
+        malformed: "not valid json";
     }
 
-    #[tokio::test]
-    async fn test_nesting_at_max_depth_accepted() {
-        let depth = deps_core::MAX_JSON_NESTING_DEPTH;
-        let content = format!(
-            r#"{{"version": 1, "extra": {}1{}}}"#,
-            "[".repeat(depth - 1),
-            "]".repeat(depth - 1)
-        );
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("Package.resolved");
-        tokio::fs::write(&path, &content).await.unwrap();
-
-        let parser = SwiftLockParser;
-        assert!(parser.parse_lockfile(&path).await.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_nesting_over_max_depth_rejected() {
-        let depth = deps_core::MAX_JSON_NESTING_DEPTH + 1;
-        let content = format!(
-            r#"{{"version": 1, "extra": {}1{}}}"#,
-            "[".repeat(depth),
-            "]".repeat(depth)
-        );
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("Package.resolved");
-        tokio::fs::write(&path, &content).await.unwrap();
-
-        let parser = SwiftLockParser;
-        assert!(parser.parse_lockfile(&path).await.is_err());
+    // #758: the shared JSON-nesting-depth cap, replacing test_nesting_at_max_depth_accepted/
+    // test_nesting_over_max_depth_rejected — `parse_package_resolved` takes an owned
+    // `String`, not `&[u8]`, so the closure re-owns the bytes via `String::from_utf8_lossy`.
+    deps_core::json_depth_conformance! {
+        mod swift_lockfile_json_depth_conformance;
+        parse: |bytes: &[u8]| parse_package_resolved(String::from_utf8_lossy(bytes).into_owned());
+        wrap: |nested: &str| format!(r#"{{"version": 1, "extra": {nested}}}"#);
     }
 
     #[tokio::test]

--- a/crates/deps-swift/src/registry.rs
+++ b/crates/deps-swift/src/registry.rs
@@ -481,6 +481,14 @@ mod tests {
         assert!(result.is_err());
     }
 
+    // #758: the shared JSON-nesting-depth cap — this crate had no such coverage for
+    // `parse_search_response` before (issue named deps-swift as missing it).
+    deps_core::json_depth_conformance! {
+        mod swift_json_depth_conformance;
+        parse: |bytes: &[u8]| parse_search_response(bytes);
+        wrap: |nested: &str| format!(r#"{{"items": [], "extra": {nested}}}"#);
+    }
+
     #[test]
     fn test_parse_tags_v_prefix_stripped() {
         let json = r#"[{"name": "v1.2.3"}, {"name": "v0.9.0"}]"#;


### PR DESCRIPTION
## Summary

- Completes GitHub issue #758's trait-conformance test consolidation. PR #776 added `deps_core::conformance` (5 macros: `ecosystem_conformance!`, `formatter_conformance!`, `lockfile_conformance!`, `completion_guard_conformance!`, `json_depth_conformance!`) and migrated `deps-cargo` as the Wave 1 pilot. This PR migrates the remaining 13 ecosystem crates: deps-npm, deps-pypi, deps-go, deps-bundler, deps-dart, deps-maven, deps-composer, deps-gradle, deps-swift, deps-nuget, deps-github-actions, deps-gitlab-ci, deps-deno.
- Hand-copied per-crate tests replaced by the shared macros are deleted; tests asserting non-literal values (exact error text, computed boundary lengths, ancestor-search scenarios, routing-branch-specific hostile payloads) are kept hand-written where they don't fit the macros' literal-only lists.
- Test-only change. No production code touched.

## Known follow-up (not fixed in this PR, filed separately)

Several review passes (adversarial critic + automated code review) surfaced design-level gaps in `deps_core::conformance` itself — all pre-existing (inherited from the #776 pilot, not introduced here), out of scope for "migrate to existing macros":

- Layer-1 (`deps-lsp`'s cross-ecosystem hostile-payload invariant test) is the only coverage for `package_url` safety in several crates, so a single-crate `cargo nextest run -p <crate>` won't catch a regression there in isolation.
- `deps-maven`/`deps-gradle` still hand-copy a near-identical "no lockfile support" test pair; none of the 5 macros cover that shape, and `deps-github-actions`/`deps-gitlab-ci` (also lockfile-less) assert nothing there at all.
- Three test families from the original issue's coverage table (`test_select_latest_matching_not_default_none`, `test_format_version`, `test_compile_requirement_satisfiable`) remain uncovered by any of the 5 macros in a handful of crates.

Will file one consolidated follow-up issue against `deps_core::conformance`'s macro design after this merges.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4845 passed)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- [x] `cargo deny check` / `cargo audit`
- [x] Adversarial critique (verdict: minor) + automated code review + independent code review (verdict: approved)

Closes #758