### PR TITLE
fix(deps-core): structural chokepoint for outbound-URL redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **deps-core**: `RedactedUrl` structural chokepoint and `SanitizedRegistryError` wrapper for outbound-URL redaction in error/log output, migrated across every `deps-core`-internal call site (partial work on #789)
+- **deps-core**: regression test pinning `SanitizedRegistryError`'s source-chain redaction for this project's current client config (#789)
 - **deps-core, deps-deno, deps-gradle, deps-github-actions, deps-gitlab-ci**: `registry_conformance!` macro proving `Registry::select_latest_matching` is actually overridden, invoked for all four ecosystems named in #784 (resolves #784) (#787)
 - **templates**: `deps-ecosystem` formatter template fixed to compile against the current `PackageRendering`/`EcosystemFormatter` API and use `formatter_conformance!` (resolves #785) (#787)
 - **workspace**: CI gained a `semver` job (`obi1kenobi/cargo-semver-checks-action`, advisory pending a local rustdoc-format toolchain mismatch, hard-gated on the weekly scheduled sweep) flagging accidental public-API breaks; adds `#[non_exhaustive]` to the highest-churn public error/dependency/version types — `deps-core`'s `DepsError`/`FetchFailure`/`RemovalStatus`/`VulnSeverity`/`ProvenanceStatus`/`CompletionContext`/`LicensePolicy`/`SupplyChainTrustSignal`/`ScanTarget`/`Advisory` and every ecosystem crate's `*Dependency`/`*Version`/`*ParseResult`/`*DependencySection` — as a first incremental pass, not a full API-stability audit (resolves #755) (#768)
@@ -74,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-deno**: extracted `deps-deno`'s scope-aware `@scope/pkg` name-boundary parser into a shared `deps_core::package::npm_style_name_boundary` helper, reused by the `deps-npm` alias fix above instead of a per-crate reimplementation (#657)
 
 ### Changed
+- **Breaking (pre-1.0, public API)**: **deps-core**: `DepsError::RegistryError.source` is now `SanitizedRegistryError` (was `reqwest::Error`); `RegistryError.package`/`HttpStatus.url`/`Offline.url`/`ResponseTooLarge.url` are now `RedactedUrl` (was `String`) (#789)
 - **deps-core, deps-lsp, all 14 ecosystem crates**: `Ecosystem::id()` is now derived from a new required, exhaustively-typed `ecosystem_id()` method instead of a runtime string parse (resolves #791) (#798)
 - **deps-core, deps-bundler, deps-composer, deps-dart, deps-github-actions, deps-gitlab-ci, deps-go, deps-gradle, deps-maven, deps-npm, deps-nuget, deps-pypi, deps-swift**: migrated hand-written `Dependency`/`ParseResult` impls to the shared `impl_dependency!`/`impl_parse_result!` macros where they were byte-identical drop-ins (resolves #792) (#798)
 - **deps-gradle, deps-core**: POM license scan's byte-budget guard now shares a new `deps-core::xml_bounds::exhausted_with` instead of a private lossy `as usize` cast — hardens the fail-closed conversion for a 32-bit target (no behavior change on the 64-bit targets this project builds for) (resolves #725) (#771)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **deps-core**: `RedactedUrl` structural chokepoint and `SanitizedRegistryError` wrapper for outbound-URL redaction in error/log output, migrated across every `deps-core`-internal call site (partial work on #789)
-- **deps-core**: regression test pinning `SanitizedRegistryError`'s source-chain redaction for this project's current client config (#789)
+- **deps-core**: `RedactedUrl` structural chokepoint and `SanitizedRegistryError` wrapper for outbound-URL redaction in error/log output, migrated across every `deps-core`-internal call site (partial work on #789) (#800)
+- **deps-core**: regression test pinning `SanitizedRegistryError`'s source-chain redaction for this project's current client config (#789) (#800)
 - **deps-core, deps-deno, deps-gradle, deps-github-actions, deps-gitlab-ci**: `registry_conformance!` macro proving `Registry::select_latest_matching` is actually overridden, invoked for all four ecosystems named in #784 (resolves #784) (#787)
 - **templates**: `deps-ecosystem` formatter template fixed to compile against the current `PackageRendering`/`EcosystemFormatter` API and use `formatter_conformance!` (resolves #785) (#787)
 - **workspace**: CI gained a `semver` job (`obi1kenobi/cargo-semver-checks-action`, advisory pending a local rustdoc-format toolchain mismatch, hard-gated on the weekly scheduled sweep) flagging accidental public-API breaks; adds `#[non_exhaustive]` to the highest-churn public error/dependency/version types — `deps-core`'s `DepsError`/`FetchFailure`/`RemovalStatus`/`VulnSeverity`/`ProvenanceStatus`/`CompletionContext`/`LicensePolicy`/`SupplyChainTrustSignal`/`ScanTarget`/`Advisory` and every ecosystem crate's `*Dependency`/`*Version`/`*ParseResult`/`*DependencySection` — as a first incremental pass, not a full API-stability audit (resolves #755) (#768)
@@ -76,7 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core, deps-deno**: extracted `deps-deno`'s scope-aware `@scope/pkg` name-boundary parser into a shared `deps_core::package::npm_style_name_boundary` helper, reused by the `deps-npm` alias fix above instead of a per-crate reimplementation (#657)
 
 ### Changed
-- **Breaking (pre-1.0, public API)**: **deps-core**: `DepsError::RegistryError.source` is now `SanitizedRegistryError` (was `reqwest::Error`); `RegistryError.package`/`HttpStatus.url`/`Offline.url`/`ResponseTooLarge.url` are now `RedactedUrl` (was `String`) (#789)
+- **Breaking (pre-1.0, public API)**: **deps-core**: `DepsError::RegistryError.source` is now `SanitizedRegistryError` (was `reqwest::Error`); `RegistryError.package`/`HttpStatus.url`/`Offline.url`/`ResponseTooLarge.url` are now `RedactedUrl` (was `String`) (#789) (#800)
 - **deps-core, deps-lsp, all 14 ecosystem crates**: `Ecosystem::id()` is now derived from a new required, exhaustively-typed `ecosystem_id()` method instead of a runtime string parse (resolves #791) (#798)
 - **deps-core, deps-bundler, deps-composer, deps-dart, deps-github-actions, deps-gitlab-ci, deps-go, deps-gradle, deps-maven, deps-npm, deps-nuget, deps-pypi, deps-swift**: migrated hand-written `Dependency`/`ParseResult` impls to the shared `impl_dependency!`/`impl_parse_result!` macros where they were byte-identical drop-ins (resolves #792) (#798)
 - **deps-gradle, deps-core**: POM license scan's byte-budget guard now shares a new `deps-core::xml_bounds::exhausted_with` instead of a private lossy `as usize` cast — hardens the fail-closed conversion for a 32-bit target (no behavior change on the 64-bit targets this project builds for) (resolves #725) (#771)

--- a/crates/deps-core/src/cache.rs
+++ b/crates/deps-core/src/cache.rs
@@ -7,7 +7,7 @@
 //! capped to keep memory use predictable under long-running LSP sessions.
 
 use crate::error::{DepsError, Result};
-use crate::net_policy::{RegistryAccessPolicy, WorkspaceRegistryAccess};
+use crate::net_policy::{RedactedUrl, RegistryAccessPolicy, WorkspaceRegistryAccess};
 use bytes::{Bytes, BytesMut};
 use dashmap::DashMap;
 use reqwest::{Client, Response, StatusCode, Url, header};
@@ -171,7 +171,7 @@ fn ensure_https(url: &str) -> Result<()> {
     }
     Err(DepsError::CacheError(format!(
         "URL must use HTTPS: {}",
-        crate::net_policy::url_for_tracing(url)
+        RedactedUrl::new(url)
     )))
 }
 
@@ -700,13 +700,13 @@ async fn read_body_capped(url: &str, mut response: Response, limit: BodyLimit) -
         .chunk()
         .await
         .map_err(|e| DepsError::RegistryError {
-            package: url.to_string(),
-            source: e.without_url(),
+            package: RedactedUrl::new(url),
+            source: e.into(),
         })?
     {
         if body.len() + chunk.len() > limit {
             return Err(DepsError::ResponseTooLarge {
-                url: url.to_string(),
+                url: RedactedUrl::new(url),
                 limit,
             });
         }
@@ -968,7 +968,7 @@ impl HttpCache {
     fn ensure_online(&self, url: &str) -> Result<()> {
         if self.is_offline() {
             return Err(DepsError::Offline {
-                url: url.to_string(),
+                url: RedactedUrl::new(url),
             });
         }
         Ok(())
@@ -1415,7 +1415,7 @@ impl HttpCache {
     /// ignores it (see [`Self::cache_key`]'s docs).
     #[tracing::instrument(
         skip(self, extra_headers, transport, auth_id),
-        fields(url = crate::net_policy::url_for_tracing(url), cache = tracing::field::Empty)
+        fields(url = %RedactedUrl::new(url), cache = tracing::field::Empty)
     )]
     async fn get_cached_with_headers_via(
         &self,
@@ -1516,7 +1516,7 @@ impl HttpCache {
                         // both embed the raw, unredacted `url` (`DepsError::HttpStatus`'s
                         // `Display`; the wrapped `reqwest::Error` inside `RegistryError`
                         // appends its own request URL too), defeating this span's own
-                        // `url_for_tracing`-redacted `url` field two lines below it.
+                        // `RedactedUrl`-redacted `url` field two lines below it.
                         // `safe_tracing_summary` extracts only the safe (non-URL-bearing)
                         // status code plus a coarse cause discriminant.
                         let (status, cause) = e.safe_tracing_summary();
@@ -1578,8 +1578,8 @@ impl HttpCache {
         }
 
         let response = request.send().await.map_err(|e| DepsError::RegistryError {
-            package: url.to_string(),
-            source: e.without_url(),
+            package: RedactedUrl::new(url),
+            source: e.into(),
         })?;
 
         if response.status() == StatusCode::NOT_MODIFIED {
@@ -1588,7 +1588,7 @@ impl HttpCache {
 
         if !response.status().is_success() {
             return Err(DepsError::HttpStatus {
-                url: url.to_string(),
+                url: RedactedUrl::new(url),
                 status: response.status().as_u16(),
             });
         }
@@ -1639,14 +1639,14 @@ impl HttpCache {
     ) -> Result<Bytes> {
         self.ensure_online(url)?;
         ensure_https(url)?;
-        // #756 security follow-up (S-A): `url_for_tracing`, not the raw `url` — this is the
+        // #756 security follow-up (S-A): `RedactedUrl`, not the raw `url` — this is the
         // direct callee of the now-hardened `get_cached_with_headers_via`, and at `debug`
         // level, which is this project's own continuous-improvement convention
         // (`RUST_LOG=debug`).
         tracing::debug!(
             extra_headers = extra_headers.len(),
             "fetching fresh: {}",
-            crate::net_policy::url_for_tracing(url)
+            RedactedUrl::new(url)
         );
 
         let mut request = client.get(url);
@@ -1655,13 +1655,13 @@ impl HttpCache {
         }
 
         let response = request.send().await.map_err(|e| DepsError::RegistryError {
-            package: url.to_string(),
-            source: e.without_url(),
+            package: RedactedUrl::new(url),
+            source: e.into(),
         })?;
 
         if !response.status().is_success() {
             return Err(DepsError::HttpStatus {
-                url: url.to_string(),
+                url: RedactedUrl::new(url),
                 status: response.status().as_u16(),
             });
         }
@@ -1708,7 +1708,7 @@ impl HttpCache {
     /// configured size cap.
     #[tracing::instrument(
         skip(self, body),
-        fields(url = crate::net_policy::url_for_tracing(url))
+        fields(url = %RedactedUrl::new(url))
     )]
     pub async fn post_json<T: Serialize + Sync + ?Sized>(
         &self,
@@ -1726,13 +1726,13 @@ impl HttpCache {
             .send()
             .await
             .map_err(|e| DepsError::RegistryError {
-                package: url.to_string(),
-                source: e.without_url(),
+                package: RedactedUrl::new(url),
+                source: e.into(),
             })?;
 
         if !response.status().is_success() {
             return Err(DepsError::HttpStatus {
-                url: url.to_string(),
+                url: RedactedUrl::new(url),
                 status: response.status().as_u16(),
             });
         }
@@ -1832,7 +1832,7 @@ impl HttpCache {
     /// actual ambiguity at the call sites themselves.
     #[tracing::instrument(
         skip(self, extra_headers, limit, client),
-        fields(url = crate::net_policy::url_for_tracing(url))
+        fields(url = %RedactedUrl::new(url))
     )]
     async fn transport_only_via(
         &self,
@@ -1850,13 +1850,13 @@ impl HttpCache {
         }
 
         let response = request.send().await.map_err(|e| DepsError::RegistryError {
-            package: url.to_string(),
-            source: e.without_url(),
+            package: RedactedUrl::new(url),
+            source: e.into(),
         })?;
 
         if !response.status().is_success() {
             return Err(DepsError::HttpStatus {
-                url: url.to_string(),
+                url: RedactedUrl::new(url),
                 status: response.status().as_u16(),
             });
         }
@@ -3114,12 +3114,14 @@ mod tests {
         );
     }
 
-    /// #767 S3: proves `.without_url()` actually strips the URL from the wrapped
-    /// `reqwest::Error`'s own `Display`, not just that `RegistryError::package` is
-    /// redacted — a genuine transport-level error (connection refused on a closed
-    /// loopback port, so `.url()` is populated the way a builder-only error like
-    /// `Client::get("not a url").build().unwrap_err()` never is) is required to exercise
-    /// this: reverting all 5 `.without_url()` call sites in this file must fail this test.
+    /// #767 S3 / #789: proves `SanitizedRegistryError`'s `From<reqwest::Error>` actually
+    /// strips the URL from the wrapped `reqwest::Error`'s own `Display`, not just that
+    /// `RegistryError::package` is redacted — a genuine transport-level error (connection
+    /// refused on a closed loopback port, so `.url()` is populated the way a builder-only
+    /// error like `Client::get("not a url").build().unwrap_err()` never is) is required to
+    /// exercise this: reverting any of the 5 `source: e.into()` call sites in this file back
+    /// to a bare `reqwest::Error` must fail to compile, and reverting
+    /// `SanitizedRegistryError::from`'s `.without_url()` call must fail this test.
     #[tokio::test]
     async fn test_registry_error_source_redacts_url_on_real_transport_error() {
         // Bind then immediately drop a loopback listener: nothing accepts connections on
@@ -3289,7 +3291,7 @@ mod tests {
     /// #756 round 2 S1 regression: the "conditional request failed, using cache" warn (fired
     /// on exactly this stale-while-revalidate path) must never interpolate the `DepsError`
     /// itself — `DepsError::HttpStatus`'s `Display` embeds the full, unredacted URL (including
-    /// the query string), which would defeat `url_for_tracing`'s redaction on this same span's
+    /// the query string), which would defeat `RedactedUrl`'s redaction on this same span's
     /// `url` field two lines above it. Reuses the mock/seeding shape of
     /// `test_get_cached_non_2xx_on_refresh_preserves_stale_cache` with a token-bearing query
     /// string, wrapped in a real tracing capture (an actual `warn!` event fires here, unlike
@@ -3833,7 +3835,9 @@ mod tests {
 
         let result: Result<Bytes> = cache.get_cached(&url).await;
         match result {
-            Err(DepsError::Offline { url: blocked }) => assert_eq!(blocked, url),
+            Err(DepsError::Offline { url: blocked }) => {
+                assert_eq!(blocked, RedactedUrl::new(&url));
+            }
             other => panic!("expected Offline, got {other:?}"),
         }
         mock.assert_async().await;

--- a/crates/deps-core/src/deps_dev/mod.rs
+++ b/crates/deps-core/src/deps_dev/mod.rs
@@ -412,7 +412,7 @@ impl DepsDevClient {
     /// [`DEPS_DEV_CALL_TIMEOUT`].
     #[tracing::instrument(
         skip(self),
-        fields(url = crate::net_policy::url_for_tracing(url))
+        fields(url = %crate::net_policy::RedactedUrl::new(url))
     )]
     async fn get(&self, url: &str) -> Result<bytes::Bytes, DepsDevFetchError> {
         match tokio::time::timeout(

--- a/crates/deps-core/src/error.rs
+++ b/crates/deps-core/src/error.rs
@@ -1,17 +1,15 @@
 use thiserror::Error;
 
-use crate::net_policy::url_for_tracing;
+use crate::net_policy::RedactedUrl;
 
 /// Reconstructs the "{status} {reason}" text `reqwest::StatusCode`'s `Display`
 /// produces, since `HttpStatus` stores a bare `u16` for structural matching
 /// and loses the canonical reason phrase otherwise.
 ///
-/// `url` is passed through [`url_for_tracing`] before interpolation — this is the only
-/// place `HttpStatus`'s `Display` text is built, so it is the single point that must
-/// redact the query string/fragment/userinfo a workspace-declared registry URL can carry
-/// (see #767).
-fn http_status_message(status: u16, url: &str) -> String {
-    let url = url_for_tracing(url);
+/// `url` is already a [`RedactedUrl`] (#789: `HttpStatus::url`'s field type itself makes the
+/// raw value unreachable, so there is nothing left to redact here) — this is the only place
+/// `HttpStatus`'s `Display` text is built.
+fn http_status_message(status: u16, url: &RedactedUrl) -> String {
     let reason = reqwest::StatusCode::from_u16(status)
         .ok()
         .and_then(|s| s.canonical_reason());
@@ -21,36 +19,115 @@ fn http_status_message(status: u16, url: &str) -> String {
     )
 }
 
-/// Builds [`DepsError::RegistryError`]'s `Display` text with `package` redacted via
-/// [`url_for_tracing`] (#767).
+/// Builds [`DepsError::RegistryError`]'s `Display` text from its already-[`RedactedUrl`]
+/// `package` field (#767, #789).
 ///
 /// [`DepsError::RegistryError`]'s `package` field is documented as a package name, but
-/// several `deps-core::cache` call sites populate it with a URL instead, so it must still be
-/// redacted. [`url_for_tracing`] is a no-op for an actual package name (including an
-/// npm-scoped one like `@types/node`, which an earlier revision of this function mangled into
-/// `***@types/node` before [`crate::net_policy::redact_userinfo`]'s empty-userinfo false
-/// positive was fixed at the root — #767 M1/code-review follow-up).
-fn registry_error_message(package: &str, source: &reqwest::Error) -> String {
-    format!(
-        "registry request failed for {}: {source}",
-        url_for_tracing(package)
-    )
+/// several `deps-core::cache` call sites populate it with a URL instead, so it is stored as
+/// [`RedactedUrl`] rather than a plain `String` — a no-op for an actual package name
+/// (including an npm-scoped one like `@types/node`, which an earlier revision of this
+/// function mangled into `***@types/node` before
+/// [`crate::net_policy::redact_userinfo`]'s empty-userinfo false positive was fixed at the
+/// root — #767 M1/code-review follow-up). `source`'s own `Display` can no longer re-embed the
+/// raw URL either: [`SanitizedRegistryError`]'s only constructor strips it unconditionally.
+fn registry_error_message(package: &RedactedUrl, source: &SanitizedRegistryError) -> String {
+    format!("registry request failed for {package}: {source}")
 }
 
-/// Redacts `url` for [`DepsError::ResponseTooLarge`]'s `Display` text (#767).
-fn response_too_large_message(url: &str, limit: usize) -> String {
-    format!(
-        "response body for {} exceeds {limit} byte limit",
-        url_for_tracing(url)
-    )
+/// Builds [`DepsError::ResponseTooLarge`]'s `Display` text from its already-[`RedactedUrl`]
+/// `url` field (#767, #789).
+fn response_too_large_message(url: &RedactedUrl, limit: usize) -> String {
+    format!("response body for {url} exceeds {limit} byte limit")
 }
 
-/// Redacts `url` for [`DepsError::Offline`]'s `Display` text (#767).
-fn offline_message(url: &str) -> String {
-    format!(
-        "offline: request to {} was blocked by network.offline",
-        url_for_tracing(url)
-    )
+/// Builds [`DepsError::Offline`]'s `Display` text from its already-[`RedactedUrl`] `url`
+/// field (#767, #789).
+fn offline_message(url: &RedactedUrl) -> String {
+    format!("offline: request to {url} was blocked by network.offline")
+}
+
+/// Wraps a `reqwest::Error` with its embedded request URL stripped, for storage in
+/// [`DepsError::RegistryError`]'s `source` field.
+///
+/// `reqwest::Error`'s own `Display` appends `" for url (...)"` when the underlying error
+/// carries a URL — `reqwest::Error::without_url()` strips this, but relying on every
+/// `RegistryError`-construction site to remember to call it is exactly the discipline gap
+/// this type closes (issue #789, see [`RedactedUrl`]'s own docs for the same problem on the
+/// URL-string side). The only constructor (`From<reqwest::Error>`) applies `.without_url()`
+/// unconditionally, so a raw URL can never reach `DepsError`'s `Display`/`Debug` through
+/// `{source}` forwarding, even when a future call site forgets.
+///
+/// **`self.0`'s own `source` chain is never exposed**, through either `Debug` or
+/// [`std::error::Error::source`] — this is deliberate, not an oversight. `.without_url()`
+/// only clears the *outer* error's own `url` field; `reqwest`'s `source` field is
+/// independent of it, and that source is not always a URL-free `hyper`/`io` error: reqwest
+/// 0.13.4's redirect policy (`src/redirect.rs`, the `https_only` check in
+/// `TowerPolicy::redirect`) rejects an `http://` redirect target by building
+/// `crate::error::redirect(crate::error::url_bad_scheme(next_url.clone()), next_url)` — the
+/// *inner* `url_bad_scheme(...)` error is itself a full `reqwest::Error` with `next_url`
+/// populated via `.with_url(...)`, nested as the *outer* error's `source`. That inner `url`
+/// is a field `.without_url()` on the outer error never touches, and `reqwest::Error`'s own
+/// derived-style `Debug` impl recursively prints `source`'s `Debug` (including that inner
+/// `url`) — so both a manual `.source()` walk and `{:?}` on the raw `reqwest::Error` can leak
+/// it. Since `reqwest` exposes no `source_mut()`-style API to reach in and strip that nested
+/// URL, this type treats itself as a leaf node instead: its [`std::error::Error::source`]
+/// impl always returns `None`, and `Debug` is hand-written to forward to the (already-safe)
+/// `Display` text rather than to `self.0`'s own `Debug`.
+///
+/// **Precision note on what is actually verified today**: this project's own client
+/// configuration never calls `reqwest::ClientBuilder::https_only` (`grep -rn '\.https_only('
+/// crates/` finds no hits), so the nested-URL shape above cannot currently occur through this
+/// crate's own request paths — the regression test below instead exercises a genuinely
+/// populated source chain via a real connection-refused (io-level) failure, which is what
+/// this project's client config can actually produce, and confirms it is discarded. The
+/// `https_only`/redirect mechanism itself is read directly from `reqwest` 0.13.4's pinned
+/// source (`redirect.rs`), not reproduced live here (doing so would need a TLS test harness
+/// this project does not otherwise have). `source()` returning `None` unconditionally — not
+/// only when a URL-bearing nested error is possible — is what makes this correct regardless:
+/// if a future change enables `https_only` on a shared client, this type's contract does not
+/// need re-auditing.
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::error::SanitizedRegistryError;
+///
+/// // A builder-only `reqwest::Error` never carries a URL in the first place, so this
+/// // demonstrates the wrapper's `Display`/`Debug` forwarding without needing a real request.
+/// let raw = reqwest::Client::new().get("not a url").build().unwrap_err();
+/// let sanitized: SanitizedRegistryError = raw.into();
+/// assert!(!sanitized.to_string().is_empty());
+/// ```
+pub struct SanitizedRegistryError(reqwest::Error);
+
+impl From<reqwest::Error> for SanitizedRegistryError {
+    fn from(error: reqwest::Error) -> Self {
+        Self(error.without_url())
+    }
+}
+
+impl std::fmt::Display for SanitizedRegistryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl std::fmt::Debug for SanitizedRegistryError {
+    /// Hand-written, not derived: forwards to `Display` (safe — `reqwest::Error`'s own
+    /// `Display` never recurses into its `source`'s text) instead of `self.0`'s own `Debug`,
+    /// which does recurse into `source` and would reopen the nested-URL leak this type's own
+    /// docs describe.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SanitizedRegistryError({})", self.0)
+    }
+}
+
+impl std::error::Error for SanitizedRegistryError {
+    /// Always `None` — see this type's own docs for why the wrapped error's source chain is
+    /// never safe to expose, even via this trait's usual chain-walking contract.
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
 }
 
 /// Core error types for deps-lsp.
@@ -93,11 +170,13 @@ pub enum DepsError {
     /// A registry HTTP request failed at the transport layer.
     #[error("{}", registry_error_message(package, source))]
     RegistryError {
-        /// Name of the package the request was for.
-        package: String,
-        /// The underlying `reqwest` error.
+        /// Name of the package the request was for — or, at several `deps-core::cache` call
+        /// sites, the request URL instead (see [`RedactedUrl`]'s own docs: it is a no-op for
+        /// a genuine package name, so this field is safe to redact unconditionally).
+        package: RedactedUrl,
+        /// The underlying `reqwest` error, with its embedded request URL stripped.
         #[source]
-        source: reqwest::Error,
+        source: SanitizedRegistryError,
     },
 
     /// The cache layer itself failed (e.g. a poisoned lock), independent of any registry request.
@@ -126,8 +205,9 @@ pub enum DepsError {
     /// A registry HTTP request returned a non-success status code.
     #[error("{}", http_status_message(*status, url))]
     HttpStatus {
-        /// URL that was requested.
-        url: String,
+        /// URL that was requested — stored redacted (#789): the raw value is unreachable
+        /// from this field's type.
+        url: RedactedUrl,
         /// HTTP status code returned.
         status: u16,
     },
@@ -147,8 +227,9 @@ pub enum DepsError {
     /// A response body exceeded the configured size cap and was rejected before full download.
     #[error("{}", response_too_large_message(url, *limit))]
     ResponseTooLarge {
-        /// URL the oversized response came from.
-        url: String,
+        /// URL the oversized response came from — stored redacted (#789): the raw value is
+        /// unreachable from this field's type.
+        url: RedactedUrl,
         /// The size cap, in bytes, that was exceeded.
         limit: usize,
     },
@@ -186,8 +267,9 @@ pub enum DepsError {
     /// that was blocked, for diagnostic/logging purposes.
     #[error("{}", offline_message(url))]
     Offline {
-        /// The request URL that was blocked.
-        url: String,
+        /// The request URL that was blocked — stored redacted (#789): the raw value is
+        /// unreachable from this field's type.
+        url: RedactedUrl,
     },
 
     /// A multi-hop alternate/private-index chain's resolution was halted because a hop
@@ -205,14 +287,16 @@ pub enum DepsError {
     ChainResolutionHalted,
 }
 
-/// Hand-written, not derived: a derived `Debug` would print `HttpStatus.url`,
-/// `Offline.url`, `ResponseTooLarge.url`, and `RegistryError.package` raw and
-/// unredacted, reopening the exact leak this module's `Display` impls close (#767
-/// code-review follow-up) — any `tracing::warn!(?err, ...)`/`{err:?}` call site, a common
-/// and arguably more idiomatic alternative to `%err`, would bypass the hand-written
-/// `Display` text entirely and reintroduce the raw URL/query string. Every field is still
-/// shown (this is not a summary), only the four URL-shaped ones go through the same
-/// redaction their `Display` counterpart uses.
+/// Hand-written, not derived: originally because a derived `Debug` would have printed
+/// `HttpStatus.url`, `Offline.url`, `ResponseTooLarge.url`, and `RegistryError.package` raw
+/// and unredacted (#767 code-review follow-up) — any `tracing::warn!(?err, ...)`/`{err:?}`
+/// call site, a common and arguably more idiomatic alternative to `%err`, would have bypassed
+/// the hand-written `Display` text entirely and reintroduced the raw URL/query string. Since
+/// #789, those four fields are typed [`RedactedUrl`] directly, so a derived `Debug` would
+/// actually be safe too (each field's own `Debug` already forwards to redacted text) — this
+/// impl is kept hand-written anyway as defense-in-depth against a future field-type
+/// regression, not because it is still load-bearing on its own. Every field is still shown
+/// (this is not a summary).
 impl std::fmt::Debug for DepsError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -223,7 +307,7 @@ impl std::fmt::Debug for DepsError {
                 .finish(),
             Self::RegistryError { package, source } => f
                 .debug_struct("RegistryError")
-                .field("package", &url_for_tracing(package))
+                .field("package", package)
                 .field("source", source)
                 .finish(),
             Self::CacheError(message) => f.debug_tuple("CacheError").field(message).finish(),
@@ -238,7 +322,7 @@ impl std::fmt::Debug for DepsError {
                 .finish(),
             Self::HttpStatus { url, status } => f
                 .debug_struct("HttpStatus")
-                .field("url", &url_for_tracing(url))
+                .field("url", url)
                 .field("status", status)
                 .finish(),
             Self::ApiResponse {
@@ -253,7 +337,7 @@ impl std::fmt::Debug for DepsError {
                 .finish(),
             Self::ResponseTooLarge { url, limit } => f
                 .debug_struct("ResponseTooLarge")
-                .field("url", &url_for_tracing(url))
+                .field("url", url)
                 .field("limit", limit)
                 .finish(),
             Self::InvalidVersionReq(req) => f.debug_tuple("InvalidVersionReq").field(req).finish(),
@@ -267,10 +351,7 @@ impl std::fmt::Debug for DepsError {
                 f.debug_tuple("AmbiguousEcosystem").field(path).finish()
             }
             Self::InvalidUri(uri) => f.debug_tuple("InvalidUri").field(uri).finish(),
-            Self::Offline { url } => f
-                .debug_struct("Offline")
-                .field("url", &url_for_tracing(url))
-                .finish(),
+            Self::Offline { url } => f.debug_struct("Offline").field("url", url).finish(),
             Self::ChainResolutionHalted => f.write_str("ChainResolutionHalted"),
         }
     }
@@ -390,12 +471,12 @@ impl DepsError {
     /// A URL-free summary of this error, safe to attach to a `tracing` field or log line at
     /// an outbound-request chokepoint. [`Self::HttpStatus`], [`Self::Offline`],
     /// [`Self::ResponseTooLarge`], and [`Self::RegistryError`]'s own `Display` now redact
-    /// their URL via [`url_for_tracing`] (#767), but this summary deliberately still never
-    /// derives from `self`'s `Display`/`Debug`: the wrapped `reqwest::Error` inside
-    /// [`Self::RegistryError`] can still re-embed the raw URL through its own `Display`
-    /// unless a caller separately applied `reqwest::Error::without_url()` at construction,
-    /// and a future variant added here should not be able to reintroduce a leak just by
-    /// being included in a `{self}` interpolation.
+    /// their URL via [`RedactedUrl`] (#767, #789), but this summary deliberately still never
+    /// derives from `self`'s `Display`/`Debug`: a future variant added here should not be
+    /// able to reintroduce a leak just by being included in a `{self}` interpolation.
+    /// [`Self::RegistryError`]'s wrapped [`SanitizedRegistryError`] can no longer re-embed
+    /// the raw URL through its own `Display` either way, since its only constructor strips
+    /// it unconditionally.
     ///
     /// Returns the HTTP status code when this is [`Self::HttpStatus`], plus a coarse,
     /// URL-free cause discriminant for every variant — so a routine transport
@@ -463,11 +544,72 @@ pub type Result<T> = std::result::Result<T, DepsError>;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::error::Error as StdError;
 
     #[test]
     fn test_error_display() {
         let error = DepsError::CacheError("test error".into());
         assert_eq!(error.to_string(), "cache error: test error");
+    }
+
+    /// #789: `SanitizedRegistryError`'s own `Display` must never re-embed the request URL,
+    /// even when the wrapped `reqwest::Error` genuinely carries one — a builder-only error
+    /// like `Client::get("not a url").build().unwrap_err()` never populates `.url()`, so this
+    /// needs a real transport-level failure (connection refused on a closed loopback port) to
+    /// actually exercise the strip, mirroring `deps_core::cache`'s own
+    /// `test_registry_error_source_redacts_url_on_real_transport_error`.
+    #[tokio::test]
+    async fn test_sanitized_registry_error_strips_url_on_real_transport_error() {
+        let port = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.local_addr().unwrap().port()
+        };
+        let url = format!("http://127.0.0.1:{port}/pkg?token=super-secret-value");
+
+        let reqwest_err = reqwest::Client::new().get(&url).send().await.unwrap_err();
+        assert!(
+            reqwest_err.url().is_some(),
+            "test setup invariant: the underlying reqwest::Error must carry a URL"
+        );
+
+        let sanitized: SanitizedRegistryError = reqwest_err.into();
+        assert!(
+            !sanitized.to_string().contains("super-secret-value"),
+            "sanitized: {sanitized}"
+        );
+        assert!(
+            !format!("{sanitized:?}").contains("super-secret-value"),
+            "sanitized debug: {sanitized:?}"
+        );
+    }
+
+    /// #789 S2: `SanitizedRegistryError` must treat itself as a leaf node for source-chaining
+    /// purposes — `reqwest`'s redirect policy can nest a *second* `reqwest::Error` (with its
+    /// own populated `url` field) as the outer error's `source` (see the type's own docs for
+    /// the exact `https_only`/redirect code path), which `.without_url()` on the outer error
+    /// alone does not touch. This proves the wrapper discards a real, populated source chain
+    /// (not merely that one never existed): the *raw* wrapped `reqwest::Error` behind
+    /// `sanitized.0` (accessible here since `mod tests` is a child of `error`) genuinely has
+    /// `.source().is_some()` for a real connection-refused failure, yet `SanitizedRegistryError`'s
+    /// own `source()` is unconditionally `None`.
+    #[tokio::test]
+    async fn test_sanitized_registry_error_source_is_always_none() {
+        let port = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.local_addr().unwrap().port()
+        };
+        let url = format!("http://127.0.0.1:{port}/pkg?token=super-secret-value");
+
+        let reqwest_err = reqwest::Client::new().get(&url).send().await.unwrap_err();
+        let sanitized: SanitizedRegistryError = reqwest_err.into();
+        assert!(
+            sanitized.0.source().is_some(),
+            "test setup invariant: a connection-refused error must have a populated source chain"
+        );
+        assert!(
+            StdError::source(&sanitized).is_none(),
+            "SanitizedRegistryError::source() must always be None"
+        );
     }
 
     /// #756 code-review finding: `safe_tracing_summary` must never derive its output from
@@ -488,7 +630,11 @@ mod tests {
         assert_eq!(
             DepsError::RegistryError {
                 package: "https://example.com/pkg?token=secret".into(),
-                source: reqwest::Client::new().get("not a url").build().unwrap_err(),
+                source: reqwest::Client::new()
+                    .get("not a url")
+                    .build()
+                    .unwrap_err()
+                    .into(),
             }
             .safe_tracing_summary(),
             (None, "transport")
@@ -567,7 +713,11 @@ mod tests {
     fn test_registry_error_display_redacts_query_string() {
         let error = DepsError::RegistryError {
             package: "https://npm.internal/pkg?_authToken=super-secret-value".into(),
-            source: reqwest::Client::new().get("not a url").build().unwrap_err(),
+            source: reqwest::Client::new()
+                .get("not a url")
+                .build()
+                .unwrap_err()
+                .into(),
         };
         let message = error.to_string();
         assert!(
@@ -586,7 +736,11 @@ mod tests {
     fn test_registry_error_display_does_not_mangle_scoped_package_name() {
         let error = DepsError::RegistryError {
             package: "@types/node".into(),
-            source: reqwest::Client::new().get("not a url").build().unwrap_err(),
+            source: reqwest::Client::new()
+                .get("not a url")
+                .build()
+                .unwrap_err()
+                .into(),
         };
         let message = error.to_string();
         assert!(
@@ -646,7 +800,11 @@ mod tests {
             },
             DepsError::RegistryError {
                 package: "https://npm.internal/pkg?_authToken=super-secret-value".into(),
-                source: reqwest::Client::new().get("not a url").build().unwrap_err(),
+                source: reqwest::Client::new()
+                    .get("not a url")
+                    .build()
+                    .unwrap_err()
+                    .into(),
             },
         ];
         for error in credential_bearing {
@@ -656,6 +814,24 @@ mod tests {
                 "Debug leaked the credential for {error}: {debug}"
             );
         }
+    }
+
+    /// #789 S1 regression: destructuring `HttpStatus.url` directly (bypassing `Display`/
+    /// `Debug` entirely) must still yield only redacted text — the field's type itself
+    /// (`RedactedUrl`, not `String`) is what makes this true, not any redaction step at the
+    /// access site. There is no way to get the raw string back out even via direct field
+    /// access, because nothing raw was ever stored in the field to begin with.
+    #[test]
+    fn test_http_status_url_field_is_redacted_even_via_direct_destructure() {
+        let error = DepsError::HttpStatus {
+            url: RedactedUrl::new("https://npm.internal/pkg?_authToken=super-secret-value"),
+            status: 401,
+        };
+        let DepsError::HttpStatus { url, .. } = error else {
+            unreachable!()
+        };
+        assert_eq!(url.to_string(), "https://npm.internal/pkg");
+        assert!(!url.to_string().contains("super-secret-value"));
     }
 
     /// `Debug` must still show every field for the ordinary, non-URL-bearing variants —
@@ -802,7 +978,7 @@ mod tests {
             },
             DepsError::RegistryError {
                 package: "flask".into(),
-                source: reqwest_err,
+                source: reqwest_err.into(),
             },
             DepsError::CacheError("connection reset".into()),
             DepsError::PackageNotFound {

--- a/crates/deps-core/src/github.rs
+++ b/crates/deps-core/src/github.rs
@@ -300,7 +300,7 @@ impl GithubTagsClient {
     /// Propagates the underlying HTTP/cache error unchanged.
     #[tracing::instrument(
         skip(self),
-        fields(url = crate::net_policy::url_for_tracing(url))
+        fields(url = %crate::net_policy::RedactedUrl::new(url))
     )]
     pub async fn fetch_authenticated(&self, url: &str) -> Result<Bytes> {
         self.cache

--- a/crates/deps-core/src/net_policy.rs
+++ b/crates/deps-core/src/net_policy.rs
@@ -659,6 +659,84 @@ pub fn url_for_tracing(raw: &str) -> String {
     without_userinfo[..end].to_string()
 }
 
+/// A URL-bearing value that has already been redacted for safe inclusion in error or log
+/// output — the structural chokepoint for outbound-URL redaction (issue #789).
+///
+/// Eagerly redacted at construction: [`Self::new`] applies [`url_for_tracing`]'s rules
+/// immediately and retains only the resulting text, so the raw value passed in is never
+/// stored, not even transiently. The only public read surface — [`Display`](std::fmt::Display),
+/// [`AsRef<str>`], and a [`Debug`](std::fmt::Debug) impl that forwards to the redacted text —
+/// is therefore always safe to log: there is no `expose_url()`-style escape hatch, because
+/// nothing raw remains to expose. A caller that legitimately needs the raw URL (e.g. to
+/// actually issue the HTTP request) keeps working with its own `String`/`reqwest::Url`,
+/// entirely independent of any `RedactedUrl` built from the same source for error/log
+/// purposes.
+///
+/// # Examples
+///
+/// ```
+/// use deps_core::net_policy::RedactedUrl;
+///
+/// let redacted = RedactedUrl::new("https://npm.internal/pkg?token=super-secret-value");
+/// assert_eq!(redacted.to_string(), "https://npm.internal/pkg");
+///
+/// let redacted = RedactedUrl::new("https://user:hunter2@registry.example/simple");
+/// assert_eq!(redacted.to_string(), "https://***@registry.example/simple");
+/// ```
+///
+/// `PartialEq`/`Eq`/`Hash` compare the *redacted* text, not the original input: two distinct
+/// URLs differing only by a stripped component (query string, fragment, or userinfo) compare
+/// equal here even though they were different requests — e.g. `?token=a` and `?token=b`
+/// against the same path both redact to the same value. This is intentional for this type's
+/// own purpose (deduplicating/comparing error variants in tests, `deps_core::error`'s own
+/// `assert_eq!` usage), but makes `RedactedUrl` unsuitable as a cache key or any other context
+/// that needs to distinguish the underlying raw URLs — use the raw `String`/`reqwest::Url`
+/// value for that instead.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct RedactedUrl(String);
+
+impl RedactedUrl {
+    /// Redacts `raw` immediately via [`url_for_tracing`], retaining only the resulting text.
+    #[must_use]
+    pub fn new(raw: &str) -> Self {
+        Self(url_for_tracing(raw))
+    }
+}
+
+impl From<&str> for RedactedUrl {
+    fn from(raw: &str) -> Self {
+        Self::new(raw)
+    }
+}
+
+impl From<String> for RedactedUrl {
+    fn from(raw: String) -> Self {
+        Self::new(&raw)
+    }
+}
+
+impl std::fmt::Display for RedactedUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::fmt::Debug for RedactedUrl {
+    /// Forwards to the redacted text's own `Debug` (a quoted string), not a struct-wrapper
+    /// rendering — so a `RedactedUrl` embedded in a hand-written `Debug` impl (see
+    /// `deps_core::error::DepsError`) reads identically to the plain `String` field it
+    /// replaces.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.0, f)
+    }
+}
+
+impl AsRef<str> for RedactedUrl {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
 /// Whether `url`'s host is loopback (`127.0.0.1`, `localhost`, or `::1`) with an `http`
 /// scheme — the shape every `mockito::Server` binds to.
 ///
@@ -746,7 +824,7 @@ pub fn validate_index_url(
         let class = classify_host(&url);
         if !policy.get().allows(class) {
             tracing::warn!(
-                url = url_for_tracing(raw_for_log),
+                url = %RedactedUrl::new(raw_for_log),
                 ?class,
                 ecosystem,
                 "workspace-declared registry index host blocked by registries.workspace_registries policy"
@@ -1138,6 +1216,52 @@ mod tests {
             assert_matches!(result, Err(IndexUrlError::BlockedHost { .. }));
         });
         assert!(!log.contains("super-secret-value"), "log: {log}");
+    }
+
+    /// FR-003: `RedactedUrl::new` must match `url_for_tracing`'s output byte-for-byte for
+    /// every input this module's own regression suite already pins.
+    #[test]
+    fn test_redacted_url_matches_url_for_tracing_byte_for_byte() {
+        let inputs = [
+            "https://npm.internal/pkg?token=super-secret-value",
+            "https://user:hunter2@registry.example/simple?token=x",
+            "https://registry.example/simple",
+            "not-a-url-at-all",
+            "@types/node",
+        ];
+        for raw in inputs {
+            assert_eq!(RedactedUrl::new(raw).to_string(), url_for_tracing(raw));
+        }
+    }
+
+    /// NFR-004: the only public read surface (`Display`/`AsRef<str>`) returns redacted text
+    /// only, for a known-sensitive input — there is no accessor that could return `raw`.
+    #[test]
+    fn test_redacted_url_display_and_as_ref_never_expose_raw_credential() {
+        let raw = "https://user:hunter2@registry.example/simple?token=super-secret-value";
+        let redacted = RedactedUrl::new(raw);
+        assert!(!redacted.to_string().contains("hunter2"));
+        assert!(!redacted.to_string().contains("super-secret-value"));
+        assert!(!redacted.as_ref().contains("hunter2"));
+        assert!(!redacted.as_ref().contains("super-secret-value"));
+        assert_eq!(redacted.to_string(), "https://***@registry.example/simple");
+    }
+
+    /// `Debug` forwards to the redacted text's own quoted-string rendering, not a
+    /// struct-wrapper form, and must never expose the raw credential either.
+    #[test]
+    fn test_redacted_url_debug_forwards_to_inner_string_and_redacts() {
+        let redacted = RedactedUrl::new("https://user:hunter2@registry.example/simple");
+        assert_eq!(
+            format!("{redacted:?}"),
+            "\"https://***@registry.example/simple\""
+        );
+    }
+
+    /// The scoped-package-name no-op (#767 M1) must hold through `RedactedUrl` too.
+    #[test]
+    fn test_redacted_url_noop_for_scoped_package_name() {
+        assert_eq!(RedactedUrl::new("@types/node").to_string(), "@types/node");
     }
 
     #[test]

--- a/crates/deps-core/src/osv/mod.rs
+++ b/crates/deps-core/src/osv/mod.rs
@@ -364,7 +364,10 @@ impl OsvClient {
         truncated: &mut Vec<ScanTarget>,
     ) {
         let url = self.batch_url();
-        tracing::Span::current().record("url", crate::net_policy::url_for_tracing(&url));
+        tracing::Span::current().record(
+            "url",
+            tracing::field::display(crate::net_policy::RedactedUrl::new(&url)),
+        );
 
         let queries: Vec<OsvQuery> = chunk
             .iter()
@@ -596,7 +599,10 @@ impl OsvClient {
     #[tracing::instrument(skip(self), fields(url = tracing::field::Empty))]
     async fn fetch_single_record(&self, id: &str) -> Option<OsvVulnRecord> {
         let url = self.vuln_record_url(id);
-        tracing::Span::current().record("url", crate::net_policy::url_for_tracing(&url));
+        tracing::Span::current().record(
+            "url",
+            tracing::field::display(crate::net_policy::RedactedUrl::new(&url)),
+        );
         match self.cache.get_transport_only(&url).await {
             Ok(bytes) => match crate::parser::parse_json_checked::<OsvVulnRecord>(&bytes) {
                 Ok(record) => Some(record),
@@ -626,7 +632,10 @@ impl OsvClient {
         target: &ScanTarget,
     ) -> Option<OsvSingleQueryResponse> {
         let url = self.single_query_url();
-        tracing::Span::current().record("url", crate::net_policy::url_for_tracing(&url));
+        tracing::Span::current().record(
+            "url",
+            tracing::field::display(crate::net_policy::RedactedUrl::new(&url)),
+        );
 
         let body = OsvQuery {
             package: OsvPackage {

--- a/crates/deps-lsp/src/document/fetch.rs
+++ b/crates/deps-lsp/src/document/fetch.rs
@@ -2672,7 +2672,7 @@ mod tests {
             {
                 Box::pin(async move {
                     Err(deps_core::error::DepsError::HttpStatus {
-                        url: format!("https://example.com/{name}"),
+                        url: format!("https://example.com/{name}").into(),
                         status: 404,
                     })
                 })
@@ -2686,7 +2686,7 @@ mod tests {
             {
                 Box::pin(async move {
                     Err(deps_core::error::DepsError::HttpStatus {
-                        url: format!("https://example.com/{name}"),
+                        url: format!("https://example.com/{name}").into(),
                         status: 404,
                     })
                 })

--- a/crates/deps-maven/src/registry.rs
+++ b/crates/deps-maven/src/registry.rs
@@ -1689,7 +1689,7 @@ mod tests {
                 calls.fetch_add(1, Ordering::SeqCst);
                 async {
                     Err(DepsError::HttpStatus {
-                        url: MAVEN_SEARCH_BASE.to_string(),
+                        url: MAVEN_SEARCH_BASE.into(),
                         status: 400,
                     })
                 }
@@ -1713,7 +1713,7 @@ mod tests {
                 async move {
                     if n == 0 {
                         Err(DepsError::HttpStatus {
-                            url: MAVEN_SEARCH_BASE.to_string(),
+                            url: MAVEN_SEARCH_BASE.into(),
                             status: 503,
                         })
                     } else {

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -75,7 +75,7 @@ status: moc
 | 051 | [[051-disk-persistent-registry-cache/spec\|Disk-persistent registry cache]] | specify | research/parity, P3, 9 open `[NEEDS CLARIFICATION]` items |
 | 052 | [[052-pnpm-lockfile-provider/spec\|pnpm-lock.yaml lock file provider (npm ecosystem)]] | specify | ready — enhancement/cross-ecosystem, P3, 0 open `[NEEDS CLARIFICATION]` items, issue #709 (scoped to pnpm-lock.yaml only) |
 | 053 | [[053-ecosystem-sealing-inversion-decision-record/spec\|Ecosystem sealing inversion decision record]] | specify | research/decision-record, P4, shipped — won't-do, spec is the artifact (issue #774 to be closed referencing this spec) |
-| 054 | [[054-redacted-url-structural-chokepoint/spec\|Structural chokepoint for outbound-URL redaction in error/log output]] | specify | ready — enhancement/security, P2, 0 open `[NEEDS CLARIFICATION]` items, issue #789 — follow-up to #767/#775 |
+| 054 | [[054-redacted-url-structural-chokepoint/spec\|Structural chokepoint for outbound-URL redaction in error/log output]] | specify | in review — enhancement/security, P2, 0 open `[NEEDS CLARIFICATION]` items, issue #789, PR #800 (deps-core stage), ecosystem-crate migration tracked in #801 — follow-up to #767/#775 |
 
 ## Completed Specs
 


### PR DESCRIPTION
## Summary

- Introduces `RedactedUrl` (`deps-core::net_policy`) as a type-level chokepoint for outbound-URL redaction in error/log output, replacing the per-call-site `url_for_tracing()` discipline that missed two `deps-cargo` sites during #775's review.
- Construction is eager and one-way: `RedactedUrl::new` applies the existing redaction rules immediately and retains only the redacted text, so the raw value is never stored inside the type and there is no accessor that returns it.
- `DepsError::HttpStatus.url`, `Offline.url`, `ResponseTooLarge.url`, and `RegistryError.package` change from `String` to `RedactedUrl`, closing the actual gap found in review: without a field-type change, a raw URL was still reachable through direct destructuring even though `Display`/`Debug` redacted it.
- `DepsError::RegistryError.source` changes from `reqwest::Error` to `SanitizedRegistryError`, whose only constructor unconditionally strips the URL via `.without_url()`; its `source()` returns `None` unconditionally rather than selectively re-sanitizing a nested `reqwest::Error` it doesn't own, closing the same leak class for a currently-unreachable `https_only`-redirect source-chain shape (`reqwest`'s `Kind::Redirect`/`https_only` policy branch can nest a second `reqwest::Error` with its own unstripped URL as `#[source]` — dormant today since nothing in this workspace calls `.https_only(true)`).
- Migrates every `deps-core`-internal call site (`error.rs`, `cache.rs`, `github.rs`, `net_policy.rs`, `osv/mod.rs`, `deps_dev/mod.rs`).

## Scope

This is a staged rollout per `specs/054-redacted-url-structural-chokepoint/spec.md` (merged separately): this PR covers `deps-core` only. The six ecosystem crates that still call `url_for_tracing()` directly (`deps-cargo`, `deps-npm`, `deps-pypi`, `deps-go`, `deps-nuget`, `deps-maven`) are unaffected — only `#[cfg(test)]` sites in `deps-maven`/`deps-lsp` needed a mechanical `.to_string()` -> `.into()` fix to keep compiling against the new field types. Migrating those crates' own error paths is tracked as follow-up.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4891 passed)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- [x] New regression test proving direct field destructure of `HttpStatus`/`Offline`/`ResponseTooLarge`/`RegistryError` cannot yield the raw URL
- [x] New regression test proving `SanitizedRegistryError::source()` discards a real source chain rather than one that never existed

Closes #789