### PR TITLE
docs(deps-core): re-export tower_lsp_server and document version coupling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **deps-core**: document tower-lsp-server/deps-core version coupling; re-export `tower_lsp_server` from `deps-core` (#832)
+- **deps-core**: document tower-lsp-server/deps-core version coupling; re-export `tower_lsp_server` from `deps-core` (resolves #832) (#839)
 - **deps-core**: `RedactedUrl` structural chokepoint and `SanitizedRegistryError` wrapper for outbound-URL redaction in error/log output, migrated across every `deps-core`-internal call site (partial work on #789) (#800)
 - **deps-core**: regression test pinning `SanitizedRegistryError`'s source-chain redaction for this project's current client config (#789) (#800)
 - **deps-core, deps-deno, deps-gradle, deps-github-actions, deps-gitlab-ci**: `registry_conformance!` macro proving `Registry::select_latest_matching` is actually overridden, invoked for all four ecosystems named in #784 (resolves #784) (#787)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **deps-core**: document tower-lsp-server/deps-core version coupling; re-export `tower_lsp_server` from `deps-core` (#832)
 - **deps-core**: `RedactedUrl` structural chokepoint and `SanitizedRegistryError` wrapper for outbound-URL redaction in error/log output, migrated across every `deps-core`-internal call site (partial work on #789) (#800)
 - **deps-core**: regression test pinning `SanitizedRegistryError`'s source-chain redaction for this project's current client config (#789) (#800)
 - **deps-core, deps-deno, deps-gradle, deps-github-actions, deps-gitlab-ci**: `registry_conformance!` macro proving `Registry::select_latest_matching` is actually overridden, invoked for all four ecosystems named in #784 (resolves #784) (#787)

--- a/README.md
+++ b/README.md
@@ -591,6 +591,21 @@ cargo bench --workspace
 
 View HTML report: `open target/criterion/report/index.html`
 
+## Versioning
+
+`deps-core`'s public trait signatures (`Ecosystem`, `Dependency`, `ParseResult`,
+`EcosystemFormatter`) — and its public `lsp_helpers` / `completion` helper functions —
+are typed directly against `tower_lsp_server::ls_types` types. `tower-lsp-server` is pinned
+pre-1.0, so a `tower-lsp-server` minor bump (e.g. 0.23 → 0.24) is not an implementation
+detail `deps-core` can absorb silently — it forces a breaking release of `deps-core`: a
+minor version bump while `deps-core` itself remains pre-1.0, a major version bump once
+`deps-core` reaches 1.0.
+
+If you implement `Ecosystem` outside this workspace, depend on the exact matching
+`tower-lsp-server` version via `deps_core::tower_lsp_server` rather than adding your own
+separate direct dependency on `tower-lsp-server`, to avoid it drifting out of sync with the
+version `deps-core` was built against.
+
 ## Contributing
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md) for setup, style, and testing expectations.

--- a/crates/deps-core/README.md
+++ b/crates/deps-core/README.md
@@ -63,6 +63,21 @@ impl Ecosystem for MyEcosystem {
 }
 ```
 
+## Versioning
+
+`deps-core`'s public trait signatures (`Ecosystem`, `Dependency`, `ParseResult`,
+`EcosystemFormatter`) — and its public `lsp_helpers` / `completion` helper functions —
+are typed directly against `tower_lsp_server::ls_types` types. `tower-lsp-server` is pinned
+pre-1.0, so a `tower-lsp-server` minor bump (e.g. 0.23 → 0.24) is not an implementation
+detail `deps-core` can absorb silently — it forces a breaking release of `deps-core`: a
+minor version bump while `deps-core` itself remains pre-1.0, a major version bump once
+`deps-core` reaches 1.0.
+
+If you implement `Ecosystem` outside this workspace, depend on the exact matching
+`tower-lsp-server` version via `deps_core::tower_lsp_server` rather than adding your own
+separate direct dependency on `tower-lsp-server`, to avoid it drifting out of sync with the
+version `deps-core` was built against.
+
 ## License
 
 [MIT](../../LICENSE)

--- a/crates/deps-core/src/lib.rs
+++ b/crates/deps-core/src/lib.rs
@@ -27,6 +27,21 @@
 //! with no `pub` fields is deliberately left exhaustive instead, since `#[non_exhaustive]`
 //! would be a semantic no-op for it — an external crate can't literal-construct or
 //! destructure it either way.
+//!
+//! ## LSP type stability (issue #832)
+//!
+//! The `Ecosystem`, `Dependency`, `ParseResult`, and `EcosystemFormatter` trait signatures
+//! — and the public `lsp_helpers` / `completion` helper functions — are typed directly
+//! against `tower_lsp_server::ls_types` types (`Hover`, `Diagnostic`, `CodeAction`, and so
+//! on). `tower-lsp-server` is pinned pre-1.0, so a `tower-lsp-server` minor bump (e.g. 0.23
+//! → 0.24) is not an implementation detail this crate can absorb silently — it forces a
+//! breaking release of `deps-core`: a minor version bump while `deps-core` itself remains
+//! pre-1.0, a major version bump once `deps-core` reaches 1.0.
+//!
+//! Downstream consumers implementing [`ecosystem::Ecosystem`] should depend on the exact
+//! matching `tower-lsp-server` version through the [`tower_lsp_server`] re-export rather than
+//! adding their own separate direct dependency, which could otherwise drift out of sync with
+//! the version `deps-core` was built against.
 
 // #673: re-enable the three cast-safety pedantic lints the workspace allows by default
 // (`Cargo.toml`'s `[workspace.lints.clippy]`), specifically for this crate — deps-core
@@ -88,6 +103,12 @@ pub mod secret;
 pub mod test_util;
 pub mod version_matcher;
 pub mod xml_bounds;
+
+/// Re-export of the LSP protocol types that appear in this crate's public trait
+/// signatures. `deps-core`'s version tracks `tower-lsp-server`'s: a
+/// `tower-lsp-server` bump is a breaking change here, by construction. See the
+/// "LSP type stability" section of this module's docs for detail.
+pub use tower_lsp_server;
 
 // Re-export commonly used types
 pub use cache::{BodyLimit, CachedResponse, HttpCache};


### PR DESCRIPTION
## Summary

- Add `pub use tower_lsp_server;` to `deps-core` so downstream `Ecosystem` implementors can depend on the exact matching `tower-lsp-server` version through `deps-core` instead of a separate, potentially drifting direct dependency.
- Document the existing semver coupling: `deps-core`'s public trait signatures (`Ecosystem`, `Dependency`, `ParseResult`, `EcosystemFormatter`) and public `lsp_helpers`/`completion` helper functions are typed against `tower_lsp_server::ls_types`, so a `tower-lsp-server` minor bump forces a breaking `deps-core` release — a minor bump while `deps-core` remains pre-1.0, a major bump once it reaches 1.0.
- Mirrors the versioning note in both the root `README.md` (binary consumers) and `crates/deps-core/README.md` (the crate's actual crates.io/docs.rs page).
- No behavior change: `tower-lsp-server = "0.23"` in root `Cargo.toml` is unchanged. This is Option B from the issue — Option A (gen-lsp-types migration) and Option C (owned-types insulation) are explicitly out of scope, tracked separately.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4977 passed)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`

Resolves #832