### PR TITLE
fix(fuzz): strip sentinel collisions from redact_userinfo's fuzzed tail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps-core**: unified `net_policy`'s duplicated userinfo-redaction carve-out rules into one shared `redact_credential` scanner — zero behavior change (resolves #846) (#863)
 
 ### Fixed
-- `fuzz/redact_userinfo`: fixed a false-positive crash where the fuzzer-controlled host/port tail could coincidentally reproduce the sentinel literal, tripping the leak assertion outside any credential; no `net_policy` behavior change
+- `fuzz/redact_userinfo`: fixed a false-positive crash where the fuzzer-controlled host/port tail could coincidentally reproduce the sentinel literal, tripping the leak assertion outside any credential; no `net_policy` behavior change (#864)
 
 ## [0.14.0] - 2026-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **deps-core**: unified `net_policy`'s duplicated userinfo-redaction carve-out rules into one shared `redact_credential` scanner — zero behavior change (resolves #846) (#863)
 
+### Fixed
+- `fuzz/redact_userinfo`: fixed a false-positive crash where the fuzzer-controlled host/port tail could coincidentally reproduce the sentinel literal, tripping the leak assertion outside any credential; no `net_policy` behavior change
+
 ## [0.14.0] - 2026-09-11
 
 ### Added

--- a/fuzz/fuzz_targets/redact_userinfo.rs
+++ b/fuzz/fuzz_targets/redact_userinfo.rs
@@ -35,12 +35,23 @@ const SENTINEL: &str = "FUZZSECRET";
 
 /// An alphanumeric-only tail derived from the fuzzer's raw bytes — see this file's own module
 /// doc comment for why non-alphanumeric bytes are filtered out rather than passed through.
+///
+/// libFuzzer's CMP-tracing instrumentation observes `SENTINEL` inside this file's own `assert!`
+/// and auto-adds it as a dictionary token, so the raw byte stream can — and, once discovered, will
+/// repeatedly — spell out `SENTINEL` verbatim. Every template below places `tail` in a
+/// non-credential position (the host/port), so a `tail` that happens to equal `SENTINEL` produces
+/// an output that legitimately contains it outside any credential, which is not a leak but would
+/// still trip invariant (b)'s blanket `!redacted.contains(SENTINEL)` check. Strip any occurrence
+/// of `SENTINEL` from the tail so the assertion only ever observes the one deliberately injected
+/// credential.
 fn tail_from(data: &[u8]) -> String {
-    data.iter()
+    let tail: String = data
+        .iter()
         .filter(|b| b.is_ascii_alphanumeric())
         .take(16)
         .map(|&b| b as char)
-        .collect()
+        .collect();
+    tail.replace(SENTINEL, "")
 }
 
 fuzz_target!(|data: &[u8]| {


### PR DESCRIPTION
## Summary
- CI run https://github.com/bug-ops/deps-lsp/actions/runs/34631214219/job/103368386616 failed: the `redact_userinfo` fuzz target panicked with `credential leaked: input="***host:999999FUZZSECRET" output="https://***@host:999999FUZZSECRET"`.
- Root cause: libFuzzer's CMP-tracing instrumentation observes the harness's own `SENTINEL` literal (via the target's `assert!`) and auto-derives it as a dictionary token, so the fuzzer-controlled, alphanumeric-filtered tail placed in each template's host/port position can — and did — coincidentally reproduce `SENTINEL` verbatim. `redact_userinfo` correctly redacted the actual injected credential (`***`); the blanket `!redacted.contains(SENTINEL)` assertion also fired on this legitimate, non-credential occurrence of the same literal sitting in the host field.
- This is a fuzz-harness self-collision, not a leak in `deps-core::net_policy`. Fixed by stripping any `SENTINEL` occurrence from the generated tail in `tail_from`, so the assertion can only ever observe the one deliberately injected credential.
- Verified by reconstructing the exact crashing input bytes locally, confirming it no longer panics, then running the target for 60s (~1M executions) with no further crashes.

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (4910 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- [x] Reproduced the CI crash input locally against `redact_userinfo`, confirmed it no longer panics
- [x] `cargo +nightly fuzz run redact_userinfo -- -max_total_time=60` (~1M execs, no crashes)

https://claude.ai/code/session_017pmMypiUxYFyaDSiqseeqQ