### PR TITLE
fix(deps-lsp,deps-core,deps-cargo,deps-deno,deps-dart,deps-swift,deps-maven): instrument silent parse, registry-fetch, and filesystem paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-gradle**: `fetch_license_from` gained a `tracing::instrument` span (matching sibling ecosystem crates' HTTP boundaries), closing Gradle's remaining observability gap (resolves #823)
 
 ### Fixed
+- **deps-lsp, deps-core, deps-deno, deps-dart, deps-swift, deps-maven, deps-cargo**: added tracing spans and error detail to previously silent parse, registry-fetch, and filesystem paths (resolves #836) (PR TBD)
 - **deps-pypi**: `register_named_source`'s doc comment now notes it has no production caller and points to `register_chain` as the live path for named sources, closing the staleness that previously misdirected a security fix (resolves #828)
 - **deps-lsp**: fixed a `max_concurrent_fetches = 0` deadlock that could wedge fetches server-wide by starving the shared `fetch_permits` pool (resolves #833) (#841)
 - **deps-cargo, deps-npm, deps-pypi**: alternate-registry-router tracing sites now log a `RedactedUrl`-wrapped index/key instead of the raw string, closing a query-string-credential leak on a validated `RegistryIndex`/`NpmRegistryIndex`/`PypiIndexUrl` (resolves #824)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-gradle**: `fetch_license_from` gained a `tracing::instrument` span (matching sibling ecosystem crates' HTTP boundaries), closing Gradle's remaining observability gap (resolves #823)
 
 ### Fixed
-- **deps-lsp, deps-core, deps-deno, deps-dart, deps-swift, deps-maven, deps-cargo**: added tracing spans and error detail to previously silent parse, registry-fetch, and filesystem paths (resolves #836) (PR TBD)
+- **deps-lsp, deps-core, deps-deno, deps-dart, deps-swift, deps-maven, deps-cargo**: added tracing spans and error detail to previously silent parse, registry-fetch, and filesystem paths (resolves #836) (#842)
 - **deps-pypi**: `register_named_source`'s doc comment now notes it has no production caller and points to `register_chain` as the live path for named sources, closing the staleness that previously misdirected a security fix (resolves #828)
 - **deps-lsp**: fixed a `max_concurrent_fetches = 0` deadlock that could wedge fetches server-wide by starving the shared `fetch_permits` pool (resolves #833) (#841)
 - **deps-cargo, deps-npm, deps-pypi**: alternate-registry-router tracing sites now log a `RedactedUrl`-wrapped index/key instead of the raw string, closing a query-string-credential leak on a validated `RegistryIndex`/`NpmRegistryIndex`/`PypiIndexUrl` (resolves #824)

--- a/crates/deps-cargo/src/parser.rs
+++ b/crates/deps-cargo/src/parser.rs
@@ -741,13 +741,25 @@ fn discover_workspace(doc_uri: &Uri) -> Result<WorkspaceDiscovery> {
                                     path = %workspace_toml.display(),
                                     "skipping ancestor Cargo.toml during workspace root discovery: nesting depth exceeds maximum"
                                 );
-                            } else if let Ok(doc) = toml_span::parse(&content)
-                                && doc
-                                    .as_table()
-                                    .and_then(|t| get_val(t, "workspace"))
-                                    .is_some()
-                            {
-                                workspace_root = Some(dir.to_path_buf());
+                            } else {
+                                match toml_span::parse(&content) {
+                                    Ok(doc) => {
+                                        if doc
+                                            .as_table()
+                                            .and_then(|t| get_val(t, "workspace"))
+                                            .is_some()
+                                        {
+                                            workspace_root = Some(dir.to_path_buf());
+                                        }
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            path = %workspace_toml.display(),
+                                            error = %e,
+                                            "skipping ancestor Cargo.toml during workspace root discovery: TOML parse failed"
+                                        );
+                                    }
+                                }
                             }
                         }
                         Ok(None) => {
@@ -761,7 +773,13 @@ fn discover_workspace(doc_uri: &Uri) -> Result<WorkspaceDiscovery> {
                                 "skipping ancestor Cargo.toml during workspace root discovery: exceeds size cap on read"
                             );
                         }
-                        Err(_) => {}
+                        Err(e) => {
+                            tracing::warn!(
+                                path = %workspace_toml.display(),
+                                error = %e,
+                                "skipping ancestor Cargo.toml during workspace root discovery: read failed"
+                            );
+                        }
                     }
                 }
             }
@@ -1996,6 +2014,52 @@ tokio = "1.0"
             stats_after - stats_before,
             2 * MAX_CONFIG_ANCESTOR_DEPTH,
             "expected exactly two stats per ancestor for all MAX_CONFIG_ANCESTOR_DEPTH levels"
+        );
+    }
+
+    /// #836 item 4: a genuine I/O error reading an ancestor `Cargo.toml` (as opposed to the
+    /// size-cap/nesting-depth rejections, which already warned) must not be silently dropped.
+    #[cfg(unix)]
+    #[test]
+    fn test_discover_workspace_logs_warn_on_unreadable_ancestor_cargo_toml() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = deps_core::fs_probe::snapshot_guard();
+
+        let root = tempfile::tempdir().unwrap();
+        let project_dir = root.path().join("proj");
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let opened_content = "[dependencies]\nserde = \"1.0\"\n";
+        let opened_path = project_dir.join("Cargo.toml");
+        std::fs::write(&opened_path, opened_content).unwrap();
+        let doc_uri = Uri::from_file_path(&opened_path).unwrap();
+
+        let unreadable_manifest = root.path().join("Cargo.toml");
+        std::fs::write(&unreadable_manifest, "[workspace]\nmembers = [\"proj\"]\n").unwrap();
+        let mut perms = std::fs::metadata(&unreadable_manifest)
+            .unwrap()
+            .permissions();
+        perms.set_mode(0o000);
+        std::fs::set_permissions(&unreadable_manifest, perms.clone()).unwrap();
+
+        let output = deps_core::test_util::capture_tracing_output(|| {
+            discover_workspace(&doc_uri).unwrap();
+        });
+
+        // Restore permissions so the tempdir can clean itself up.
+        perms.set_mode(0o644);
+        let _ = std::fs::set_permissions(&unreadable_manifest, perms);
+
+        assert!(
+            output.contains(
+                "skipping ancestor Cargo.toml during workspace root discovery: read failed"
+            ),
+            "expected a warn log for the unreadable ancestor Cargo.toml, got: {output:?}"
+        );
+        assert!(
+            output.contains(&unreadable_manifest.display().to_string()),
+            "expected the warn log to include the unreadable ancestor's path, got: {output:?}"
         );
     }
 }

--- a/crates/deps-cargo/src/registry.rs
+++ b/crates/deps-cargo/src/registry.rs
@@ -101,6 +101,7 @@ impl CratesIoRegistry {
     /// assert!(!versions.is_empty());
     /// # }
     /// ```
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_versions(&self, name: &str) -> Result<Vec<CargoVersion>> {
         self.sparse.get_versions(name).await
     }
@@ -507,6 +508,7 @@ impl CargoRegistry {
         self.alternates.get(index).map(|entry| Arc::clone(&entry))
     }
 
+    #[tracing::instrument(skip_all, fields(package = ?name, index = tracing::field::Empty), level = "debug")]
     async fn get_versions_for_source(
         &self,
         name: &PackageName,
@@ -517,23 +519,27 @@ impl CargoRegistry {
             DependencySource::AlternateRegistry {
                 index,
                 mirrors_crates_io,
-            } => match self.alternate_client(index) {
-                Some(client) => client.get_versions(name.as_str()).await,
-                // M2 (plan-1b §6): an unregistered *verified crates.io mirror* degrades to
-                // crates.io rather than blanking the whole manifest — correct for a mirror
-                // (Cargo verifies per-version checksum equality against crates.io for it),
-                // wrong for a genuinely private/unregistered registry, which must keep
-                // failing `PackageNotFound` below.
-                None if *mirrors_crates_io => {
-                    self.crates_io
-                        .get_versions_with(name.as_str(), freshness)
-                        .await
+            } => {
+                tracing::Span::current()
+                    .record("index", tracing::field::display(RedactedUrl::new(index)));
+                match self.alternate_client(index) {
+                    Some(client) => client.get_versions(name.as_str()).await,
+                    // M2 (plan-1b §6): an unregistered *verified crates.io mirror* degrades to
+                    // crates.io rather than blanking the whole manifest — correct for a mirror
+                    // (Cargo verifies per-version checksum equality against crates.io for it),
+                    // wrong for a genuinely private/unregistered registry, which must keep
+                    // failing `PackageNotFound` below.
+                    None if *mirrors_crates_io => {
+                        self.crates_io
+                            .get_versions_with(name.as_str(), freshness)
+                            .await
+                    }
+                    None => Err(DepsError::PackageNotFound {
+                        package: name.to_string(),
+                        registry: "alternate registry (not registered)",
+                    }),
                 }
-                None => Err(DepsError::PackageNotFound {
-                    package: name.to_string(),
-                    registry: "alternate registry (not registered)",
-                }),
-            },
+            }
             _ => {
                 self.crates_io
                     .get_versions_with(name.as_str(), freshness)
@@ -542,6 +548,7 @@ impl CargoRegistry {
         }
     }
 
+    #[tracing::instrument(skip_all, fields(package = ?name, version = ?req, index = tracing::field::Empty), level = "debug")]
     async fn get_latest_matching_for_source(
         &self,
         name: &PackageName,
@@ -552,25 +559,29 @@ impl CargoRegistry {
             DependencySource::AlternateRegistry {
                 index,
                 mirrors_crates_io,
-            } => match self.alternate_client(index) {
-                Some(client) => {
-                    client
-                        .get_latest_matching(name.as_str(), req.as_str())
-                        .await
+            } => {
+                tracing::Span::current()
+                    .record("index", tracing::field::display(RedactedUrl::new(index)));
+                match self.alternate_client(index) {
+                    Some(client) => {
+                        client
+                            .get_latest_matching(name.as_str(), req.as_str())
+                            .await
+                    }
+                    // M2 (plan-1b §6, N4): the hover-fallback/background-fetch-mirror dispatch
+                    // site needs the identical arm — this exact enumeration has been wrong twice
+                    // during design review, so both sites are asserted independently in tests.
+                    None if *mirrors_crates_io => {
+                        self.crates_io
+                            .get_latest_matching(name.as_str(), req.as_str())
+                            .await
+                    }
+                    None => Err(DepsError::PackageNotFound {
+                        package: name.to_string(),
+                        registry: "alternate registry (not registered)",
+                    }),
                 }
-                // M2 (plan-1b §6, N4): the hover-fallback/background-fetch-mirror dispatch
-                // site needs the identical arm — this exact enumeration has been wrong twice
-                // during design review, so both sites are asserted independently in tests.
-                None if *mirrors_crates_io => {
-                    self.crates_io
-                        .get_latest_matching(name.as_str(), req.as_str())
-                        .await
-                }
-                None => Err(DepsError::PackageNotFound {
-                    package: name.to_string(),
-                    registry: "alternate registry (not registered)",
-                }),
-            },
+            }
             _ => {
                 self.crates_io
                     .get_latest_matching(name.as_str(), req.as_str())

--- a/crates/deps-core/src/lockfile.rs
+++ b/crates/deps-core/src/lockfile.rs
@@ -64,6 +64,7 @@ pub const MAX_LOCKFILE_BYTES: u64 = 32 * 1024 * 1024;
 /// # Ok(())
 /// # }
 /// ```
+#[tracing::instrument(skip_all, fields(path = %path.display(), file_type = %file_type), level = "debug")]
 pub async fn read_lockfile_content(path: &Path, file_type: &str) -> Result<String> {
     let to_parse_error = |e: std::io::Error| DepsError::ParseError {
         file_type: format!("{file_type} at {}", path.display()),
@@ -155,6 +156,7 @@ pub async fn read_lockfile_content(path: &Path, file_type: &str) -> Result<Strin
 /// # Ok(())
 /// # }
 /// ```
+#[tracing::instrument(skip_all, fields(path = %path.display(), file_type = %file_type), level = "debug")]
 pub async fn read_and_parse_lockfile<T, F>(path: &Path, file_type: &str, parse: F) -> Result<T>
 where
     F: FnOnce(String) -> Result<T> + Send + 'static,

--- a/crates/deps-core/src/mtime_cache.rs
+++ b/crates/deps-core/src/mtime_cache.rs
@@ -157,6 +157,7 @@ impl<T> MtimeFileCache<T> {
     /// let second = cache.get_or_parse(&path, str::to_owned).unwrap();
     /// assert!(Arc::ptr_eq(&first, &second), "an unchanged file is served from cache");
     /// ```
+    #[tracing::instrument(skip_all, fields(path = %path.display(), label = self.label), level = "debug")]
     pub fn get_or_parse(&self, path: &Path, parse: impl FnOnce(&str) -> T) -> Option<Arc<T>> {
         let metadata = fs_probe::metadata(path).ok()?;
         if !metadata.is_file() {

--- a/crates/deps-dart/src/registry.rs
+++ b/crates/deps-dart/src/registry.rs
@@ -171,6 +171,7 @@ impl PubDevRegistry {
     /// Returns an empty `Vec` (never an error) when the fetch fails or no `license:`
     /// tag is present — graceful degradation (NFR-003), since this is a best-effort
     /// secondary signal, not core version data.
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_license(&self, name: &str) -> Vec<String> {
         if reject_dot_segment(name).is_err() {
             return Vec::new();

--- a/crates/deps-deno/src/registry.rs
+++ b/crates/deps-deno/src/registry.rs
@@ -271,6 +271,7 @@ impl JsrRegistry {
     /// `license` field, or a dot-prefixed `scope`/`name`/`version` segment — graceful
     /// degradation (NFR-003), since this is a best-effort secondary signal, not core
     /// version data.
+    #[tracing::instrument(skip_all, fields(scope = ?scope, package = ?name, version = ?version), level = "debug")]
     pub async fn get_license(&self, scope: &str, name: &str, version: &str) -> Vec<String> {
         if is_dot_prefixed(scope) || is_dot_prefixed(name) || is_dot_prefixed(version) {
             return Vec::new();
@@ -347,6 +348,7 @@ impl JsrRegistry {
     /// Issues the raw `api.jsr.io/packages?query=` request with no scope-aware
     /// post-processing. Used directly for an unscoped query, and as the underlying fetch
     /// for [`Self::search`]'s scope-qualified path.
+    #[tracing::instrument(skip_all, fields(query = ?query), level = "debug")]
     async fn fetch_search(&self, query: &str, limit: usize) -> Result<Vec<JsrPackage>> {
         let url = format!(
             "{}/packages?query={}&limit={}",
@@ -466,6 +468,7 @@ impl DenoRegistry {
     /// already does — out of scope for this pre-fetch (deferred as a follow-up, see
     /// spec 010's tier-3 rollout notes). An `npm:` specifier degrades gracefully to an
     /// empty `Vec` (NFR-003), same as any other missing-source case.
+    #[tracing::instrument(skip_all, fields(package = ?name, version = ?version), level = "debug")]
     pub async fn get_license(&self, name: &PackageName, version: &str) -> Vec<String> {
         match split_scheme(name.as_str()) {
             Some((Scheme::Jsr, rest)) => match split_scoped(rest) {

--- a/crates/deps-lsp/src/document/lifecycle.rs
+++ b/crates/deps-lsp/src/document/lifecycle.rs
@@ -108,13 +108,18 @@ pub async fn handle_document_open(
     // Try to parse manifest (may fail for incomplete syntax)
     let parse_result = deps_core::ecosystem::parse_manifest_blocking(&ecosystem, &content, &uri)
         .await
+        .inspect_err(|e| {
+            tracing::debug!(
+                error = %e,
+                "Failed to parse manifest, storing document without parse result"
+            );
+        })
         .ok();
 
     // Create document state (parse_result may be None)
     let mut doc_state = if let Some(pr) = parse_result {
         DocumentState::new_from_parse_result(ecosystem.ecosystem_id(), content, pr)
     } else {
-        tracing::debug!("Failed to parse manifest, storing document without parse result");
         DocumentState::new_without_parse_result(ecosystem.ecosystem_id(), content)
     };
     doc_state.set_version(version);
@@ -508,6 +513,12 @@ async fn parse_and_diff_manifest(
     // Try to parse manifest (may fail for incomplete syntax)
     let parse_result = deps_core::ecosystem::parse_manifest_blocking(ecosystem, content, uri)
         .await
+        .inspect_err(|e| {
+            tracing::debug!(
+                error = %e,
+                "Failed to parse manifest, storing document without parse result"
+            );
+        })
         .ok();
 
     // Extract new dependency name -> version_requirement map for diff
@@ -587,7 +598,6 @@ fn commit_parsed_document(
     let mut doc_state = if let Some(pr) = parse_result {
         DocumentState::new_from_parse_result(ecosystem.ecosystem_id(), content, pr)
     } else {
-        tracing::debug!("Failed to parse manifest, storing document without parse result");
         DocumentState::new_without_parse_result(ecosystem.ecosystem_id(), content)
     };
     doc_state.set_version(version);

--- a/crates/deps-lsp/src/document/loader.rs
+++ b/crates/deps-lsp/src/document/loader.rs
@@ -80,6 +80,7 @@ const LARGE_FILE_THRESHOLD: u64 = 1_000_000; // 1MB
 /// # Ok(())
 /// # }
 /// ```
+#[tracing::instrument(skip_all, fields(uri = ?uri), level = "debug")]
 pub async fn load_document_from_disk(uri: &Uri) -> Result<String> {
     // Convert URI to filesystem path. Owned (not `Cow::Borrowed`), since the read below runs
     // in `spawn_blocking` and needs a `'static` path.

--- a/crates/deps-maven/src/registry.rs
+++ b/crates/deps-maven/src/registry.rs
@@ -289,6 +289,7 @@ impl MavenCentralRegistry {
     /// whichever repository base (Maven Central, Google Maven, or the Gradle Plugin
     /// Portal fallback) actually served it — `metadata_urls`' bases differ per group, so
     /// the winning base can only be known after the fetch succeeds, not guessed upfront.
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     async fn get_metadata(
         &self,
         name: &str,
@@ -333,6 +334,7 @@ impl MavenCentralRegistry {
     /// Never fails the caller: any fetch error, timeout, or unparseable body degrades to
     /// an empty map, logged at `debug`, so a listing outage never affects the version list
     /// itself — only whether ages are shown alongside it.
+    #[tracing::instrument(skip_all, fields(url = %RedactedUrl::new(base)), level = "debug")]
     async fn fetch_publish_times(&self, base: &str) -> HashMap<String, PublishTime> {
         match self.cache.get_cached(base).await {
             Ok(data) => parse_publish_times(&data),
@@ -384,6 +386,7 @@ impl MavenCentralRegistry {
     /// # Errors
     ///
     /// Same as [`Self::get_versions_typed_with`].
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_versions_typed(&self, name: &str) -> Result<Vec<MavenVersion>> {
         self.get_versions_typed_with(name, false).await
     }

--- a/crates/deps-swift/src/registry.rs
+++ b/crates/deps-swift/src/registry.rs
@@ -99,6 +99,7 @@ impl SwiftRegistry {
     ///
     /// Thin wrapper around the shared [`ReleaseDatesCache::fetch`] — see its docs for
     /// the best-effort/memoization contract.
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     async fn release_dates(&self, name: &str) -> Arc<HashMap<String, PublishTime>> {
         self.release_dates.fetch(&self.github, name, "Swift").await
     }
@@ -112,6 +113,7 @@ impl SwiftRegistry {
     /// `license` field, or GitHub's `"NOASSERTION"` sentinel (a detected-but-
     /// unclassified `LICENSE` file, not a real SPDX identifier) — graceful degradation
     /// (NFR-003), since this is a best-effort secondary signal, not core version data.
+    #[tracing::instrument(skip_all, fields(package = ?name), level = "debug")]
     pub async fn get_license(&self, name: &str) -> Vec<String> {
         if validate_owner_repo(name).is_err() {
             return Vec::new();


### PR DESCRIPTION
## Summary

Fixes issue #836 (items 1-4; item 5 and issue #823 are explicitly out of scope):

- **Parse errors at manifest entry points**: both sites in `crates/deps-lsp/src/document/lifecycle.rs` that discarded a `DepsError` via `.ok()` now log it with `.inspect_err(...)` before discarding, so "why is my manifest not being analyzed?" is answerable from the log at debug level. Removed a now-duplicative bare debug log in `commit_parsed_document`.
- **Side-channel registry fetches**: added `#[tracing::instrument]` to license/publish-time fetch functions in `deps-deno`, `deps-dart`, `deps-swift`, `deps-maven`, `deps-cargo` registries, matching the existing instrumentation style of each file's already-instrumented version-listing siblings. `deps-cargo`'s per-source spans record the registry `index` as a `RedactedUrl` (never the raw value, which can carry userinfo credentials for an alternate registry).
- **Filesystem boundaries**: added `#[tracing::instrument]` to `deps-lsp`'s `load_document_from_disk`, `deps-core`'s `read_lockfile_content`/`read_and_parse_lockfile`, and `deps-core`'s mtime-cache lookup, so cold-start latency can be attributed between disk and network.
- **Inconsistent error arm**: `deps-cargo`'s ancestor-`Cargo.toml` workspace-root discovery now logs both a genuine I/O error and a TOML-parse failure via `tracing::warn!` with the path, consistent with the sibling size-cap/nesting-depth arms in the same match (the parse-failure arm was an adjacent gap found during review, same pattern as the named `Err(_) => {}` site).

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4985 passed, 60 skipped, 0 failed)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- [x] Added a regression test (`crates/deps-cargo/src/parser.rs`) covering the fixed I/O-error log path, using existing `capture_tracing_output` test infra
- [x] `CHANGELOG.md` updated under `[Unreleased]`

Closes #836