### PR TITLE
fix(deps-lsp): clamp with_max_concurrent_fetches(0) to prevent buffer_unordered deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **deps-pypi**: `register_named_source`'s doc comment now notes it has no production caller and points to `register_chain` as the live path for named sources, closing the staleness that previously misdirected a security fix (resolves #828)
+- **deps-lsp**: fixed a `max_concurrent_fetches = 0` deadlock that could wedge fetches server-wide by starving the shared `fetch_permits` pool (resolves #833) (#841)
 - **deps-cargo, deps-npm, deps-pypi**: alternate-registry-router tracing sites now log a `RedactedUrl`-wrapped index/key instead of the raw string, closing a query-string-credential leak on a validated `RegistryIndex`/`NpmRegistryIndex`/`PypiIndexUrl` (resolves #824)
 - **deps-go**: the three `compile_glob` malformed-`GOPRIVATE`-pattern warnings now log through `RedactedUrl` instead of `redact_userinfo` alone, closing a query-string-credential leak; `redact_userinfo` now has no production caller outside `deps-core` (resolves #822)
 - **deps-core, deps-maven, deps-nuget**: shared the bracket-interval version-range grammar via `deps_core::interval`, fixing `deps-nuget` silently accepting malformed ranges `deps-maven`/`deps-gradle` already rejected (resolves #821) (#830)

--- a/crates/deps-lsp/src/config.rs
+++ b/crates/deps-lsp/src/config.rs
@@ -472,16 +472,33 @@ impl CacheConfig {
         self
     }
 
-    /// Overrides [`Self::max_concurrent_fetches`]. See [`Self::new`]. Not clamped to the
-    /// `>= 1` floor `deserialize_max_concurrent` enforces on untrusted LSP-client input —
-    /// unlike [`Self::with_fetch_timeout_secs`], this value is also relied on internally as
-    /// a divisor (`handlers::diagnostics::loading_ceiling`) and as `futures::StreamExt::
-    /// buffer_unordered`'s concurrency limit (`document::fetch`), so a `0` constructed
-    /// through this setter depends on `loading_ceiling`'s own defensive `.max(1)`
-    /// re-guard rather than on this setter enforcing the floor itself.
+    /// Overrides [`Self::max_concurrent_fetches`]. See [`Self::new`]. Enforces the same
+    /// `>= 1` floor (`MIN_CONCURRENT_FETCHES`) that `deserialize_max_concurrent` enforces
+    /// on untrusted LSP-client input — but, unlike that deserializer, does not also cap the
+    /// `MAX_CONCURRENT_FETCHES` ceiling, so a very large value passes through uncapped: this
+    /// value is used directly as `futures::StreamExt::buffer_unordered`'s concurrency limit
+    /// (`document::fetch`), and `buffer_unordered(0)` never polls its source stream, hanging
+    /// the fetch forever instead of erroring (issue #833) — unlike
+    /// [`Self::with_fetch_timeout_secs`], `0` here is not a merely degenerate value, so this
+    /// setter enforces the floor itself rather than relying on a downstream re-guard
+    /// (`handlers::diagnostics::loading_ceiling` also re-guards its own divisor, but that is
+    /// a second, independent consumer, not a safety net for this one).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use deps_lsp::config::CacheConfig;
+    ///
+    /// let config = CacheConfig::new().with_max_concurrent_fetches(0);
+    /// assert_eq!(config.max_concurrent_fetches, 1);
+    /// ```
     #[must_use]
     pub const fn with_max_concurrent_fetches(mut self, max_concurrent_fetches: usize) -> Self {
-        self.max_concurrent_fetches = max_concurrent_fetches;
+        self.max_concurrent_fetches = if max_concurrent_fetches == 0 {
+            MIN_CONCURRENT_FETCHES
+        } else {
+            max_concurrent_fetches
+        };
         self
     }
 }
@@ -1606,6 +1623,14 @@ mod tests {
         assert!(config.enabled);
         assert_eq!(config.fetch_timeout_secs, 5);
         assert_eq!(config.max_concurrent_fetches, 20);
+    }
+
+    #[test]
+    fn test_cache_config_with_max_concurrent_fetches_clamps_zero_to_one() {
+        // Regression test for issue #833: `buffer_unordered(0)` never completes, so
+        // this setter must not let a `0` reach `document::fetch`.
+        let config = CacheConfig::new().with_max_concurrent_fetches(0);
+        assert_eq!(config.max_concurrent_fetches, MIN_CONCURRENT_FETCHES);
     }
 
     #[test]

--- a/crates/deps-lsp/src/document/fetch.rs
+++ b/crates/deps-lsp/src/document/fetch.rs
@@ -211,7 +211,8 @@ pub(crate) struct FetchResult {
 ///   yank status
 /// * `progress` - Optional progress tracker (will be updated after each fetch)
 /// * `timeout_secs` - Timeout for each individual package fetch (default: 10s)
-/// * `max_concurrent` - Maximum concurrent fetches (default: 20)
+/// * `max_concurrent` - Maximum concurrent fetches (default: 20); clamped to `>= 1`
+///   internally, since `buffer_unordered(0)` would hang forever (issue #833)
 ///
 /// # Timeout Behavior
 ///
@@ -295,7 +296,13 @@ pub(crate) async fn fetch_latest_versions_parallel(
                 .await
             }
         })
-        .buffer_unordered(max_concurrent)
+        // `.max(1)`: `CacheConfig.max_concurrent_fetches` is a `pub` field, so an in-crate
+        // direct field assignment (see the test setup at `server.rs:1680`) bypasses
+        // `with_max_concurrent_fetches`'s own clamp; this is defence-in-depth against a
+        // future in-crate caller doing the same with `0`. `buffer_unordered(0)` never
+        // polls its source stream — it returns `Pending` forever instead of erroring,
+        // hanging every fetch through this document indefinitely (issue #833).
+        .buffer_unordered(max_concurrent.max(1))
         .collect()
         .await;
 
@@ -1446,6 +1453,77 @@ mod tests {
             max <= 22,
             "Concurrency limit violated: {} concurrent requests (limit: 20)",
             max
+        );
+    }
+
+    /// Regression test for issue #833: `buffer_unordered(0)` never polls its source
+    /// stream and returns `Pending` forever, so a `max_concurrent` of `0` reaching this
+    /// call previously hung the fetch indefinitely instead of completing or erroring.
+    /// Wrapped in a short outer timeout so a regression fails fast instead of hanging
+    /// the test suite.
+    #[tokio::test]
+    async fn test_fetch_latest_versions_parallel_zero_max_concurrent_still_completes() {
+        use deps_core::{Metadata, Registry, Version};
+        use std::any::Any;
+
+        struct InstantRegistry;
+
+        impl Registry for InstantRegistry {
+            fn get_versions<'a>(
+                &'a self,
+                _name: &'a deps_core::PackageName,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Version>>>>
+            {
+                Box::pin(async move { Ok(vec![]) })
+            }
+
+            fn get_latest_matching<'a>(
+                &'a self,
+                _name: &'a deps_core::PackageName,
+                _req: &'a deps_core::VersionReq,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Option<Box<dyn Version>>>>
+            {
+                Box::pin(async move { Ok(None) })
+            }
+
+            fn search<'a>(
+                &'a self,
+                _query: &'a str,
+                _limit: usize,
+            ) -> deps_core::ecosystem::BoxFuture<'a, deps_core::Result<Vec<Box<dyn Metadata>>>>
+            {
+                Box::pin(async move { Ok(vec![]) })
+            }
+
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        let registry: Arc<dyn Registry> = Arc::new(InstantRegistry);
+        let packages = vec![PackageName::new("some-package")];
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            fetch_latest_versions_parallel(
+                registry,
+                with_registry_source(packages),
+                &HashMap::new(),
+                None,
+                deps_core::freshness::FreshnessSettings::default(),
+                5,
+                0,
+                None,
+            ),
+        )
+        .await
+        .expect("fetch with max_concurrent=0 must not hang forever");
+
+        assert!(
+            result
+                .no_comparable_versions
+                .contains(&PackageName::new("some-package")),
+            "fetch must still run to completion when max_concurrent is 0"
         );
     }
 


### PR DESCRIPTION
## Summary
- `DepsConfig::with_max_concurrent_fetches(0)` reached `futures::StreamExt::buffer_unordered` unclamped on the document-fetch path; `buffer_unordered(0)` never polls its source stream and returns `Pending` forever, hanging the fetch indefinitely and starving the shared `fetch_permits` pool server-wide.
- The setter's own doc comment claimed safety via `loading_ceiling`'s `.max(1)` re-guard, but that only covered one of two consumers — `document/lifecycle.rs` bypassed it entirely.
- The setter now clamps to the existing `MIN_CONCURRENT_FETCHES` floor (matching `deserialize_max_concurrent`'s floor for untrusted LSP-client input), and the `buffer_unordered` call site itself carries a defensive `.max(1)` against any in-crate direct field assignment bypassing the setter.
- Doc comments rewritten to accurately state what is and isn't enforced (the ceiling `MAX_CONCURRENT_FETCHES` is intentionally out of scope for this fix).

## Test plan
- [x] Added regression test `test_cache_config_with_max_concurrent_fetches_clamps_zero_to_one` (config.rs)
- [x] Added regression test `test_fetch_latest_versions_parallel_zero_max_concurrent_still_completes` (fetch.rs), wrapped in a 5s timeout so a regression fails fast instead of hanging the suite
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4979 passed)
- [x] Strict rustdoc gate: `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- [x] `cargo test --doc --workspace` (39 passed)

Closes #833