### PR TITLE
test(deps-core): extend conformance macros for select_latest_matching coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **deps-core, deps-deno, deps-gradle, deps-github-actions, deps-gitlab-ci**: `registry_conformance!` macro proving `Registry::select_latest_matching` is actually overridden, invoked for all four ecosystems named in #784 (resolves #784)
+- **templates**: `deps-ecosystem` formatter template fixed to compile against the current `PackageRendering`/`EcosystemFormatter` API and use `formatter_conformance!` (resolves #785)
 - **workspace**: CI gained a `semver` job (`obi1kenobi/cargo-semver-checks-action`, advisory pending a local rustdoc-format toolchain mismatch, hard-gated on the weekly scheduled sweep) flagging accidental public-API breaks; adds `#[non_exhaustive]` to the highest-churn public error/dependency/version types — `deps-core`'s `DepsError`/`FetchFailure`/`RemovalStatus`/`VulnSeverity`/`ProvenanceStatus`/`CompletionContext`/`LicensePolicy`/`SupplyChainTrustSignal`/`ScanTarget`/`Advisory` and every ecosystem crate's `*Dependency`/`*Version`/`*ParseResult`/`*DependencySection` — as a first incremental pass, not a full API-stability audit (resolves #755) (#768)
 - **deps-lsp, deps-core**: `tracing::instrument` spans on the LSP request handlers and the shared registry HTTP/cache layer, correlating each request with one parent span instead of only leaf-level ecosystem spans (resolves #756) (#766)
 - `fuzz/` workspace: cargo-fuzz target for `Ecosystem::fallback_completion_prefix`/`fallback_completion_is_bare`, the raw-text scanners driving the parse-failure completion path, across all 14 ecosystems (resolves #740) (#745)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **deps-core, deps-deno, deps-gradle, deps-github-actions, deps-gitlab-ci**: `registry_conformance!` macro proving `Registry::select_latest_matching` is actually overridden, invoked for all four ecosystems named in #784 (resolves #784)
-- **templates**: `deps-ecosystem` formatter template fixed to compile against the current `PackageRendering`/`EcosystemFormatter` API and use `formatter_conformance!` (resolves #785)
+- **deps-core, deps-deno, deps-gradle, deps-github-actions, deps-gitlab-ci**: `registry_conformance!` macro proving `Registry::select_latest_matching` is actually overridden, invoked for all four ecosystems named in #784 (resolves #784) (#787)
+- **templates**: `deps-ecosystem` formatter template fixed to compile against the current `PackageRendering`/`EcosystemFormatter` API and use `formatter_conformance!` (resolves #785) (#787)
 - **workspace**: CI gained a `semver` job (`obi1kenobi/cargo-semver-checks-action`, advisory pending a local rustdoc-format toolchain mismatch, hard-gated on the weekly scheduled sweep) flagging accidental public-API breaks; adds `#[non_exhaustive]` to the highest-churn public error/dependency/version types — `deps-core`'s `DepsError`/`FetchFailure`/`RemovalStatus`/`VulnSeverity`/`ProvenanceStatus`/`CompletionContext`/`LicensePolicy`/`SupplyChainTrustSignal`/`ScanTarget`/`Advisory` and every ecosystem crate's `*Dependency`/`*Version`/`*ParseResult`/`*DependencySection` — as a first incremental pass, not a full API-stability audit (resolves #755) (#768)
 - **deps-lsp, deps-core**: `tracing::instrument` spans on the LSP request handlers and the shared registry HTTP/cache layer, correlating each request with one parent span instead of only leaf-level ecosystem spans (resolves #756) (#766)
 - `fuzz/` workspace: cargo-fuzz target for `Ecosystem::fallback_completion_prefix`/`fallback_completion_is_bare`, the raw-text scanners driving the parse-failure completion path, across all 14 ecosystems (resolves #740) (#745)

--- a/crates/deps-core/src/conformance.rs
+++ b/crates/deps-core/src/conformance.rs
@@ -8,10 +8,12 @@
 //! Every ecosystem crate historically hand-copied the same family of tests — "does
 //! `Ecosystem::id()` match", "does `package_url` produce this exact link", "does locating a
 //! lock file work in the same directory", "does a too-short completion prefix return no
-//! results", "does JSON nesting beyond the shared depth cap get rejected" — with no structural
-//! link between the copies, so a fix or a new edge case applied to one crate's copy routinely
-//! never reached the other thirteen. This module is the single implementation of each family;
-//! the five `#[macro_export]`ed macros below only generate `#[test] fn` scaffolding around the
+//! results", "does JSON nesting beyond the shared depth cap get rejected", "does a registry
+//! actually override `select_latest_matching` instead of inheriting the trait's `None`
+//! default" — with no structural link between the copies, so a fix or a new edge case applied
+//! to one crate's copy routinely never reached the other thirteen. This module is the single
+//! implementation of each family;
+//! the six `#[macro_export]`ed macros below only generate `#[test] fn` scaffolding around the
 //! plain `assert_*` functions here, so a fix to an assertion fixes every ecosystem invoking it
 //! at once.
 //!
@@ -571,6 +573,35 @@ pub fn assert_json_nesting_over_max_depth_rejected<T, E>(
     assert!(
         parse(json.as_bytes()).is_err(),
         "nesting beyond the maximum allowed depth must be rejected"
+    );
+}
+
+// ---------------------------------------------------------------------------------------
+// Macro 6: `registry_conformance!` — a [`crate::Registry`] actually overrides
+// [`crate::Registry::select_latest_matching`] rather than inheriting its `None` default.
+// ---------------------------------------------------------------------------------------
+
+/// Asserts `registry.select_latest_matching(versions, &VersionReq::new(req))` equals
+/// `Some(expected_index)`.
+///
+/// `expected_index` is `usize`, not `Option<usize>`, so the trait's `None` default is
+/// inexpressible by construction here — a registry that never overrides
+/// [`crate::Registry::select_latest_matching`] fails this assertion rather than passing it
+/// vacuously (#784).
+///
+/// `versions` must be newest-first (the same ordering [`crate::Registry::get_versions`]
+/// returns) — `expected_index` indexes this slice as given, not re-sorted.
+pub fn assert_select_latest_matching_overridden(
+    registry: &dyn crate::Registry,
+    versions: &[Box<dyn crate::Version>],
+    req: &str,
+    expected_index: usize,
+) {
+    let req = crate::VersionReq::new(req);
+    assert_eq!(
+        registry.select_latest_matching(versions, &req),
+        Some(expected_index),
+        "select_latest_matching({req:?}) index mismatch"
     );
 }
 
@@ -1203,6 +1234,143 @@ macro_rules! json_depth_conformance {
             #[test]
             fn json_nesting_over_max_depth_rejected() {
                 json_nesting_over_max_depth_rejected_impl();
+            }
+        }
+    };
+}
+
+/// Generates a `select_latest_matching_not_default_none` conformance test for a
+/// [`crate::Registry`] implementation (#758 macro 6, #784).
+///
+/// [`crate::Registry::select_latest_matching`] defaults to `None` so that test doubles
+/// which never resolve a "latest" compile unchanged; a real registry reachable from the LSP
+/// fetch path must override it. This macro proves that override actually fires for at least
+/// one non-wildcard requirement, rather than silently inheriting the default.
+///
+/// **Known limitation** (mirrors [`ecosystem_conformance!`]'s and
+/// [`completion_guard_conformance!`]'s doc on what a directly-constructed fixture cannot
+/// prove): this constructs the registry type directly via `build:`/`build_arc:`, so it
+/// proves that *type* overrides the method — not that the owning
+/// [`Ecosystem::registry()`](crate::Ecosystem::registry) actually wires that type into the
+/// LSP fetch path. Where that wiring is itself the risk (a registry type shared across
+/// crates via a facade), invoke with `build_arc:` against the real `Ecosystem::registry()`
+/// call instead of `build:` against the type directly.
+///
+/// Two mutually exclusive forms, chosen by which keyword introduces the fixture:
+/// - `build:` — `$build` must be an **owned, concrete** registry type (uniform with every
+///   other macro's `build:` arm). `&Arc<dyn Registry>` does not unsize-coerce to
+///   `&dyn Registry`, so a `build:` expression that yields an `Arc` is a compile error, not
+///   a runtime failure — use `build_arc:` instead for that shape.
+/// - `build_arc:` — `$build` must yield `Arc<dyn Registry>` (typically
+///   `SomeEcosystem::new(..).registry()`); the macro dereferences it before asserting. Use
+///   this to prove the wiring path itself, e.g. when the registry type is defined in a
+///   different crate than the ecosystem invoking this macro and a `build:` fixture would
+///   only duplicate that other crate's own conformance test.
+///
+/// `versions` must be an explicit `Vec<Box<dyn Version>>` — the annotation is load-bearing:
+/// it lets a bare `vec![Box::new(..), ..]` coerce each element without the call site
+/// importing [`crate::Version`] itself.
+///
+/// Must be invoked inside your own `#[cfg(test)] mod tests { ... }` — see
+/// [`ecosystem_conformance!`]'s doc for why this macro does not emit its own `#[cfg(test)]`,
+/// and for why each assertion is a plain `_impl` fn called by a thin `#[test]` wrapper.
+///
+/// # Examples
+///
+/// `build:` against an owned, concrete registry. Wrapped in an explicit `mod example` — see
+/// [`ecosystem_conformance!`]'s doc for why:
+///
+/// ```
+/// mod example {
+/// # use std::any::Any;
+/// # struct FakeVersion { version: deps_core::ConcreteVersion }
+/// # deps_core::impl_version!(FakeVersion {
+/// #     version: version,
+/// #     status: |_: &FakeVersion| deps_core::RemovalStatus::Available,
+/// # });
+/// # struct FakeRegistry;
+/// # impl deps_core::Registry for FakeRegistry {
+/// #     fn get_versions<'a>(&'a self, _name: &'a deps_core::PackageName)
+/// #         -> std::pin::Pin<Box<dyn std::future::Future<Output = deps_core::Result<Vec<Box<dyn deps_core::Version>>>> + Send + 'a>> {
+/// #         Box::pin(async move { Ok(vec![]) })
+/// #     }
+/// #     fn get_latest_matching<'a>(&'a self, _name: &'a deps_core::PackageName, _req: &'a deps_core::VersionReq)
+/// #         -> std::pin::Pin<Box<dyn std::future::Future<Output = deps_core::Result<Option<Box<dyn deps_core::Version>>>> + Send + 'a>> {
+/// #         Box::pin(async move { Ok(None) })
+/// #     }
+/// #     fn search<'a>(&'a self, _query: &'a str, _limit: usize)
+/// #         -> std::pin::Pin<Box<dyn std::future::Future<Output = deps_core::Result<Vec<Box<dyn deps_core::Metadata>>>> + Send + 'a>> {
+/// #         Box::pin(async move { Ok(vec![]) })
+/// #     }
+/// #     fn select_latest_matching(&self, versions: &[Box<dyn deps_core::Version>], req: &deps_core::VersionReq) -> Option<usize> {
+/// #         let req = req.as_str();
+/// #         versions.iter().position(|v| v.version_string().as_str() == req)
+/// #     }
+/// #     fn as_any(&self) -> &dyn Any { self }
+/// # }
+/// deps_core::registry_conformance! {
+///     mod fake_registry_conformance;
+///     build: FakeRegistry;
+///     select_latest_matching: {
+///         versions: vec![
+///             Box::new(FakeVersion { version: "2.0.0".into() }),
+///             Box::new(FakeVersion { version: "1.0.0".into() }),
+///         ];
+///         req: "1.0.0";
+///         expected_index: 1;
+///     };
+/// }
+/// }
+/// ```
+#[macro_export]
+macro_rules! registry_conformance {
+    (
+        mod $mod_name:ident;
+        build: $build:expr;
+        select_latest_matching: {
+            versions: $versions:expr;
+            req: $req:literal;
+            expected_index: $expected:literal;
+        } $(;)?
+    ) => {
+        mod $mod_name {
+            use super::*;
+
+            fn select_latest_matching_not_default_none_impl() {
+                let registry = $build;
+                let versions: ::std::vec::Vec<::std::boxed::Box<dyn $crate::Version>> = $versions;
+                $crate::conformance::assert_select_latest_matching_overridden(
+                    &registry, &versions, $req, $expected,
+                );
+            }
+            #[test]
+            fn select_latest_matching_not_default_none() {
+                select_latest_matching_not_default_none_impl();
+            }
+        }
+    };
+    (
+        mod $mod_name:ident;
+        build_arc: $build:expr;
+        select_latest_matching: {
+            versions: $versions:expr;
+            req: $req:literal;
+            expected_index: $expected:literal;
+        } $(;)?
+    ) => {
+        mod $mod_name {
+            use super::*;
+
+            fn select_latest_matching_not_default_none_impl() {
+                let registry: ::std::sync::Arc<dyn $crate::Registry> = $build;
+                let versions: ::std::vec::Vec<::std::boxed::Box<dyn $crate::Version>> = $versions;
+                $crate::conformance::assert_select_latest_matching_overridden(
+                    &*registry, &versions, $req, $expected,
+                );
+            }
+            #[test]
+            fn select_latest_matching_not_default_none() {
+                select_latest_matching_not_default_none_impl();
             }
         }
     };

--- a/crates/deps-deno/src/registry.rs
+++ b/crates/deps-deno/src/registry.rs
@@ -751,6 +751,25 @@ mod tests {
         wrap: |nested: &str| format!(r#"{{"versions": {{}}, "extra": {nested}}}"#);
     }
 
+    // #784: `DenoRegistry::select_latest_matching` (above, `select_latest_matching`)
+    // delegates entirely to npm's implementation, which is downcast-free — this
+    // `JsrVersion` fixture only survives that delegation for that reason. If
+    // `deps_npm::NpmRegistry::select_latest_matching` (`deps-npm/src/registry.rs:925-953`)
+    // ever downcasts to a concrete npm version type, this test starts failing with a bare
+    // `None` from what otherwise looks like a valid fixture — the fix is in npm, not here.
+    deps_core::registry_conformance! {
+        mod deno_registry_conformance;
+        build: DenoRegistry::new(Arc::new(HttpCache::new()));
+        select_latest_matching: {
+            versions: vec![
+                Box::new(JsrVersion::new("2.0.0".into(), false)),
+                Box::new(JsrVersion::new("1.0.0".into(), false)),
+            ];
+            req: "^1.0.0";
+            expected_index: 1;
+        };
+    }
+
     #[test]
     fn test_parse_search_response_prefixes_name_with_scheme_and_maps_github_repo() {
         let json = r#"{

--- a/crates/deps-github-actions/src/registry.rs
+++ b/crates/deps-github-actions/src/registry.rs
@@ -1048,6 +1048,32 @@ mod tests {
         assert_eq!(registry.select_latest_matching(&versions, &req), Some(0));
     }
 
+    // #784: exercises the non-wildcard `semver::VersionReq` branch of
+    // `select_latest_matching` (above) — the wildcard/existence-ladder branch is already
+    // proven by `test_select_latest_matching_wildcard_uses_existence_ladder` above.
+    deps_core::registry_conformance! {
+        mod github_actions_registry_conformance;
+        build: mock_registry("http://127.0.0.1:1", false);
+        select_latest_matching: {
+            versions: vec![
+                Box::new(GithubActionsVersion {
+                    version: "v2.0.0".into(),
+                    sha: "a".repeat(40),
+                    prerelease: false,
+                    published_at: None,
+                }),
+                Box::new(GithubActionsVersion {
+                    version: "v1.0.0".into(),
+                    sha: "a".repeat(40),
+                    prerelease: false,
+                    published_at: None,
+                }),
+            ];
+            req: "^1.0.0";
+            expected_index: 1;
+        };
+    }
+
     #[test]
     fn test_evict_in_flight_never_evicts_held_lock() {
         // Deterministic, not probabilistic (critic M4): every entry but one is held

--- a/crates/deps-gitlab-ci/src/registry.rs
+++ b/crates/deps-gitlab-ci/src/registry.rs
@@ -1034,4 +1034,17 @@ mod tests {
             .unwrap();
         assert_eq!(versions[idx].version_string().as_str(), "2.0.0");
     }
+
+    // #784: reuses the `version()` fixture from the tilde-semantics tests above — those
+    // already pin the exact matched version, this proves the method is actually overridden
+    // rather than silently inheriting the trait's `None` default.
+    deps_core::registry_conformance! {
+        mod gitlab_ci_registry_conformance;
+        build: GitlabCiRegistry::new(test_client());
+        select_latest_matching: {
+            versions: vec![version("1.3.0", false), version("1.2.5", false)];
+            req: "1.2";
+            expected_index: 1;
+        };
+    }
 }

--- a/crates/deps-gradle/src/ecosystem.rs
+++ b/crates/deps-gradle/src/ecosystem.rs
@@ -438,6 +438,28 @@ mod tests {
         no_lockfile_support: true;
     }
 
+    // #784: `build_arc:` (not `build:`) against the real `Ecosystem::registry()` wiring —
+    // `GradleEcosystem` reuses `deps_maven::MavenCentralRegistry` unchanged (#233), so a
+    // `build:` fixture constructing that type directly would only duplicate
+    // `deps-maven/src/registry.rs`'s own `test_select_latest_matching_not_default_none`
+    // and prove nothing gradle-specific; this proves the type Gradle's `registry()` hands
+    // back actually overrides the method. `req: "*"` (rather than an exact-string pin) also
+    // exercises the wildcard/existence-ladder branch both LSP fetch call sites
+    // (`deps-lsp/src/document/fetch.rs`, `deps-core/src/lsp_helpers/hover.rs`) actually take,
+    // instead of a branch production code never reaches.
+    deps_core::registry_conformance! {
+        mod gradle_registry_conformance;
+        build_arc: GradleEcosystem::new(make_cache()).registry();
+        select_latest_matching: {
+            versions: vec![
+                Box::new(deps_maven::MavenVersion::new("3.2.0".into())),
+                Box::new(deps_maven::MavenVersion::new("3.1.0".into())),
+            ];
+            req: "*";
+            expected_index: 0;
+        };
+    }
+
     // #758: the shared completion-prefix-length guard
     // (`deps_core::completion::complete_package_names_generic`), replacing
     // test_complete_package_names_short_prefix — also closes the missing max-length case

--- a/docs/ECOSYSTEM_GUIDE.md
+++ b/docs/ECOSYSTEM_GUIDE.md
@@ -2048,20 +2048,19 @@ fn parse_lock_content(content: &str) -> deps_core::error::Result<ResolvedPackage
 Create the formatter in `formatter.rs`:
 
 ```rust
-use deps_core::lsp_helpers::EcosystemFormatter;
+use deps_core::lsp_helpers::{
+    DiagnosticMessages, DiagnosticPolicy, OsvNaming, PackageNaming, PackageRendering,
+    RequirementResolution, SourcePolicy,
+};
+use deps_core::{ConcreteVersion, PackageName};
 
+// `EcosystemFormatter` is a blanket impl over these seven concern traits — never write
+// `impl EcosystemFormatter for {Ecosystem}Formatter` directly. Implement only the trait
+// that owns the behavior you need to customize; an empty body relies entirely on that
+// trait's own default.
 pub struct {Ecosystem}Formatter;
 
-impl EcosystemFormatter for {Ecosystem}Formatter {
-    fn format_version_for_text_edit(&self, version: &deps_core::ConcreteVersion) -> String {
-        // Format version string for use in code action text edits
-        format!("\"{}\"", version)
-    }
-
-    fn package_url(&self, name: &deps_core::PackageName) -> String {
-        format!("https://registry.example.com/packages/{}", name)
-    }
-
+impl PackageNaming for {Ecosystem}Formatter {
     // Optional: lint manifest-declared names against this ecosystem's naming
     // rules. Default is always `Ok(())` — only override to warn on names the
     // ecosystem's own tooling would never accept (see `deps-npm`'s
@@ -2071,7 +2070,38 @@ impl EcosystemFormatter for {Ecosystem}Formatter {
         Ok(())
     }
 }
+
+impl PackageRendering for {Ecosystem}Formatter {
+    fn format_version_for_text_edit(&self, version: &ConcreteVersion) -> String {
+        // Format version string for use in code action text edits
+        format!("\"{}\"", version)
+    }
+
+    fn package_url(&self, name: &PackageName) -> String {
+        // `encode` guards the hostile-input-safety check `formatter_conformance!` generates
+        // unconditionally for every invocation — an unencoded name fails that test.
+        format!(
+            "https://registry.example.com/packages/{}",
+            urlencoding::encode(name.as_str())
+        )
+    }
+}
+
+impl RequirementResolution for {Ecosystem}Formatter {}
+
+impl DiagnosticMessages for {Ecosystem}Formatter {}
+
+impl DiagnosticPolicy for {Ecosystem}Formatter {}
+
+impl SourcePolicy for {Ecosystem}Formatter {}
+
+impl OsvNaming for {Ecosystem}Formatter {}
 ```
+
+Replace hand-written `test_format_version`/`test_package_url` tests with one
+`deps_core::formatter_conformance!` invocation (see
+`templates/deps-ecosystem/src/formatter.rs.template` or `deps-github-actions/src/formatter.rs`
+for a full example).
 
 ## Step 9: Create lib.rs
 
@@ -2182,7 +2212,9 @@ Before submitting a PR for a new ecosystem:
 - [ ] Types implementing `Dependency` and `Version` traits (with `source()` method)
 - [ ] Parser with accurate position tracking for names AND versions
 - [ ] Lock file parser implementing `LockFileProvider` trait (`locate_lockfile` + `parse_lockfile`)
-- [ ] Formatter implementing `EcosystemFormatter` trait (`format_version_for_text_edit` + `package_url`)
+- [ ] Formatter implementing `PackageRendering` (`format_version_for_text_edit` + `package_url`)
+      plus the other six `EcosystemFormatter` concern traits — never `impl EcosystemFormatter`
+      directly, it is a blanket impl
 - [ ] Registry client implementing `deps_core::Registry` trait with BoxFuture signatures
 - [ ] Ecosystem impl with `impl deps_core::ecosystem::private::Sealed` block (the workspace's
       documented-contract sealing convention, not a compiler-enforced restriction)

--- a/templates/deps-ecosystem/Cargo.toml.template
+++ b/templates/deps-ecosystem/Cargo.toml.template
@@ -11,8 +11,11 @@ license.workspace = true
 repository.workspace = true
 description = "{ECOSYSTEM_DISPLAY} support for deps-lsp"
 
+[lints]
+workspace = true
+
 [dependencies]
-deps-core = { path = "../deps-core" }
+deps-core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -22,4 +25,11 @@ tracing = { workspace = true }
 urlencoding = { workspace = true }
 
 [dev-dependencies]
+# Required for `deps_core::conformance` (and its `formatter_conformance!`/etc. macros) to be
+# compiled in this crate's own tests — without `test-util`, that module is cfg-gated out.
+deps-core = { workspace = true, features = ["test-util"] }
+# `registry.rs.template`'s `test_get_versions` is `#[tokio::test]`; the `[dependencies]`
+# `tokio` line above carries no `macros`/`rt-multi-thread` features, so a scaffolded crate's
+# own tests cannot build without also declaring them here.
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tokio-test = { workspace = true }

--- a/templates/deps-ecosystem/src/formatter.rs.template
+++ b/templates/deps-ecosystem/src/formatter.rs.template
@@ -1,35 +1,63 @@
-use deps_core::lsp_helpers::EcosystemFormatter;
+use deps_core::lsp_helpers::{
+    DiagnosticMessages, DiagnosticPolicy, OsvNaming, PackageNaming, PackageRendering,
+    RequirementResolution, SourcePolicy,
+};
+use deps_core::{ConcreteVersion, PackageName};
 
+/// [`EcosystemFormatter`](deps_core::lsp_helpers::EcosystemFormatter) implementation for
+/// {ECOSYSTEM_DISPLAY}.
+///
+/// `EcosystemFormatter` is a blanket impl over seven concern traits (see its own doc) — never
+/// `impl EcosystemFormatter for {ECOSYSTEM_PASCAL}Formatter` directly. Implement only the
+/// concern trait that owns the behavior you need to customize; every trait below with an
+/// empty body is relying entirely on that trait's own defaults.
 pub struct {ECOSYSTEM_PASCAL}Formatter;
 
-impl EcosystemFormatter for {ECOSYSTEM_PASCAL}Formatter {
-    fn format_version_for_text_edit(&self, version: &str) -> String {
+impl PackageNaming for {ECOSYSTEM_PASCAL}Formatter {}
+
+impl PackageRendering for {ECOSYSTEM_PASCAL}Formatter {
+    fn format_version_for_text_edit(&self, version: &ConcreteVersion) -> String {
         // TODO: Format version according to ecosystem conventions
-        format!("\"{}\"", version)
+        version.as_str().to_string()
     }
 
-    fn package_url(&self, name: &str) -> String {
-        // TODO: Return package URL for this ecosystem
-        format!("https://example.com/packages/{}", name)
+    fn package_url(&self, name: &PackageName) -> String {
+        // TODO: Return the real package URL for this ecosystem's registry. `encode` guards
+        // the markdown-link-destination hazards (newline, percent, control chars, brackets
+        // and parens) that `formatter_conformance!`'s unconditional hostile-input check
+        // asserts against.
+        format!(
+            "https://example.com/packages/{}",
+            urlencoding::encode(name.as_str())
+        )
     }
 }
+
+impl RequirementResolution for {ECOSYSTEM_PASCAL}Formatter {}
+
+impl DiagnosticMessages for {ECOSYSTEM_PASCAL}Formatter {}
+
+impl DiagnosticPolicy for {ECOSYSTEM_PASCAL}Formatter {}
+
+impl SourcePolicy for {ECOSYSTEM_PASCAL}Formatter {}
+
+impl OsvNaming for {ECOSYSTEM_PASCAL}Formatter {}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_format_version() {
-        let formatter = {ECOSYSTEM_PASCAL}Formatter;
-        assert_eq!(
-            formatter.format_version_for_text_edit("1.0.0"),
-            "\"1.0.0\""
-        );
-    }
-
-    #[test]
-    fn test_package_url() {
-        let formatter = {ECOSYSTEM_PASCAL}Formatter;
-        assert!(formatter.package_url("test-pkg").contains("test-pkg"));
+    // Exact-value `EcosystemFormatter` conformance (see `deps_core::conformance`'s doc) —
+    // replaces hand-written `test_format_version`/`test_package_url` tests. Add
+    // `accepts:`/`rejects:`/`version_roundtrip:`/`hostile_package_url_expected:` arms here
+    // as this formatter grows real `validate_package_name`/`version_satisfies_requirement`
+    // overrides — see `deps-cargo`'s or `deps-github-actions`'s `formatter.rs` for examples.
+    deps_core::formatter_conformance! {
+        mod {ECOSYSTEM_SNAKE}_formatter_conformance;
+        build: {ECOSYSTEM_PASCAL}Formatter;
+        package_url: {
+            "test-pkg" => "https://example.com/packages/test-pkg",
+        };
+        format_version: [ "1.0.0" => "1.0.0" ];
     }
 }


### PR DESCRIPTION
## Summary

- Adds `registry_conformance!` to `deps_core::conformance` (two arms: `build:` for an owned concrete registry, `build_arc:` for `Arc<dyn Registry>`) proving `Registry::select_latest_matching` is actually overridden rather than falling back to the trait's default `None`, invoked for all four crates named in #784: deno, gradle, github-actions, gitlab-ci.
- Rewrites `templates/deps-ecosystem/src/formatter.rs.template`, which previously could not compile (`EcosystemFormatter` is a blanket impl over seven concern traits, not directly implementable via `impl EcosystemFormatter for X`) and never referenced `deps_core::conformance`, closing #785. `Cargo.toml.template` and `docs/ECOSYSTEM_GUIDE.md` updated to match.

## Design notes

- Neither of #784's two proposed options (closure-taking macro arm, or a shared fixture trait) was used. A shared fixture trait is blocked outright by the orphan rule: `deps-gradle`'s registry type is `deps_maven::MavenCentralRegistry`, defined in a different crate. A plain `expr`-fragment macro arm turned out sufficient instead.
- `github-actions` and `gitlab-ci` already had stronger hand-written `select_latest_matching` coverage (gitlab-ci asserts the exact selected version string); those existing tests are untouched. The new macro invocations there are additive, giving all four crates uniform, macro-reachable coverage as #784's issue body asked for.
- Gradle's invocation exercises the real `GradleEcosystem::registry()` wiring (via the `build_arc:` arm) rather than duplicating `deps-maven`'s own registry test, and uses a wildcard requirement to match the branch production code (`fetch.rs`, `hover.rs`) actually takes.

## Non-goals (deliberately out of scope)

- The 10 ecosystem crates that already hand-write `test_select_latest_matching_not_default_none` with ecosystem-specific semantics are not migrated to the new macro.
- The other 6 stale `templates/deps-ecosystem/src/*.template` files (`registry.rs.template`, `ecosystem.rs.template`, etc.) are not rewritten — worth a separate follow-up issue.

## Test plan

- `cargo nextest run --workspace --all-features --no-fail-fast` — 4869 passed, 0 failed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean
- `cargo test -p deps-core --doc --all-features` — 211 passed, including the new macro's doctest

Closes #784
Closes #785