### PR TITLE
fix(ci): cache cross-rs custom Docker image for musl cross-check legs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,36 @@ jobs:
         if: matrix.use_cross_tool
         uses: taiki-e/install-action@a82845735191974ac374fc0472388c6df0a158ca  # cross
 
+      # `cross`'s `pre-build` steps for the musl targets (Cross.toml) run `apt-get
+      # update && apt-get install cmake` inside a fresh Docker image build on every
+      # run — needed because aws-lc-sys (pulled in transitively via reqwest's
+      # rustls/aws-lc-rs backend) requires cmake to cross-compile, which the stock
+      # cross-rs musl images don't ship. That `apt-get update` hits Ubuntu 18.04's
+      # archive mirror, observed taking 6-7+ minutes on its own (a single `Fetched
+      # 48.5 MB in 6min 42s (121 kB/s)` run) and accounts for most of this job's
+      # wall time — see #815 for the mirror-flakiness background.
+      #
+      # `cross` tags the image it builds with a content hash of the Dockerfile/
+      # pre-build commands and skips rebuilding whenever an image with that exact
+      # tag already exists locally, so restoring a previously built image via
+      # `docker load` before invoking `cross build` lets it skip the apt-get step
+      # entirely on a cache hit. `docker save`/`load` preserves the tag, so we
+      # don't need to know cross's hash ourselves.
+      - name: Cache cross custom Docker image
+        if: matrix.use_cross_tool
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        id: cross-image-cache
+        with:
+          path: /tmp/cross-image-cache
+          key: cross-image-${{ matrix.target }}-${{ hashFiles('Cross.toml') }}-v1
+
+      - name: Load cached cross custom Docker image
+        if: matrix.use_cross_tool && steps.cross-image-cache.outputs.cache-hit == 'true'
+        run: |
+          if [ -f "/tmp/cross-image-cache/${{ matrix.target }}.tar" ]; then
+            docker load -i "/tmp/cross-image-cache/${{ matrix.target }}.tar"
+          fi
+
       - name: Build for cross-compile target
         if: ${{ !matrix.use_cross_tool }}
         run: cargo build --workspace --target ${{ matrix.target }}
@@ -305,6 +335,21 @@ jobs:
       - name: Build for cross-compile target (musl via cross)
         if: matrix.use_cross_tool
         run: cross build --workspace --target ${{ matrix.target }}
+
+      # Populates the cache path for the `actions/cache` step above to pick up and
+      # upload at job end (its automatic post-step). Skipped on a cache hit (no new
+      # image was built, nothing changed to save) and on i686, which has no
+      # `pre-build` entry in Cross.toml and so builds no custom image at all — the
+      # glob simply matches nothing there. `always()` so a cargo-level build failure
+      # (unrelated to the image) doesn't discard the already-paid-for apt-get work.
+      - name: Save cross custom Docker image to cache
+        if: always() && matrix.use_cross_tool && steps.cross-image-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p /tmp/cross-image-cache
+          images=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep '^cross-custom-' || true)
+          if [ -n "$images" ]; then
+            docker save $images -o "/tmp/cross-image-cache/${{ matrix.target }}.tar"
+          fi
 
       - name: Run tests for cross-compile target (exercises pointer-width guards)
         # Plain `cargo test` via `cross`, not `cargo nextest`: the default cross-rs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking (pre-1.0, public API)**: **workspace**: extends the `#[non_exhaustive]` API-stability pass to `deps-core`'s remaining public LSP/registry/version DTOs and every ecosystem crate's registry response types, growth-prone enums, and `*ParseContext` types, reworking several multi-arg `Foo::new` constructors into required-fields-only constructors with `with_*` setters along the way (resolves #769) (#777)
 - **Breaking (pre-1.0, public API)**: **deps-lsp**: extends the `#[non_exhaustive]` API-stability pass to `deps-lsp`'s own public config DTOs (`DepsConfig` and its 11 section structs), `WorkspaceRegistriesSetting`, and `EcosystemRuntime`, adding `new()`/`with_*` builders to the six config structs with prior external struct-literal construction (resolves #778) (#780)
 
+- **CI**: `cross-check`'s musl legs cache the custom `cross` Docker image (`docker save`/`load` via `actions/cache`) that installs `cmake` for `aws-lc-sys`, avoiding a multi-minute `apt-get update` against a slow mirror on every run
 - **CI**: `cross-check` matrix gained an `i686-unknown-linux-musl` leg that builds and runs the test suite so `#[cfg(target_pointer_width = "32")]` code gets real coverage on a 32-bit target (resolves #790) (#803)
 - **workspace**: added `.gitleaks.toml` allowlisting `actions/cache` cache-key lines in `.github/workflows/*.yml` that `gitleaks`'s `generic-api-key` rule otherwise false-positives on (resolves #797) (#803)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking (pre-1.0, public API)**: **workspace**: extends the `#[non_exhaustive]` API-stability pass to `deps-core`'s remaining public LSP/registry/version DTOs and every ecosystem crate's registry response types, growth-prone enums, and `*ParseContext` types, reworking several multi-arg `Foo::new` constructors into required-fields-only constructors with `with_*` setters along the way (resolves #769) (#777)
 - **Breaking (pre-1.0, public API)**: **deps-lsp**: extends the `#[non_exhaustive]` API-stability pass to `deps-lsp`'s own public config DTOs (`DepsConfig` and its 11 section structs), `WorkspaceRegistriesSetting`, and `EcosystemRuntime`, adding `new()`/`with_*` builders to the six config structs with prior external struct-literal construction (resolves #778) (#780)
 
-- **CI**: `cross-check`'s musl legs cache the custom `cross` Docker image (`docker save`/`load` via `actions/cache`) that installs `cmake` for `aws-lc-sys`, avoiding a multi-minute `apt-get update` against a slow mirror on every run
+- **CI**: `cross-check`'s musl legs cache the custom `cross` Docker image (`docker save`/`load` via `actions/cache`) that installs `cmake` for `aws-lc-sys`, avoiding a multi-minute `apt-get update` against a slow mirror on every run (#844)
 - **CI**: `cross-check` matrix gained an `i686-unknown-linux-musl` leg that builds and runs the test suite so `#[cfg(target_pointer_width = "32")]` code gets real coverage on a 32-bit target (resolves #790) (#803)
 - **workspace**: added `.gitleaks.toml` allowlisting `actions/cache` cache-key lines in `.github/workflows/*.yml` that `gitleaks`'s `generic-api-key` rule otherwise false-positives on (resolves #797) (#803)
 


### PR DESCRIPTION
## Summary
- The `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` cross-check legs (`.github/workflows/ci.yml`, job `cross-check`) run a `cross` pre-build step (`Cross.toml`) that installs `cmake` via `apt-get`, required because `aws-lc-sys` (pulled in transitively by `reqwest`'s rustls/aws-lc-rs backend) needs it to cross-compile and the stock `cross-rs` musl images don't ship it.
- That `apt-get update`, against Ubuntu 18.04's archive mirror inside the container, was measured taking 6-7+ minutes on its own in a recent `aarch64-unknown-linux-musl` run (`Fetched 48.5 MB in 6min 42s (121 kB/s)`, step total 435.7s) - it dominates the job's wall time and repeats on every single CI run since `cross`'s custom image is rebuilt from scratch each time, with no Docker layer caching in place.
- `cross` tags the custom image it builds with a content hash of the Dockerfile/pre-build commands, and skips rebuilding entirely when an image with that exact tag is already present in the local Docker daemon. This PR persists that built image across CI runs with `actions/cache` (`docker save`/`docker load`, which preserves the tag), so a cache hit lets `cross` skip the `apt-get` step altogether and go straight to compiling.
- The existing Rust-level cache (`moonrepo/setup-rust`'s `cache-target`) was already working correctly and is untouched - the actual `cargo`/`cross` compile step itself only took ~1m30s in the runs inspected; the missing piece was purely the Docker image layer.

## Root cause
Not `cross` using QEMU emulation (target binaries for `aarch64`/`x86_64`-musl compile natively via the cross-toolchain, no QEMU involved) and not a missing Rust dependency cache - it was a slow package-mirror fetch inside an uncached Docker image build, re-executed on every run.

## Expected impact
Removes the multi-minute `apt-get update`/`install cmake` cost on a cache hit for both musl legs (the two legs that define a `pre-build` in `Cross.toml`; `i686-unknown-linux-musl` has none and is unaffected). First run after this merges still pays the full cost once to populate the cache; every run after that should skip straight to the `cross build` compile step.

## Tradeoffs
- Adds a Docker image tarball (a few hundred MB) to the repo's GitHub Actions cache; well within the 10 GB per-repo cache budget.
- Cache key is `cross-image-<target>-<hash of Cross.toml>-v1`. It does not track the pinned `cross` tool version, so if `cross`'s internal image-tagging scheme changes between tool versions, the cache simply misses (self-healing, not a failure) until the key is bumped.

## Test plan
- [x] `fy parse .github/workflows/ci.yml` - valid YAML
- [x] `cargo check --workspace --all-features` - unaffected by a CI-only change, included as a sanity check
- [ ] Confirm in the PR's own `cross-check (aarch64-unknown-linux-musl)` / `cross-check (x86_64-unknown-linux-musl)` runs that the first run still builds the image (cache miss) and a subsequent push shows a much shorter job (cache hit)