### PR TITLE
fix: route remaining registry log sites through RedactedUrl chokepoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-bundler, deps-cargo, deps-composer, deps-dart, deps-go, deps-maven, deps-npm, deps-nuget, deps-pypi, deps-swift**: migrated onto `registry_conformance!` (now 14/14 crates, was 4/14) and extended `completion_guard_conformance!` to maven/swift (11/14; go/github-actions/gitlab-ci confirmed N/A) (resolves #794) (#805)
 
 ### Fixed
+- **deps-cargo, deps-npm, deps-pypi**: alternate-registry-router tracing sites now log a `RedactedUrl`-wrapped index/key instead of the raw string, closing a query-string-credential leak on a validated `RegistryIndex`/`NpmRegistryIndex`/`PypiIndexUrl` (resolves #824)
+- **deps-go**: the three `compile_glob` malformed-`GOPRIVATE`-pattern warnings now log through `RedactedUrl` instead of `redact_userinfo` alone, closing a query-string-credential leak; `redact_userinfo` now has no production caller outside `deps-core` (resolves #822)
 - **deps-core**: `redact_userinfo`'s unparseable-URL fallback now also redacts a colon-separated credential with no `@` (e.g. an npm `oauth2:`/GitLab CI job-token line), closing a gap that let such values reach tracing/log output and `window/showMessage` unredacted (resolves #810) (#814)
 - **deps-core**: `url_for_tracing`/`redact_userinfo` now redact a non-special-scheme `scheme:/path` credential (e.g. `c:/user:hunter2@evil`) that previously bypassed all redaction (resolves #811)
 - **deps-core, deps-gitlab-ci, deps-lsp**: `IndexUrlError::InvalidUrl`'s payload is now a `RedactedUrl`, closing credential-log paths (tracing and `window/showMessage`) via a hostile `registries.gitlab_instance_host` value (resolves #808) (#809)

--- a/crates/deps-cargo/src/registry.rs
+++ b/crates/deps-cargo/src/registry.rs
@@ -28,7 +28,7 @@ use crate::config::{AuthToken, RegistryIndex};
 use crate::sparse::SparseIndexClient;
 use crate::types::{CargoVersion, CrateInfo};
 use deps_core::parser::DependencySource;
-use deps_core::{DepsError, HttpCache, PackageName, Result};
+use deps_core::{DepsError, HttpCache, PackageName, Result, net_policy::RedactedUrl};
 use semver::{Version, VersionReq};
 use serde::Deserialize;
 use std::any::Any;
@@ -453,7 +453,7 @@ impl CargoRegistry {
         let at_capacity = self.alternates.len() >= MAX_ALTERNATE_REGISTRIES;
         let key = index.as_str().to_string();
         let incoming_trust = index.trust();
-        let index_display = index.to_string();
+        let index_display = RedactedUrl::new(index.as_str());
 
         match self.alternates.entry(key) {
             dashmap::mapref::entry::Entry::Occupied(mut slot) => {
@@ -1150,6 +1150,58 @@ mod tests {
             registry
                 .alternate_client("https://overflow.example/")
                 .is_none()
+        );
+    }
+
+    // Issue #824: `validate_index_url` rejects userinfo but preserves the query string, so
+    // a validated index can still carry `?api_key=...`. The trust-fold warn (line ~464) must
+    // log through `RedactedUrl`, not the raw `index.to_string()`.
+    #[tokio::test]
+    async fn test_cargo_registry_register_alternate_redacts_query_credential_on_trust_fold() {
+        let cache = Arc::new(HttpCache::new());
+        let registry = CargoRegistry::new(cache);
+        let url = "https://index.mycorp.dev/?api_key=SUPERSECRET_TOKEN";
+
+        let log = deps_core::test_util::capture_tracing_output(|| {
+            registry.register_alternate(
+                test_index_with_trust(url, IndexTrust::Trusted),
+                Some(AuthToken::new("token".to_string())),
+            );
+            registry.register_alternate(
+                test_index_with_trust(url, IndexTrust::WorkspaceDeclared),
+                None,
+            );
+        });
+
+        assert!(log.contains("re-registration folds"), "log: {log}");
+        assert!(!log.contains("SUPERSECRET_TOKEN"), "log: {log}");
+        assert!(
+            log.contains("index.mycorp.dev"),
+            "redaction must not remove the non-secret host: {log}"
+        );
+    }
+
+    // Issue #824: same query-string credential leak, but on the alternate-registry-cap warn
+    // path (line ~479).
+    #[tokio::test]
+    async fn test_cargo_registry_register_alternate_redacts_query_credential_on_cap_reached() {
+        let cache = Arc::new(HttpCache::new());
+        let registry = CargoRegistry::new(cache);
+        for i in 0..MAX_ALTERNATE_REGISTRIES {
+            let index = test_index(&format!("https://index{i}.example"));
+            registry.register_alternate(index, None);
+        }
+
+        let overflow = test_index("https://overflow.example/?api_key=SUPERSECRET_TOKEN");
+        let log = deps_core::test_util::capture_tracing_output(|| {
+            registry.register_alternate(overflow, None);
+        });
+
+        assert!(log.contains("alternate registry cap reached"), "log: {log}");
+        assert!(!log.contains("SUPERSECRET_TOKEN"), "log: {log}");
+        assert!(
+            log.contains("overflow.example"),
+            "redaction must not remove the non-secret host: {log}"
         );
     }
 }

--- a/crates/deps-go/src/config.rs
+++ b/crates/deps-go/src/config.rs
@@ -32,9 +32,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
-use deps_core::net_policy::{
-    PolicyGate, RedactedUrl, RegistryAccessPolicy, redact_userinfo, validate_index_url,
-};
+use deps_core::net_policy::{PolicyGate, RedactedUrl, RegistryAccessPolicy, validate_index_url};
 use deps_core::parser::DependencySource;
 
 /// Why a candidate `GOPROXY` hop URL failed [`GoProxyUrl::new`]'s validation.
@@ -519,6 +517,13 @@ impl GlobPattern {
 /// unterminated class.
 // `chars[i]` is guarded by `i < chars.len()` and `chars[j]` by `j < chars.len()`, both from
 // their enclosing loop conditions.
+//
+// The three `tracing::warn!`s below log `pattern` through `RedactedUrl::new`, which truncates
+// at the first `?`/`#` (issue #822) — but `?` is also this glob dialect's own `GlobToken::Any`
+// wildcard, so a malformed pattern containing one (e.g. `corp.example/repo?/pkg[abc`) logs a
+// truncated prefix that no longer shows the actual defect location. Deliberate: security
+// (never risk a credential-bearing query-string-shaped suffix reaching the log) over
+// observability here.
 #[allow(clippy::indexing_slicing)]
 fn compile_glob(pattern: &str) -> Option<Vec<GlobToken>> {
     let chars: Vec<char> = pattern.chars().collect();
@@ -537,7 +542,7 @@ fn compile_glob(pattern: &str) -> Option<Vec<GlobToken>> {
             '\\' => {
                 let Some(&escaped) = chars.get(i + 1) else {
                     tracing::warn!(
-                        pattern = redact_userinfo(pattern),
+                        pattern = %RedactedUrl::new(pattern),
                         "GOPRIVATE pattern ends with a trailing unescaped '\\'; it will never \
                          match, so affected modules route to the public proxy instead of being \
                          treated as private"
@@ -567,7 +572,7 @@ fn compile_glob(pattern: &str) -> Option<Vec<GlobToken>> {
                             // behaves normally — so this only logs for observability rather
                             // than invalidating the whole pattern.
                             tracing::warn!(
-                                pattern = redact_userinfo(pattern),
+                                pattern = %RedactedUrl::new(pattern),
                                 "GOPRIVATE pattern has a reversed '[' character-class range \
                                  (lo > hi); that range can never match any character, but the \
                                  rest of the pattern is still evaluated normally, matching Go's \
@@ -583,7 +588,7 @@ fn compile_glob(pattern: &str) -> Option<Vec<GlobToken>> {
                 }
                 if chars.get(j) != Some(&']') {
                     tracing::warn!(
-                        pattern = redact_userinfo(pattern),
+                        pattern = %RedactedUrl::new(pattern),
                         "GOPRIVATE pattern has an unterminated '[' character class; it will \
                          never match, so affected modules route to the public proxy instead of \
                          being treated as private"
@@ -1729,6 +1734,70 @@ mod tests {
         assert!(
             !log.contains("hunter2"),
             "tracing output leaked credential: {log:?}"
+        );
+    }
+
+    /// Issue #822: the three `compile_glob` warn sites (dangling escape, reversed
+    /// character-class range, unterminated character class) used `redact_userinfo` alone,
+    /// which strips userinfo but preserves the query string — a query-string-shaped
+    /// credential embedded in a malformed GOPRIVATE pattern must not leak through the log.
+    #[test]
+    fn test_compile_glob_dangling_escape_warn_redacts_query_credential() {
+        let log = deps_core::test_util::capture_tracing_output(|| {
+            let config = GoEnvConfig::parse(
+                r"GOPRIVATE=git.corp.example/pkg?token=SUPERSECRET_TOKEN\",
+                &all_policy(),
+            );
+            assert!(!config.has_goprivate());
+        });
+        assert!(
+            log.contains("trailing unescaped"),
+            "expected dangling-escape warning: {log}"
+        );
+        assert!(!log.contains("SUPERSECRET_TOKEN"), "log: {log}");
+        assert!(
+            log.contains("git.corp.example"),
+            "redaction must not remove the non-secret host: {log}"
+        );
+    }
+
+    #[test]
+    fn test_compile_glob_reversed_range_warn_redacts_query_credential() {
+        let log = deps_core::test_util::capture_tracing_output(|| {
+            let config = GoEnvConfig::parse(
+                "GOPRIVATE=git.corp.example/repo?token=SUPERSECRET_TOKEN[c-a]",
+                &all_policy(),
+            );
+            assert!(config.has_goprivate());
+        });
+        assert!(
+            log.contains("reversed"),
+            "expected reversed-range warning: {log}"
+        );
+        assert!(!log.contains("SUPERSECRET_TOKEN"), "log: {log}");
+        assert!(
+            log.contains("git.corp.example"),
+            "redaction must not remove the non-secret host: {log}"
+        );
+    }
+
+    #[test]
+    fn test_compile_glob_unterminated_class_warn_redacts_query_credential() {
+        let log = deps_core::test_util::capture_tracing_output(|| {
+            let config = GoEnvConfig::parse(
+                "GOPRIVATE=git.corp.example/repo?token=SUPERSECRET_TOKEN[abc",
+                &all_policy(),
+            );
+            assert!(!config.has_goprivate());
+        });
+        assert!(
+            log.contains("unterminated"),
+            "expected unterminated-class warning: {log}"
+        );
+        assert!(!log.contains("SUPERSECRET_TOKEN"), "log: {log}");
+        assert!(
+            log.contains("git.corp.example"),
+            "redaction must not remove the non-secret host: {log}"
         );
     }
 

--- a/crates/deps-npm/src/registry.rs
+++ b/crates/deps-npm/src/registry.rs
@@ -11,7 +11,7 @@ use crate::types::{NpmPackage, NpmVersion};
 use dashmap::DashMap;
 use deps_core::{
     DepsError, HOVER_RECENT_VERSIONS, HttpCache, PublishTime, Result, is_dot_segment,
-    lsp_helpers::warn_rejected_value, parser::DependencySource,
+    lsp_helpers::warn_rejected_value, net_policy::RedactedUrl, parser::DependencySource,
 };
 use serde::Deserialize;
 use std::any::Any;
@@ -302,7 +302,7 @@ impl NpmRegistry {
         if let dashmap::mapref::entry::Entry::Vacant(slot) = self.alternates.entry(key.clone()) {
             if at_capacity {
                 tracing::warn!(
-                    index = %key,
+                    index = %RedactedUrl::new(&key),
                     cap = MAX_ALTERNATE_REGISTRIES,
                     "npm alternate registry cap reached; not registering a new index"
                 );
@@ -2678,6 +2678,35 @@ mod tests {
         registry.register_alternate(overflow.clone());
         assert_eq!(registry.alternates.len(), MAX_ALTERNATE_REGISTRIES);
         assert!(registry.alternate_client(overflow.as_str()).is_none());
+    }
+
+    // Issue #824: `validate_index_url` rejects userinfo but preserves the query string, so
+    // a validated `NpmRegistryIndex` can still carry `?_authToken=...`. The cap-reached warn
+    // must log through `RedactedUrl`, not the raw index string.
+    #[test]
+    fn test_register_alternate_redacts_query_credential_on_cap_reached() {
+        let cache = Arc::new(HttpCache::new());
+        let registry = NpmRegistry::new(cache);
+
+        for i in 0..MAX_ALTERNATE_REGISTRIES {
+            let index = alternate_index(&format!("https://registry-{i}.example"));
+            registry.register_alternate(index);
+        }
+
+        let overflow = alternate_index("https://overflow.example/?_authToken=SUPERSECRET_TOKEN");
+        let log = deps_core::test_util::capture_tracing_output(|| {
+            registry.register_alternate(overflow);
+        });
+
+        assert!(
+            log.contains("npm alternate registry cap reached"),
+            "log: {log}"
+        );
+        assert!(!log.contains("SUPERSECRET_TOKEN"), "log: {log}");
+        assert!(
+            log.contains("overflow.example"),
+            "redaction must not remove the non-secret host: {log}"
+        );
     }
 
     /// M2: `NpmRegistry` is `Clone` and `deps-lsp` hands a clone to `deps-deno`'s

--- a/crates/deps-pypi/src/registry.rs
+++ b/crates/deps-pypi/src/registry.rs
@@ -15,6 +15,7 @@ use dashmap::DashMap;
 use deps_core::parser::DependencySource;
 use deps_core::{
     DepsError, FreshnessSettings, HttpCache, Result, lsp_helpers::warn_rejected_value,
+    net_policy::RedactedUrl,
 };
 use pep440_rs::{Version, VersionSpecifiers};
 use serde::Deserialize;
@@ -327,7 +328,7 @@ impl PypiRegistry {
         {
             if at_capacity {
                 tracing::warn!(
-                    key = %chain.key,
+                    key = %RedactedUrl::new(&chain.key),
                     cap = MAX_ALTERNATE_REGISTRIES,
                     "PyPI alternate registry cap reached; not registering a new chain"
                 );
@@ -372,7 +373,7 @@ impl PypiRegistry {
         if let dashmap::mapref::entry::Entry::Vacant(slot) = root.alternates.entry(key.clone()) {
             if at_capacity {
                 tracing::warn!(
-                    key = %key,
+                    key = %RedactedUrl::new(&key),
                     cap = MAX_ALTERNATE_REGISTRIES,
                     "PyPI alternate registry cap reached; not registering a new named source"
                 );
@@ -2386,6 +2387,53 @@ mod tests {
         };
         PypiRegistry::register_chain(&root, &overflow);
         assert!(root.alternate_client("overflow").is_none());
+    }
+
+    // Issue #824 (S1 correction): a named source's `ResolvedChain::key` is its own literal
+    // index URL (`PypiIndexConfig::resolved_chains`), routed through `register_chain` — not
+    // `register_named_source`, which has no production caller. `validate_index_url` rejects
+    // userinfo but preserves the query string, so a real Poetry `source =`/uv `index =`
+    // named source can still carry `?_authToken=...` all the way into `register_chain`'s
+    // cap-reached warn; it must log through `RedactedUrl`, not the raw chain key.
+    #[test]
+    fn test_register_chain_redacts_query_credential_for_named_source_on_cap_reached() {
+        let cache = Arc::new(HttpCache::new());
+        let root = Arc::new(PypiRegistry::new(cache));
+        for i in 0..MAX_ALTERNATE_REGISTRIES {
+            let chain = crate::config::ResolvedChain {
+                key: format!("chain-{i}"),
+                hops: vec![index_url("https://a.example/simple")],
+                implicit_public_fallback: false,
+            };
+            PypiRegistry::register_chain(&root, &chain);
+        }
+
+        let mut config = crate::config::PypiIndexConfig::new();
+        config.add_named_source_resolved(
+            "internal".to_string(),
+            Ok(index_url(
+                "https://overflow.example/simple?_authToken=SUPERSECRET_TOKEN",
+            )),
+        );
+        let named_chain = config
+            .resolved_chains()
+            .into_iter()
+            .find(|chain| chain.key.contains("overflow.example"))
+            .expect("named source produces a chain keyed by its own literal URL");
+
+        let log = capture_tracing_output(|| {
+            PypiRegistry::register_chain(&root, &named_chain);
+        });
+
+        assert!(
+            log.contains("PyPI alternate registry cap reached"),
+            "log: {log}"
+        );
+        assert!(!log.contains("SUPERSECRET_TOKEN"), "log: {log}");
+        assert!(
+            log.contains("overflow.example"),
+            "redaction must not remove the non-secret host: {log}"
+        );
     }
 
     /// The C1 invariant: a chain-hop leaf's own `alternates` map is always empty — calling


### PR DESCRIPTION
## Summary
- deps-cargo, deps-npm, and deps-pypi's alternate-registry-router tracing sites logged a validated index/chain key verbatim via `%`/Display; a query-string credential (`?api_key=...`, `?_authToken=...`) that survives `validate_index_url` (which only rejects userinfo) reached tracing output unredacted. All affected sites now wrap the logged value in `deps_core::net_policy::RedactedUrl::new(...)`, matching the existing pattern in deps-cargo's sparse index client.
- deps-go's three `compile_glob` malformed-`GOPRIVATE`-pattern warnings used the weaker `redact_userinfo` helper, which preserves query strings/fragments and returns a plain `String` instead of a type that proves redaction happened. Switched to `RedactedUrl::new`; `redact_userinfo` now has no production caller outside `deps-core`.
- The PyPI fix initially targeted `register_named_source`, a function with zero production callers — retargeted to the actual live path, `register_chain`'s cap-reached warn, after adversarial review caught the miss.
- Added 7 regression tests (3 go, 2 cargo, 1 npm, 1 pypi) asserting the credential is absent from tracing output while the non-secret part still renders.
- Added a comment on deps-go's `compile_glob` noting that `RedactedUrl` truncates at the first `?`/`#`, which is also the GOPRIVATE glob wildcard token, so the logged pattern prefix can be shorter than the actual defect location — a deliberate security-over-observability trade-off.

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4964 passed, 0 failed)
- [x] Rebased onto origin/main (clean, no conflicts)

Closes #824
Closes #822