### PR TITLE
fix(deps-core): compare parsed URL origins instead of string prefixes in redirect pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: `deps_core::conformance` gained a `package_url` hostile-input-safety check (now generated unconditionally by `formatter_conformance!` for all 14 ecosystem crates) and a `no_lockfile_support`/`format_version` optional macro arm, closing design gaps found while reviewing #781 (resolves #782) (#786)
 
 ### Fixed
+- **deps-core, deps-gitlab-ci, deps-cargo, deps-nuget**: fixed origin-pinning redirect policy to compare parsed URL origins/paths instead of raw string prefixes, closing a credential-leak bypass (#795)
 - **deps-core**: corrected a stale doc-comment reference to a nonexistent item in `in_use_version.rs` (resolves #773) (#779)
 - **deps-core, deps-cargo, deps-npm, deps-pypi, deps-go, deps-nuget, deps-maven**: `DepsError`'s `Display`/`Debug` and several ecosystem-crate warn/debug log lines no longer embed a workspace-declared registry URL's raw query string, closing a credential-exfiltration path via `window/showMessage` and `tracing` logs (resolves #767) (#775)
 - **deps-gradle**: version catalog/DSL completion no longer miscounts an escaped quote, via a generalized, quote-character-parameterized `deps-core` quote-parity helper (resolves #738) (#771)

--- a/crates/deps-core/src/cache.rs
+++ b/crates/deps-core/src/cache.rs
@@ -318,21 +318,71 @@ fn redirect_policy(guard: AddrGuard) -> reqwest::redirect::Policy {
 
 /// Redirect policy for a [`HttpCache::transport_for_origin`]-scoped client.
 ///
-/// Stops any hop whose URL no longer starts with `trusted_origin` — for a caller (e.g.
-/// NuGet's registration-hive paging) that already validated the *initial* request URL
-/// against a trusted prefix and needs that guarantee to hold through a redirect too. This
-/// alone also covers a downgrade to plain `http://`: every current caller passes an
-/// `https://`-prefixed `trusted_origin`, so an `http://` target already fails the prefix
-/// check — a separate scheme check (as [`redirect_policy`] has, for its no-trusted-prefix
-/// case) would be dead code here.
-fn trusted_origin_redirect_policy(trusted_origin: String) -> reqwest::redirect::Policy {
+/// Stops any hop unless [`crate::net_policy::is_trusted_prefix`] accepts it against
+/// `trusted_origin`, parsed once at [`Transport`] construction — origin equality (scheme,
+/// host, and port must match exactly) **and** the hop's path lying at or under
+/// `trusted_origin`'s own path, at a proper path-segment boundary.
+///
+/// Origin equality is the issue #795 fix: the pre-#795 behavior
+/// (`attempt.url().as_str().starts_with(&trusted_origin)`, a raw string-prefix test) is
+/// satisfied by `https://gitlab.mycorp.dev.evil.com/...`, `https://gitlab.mycorp.dev-evil.com/...`,
+/// and `https://gitlab.mycorp.dev@evil.com/...` alike, even though only the last of those
+/// three actually shares a host with `evil.com` — `Url::origin()` ignores userinfo and
+/// matches scheme+host+port exactly, closing all three shapes at once. This also still
+/// covers a downgrade to plain `http://`: an `http://` hop's origin can never equal an
+/// `https://`-scheme trusted origin, which every current caller passes — a separate scheme
+/// check (as [`redirect_policy`] has, for its no-trusted-origin case) would be dead code
+/// here.
+///
+/// The path-segment-boundary check is **not** subsumed by origin equality, and deliberately
+/// kept: a caller (NuGet's registration-hive/flat-container paging, or `deps-cargo`'s sparse
+/// index, whose `RegistryIndex::as_str()` carries no trailing-slash guarantee either way —
+/// issue #795 S1) pins to a specific *path* on a registry host that also serves other,
+/// less-trusted paths, not merely to the host itself. A plain `str::starts_with` on the raw
+/// path (this function's pre-S1-fix shape) is itself vulnerable to the same class of bug one
+/// level down: a trusted path of `/cargo/index` would wrongly accept the same-origin sibling
+/// `/cargo/index-public/steal` or `/cargo/indexEVIL`, since both start with the trusted
+/// string textually. [`crate::net_policy::is_trusted_prefix`] requires a hop's path to equal
+/// the trusted path or continue immediately after a `/` following it, closing that
+/// regardless of whether `trusted_origin`'s own path happens to end in `/`.
+///
+/// A `trusted_origin` that fails to parse matches no hop — every redirect is stopped
+/// (fail-closed) rather than treated as "no restriction" — logged once at construction time
+/// via `tracing::warn!` rather than silently, since a caller-side bug producing an
+/// unparseable `trusted_origin` would otherwise present only as every redirect on that
+/// transport mysteriously failing. This is reachable today: `deps-nuget`'s Public tier builds
+/// `trusted_prefix` from a service-index `@id` string that is never `Url`-validated (that
+/// validation only runs for [`crate::net_policy::validate_index_url`]'s
+/// `NuGetRegistryTier::WorkspaceDeclared` path), so a malformed `@id` reaches this parse.
+fn trusted_origin_redirect_policy(trusted_origin: &str) -> reqwest::redirect::Policy {
+    let trusted = match Url::parse(trusted_origin) {
+        Ok(url) => Some(url),
+        Err(error) => {
+            tracing::warn!(
+                trusted_origin = crate::net_policy::url_for_tracing(trusted_origin),
+                %error,
+                "trusted_origin failed to parse; every redirect hop on this transport will be rejected"
+            );
+            None
+        }
+    };
     reqwest::redirect::Policy::custom(move |attempt| {
-        if attempt.url().as_str().starts_with(&trusted_origin) {
+        if is_trusted_origin(attempt.url(), trusted.as_ref()) {
             reqwest::redirect::Policy::default().redirect(attempt)
         } else {
             attempt.stop()
         }
     })
+}
+
+/// The origin-and-path decision [`trusted_origin_redirect_policy`]'s closure makes on every
+/// redirect hop, extracted as a pure function so the bypass shapes from issue #795 can be
+/// regression-tested directly against it — `reqwest::redirect::Attempt`'s fields are private
+/// outside the `reqwest` crate, so the closure itself cannot be unit-tested without going
+/// through a real HTTP round trip. Delegates to [`crate::net_policy::is_trusted_prefix`],
+/// shared with `deps-nuget`'s registration-hive page `@id` pre-check (issue #795 S2).
+fn is_trusted_origin(hop_url: &Url, trusted: Option<&Url>) -> bool {
+    trusted.is_some_and(|t| crate::net_policy::is_trusted_prefix(hop_url, t))
 }
 
 /// Error returned by [`BlockedAddrResolver`] when a DNS resolution cannot be trusted for
@@ -588,7 +638,7 @@ impl Transport {
     fn origin_pinned(trusted_origin: &str) -> Self {
         Self {
             client: build_client_inner(
-                trusted_origin_redirect_policy(trusted_origin.to_string()),
+                trusted_origin_redirect_policy(trusted_origin),
                 BlockedAddrResolver::new(AddrGuard::Baseline),
             ),
             tier: CacheTier::Baseline,
@@ -613,7 +663,7 @@ impl Transport {
         let snapshot = policy.get();
         Self {
             client: build_client_inner(
-                trusted_origin_redirect_policy(trusted_origin.to_string()),
+                trusted_origin_redirect_policy(trusted_origin),
                 BlockedAddrResolver::new(AddrGuard::WorkspaceDeclared(snapshot)),
             ),
             tier: CacheTier::Pinned {
@@ -1097,8 +1147,9 @@ impl HttpCache {
             .await
     }
 
-    /// Like [`Self::get_cached`], but additionally stops any redirect hop whose target no
-    /// longer starts with `trusted_origin` (e.g. `https://api.nuget.org/v3/registration5-gz/`).
+    /// Like [`Self::get_cached`], but additionally stops any redirect hop that does not match
+    /// `trusted_origin` via [`crate::net_policy::is_trusted_prefix`] (origin equality plus a
+    /// path-segment-boundary prefix check, e.g. against `https://api.nuget.org/v3/registration5-gz/`).
     ///
     /// For a caller that already validated the *initial* request URL against a trusted
     /// prefix (NuGet's registration-hive paging validates `page.id` this way) and needs
@@ -1752,7 +1803,8 @@ impl HttpCache {
     }
 
     /// Same as [`Self::get_transport_only_with_headers_limited`], but additionally
-    /// stops any redirect hop whose target no longer starts with `trusted_origin`
+    /// stops any redirect hop that does not match `trusted_origin` via
+    /// [`crate::net_policy::is_trusted_prefix`]
     /// (see [`Self::get_cached_trusted_origin`], which applies the identical policy
     /// to the entry-cached path). For a caller carrying a materially larger
     /// [`BodyLimit`] than [`BodyLimit::DEFAULT`] — the bigger the budget, the more
@@ -2444,6 +2496,110 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.as_ref(), b"trusted data");
+    }
+
+    /// Issue #795: a raw `str::starts_with` prefix test (the pre-fix behavior) is satisfied
+    /// by a subdomain-suffix bypass — `gitlab.mycorp.dev.evil.com` starts with
+    /// `https://gitlab.mycorp.dev` as a string, even though its actual host is
+    /// `gitlab.mycorp.dev.evil.com`, entirely under attacker control. Parsed-origin equality
+    /// must reject it.
+    #[test]
+    fn test_is_trusted_origin_rejects_subdomain_suffix_bypass() {
+        let trusted = Url::parse("https://gitlab.mycorp.dev").unwrap();
+        let hop = Url::parse("https://gitlab.mycorp.dev.evil.com/steal").unwrap();
+        assert!(!is_trusted_origin(&hop, Some(&trusted)));
+    }
+
+    /// Issue #795: a userinfo bypass — `https://gitlab.mycorp.dev@evil.com/...` also starts
+    /// with the trusted origin as a string, but its host is `evil.com`; `gitlab.mycorp.dev`
+    /// is merely a (discarded) username. `Url::origin()` ignores userinfo entirely, so this
+    /// must be rejected.
+    #[test]
+    fn test_is_trusted_origin_rejects_userinfo_bypass() {
+        let trusted = Url::parse("https://gitlab.mycorp.dev").unwrap();
+        let hop = Url::parse("https://gitlab.mycorp.dev@evil.com/steal").unwrap();
+        assert!(!is_trusted_origin(&hop, Some(&trusted)));
+    }
+
+    /// Issue #795: a hyphen-suffix bypass — `gitlab.mycorp.dev-evil.com` again starts with
+    /// the trusted origin as a string while being an entirely distinct, attacker-controlled
+    /// host.
+    #[test]
+    fn test_is_trusted_origin_rejects_hyphen_suffix_bypass() {
+        let trusted = Url::parse("https://gitlab.mycorp.dev").unwrap();
+        let hop = Url::parse("https://gitlab.mycorp.dev-evil.com/steal").unwrap();
+        assert!(!is_trusted_origin(&hop, Some(&trusted)));
+    }
+
+    /// Companion to the three bypass-rejection tests above: the legitimate same-origin case
+    /// (a different path, same scheme/host/port) must still be accepted.
+    #[test]
+    fn test_is_trusted_origin_accepts_exact_origin_match() {
+        let trusted = Url::parse("https://gitlab.mycorp.dev").unwrap();
+        let hop = Url::parse("https://gitlab.mycorp.dev/api/v4/x").unwrap();
+        assert!(is_trusted_origin(&hop, Some(&trusted)));
+    }
+
+    /// A `trusted_origin` that fails to parse must fail closed — every hop is rejected,
+    /// never treated as "no restriction".
+    #[test]
+    fn test_is_trusted_origin_rejects_when_trusted_origin_unparseable() {
+        let hop = Url::parse("https://gitlab.mycorp.dev/api/v4/x").unwrap();
+        assert!(!is_trusted_origin(&hop, None));
+    }
+
+    /// Path-prefix scoping (NuGet's registration-hive/flat-container pinning) must survive
+    /// the #795 origin-equality fix: same origin, but a hop outside the trusted path, is
+    /// still rejected — this is what `test_get_cached_trusted_origin_rejects_sibling_path_prefix`
+    /// exercises end-to-end; this is the same property pinned at the unit level.
+    #[test]
+    fn test_is_trusted_origin_rejects_same_origin_sibling_path() {
+        let trusted = Url::parse("https://registry.example/v3/registration5-gz/").unwrap();
+        let hop = Url::parse("https://registry.example/v3/registration5-gzX/evil").unwrap();
+        assert!(!is_trusted_origin(&hop, Some(&trusted)));
+    }
+
+    /// Companion: same origin, hop path under the trusted path prefix, is still accepted.
+    #[test]
+    fn test_is_trusted_origin_accepts_same_origin_nested_path() {
+        let trusted = Url::parse("https://registry.example/v3/registration5-gz/").unwrap();
+        let hop =
+            Url::parse("https://registry.example/v3/registration5-gz/serde/page1.json").unwrap();
+        assert!(is_trusted_origin(&hop, Some(&trusted)));
+    }
+
+    /// Issue #795 S1: unlike the two trailing-slash tests above (which, with a trailing `/`
+    /// already present in the trusted path, would have passed even under the pre-S1-fix raw
+    /// `str::starts_with` check — they do not actually exercise the segment-boundary fix),
+    /// `RegistryIndex::as_str()` (`deps-cargo`'s sparse-index trusted origin) carries **no**
+    /// trailing-slash guarantee. This reproduces that exact shape and the critic's repro: a
+    /// same-origin sibling whose path merely shares a textual prefix must still be rejected.
+    #[test]
+    fn test_is_trusted_origin_rejects_same_origin_sibling_path_no_trailing_slash() {
+        let trusted = Url::parse("https://artifacts.corp/cargo/index").unwrap();
+        for sibling in [
+            "https://artifacts.corp/cargo/index-public/steal",
+            "https://artifacts.corp/cargo/indexEVIL",
+            "https://artifacts.corp/cargo/index.evil/x",
+        ] {
+            let hop = Url::parse(sibling).unwrap();
+            assert!(
+                !is_trusted_origin(&hop, Some(&trusted)),
+                "expected {sibling} to be rejected"
+            );
+        }
+    }
+
+    /// Companion: the trusted path itself, and a proper child path, are still accepted when
+    /// the trusted path carries no trailing slash — the real `deps-cargo` request shape
+    /// (`sparse_index_url` appends `/{crate_path}` to the trimmed base).
+    #[test]
+    fn test_is_trusted_origin_accepts_self_and_child_no_trailing_slash() {
+        let trusted = Url::parse("https://artifacts.corp/cargo/index").unwrap();
+        let itself = Url::parse("https://artifacts.corp/cargo/index").unwrap();
+        let child = Url::parse("https://artifacts.corp/cargo/index/se/rd/serde").unwrap();
+        assert!(is_trusted_origin(&itself, Some(&trusted)));
+        assert!(is_trusted_origin(&child, Some(&trusted)));
     }
 
     // Proves every hop is re-checked, not just the first: a same-origin hop is followed,

--- a/crates/deps-core/src/net_policy.rs
+++ b/crates/deps-core/src/net_policy.rs
@@ -252,6 +252,62 @@ pub fn classify_host(url: &url::Url) -> HostClass {
     }
 }
 
+/// Whether `candidate` is trusted against `trusted`: they share an [`url::Url::origin`], and
+/// `candidate`'s path lies at or under `trusted`'s path at a proper path-segment boundary.
+///
+/// The origin-and-path pin shared by [`crate::cache::HttpCache`]'s trusted-origin request
+/// family (redirect-hop confinement) and `deps-nuget`'s registration-hive page `@id`
+/// pre-check — centralized here (issue #795 S1/S2) because both independently needed the
+/// same fix for the same class of bug: a raw `str::starts_with` test — on the full URL
+/// string, or even on the path alone — is satisfied by a same-origin *sibling* whose path
+/// merely shares a textual prefix. A trusted path of `/cargo/index` must reject
+/// `/cargo/indexEVIL`, `/cargo/index-public/steal`, and `/cargo/index.evil/x` alike, while
+/// still accepting `/cargo/index` itself and `/cargo/index/se/rd/serde`. Comparing origins
+/// structurally (not textually) closes the analogous host-level bypass this same function
+/// also guards against — see [`classify_host`]'s sibling concerns and issue #795's own
+/// bypass shapes (`<host>.evil.com`, `<host>@evil.com`, `<host>-evil.com`).
+///
+/// Correct regardless of whether `trusted`'s path happens to already end in `/`: `/cargo/index`
+/// and `/cargo/index/` are treated identically as the trust boundary.
+///
+/// Assumes a special URL scheme (`http`/`https`): for any other scheme, [`url::Url::origin`]
+/// returns a fresh opaque origin per parse that never compares equal to another, even a
+/// re-parse of the identical string, so this fails closed (rejects everything) rather than
+/// silently trusting one.
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::net_policy::is_trusted_prefix;
+/// use url::Url;
+///
+/// let trusted = Url::parse("https://artifacts.corp/cargo/index").unwrap();
+/// let sibling = Url::parse("https://artifacts.corp/cargo/indexEVIL/steal").unwrap();
+/// let nested = Url::parse("https://artifacts.corp/cargo/index/se/rd/serde").unwrap();
+/// let off_host = Url::parse("https://artifacts.corp.evil.com/cargo/index").unwrap();
+///
+/// assert!(!is_trusted_prefix(&sibling, &trusted));
+/// assert!(is_trusted_prefix(&nested, &trusted));
+/// assert!(!is_trusted_prefix(&off_host, &trusted));
+/// ```
+#[must_use]
+pub fn is_trusted_prefix(candidate: &url::Url, trusted: &url::Url) -> bool {
+    candidate.origin() == trusted.origin() && path_under_prefix(candidate.path(), trusted.path())
+}
+
+/// Whether `path` equals `prefix`, or continues immediately after a `/` following it —
+/// [`is_trusted_prefix`]'s path-segment-boundary check, extracted so both branches (exact
+/// match and proper-child match) are independently readable. A trailing `/` on `prefix` is
+/// normalized away first, so a caller-supplied trusted path is compared identically whether
+/// or not it happens to end in one.
+fn path_under_prefix(path: &str, prefix: &str) -> bool {
+    let prefix = prefix.trim_end_matches('/');
+    path == prefix
+        || path
+            .strip_prefix(prefix)
+            .is_some_and(|rest| rest.starts_with('/'))
+}
+
 /// The user-facing policy governing whether a workspace-declared registry index is ever
 /// fetched at all.
 ///
@@ -709,6 +765,95 @@ mod tests {
 
     fn host_class(url: &str) -> HostClass {
         classify_host(&url::Url::parse(url).unwrap())
+    }
+
+    fn trusted_prefix(candidate: &str, trusted: &str) -> bool {
+        is_trusted_prefix(
+            &url::Url::parse(candidate).unwrap(),
+            &url::Url::parse(trusted).unwrap(),
+        )
+    }
+
+    /// Issue #795 S1: a trusted path with no trailing slash (the real `deps-cargo` sparse
+    /// index shape, `RegistryIndex::as_str()`) must still reject a same-origin sibling whose
+    /// path merely shares a textual prefix — the exact repro the critic supplied.
+    #[test]
+    fn test_is_trusted_prefix_rejects_sibling_path_no_trailing_slash() {
+        let trusted = "https://artifacts.corp/cargo/index";
+        assert!(!trusted_prefix(
+            "https://artifacts.corp/cargo/index-public/steal",
+            trusted
+        ));
+        assert!(!trusted_prefix(
+            "https://artifacts.corp/cargo/indexEVIL",
+            trusted
+        ));
+        assert!(!trusted_prefix(
+            "https://artifacts.corp/cargo/index.evil/x",
+            trusted
+        ));
+    }
+
+    /// Companion: the trusted path itself and a proper child path are still accepted when
+    /// the trusted path has no trailing slash.
+    #[test]
+    fn test_is_trusted_prefix_accepts_self_and_child_no_trailing_slash() {
+        let trusted = "https://artifacts.corp/cargo/index";
+        assert!(trusted_prefix(
+            "https://artifacts.corp/cargo/index",
+            trusted
+        ));
+        assert!(trusted_prefix(
+            "https://artifacts.corp/cargo/index/se/rd/serde",
+            trusted
+        ));
+    }
+
+    /// A trusted path *with* a trailing slash must behave identically to the no-trailing-
+    /// slash form above — the trailing slash is normalized away, not load-bearing.
+    #[test]
+    fn test_is_trusted_prefix_trailing_slash_equivalent_to_no_trailing_slash() {
+        let trusted = "https://artifacts.corp/cargo/index/";
+        assert!(!trusted_prefix(
+            "https://artifacts.corp/cargo/indexEVIL",
+            trusted
+        ));
+        assert!(trusted_prefix(
+            "https://artifacts.corp/cargo/index/se/rd/serde",
+            trusted
+        ));
+    }
+
+    /// A trusted path with more than one trailing slash must still trust its legitimate
+    /// single-slash children — `trim_end_matches` (not a single `strip_suffix`) is required
+    /// to fully normalize the prefix before comparison.
+    #[test]
+    fn test_is_trusted_prefix_doubled_trailing_slash_still_trusts_children() {
+        let trusted = "https://artifacts.corp/v3-flatcontainer//";
+        assert!(trusted_prefix(
+            "https://artifacts.corp/v3-flatcontainer/serde/index.json",
+            trusted
+        ));
+    }
+
+    /// Origin mismatch is rejected even when the path would otherwise match — the
+    /// origin-equality half of this check, independent of the path half.
+    #[test]
+    fn test_is_trusted_prefix_rejects_origin_mismatch() {
+        assert!(!trusted_prefix(
+            "https://artifacts.corp.evil.com/cargo/index",
+            "https://artifacts.corp/cargo/index"
+        ));
+    }
+
+    /// A root-path trusted origin (`/`) trusts every path on that origin — the shape every
+    /// non-NuGet caller (`deps-pypi`, `deps_dev`, `deps-gitlab-ci`) uses.
+    #[test]
+    fn test_is_trusted_prefix_root_path_trusts_everything_on_origin() {
+        assert!(trusted_prefix(
+            "https://registry.example/anything/at/all",
+            "https://registry.example/"
+        ));
     }
 
     #[test]

--- a/crates/deps-nuget/src/registry.rs
+++ b/crates/deps-nuget/src/registry.rs
@@ -10,7 +10,7 @@ use crate::config::{NuGetAuth, NuGetSourceChain, ResolvedHop};
 use crate::types::{NuGetVersion, PackageInfo};
 use crate::version::compare_versions;
 use dashmap::DashMap;
-use deps_core::net_policy::{PolicyGate, RegistryAccessPolicy};
+use deps_core::net_policy::{PolicyGate, RegistryAccessPolicy, is_trusted_prefix};
 use deps_core::parser::DependencySource;
 use deps_core::{
     DepsError, FreshnessSettings, HOVER_RECENT_VERSIONS, HttpCache, PublishTime, Result,
@@ -75,12 +75,15 @@ fn chain_auth_digest(hops: &[ResolvedHop]) -> u64 {
 }
 
 /// `Url::parse(s).ok().map(|u| u.origin().ascii_serialization() + "/")` (issue #561, §3.1/M1)
-/// — the sole comparison helper for C1's origin-binding rule, used at both comparison points in
-/// [`NuGetRegistry::fetch`]. Normalization-immune (host case, default port, IDN) — a plain
-/// string `starts_with` against a feed-supplied, un-reparsed value is not sufficient, and would
-/// not defeat a suffix trick like `https://pkgs.dev.azure.com.evil.test/`. A parse failure on
-/// either side is `None`, which [`NuGetRegistry::fetch`] treats as a mismatch — fail closed,
-/// unauthenticated, never an error.
+/// — derives a normalized origin string (always carrying a root `/` path) for
+/// [`NuGetRegistry::declared_origin`] and other origin-only contexts. Normalization-immune
+/// (host case, default port, IDN) — a plain string `starts_with` against a feed-supplied,
+/// un-reparsed value is not sufficient, and would not defeat a suffix trick like
+/// `https://pkgs.dev.azure.com.evil.test/`. [`NuGetRegistry::fetch`]'s own origin-binding
+/// decision no longer compares these strings directly — it re-parses `declared_origin` and
+/// checks [`is_trusted_prefix`] instead (issue #795 S2 follow-up), the same predicate every
+/// other origin/prefix-trust decision in this codebase uses. A parse failure here is `None`,
+/// which callers treat as a mismatch — fail closed, never an error.
 fn origin_of(s: &str) -> Option<String> {
     url::Url::parse(s)
         .ok()
@@ -534,8 +537,12 @@ impl NuGetRegistry {
     /// Dispatches to:
     /// 1. The authenticated, origin-pinned transport — iff [`Self::auth`] is `Some` **and**
     ///    both `url`'s origin and `trusted_prefix`'s origin equal [`Self::declared_origin`]
-    ///    (C1, §3.1). A parse failure on either side of that comparison is a mismatch, never an
-    ///    error — fails closed to arm 2/3, unauthenticated.
+    ///    (C1, §3.1), checked via the same [`is_trusted_prefix`] predicate the redirect-hop and
+    ///    registration-page pre-checks use (issue #795 S2 follow-up) — `declared_origin` always
+    ///    carries a root `/` path (see [`origin_of`]), so the check reduces to plain origin
+    ///    equality here, keeping this decision and the redirect/page-trust decisions from being
+    ///    able to silently disagree. A parse failure on either side of that comparison is a
+    ///    mismatch, never an error — fails closed to arm 2/3, unauthenticated.
     /// 2. The unauthenticated, origin-pinned workspace transport (#562) — when [`Self::tier`]
     ///    is [`NuGetRegistryTier::WorkspaceDeclared`] and arm 1 declined.
     /// 3. Today's public `get_cached_trusted_origin` path — otherwise, byte-identical to spec
@@ -545,9 +552,10 @@ impl NuGetRegistry {
     ///
     /// Whatever the underlying `HttpCache` fetch returns.
     async fn fetch(&self, url: &str, trusted_prefix: &str) -> Result<bytes::Bytes> {
-        let declared = self.declared_origin.as_str();
-        let can_authenticate = origin_of(url).as_deref() == Some(declared)
-            && origin_of(trusted_prefix).as_deref() == Some(declared);
+        let can_authenticate = url::Url::parse(&self.declared_origin).is_ok_and(|declared| {
+            url::Url::parse(url).is_ok_and(|u| is_trusted_prefix(&u, &declared))
+                && url::Url::parse(trusted_prefix).is_ok_and(|t| is_trusted_prefix(&t, &declared))
+        });
 
         if let Some(auth) = self.auth.as_ref()
             && can_authenticate
@@ -851,6 +859,14 @@ impl NuGetRegistry {
     /// Never fails the caller: a malformed index, an unreachable page, or a page `@id`
     /// outside `trusted_prefix` all degrade to fewer (or zero) entries in the returned
     /// [`RegistrationEnrichment`].
+    ///
+    /// `trusted_prefix` itself is never `Url`-validated ahead of this call for the default
+    /// Public tier (only [`NuGetRegistryTier::WorkspaceDeclared`] runs
+    /// [`deps_core::net_policy::validate_index_url`]), so a feed-supplied `registrations_base_url`
+    /// that fails to parse here is a deliberate fail-closed trade-off: every external page is
+    /// skipped rather than trusted on an unparsed prefix, at the cost of silently losing
+    /// registration-hive enrichment for an otherwise-tolerable feed quirk — logged via
+    /// `tracing::warn!` below so the loss is observable instead of a silent hover-content gap.
     async fn registration_enrichment_from_index(
         &self,
         index_body: &[u8],
@@ -860,6 +876,26 @@ impl NuGetRegistry {
         let Ok(index) = deps_core::parse_json_checked::<RegistrationIndex>(index_body) else {
             return enrichment;
         };
+
+        // Parsed once, reused for every page `@id` below (issue #795 S2): a `page.id` outside
+        // `trusted_prefix` is checked via `is_trusted_prefix` (origin equality plus a
+        // path-segment-boundary prefix match), not a raw `str::starts_with` — the same fix
+        // `trusted_origin_redirect_policy` needed, since a raw prefix test on `page.id` would
+        // let a same-origin sibling page (e.g. `{trusted_prefix}EVIL/...`) slip past this
+        // pre-check even though `Self::fetch`'s own redirect-hop transport would still stop
+        // it downstream. `None` (fail-closed) trusts no external page, but — unlike returning
+        // early here — still lets inline `page.items` entries accumulate below, since those
+        // are part of the already-trusted index body itself and need no `page.id` check.
+        let trusted = url::Url::parse(trusted_prefix)
+            .inspect_err(|error| {
+                tracing::warn!(
+                    trusted_prefix = deps_core::net_policy::url_for_tracing(trusted_prefix),
+                    %error,
+                    "registration trusted_prefix failed to parse; every external registration \
+                     page will be skipped for this package"
+                );
+            })
+            .ok();
 
         let mut collected = 0usize;
         let mut external_fetches = 0usize;
@@ -878,7 +914,10 @@ impl NuGetRegistry {
                     // trusted — the feed chooses `@id` values. `Self::fetch`'s underlying
                     // transport additionally stops any redirect that would otherwise escape
                     // `trusted_prefix` after this initial check passes (S2/M2).
-                    if !page.id.starts_with(trusted_prefix) {
+                    let is_trusted = trusted.as_ref().is_some_and(|trusted| {
+                        url::Url::parse(&page.id).is_ok_and(|id| is_trusted_prefix(&id, trusted))
+                    });
+                    if !is_trusted {
                         continue;
                     }
                     if external_fetches >= MAX_EXTERNAL_PAGE_FETCHES {


### PR DESCRIPTION
## Summary

- `trusted_origin_redirect_policy` (`crates/deps-core/src/cache.rs`) compared redirect-hop URLs against a pinned origin with a raw `str::starts_with` test. Two callers (`deps-gitlab-ci`, `deps-nuget`) pass a `trusted_origin` with no guaranteed trailing delimiter, so the check was bypassable by a same-string-prefix host that is not the pinned origin at all (`<origin>.evil.com`, `<origin>@evil.com`, `<origin>-evil.com`). Since `deps-gitlab-ci` uses a custom `PRIVATE-TOKEN` header that reqwest's own cross-host stripping does not cover, a compromised or misconfigured self-hosted GitLab instance could redirect a request off-origin and exfiltrate the token.
- Replaced the check with `deps_core::net_policy::is_trusted_prefix`: parsed URL origin equality plus a path-segment-boundary prefix match, centralized so `deps-core`'s redirect-hop check and `deps-nuget`'s registration-hive page `@id` pre-check share one predicate.
- The path axis needed the identical class of fix one level down: a raw path-prefix test accepts same-origin siblings (e.g. `/cargo/index-public` for a trusted `/cargo/index`), and `deps-cargo`'s sparse-index trusted origin carries no trailing-slash guarantee either.
- Migrated `deps-nuget`'s separate `origin_of`-based auth-header-attachment check onto the same shared predicate, so that decision and the redirect/page-trust decisions can't silently diverge.
- Added regression coverage for all three bypass shapes, the path-segment-boundary case (with and without a trailing slash on the trusted side), a doubled-trailing-slash edge case, and origin-mismatch/root-path cases.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4884 passed)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`

Closes #795