### PR TITLE
ci: wire gitleaks into security job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,8 +190,11 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
+        with:
+          fetch-depth: 0
 
       - name: Install cargo-deny
         uses: taiki-e/install-action@5724fe4561a201b0d36bddf13177e3557b43787b  # cargo-deny
@@ -199,24 +202,23 @@ jobs:
       - name: Run cargo-deny
         run: cargo deny check
 
-      - name: Install gitleaks
-        # gitleaks/gitleaks-action requires a paid GITLEAKS_LICENSE for organization-owned
-        # repos (bug-ops is an org, not a personal account) even though this repo is public
-        # — see the action's README "Do I need a free license key?" section. taiki-e/install-
-        # action has no gitleaks manifest either, so the CLI is fetched directly from the
-        # pinned release and checksum-verified instead.
-        run: |
-          curl -sSLO https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz
-          echo "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  gitleaks_8.30.1_linux_x64.tar.gz" | sha256sum -c -
-          tar -xzf gitleaks_8.30.1_linux_x64.tar.gz gitleaks
-          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
-
       - name: Run gitleaks
-        # `dir` scans the checked-out tree rather than git history, since the checkout step
-        # above is a shallow, single-commit clone (no fetch-depth: 0). Picks up
-        # .gitleaks.toml (#803) from the repo root automatically per gitleaks' config
-        # precedence (target-path/.gitleaks.toml), no --config flag needed.
-        run: gitleaks dir . --no-banner --redact
+        # bug-ops is a personal account, not an organization (verified via `gh api
+        # users/bug-ops --jq '{login, type, name}'` -> "type": "User"), so
+        # gitleaks-action's GITLEAKS_LICENSE requirement (free, but org-account-only)
+        # does not apply here — per the action's README, "If you are scanning repos that
+        # belong to a personal account, then no license key is required." Auto-discovers
+        # .gitleaks.toml (#803) from the repo root, same precedence as the bare CLI, so
+        # no extra config flag is needed. Requires `fetch-depth: 0` above: `Scan()` always
+        # runs `git log --no-merges --first-parent <base>^..<head>`, which needs history
+        # beyond the default shallow checkout. `pull-requests: write` above is required
+        # too: `ScanPullRequest()`'s commit-listing call isn't wrapped in try/catch and
+        # 403s without it. GITLEAKS_VERSION pins the scanner explicitly — the action
+        # otherwise defaults to an older hardcoded version.
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e  # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_VERSION: 8.30.1
 
   test:
     name: Test (${{ matrix.os }}${{ matrix.rust != 'stable' && format(' / {0}', matrix.rust) || '' }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,10 @@ jobs:
   security:
     name: Security Audit
     needs: changes
-    if: needs.changes.outputs.rust == 'true' || github.event_name == 'schedule'
+    # gitleaks scans the whole checked-out tree regardless of which paths changed, so a
+    # workflow-only PR (like the one that wired gitleaks in) needs to trigger this job too,
+    # not just rust changes — otherwise the step can merge without ever having run.
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflows == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,25 @@ jobs:
       - name: Run cargo-deny
         run: cargo deny check
 
+      - name: Install gitleaks
+        # gitleaks/gitleaks-action requires a paid GITLEAKS_LICENSE for organization-owned
+        # repos (bug-ops is an org, not a personal account) even though this repo is public
+        # — see the action's README "Do I need a free license key?" section. taiki-e/install-
+        # action has no gitleaks manifest either, so the CLI is fetched directly from the
+        # pinned release and checksum-verified instead.
+        run: |
+          curl -sSLO https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz
+          echo "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  gitleaks_8.30.1_linux_x64.tar.gz" | sha256sum -c -
+          tar -xzf gitleaks_8.30.1_linux_x64.tar.gz gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+
+      - name: Run gitleaks
+        # `dir` scans the checked-out tree rather than git history, since the checkout step
+        # above is a shallow, single-commit clone (no fetch-depth: 0). Picks up
+        # .gitleaks.toml (#803) from the repo root automatically per gitleaks' config
+        # precedence (target-path/.gitleaks.toml), no --config flag needed.
+        run: gitleaks dir . --no-banner --redact
+
   test:
     name: Test (${{ matrix.os }}${{ matrix.rust != 'stable' && format(' / {0}', matrix.rust) || '' }})
     needs: changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: `deps_core::conformance` gained a `package_url` hostile-input-safety check (now generated unconditionally by `formatter_conformance!` for all 14 ecosystem crates) and a `no_lockfile_support`/`format_version` optional macro arm, closing design gaps found while reviewing #781 (resolves #782) (#786)
 - **deps-bundler, deps-cargo, deps-composer, deps-dart, deps-go, deps-maven, deps-npm, deps-nuget, deps-pypi, deps-swift**: migrated onto `registry_conformance!` (now 14/14 crates, was 4/14) and extended `completion_guard_conformance!` to maven/swift (11/14; go/github-actions/gitlab-ci confirmed N/A) (resolves #794) (#805)
 - **deps-gradle**: `fetch_license_from` gained a `tracing::instrument` span (matching sibling ecosystem crates' HTTP boundaries), closing Gradle's remaining observability gap (resolves #823)
-- **workspace**: CI's `security` job now runs `gitleaks` against `.gitleaks.toml` (#803), wiring up previously-dead secret-scanning config (resolves #825)
+- **workspace**: CI's `security` job now runs `gitleaks` against `.gitleaks.toml` (#803), wiring up previously-dead secret-scanning config (resolves #825) (#840)
 
 ### Fixed
 - **deps-lsp, deps-core, deps-deno, deps-dart, deps-swift, deps-maven, deps-cargo**: added tracing spans and error detail to previously silent parse, registry-fetch, and filesystem paths (resolves #836) (#842)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: `deps_core::conformance` gained a `package_url` hostile-input-safety check (now generated unconditionally by `formatter_conformance!` for all 14 ecosystem crates) and a `no_lockfile_support`/`format_version` optional macro arm, closing design gaps found while reviewing #781 (resolves #782) (#786)
 - **deps-bundler, deps-cargo, deps-composer, deps-dart, deps-go, deps-maven, deps-npm, deps-nuget, deps-pypi, deps-swift**: migrated onto `registry_conformance!` (now 14/14 crates, was 4/14) and extended `completion_guard_conformance!` to maven/swift (11/14; go/github-actions/gitlab-ci confirmed N/A) (resolves #794) (#805)
 - **deps-gradle**: `fetch_license_from` gained a `tracing::instrument` span (matching sibling ecosystem crates' HTTP boundaries), closing Gradle's remaining observability gap (resolves #823)
+- **workspace**: CI's `security` job now runs `gitleaks` against `.gitleaks.toml` (#803), wiring up previously-dead secret-scanning config (resolves #825)
 
 ### Fixed
 - **deps-lsp, deps-core, deps-deno, deps-dart, deps-swift, deps-maven, deps-cargo**: added tracing spans and error detail to previously silent parse, registry-fetch, and filesystem paths (resolves #836) (#842)


### PR DESCRIPTION
## Summary

- `.gitleaks.toml` was added by #803 but nothing in `.github/workflows/ci.yml` ever invoked gitleaks against it, leaving it as unreferenced config.
- Adds a `Run gitleaks` step to the existing `security` job, after `cargo deny check`, using the official `gitleaks/gitleaks-action@v3.0.0` (pinned by commit SHA).
- `bug-ops` is a **personal** GitHub account, not an organization (verified: `gh api users/bug-ops --jq '{login, type, name}'` → `"type": "User"`), so `gitleaks-action`'s `GITLEAKS_LICENSE` requirement does not apply — that's free but only required for organization-owned repos per the action's own README.
- The action auto-discovers `.gitleaks.toml` from the repo root, same precedence as the bare CLI.

## Review-driven fixes

Two rounds of review caught real functional gaps beyond the initial wiring:
- **`fetch-depth: 0`** added to the job's `actions/checkout` step — the action's scan mode always runs `gitleaks detect --log-opts="--no-merges --first-parent <base>^..<head>"` for push/pull_request events, which needs commit history beyond the default shallow clone.
- **`pull-requests: write`** added to the job's `permissions:` block — on `pull_request` events the action calls `GET /repos/{owner}/{repo}/pulls/{pull_number}/commits` before scanning, and that call is not wrapped in try/catch in the action's source, so it 403s uncaught without this scope.
- **`GITLEAKS_VERSION: 8.30.1`** pinned explicitly in `env:` — the action otherwise defaults to a hardcoded, older gitleaks version.

Earlier iterations of this PR tried a hand-rolled curl/sha256sum/tar/sudo-install of the CLI binary, then a digest-pinned `docker run` — both were replaced once the personal-account/no-license fact was established, since the official action is simpler and equally supply-chain-safe when pinned by commit SHA.

## Gating fix

The `security` job only triggered on `rust`-path changes, which meant this very PR (workflow-only) would merge without its own new gitleaks step ever running in CI. Widened the job's `if:` to also trigger on `workflows`-path changes (`needs.changes.outputs.workflows == 'true'`), so a workflow-only PR self-validates. This also makes `cargo deny check` run on workflow-only changes as a side effect (same job).

Note this only widens coverage to workflow files — a secret introduced in some other non-Rust, non-workflow file (docs, fixtures, etc.) is still only caught by the weekly scheduled run, not every push/PR. Left as-is since a full redesign of the gate is a separate scope decision.

## Follow-ups for the maintainer (not addressed in this PR)

- Enable `secret_scanning_non_provider_patterns` in repo settings — an org/repo-settings change, not a workflow fix, and complementary to this gitleaks step.
- The action posts PR review comments on findings and writes a job summary by default (`GITLEAKS_ENABLE_COMMENTS`/`GITLEAKS_ENABLE_SUMMARY`, both default `true`) — a behavior change versus a bare-CLI scan, flagged here rather than suppressed since it seems like a reasonable default.

## Test plan

- [x] `fy parse` / `fy lint` on `.github/workflows/ci.yml` — valid, 0 errors, only 3 pre-existing warnings unrelated to this job
- [x] Pinned commit SHA (`e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e`) verified to resolve to both the `v3` and `v3.0.0` tags
- [x] `bug-ops` account type and gitleaks-action's license requirement verified directly against the GitHub API and the action's README
- [x] Both critical fixes (fetch-depth, permissions) verified by reading the action's bundled `dist/index.js` source at the pinned commit, not just inferred from its README
- [x] `security` job's gate widened to `workflows` changes so this PR's own CI run exercises the new gitleaks step directly (was previously `skipping` on this PR before the gating fix)
- [ ] CI run on this PR (`security` job) — confirm the step executes and passes end-to-end

Closes #825
