### PR TITLE
docs(specs,deps-core,deps-cargo,deps-go,deps-lsp): reconcile spec index and document enum exhaustiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **deps-core**: unified `net_policy`'s duplicated userinfo-redaction carve-out rules into one shared `redact_credential` scanner — zero behavior change (resolves #846) (#863)
+- **deps-core, deps-cargo, deps-go, deps-lsp**: documented the exhaustive/non_exhaustive justification for 8 public enums per `deps-core`'s API-stability policy; `HostClass` and `deps_lsp::document::DocumentState` are now `#[non_exhaustive]` (resolves #854)
+- `specs/`: reconciled `MOC-specs.md` against actual issue/PR state — 7 stale "draft, P1" spec rows marked shipped with their PR/issue references, all shipped specs moved into a "Completed Specs" section, and `specs/constitution.md` added (resolves #855)
 
 ### Fixed
 - `fuzz/redact_userinfo`: fixed a false-positive crash where the fuzzer-controlled host/port tail could coincidentally reproduce the sentinel literal, tripping the leak assertion outside any credential; no `net_policy` behavior change (#864)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **deps-core**: unified `net_policy`'s duplicated userinfo-redaction carve-out rules into one shared `redact_credential` scanner — zero behavior change (resolves #846) (#863)
-- **deps-core, deps-cargo, deps-go, deps-lsp**: documented the exhaustive/non_exhaustive justification for 8 public enums per `deps-core`'s API-stability policy; `HostClass` and `deps_lsp::document::DocumentState` are now `#[non_exhaustive]` (resolves #854)
-- `specs/`: reconciled `MOC-specs.md` against actual issue/PR state — 7 stale "draft, P1" spec rows marked shipped with their PR/issue references, all shipped specs moved into a "Completed Specs" section, and `specs/constitution.md` added (resolves #855)
+- **deps-core, deps-cargo, deps-go, deps-lsp**: documented the exhaustive/non_exhaustive justification for 8 public enums per `deps-core`'s API-stability policy; `HostClass` and `deps_lsp::document::DocumentState` are now `#[non_exhaustive]` (resolves #854) (#867)
+- `specs/`: reconciled `MOC-specs.md` against actual issue/PR state — stale "draft" spec rows marked shipped with their PR/issue references, all shipped specs moved into a "Completed Specs" section, and `specs/constitution.md` added (resolves #855) (#867)
 
 ### Fixed
 - `fuzz/redact_userinfo`: fixed a false-positive crash where the fuzzer-controlled host/port tail could coincidentally reproduce the sentinel literal, tripping the leak assertion outside any credential; no `net_policy` behavior change (#864)

--- a/crates/deps-cargo/src/config.rs
+++ b/crates/deps-cargo/src/config.rs
@@ -90,7 +90,8 @@ impl std::fmt::Display for AuthToken {
 /// entry (see the module-level docs), not a runtime branch on this enum. A future change
 /// that starts branching on this to decide whether to attach a credential reintroduces the
 /// exact vulnerability class this design closed.
-// Exhaustive: closed 2-variant CargoHome/Workspace split (issue #769).
+///
+/// **Exhaustive** (issue #769): a closed 2-variant `CargoHome`/`Workspace` split.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Provenance {
     /// Resolved from `$CARGO_HOME/config.toml` or a `CARGO_REGISTRIES_*` environment
@@ -110,8 +111,10 @@ pub enum Provenance {
 /// protecting the auth boundary; adding a policy branch on it would make that sentence false
 /// and invite a future reader to add an auth branch too. Two small enums, one invariant
 /// each.
-// Exhaustive: security-sensitive Trusted/WorkspaceDeclared split — a wildcard arm would
-// silently trust workspace-declared input (issue #769).
+///
+/// **Exhaustive** (issue #769): a security-sensitive `Trusted`/`WorkspaceDeclared` split — a
+/// wildcard arm at a future consuming match site would silently trust workspace-declared
+/// input instead of failing to compile.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum IndexTrust {
     /// `$CARGO_HOME/config.toml` or a `CARGO_REGISTRIES_*` environment variable — the

--- a/crates/deps-core/src/interval.rs
+++ b/crates/deps-core/src/interval.rs
@@ -63,8 +63,10 @@ pub enum VersionRange<V> {
 /// character serves as both an opener and a closer. `AllowReversed` adds Gradle's
 /// reversed-bracket exclusive notation on top: a leading `]` or trailing `[` is also accepted
 /// as an exclusive bound (`]1.2,1.5]`, `[1.1,2.0[`).
-// Exhaustive: 2-variant grammar selector (Standard/AllowReversed) fixed by `parse_interval`'s
-// call sites (issue #769).
+///
+/// **Exhaustive** (issue #769): a 2-variant grammar selector fixed by `parse_interval`'s call
+/// sites — a third grammar would change the calling convention there too, not slot into an
+/// existing wildcard arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BracketStyle {
     /// Maven's/NuGet's grammar: `[`/`]` inclusive, `(`/`)` exclusive only.

--- a/crates/deps-core/src/net_policy.rs
+++ b/crates/deps-core/src/net_policy.rs
@@ -27,10 +27,15 @@ use std::sync::atomic::{AtomicU8, Ordering};
 /// `BlockedAddrResolver` (a `reqwest::dns::Resolve` implementation, fail-closed on lookup
 /// errors, wired into every client via `build_guarded_client`) — see [`classify_addr`], its
 /// counterpart for already-resolved addresses.
-// Exhaustive: security-sensitive SSRF classification — a new host class landing in a
-// wildcard arm at any consuming match site would silently fall through as unclassified
-// instead of failing to compile (issue #769).
+///
+/// `#[non_exhaustive]`: unlike most security-sensitive enums in this module, a new host
+/// class is a realistic, desirable future addition — a newly-documented cloud-metadata
+/// endpoint or reserved range should ship as a non-breaking patch, not force a major version
+/// bump on every consumer. No exhaustive `match` on this enum exists outside `deps-core`
+/// today (`crate::cache::hop_targets_blocked_host` and other callers compare by equality or
+/// [`Self::never_a_registry`], not an exhaustive match), so this costs nothing in-tree.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum HostClass {
     /// `127.0.0.0/8`, `::1`, `localhost`, `*.localhost`.
     Loopback,
@@ -67,6 +72,11 @@ impl HostClass {
     /// [`HostClass::UniqueLocalV6`]/[`HostClass::InternalName`] are legitimate redirect
     /// targets for a corporate registry's own network — only the classes below are never a
     /// registry under any policy.
+    ///
+    /// Fail-open by construction for a variant not listed below: since [`HostClass`] is
+    /// `#[non_exhaustive]`, a future variant (e.g. a newly-documented cloud-metadata range)
+    /// defaults to "not never-a-registry" here until this function is explicitly updated to
+    /// include it — a new variant must be triaged into this list, not assumed covered.
     #[must_use]
     pub const fn never_a_registry(self) -> bool {
         matches!(
@@ -314,9 +324,10 @@ fn path_under_prefix(path: &str, prefix: &str) -> bool {
 /// Applied **only** to workspace-provenance URLs (a `Cargo.toml`/`.cargo/config.toml` value
 /// found inside the opened workspace) — a `$CARGO_HOME`-provenance index is the user's own
 /// trusted configuration and is never policy-checked, under any variant here.
-// Exhaustive: security-sensitive gate for registry fetches — a new variant landing in a
-// wildcard arm would silently pick an unintended access level instead of failing to
-// compile (issue #769).
+///
+/// **Exhaustive** (issue #769): security-sensitive gate for registry fetches — a new variant
+/// landing in a wildcard arm at any consuming match site would silently pick an unintended
+/// access level instead of failing to compile.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum WorkspaceRegistryAccess {
     /// Block every workspace-declared index — the only complete boundary. Also blocks the
@@ -498,9 +509,10 @@ pub enum IndexUrlError {
 ///     .is_err()
 /// );
 /// ```
-// Exhaustive: closed 2-variant Skip/Enforce gate — a third state would change the calling
-// convention at every `validate_index_url` call site, not slot into an existing wildcard
-// arm (issue #769).
+///
+/// **Exhaustive** (issue #769): a closed 2-variant Skip/Enforce gate — a third state would
+/// change the calling convention at every `validate_index_url` call site, not slot into an
+/// existing wildcard arm.
 #[derive(Debug, Clone, Copy)]
 pub enum PolicyGate<'a> {
     /// Skip the policy check entirely — the candidate's provenance is already trusted (e.g.

--- a/crates/deps-core/src/parser.rs
+++ b/crates/deps-core/src/parser.rs
@@ -1092,8 +1092,9 @@ impl DependencySource {
 /// # Thread Safety
 ///
 /// This enum is `Copy` for efficient passing across thread boundaries in async contexts.
-// Exhaustive: UI state machine — a wildcard arm at any consuming match site would render
-// nothing for a new state instead of failing to compile (issue #769).
+///
+/// **Exhaustive** (issue #769): a closed UI state machine — a wildcard arm at any consuming
+/// match site would silently render nothing for a new state instead of failing to compile.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum LoadingState {
     /// No data loaded, not currently loading

--- a/crates/deps-go/src/config.rs
+++ b/crates/deps-go/src/config.rs
@@ -171,7 +171,11 @@ fn parse_hop(raw: &str, policy: &RegistryAccessPolicy) -> Result<GoProxyHop, Inv
 /// semantics — this crate's `,`-and-`|`-both-fall-through-on-not-found first cut collapsed
 /// that distinction; see [`GoRegistry::get_versions_chained`](crate::registry::GoRegistry)
 /// (registry.rs) for where this is consulted.
-// Exhaustive: fallback rule fixed by Go's `,`/`|` GOPROXY separator grammar (issue #769).
+///
+/// **Exhaustive** (issue #769): a fallback rule fixed by Go's own `,`/`|` GOPROXY separator
+/// grammar — Go itself defines exactly these two separators, so a third variant here would
+/// mean Go changed its own grammar, which should be a deliberate, compile-time-visible update
+/// to every consuming match site, not a silent wildcard fallthrough.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChainSeparator {
     /// `,`: fall through to the next hop only on an explicit not-found response (`404`/`410`)

--- a/crates/deps-lsp/src/document/state.rs
+++ b/crates/deps-lsp/src/document/state.rs
@@ -66,6 +66,18 @@ pub use deps_core::LoadingState;
 ///
 /// assert!(state.cached_versions.is_empty());
 /// ```
+///
+/// `#[non_exhaustive]` (issue #854): most fields here are `pub` (needed so handlers across
+/// `deps-lsp` can read cache state directly), but the `parse_result` field is private — and a
+/// private field alone already blocks external struct-literal construction (`E0451`) and
+/// forces `..` on external exhaustive destructuring, with or without this attribute. So this
+/// `#[non_exhaustive]` is a no-op today, not an added restriction; it is kept anyway as
+/// forward-compatible intent in case every field is ever made `pub` (at which point silently
+/// removing it would matter) and as an explicit signal that new cache fields keep getting
+/// added here (`vulnerabilities`, `outcomes`, `licenses`, `resolved_version_candidates` all
+/// postdate the struct's original shape) so a hypothetical future fully-public version should
+/// not be exhaustively constructed either.
+#[non_exhaustive]
 pub struct DocumentState {
     /// Package ecosystem identifier, exhaustively typed.
     pub ecosystem: EcosystemId,

--- a/specs/001-yaml-rust2-saphyr-eval/spec.md
+++ b/specs/001-yaml-rust2-saphyr-eval/spec.md
@@ -9,7 +9,7 @@ tags:
   - dependencies
   - deps-dart
 created: 2026-08-19
-status: draft
+status: shipped
 related:
   - "[[constitution]]"
 ---

--- a/specs/002-osv-vulnerability-diagnostics/plan.md
+++ b/specs/002-osv-vulnerability-diagnostics/plan.md
@@ -10,7 +10,7 @@ tags:
   - deps-lsp
   - security
 created: 2026-08-19
-status: draft
+status: shipped
 related:
   - "[[spec]]"
   - "[[constitution]]"

--- a/specs/002-osv-vulnerability-diagnostics/spec.md
+++ b/specs/002-osv-vulnerability-diagnostics/spec.md
@@ -12,7 +12,7 @@ tags:
   - deps-lsp
   - security
 created: 2026-08-19
-status: draft
+status: shipped
 related:
   - "[[constitution]]"
 ---

--- a/specs/003-maven-legacy-version-sort/spec.md
+++ b/specs/003-maven-legacy-version-sort/spec.md
@@ -10,7 +10,7 @@ tags:
   - deps-gradle
   - version-sorting
 created: 2026-08-19
-status: draft
+status: shipped
 related:
   - "[[constitution]]"
 ---

--- a/specs/004-release-freshness-signal/spec.md
+++ b/specs/004-release-freshness-signal/spec.md
@@ -12,7 +12,7 @@ tags:
   - cross-ecosystem
 created: 2026-08-20
 updated: 2026-08-23
-status: approved
+status: shipped
 related:
   - "[[constitution]]"
 ---

--- a/specs/005-completion-search-blocking-timeout/spec.md
+++ b/specs/005-completion-search-blocking-timeout/spec.md
@@ -10,7 +10,7 @@ tags:
   - completion
   - performance
 created: 2026-08-20
-status: draft
+status: shipped
 related:
   - "[[constitution]]"
   - "[[MOC-specs]]"

--- a/specs/006-completion-prefix-quote-stripping/spec.md
+++ b/specs/006-completion-prefix-quote-stripping/spec.md
@@ -10,7 +10,7 @@ tags:
   - npm
   - composer
 created: 2026-08-20
-status: draft
+status: shipped
 related:
   - "[[constitution]]"
   - "[[MOC-specs]]"

--- a/specs/007-lightweight-registry-metadata/plan.md
+++ b/specs/007-lightweight-registry-metadata/plan.md
@@ -9,7 +9,7 @@ tags:
   - npm
   - pypi
 created: 2026-08-20
-status: draft
+status: shipped
 related:
   - "[[spec]]"
   - "[[constitution]]"

--- a/specs/007-lightweight-registry-metadata/spec.md
+++ b/specs/007-lightweight-registry-metadata/spec.md
@@ -10,7 +10,7 @@ tags:
   - npm
   - pypi
 created: 2026-08-20
-status: draft
+status: shipped
 related:
   - "[[constitution]]"
   - "[[MOC-specs]]"

--- a/specs/009-pypi-requirements-txt/spec.md
+++ b/specs/009-pypi-requirements-txt/spec.md
@@ -10,7 +10,7 @@ tags:
   - ecosystem/pypi
   - priority/p2
 created: 2026-08-23
-status: draft
+status: shipped
 related:
   - "[[MOC-specs]]"
 ---

--- a/specs/011-deprecation-replacement-diagnostics/spec.md
+++ b/specs/011-deprecation-replacement-diagnostics/spec.md
@@ -9,7 +9,7 @@ tags:
   - parity-gap
   - priority/p3
 created: 2026-08-23
-status: draft
+status: shipped
 related:
   - "[[MOC-specs]]"
 ---

--- a/specs/012-unsatisfiable-requirement-diagnostic/spec.md
+++ b/specs/012-unsatisfiable-requirement-diagnostic/spec.md
@@ -10,7 +10,7 @@ tags:
   - diagnostics
   - priority/p3
 created: 2026-08-23
-status: draft
+status: shipped
 related:
   - "[[MOC-specs]]"
 ---

--- a/specs/013-deno-jsr-ecosystem/spec.md
+++ b/specs/013-deno-jsr-ecosystem/spec.md
@@ -10,7 +10,7 @@ tags:
   - new-ecosystem
   - priority/p3
 created: 2026-08-23
-status: draft
+status: shipped
 related:
   - "[[MOC-specs]]"
 ---

--- a/specs/016-bundler-platform-duplicate-versions/spec.md
+++ b/specs/016-bundler-platform-duplicate-versions/spec.md
@@ -8,7 +8,7 @@ tags:
   - deps-bundler
   - rubygems
 created: 2026-08-24
-status: draft
+status: shipped
 related:
   - "[[MOC-specs]]"
 ---

--- a/specs/017-hover-latest-marker-prerelease-mismatch/spec.md
+++ b/specs/017-hover-latest-marker-prerelease-mismatch/spec.md
@@ -7,7 +7,7 @@ tags:
   - bug
   - lsp-hover
 created: 2026-08-24
-status: draft
+status: shipped
 related:
   - "[[constitution]]"
 ---

--- a/specs/018-clippy-dashmap-await-guard/spec.md
+++ b/specs/018-clippy-dashmap-await-guard/spec.md
@@ -8,7 +8,7 @@ tags:
   - tooling
   - ci
 created: 2026-08-24
-status: draft
+status: shipped
 related:
   - "[[constitution]]"
 ---

--- a/specs/019-npm-all-deprecated-unknown-package/spec.md
+++ b/specs/019-npm-all-deprecated-unknown-package/spec.md
@@ -9,7 +9,7 @@ tags:
   - deps-deno
   - npm
 created: 2026-08-24
-status: draft
+status: shipped
 related:
   - "[[MOC-specs]]"
 ---

--- a/specs/020-freshness-cooldown-diagnostics-blind/spec.md
+++ b/specs/020-freshness-cooldown-diagnostics-blind/spec.md
@@ -9,7 +9,7 @@ tags:
   - deps-core
   - freshness
 created: 2026-08-24
-status: draft
+status: shipped
 related:
   - "[[MOC-specs]]"
 ---

--- a/specs/021-maven-wildcard-latest-ignores-prerelease/spec.md
+++ b/specs/021-maven-wildcard-latest-ignores-prerelease/spec.md
@@ -9,7 +9,7 @@ tags:
   - deps-gradle
   - prerelease
 created: 2026-08-24
-status: draft
+status: shipped
 related:
   - "[[MOC-specs]]"
 ---

--- a/specs/022-pypi-package-completion-broken/spec.md
+++ b/specs/022-pypi-package-completion-broken/spec.md
@@ -10,7 +10,7 @@ tags:
   - deps-pypi
   - pyproject-toml
 created: 2026-08-24
-status: draft
+status: shipped
 related:
   - "[[MOC-specs]]"
 ---

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -19,34 +19,44 @@ status: moc
 
 | ID | Feature | Phase | Status |
 |----|---------|-------|--------|
-| 001 | [[001-yaml-rust2-saphyr-eval/spec\|Evaluate saphyr as eventual successor to yaml-rust2]] | specify | draft — recommendation: do not migrate now |
-| 002 | [[002-osv-vulnerability-diagnostics/spec\|OSV vulnerability diagnostics]] | specify | draft |
-| 003 | [[003-maven-legacy-version-sort/spec\|Fix Maven/Gradle version sort corrupted by legacy non-semver versions]] | specify | draft — bug, P1 |
-| 002 | [[002-osv-vulnerability-diagnostics/spec\|Vulnerability-aware diagnostics via OSV.dev batch API]] | plan | draft — plan complete, 5 open `[NEEDS CLARIFICATION]` items block `/sdd tasks` |
-| 004 | [[004-release-freshness-signal/spec\|Release-freshness signal for version recommendations]] | specify | draft — research/P2, 8 open `[NEEDS CLARIFICATION]` items |
-| 006 | [[006-completion-prefix-quote-stripping/spec\|Strip JSON string-delimiter quote from fallback completion prefix]] | specify | draft — bug, P2, 2 open `[NEEDS CLARIFICATION]` items |
-| 005 | [[005-completion-search-blocking-timeout/spec\|Bound latency of package-name completion fallback search]] | specify | draft — bug, P1, 4 open `[NEEDS CLARIFICATION]` items |
-| 007 | [[007-lightweight-registry-metadata/spec\|Adopt lightweight registry metadata formats for npm and PyPI version lookups]] | specify | draft — enhancement, P2 |
-| 007 | [[007-lightweight-registry-metadata/plan\|Adopt lightweight registry metadata formats for npm and PyPI version lookups]] | plan | draft — plan complete, 2 open `[NEEDS CLARIFICATION]` items block `/sdd tasks` |
 | 008 | [[008-codelens-update-all-outdated/spec\|CodeLens support for "update all outdated dependencies" action]] | specify | draft — research/parity, P2, 7 open `[NEEDS CLARIFICATION]` items |
-| 009 | [[009-pypi-requirements-txt/spec\|Support requirements.txt (pip family) in deps-pypi]] | specify | draft — enhancement/parity, P2, 7 open `[NEEDS CLARIFICATION]` items |
+| 015 | [[015-lsp-3-18-diagnostic-markup-tooltip-gap/spec\|LSP 3.18 diagnostic markup / command-tooltip support blocked by ls-types 0.0.6]] | specify | draft — research/dependency-gap, P4, 3 open `[NEEDS CLARIFICATION]` items, blocked on upstream — no `/sdd plan` (issue #308) |
+| 025 | [[025-osv-fix-target-scan-gap/spec\|OSV fix-target scan gap — recommended fix version is never independently scanned]] | specify | draft — bug, P2, 4 open `[NEEDS CLARIFICATION]` items |
+| 038 | [[038-workspace-diagnostics-pull-support/spec\|Workspace Diagnostics Pull Support]] | specify | parked — research/enhancement, P4, adoption-question resolved 2026-09-08 (wait for client support), 3 open plan-level `[NEEDS CLARIFICATION]` items remain moot until revisited (issue #547) |
+| 042 | [[042-docker-base-image-ecosystem/spec\|New ecosystem: Dockerfile FROM base-image tag/digest freshness]] | specify | draft — research/new ecosystem, P4, 5 open `[NEEDS CLARIFICATION]` items, no user demand signal (issue #557) |
+| 044 | [[044-precommit-hooks-ecosystem/spec\|New ecosystem: pre-commit hooks (.pre-commit-config.yaml repo/rev pins)]] | specify | draft — research/new ecosystem, P4, 6 open `[NEEDS CLARIFICATION]` items, tracked in issue #575 |
+| 047 | [[047-elixir-hex-ecosystem/spec\|New ecosystem: Elixir Hex (mix.exs dependency version hints)]] | specify | draft — research/new-ecosystem, P4, 6 open `[NEEDS CLARIFICATION]` items, issue #642 |
+| 051 | [[051-disk-persistent-registry-cache/spec\|Disk-persistent registry cache]] | specify | draft — research/enhancement, P4, 9 open `[NEEDS CLARIFICATION]` items, tracked in issue #700 |
+
+## Completed Specs
+
+| ID | Feature | Phase | Status |
+|----|---------|-------|--------|
+| 001 | [[001-yaml-rust2-saphyr-eval/spec\|Evaluate saphyr as eventual successor to yaml-rust2]] | specify | shipped — research/decision-record, recommendation: do not migrate now (no PR — spec is the artifact) |
+| 002 | [[002-osv-vulnerability-diagnostics/spec\|OSV vulnerability diagnostics]] | specify | shipped — research/enhancement, P4 (PR #215, issue #124) |
+| 002 | [[002-osv-vulnerability-diagnostics/plan\|Vulnerability-aware diagnostics via OSV.dev batch API]] | plan | shipped — plan delivered via PR #215 |
+| 003 | [[003-maven-legacy-version-sort/spec\|Fix Maven/Gradle version sort corrupted by legacy non-semver versions]] | specify | shipped — bug, P1 (PR #128, issue #125) |
+| 004 | [[004-release-freshness-signal/spec\|Release-freshness signal for version recommendations]] | specify | shipped — research/enhancement, P4, multi-stage rollout (PR #219 issue #145; extended by #220/#222/#294, #221/#225/#277, #293, #316) |
+| 005 | [[005-completion-search-blocking-timeout/spec\|Bound latency of package-name completion fallback search]] | specify | shipped — bug, P1 (PR #154, issue #147) |
+| 006 | [[006-completion-prefix-quote-stripping/spec\|Strip JSON string-delimiter quote from fallback completion prefix]] | specify | shipped — bug, P2 (PR #154, issue #148) |
+| 007 | [[007-lightweight-registry-metadata/spec\|Adopt lightweight registry metadata formats for npm and PyPI version lookups]] | specify | shipped — enhancement, P2 (PR #168, issue #162) |
+| 007 | [[007-lightweight-registry-metadata/plan\|Adopt lightweight registry metadata formats for npm and PyPI version lookups]] | plan | shipped — enhancement, P2 (PR #168, issue #162) |
+| 009 | [[009-pypi-requirements-txt/spec\|Support requirements.txt (pip family) in deps-pypi]] | specify | shipped — enhancement/parity, P2 (PR #234, issue #203) |
 | 010 | [[010-license-hover-policy/spec\|License in hover + license-policy diagnostics]] | plan | shipped — research/parity, P4 (PR #663 issue #204, PR #682 issues #660/#661, PR #665 issue #662) |
-| 011 | [[011-deprecation-replacement-diagnostics/spec\|Deprecation/abandoned diagnostics with suggested replacement]] | specify | draft — research/parity, P3, 9 open `[NEEDS CLARIFICATION]` items |
-| 012 | [[012-unsatisfiable-requirement-diagnostic/spec\|Diagnostic for requirements matching zero published versions]] | specify | draft — enhancement/parity, P3, 9 open `[NEEDS CLARIFICATION]` items |
-| 013 | [[013-deno-jsr-ecosystem/spec\|New ecosystem: Deno/JSR (deno.json / deno.jsonc)]] | specify | draft — research/new ecosystem, P3, 10 open `[NEEDS CLARIFICATION]` items |
+| 011 | [[011-deprecation-replacement-diagnostics/spec\|Deprecation/abandoned diagnostics with suggested replacement]] | specify | shipped — research/parity, P4 (PR #435, issue #205) |
+| 012 | [[012-unsatisfiable-requirement-diagnostic/spec\|Diagnostic for requirements matching zero published versions]] | specify | shipped — enhancement/parity, P3 (PR #256, issue #206) |
+| 013 | [[013-deno-jsr-ecosystem/spec\|New ecosystem: Deno/JSR (deno.json / deno.jsonc)]] | specify | shipped — research/new ecosystem, P3 (PR #309, issue #207) |
 | 014 | [[014-github-actions-ecosystem/spec\|New ecosystem: GitHub Actions workflow uses: pins]] | specify | shipped — research/new ecosystem, P4 (PR #471, issue #208) |
-| 015 | [[015-lsp-3-18-diagnostic-markup-tooltip-gap/spec\|LSP 3.18 diagnostic markup / command-tooltip support blocked by ls-types 0.0.6]] | specify | draft — research/dependency-gap, P4, 3 open `[NEEDS CLARIFICATION]` items, blocked on upstream — no `/sdd plan` |
-| 016 | [[016-bundler-platform-duplicate-versions/spec\|Deduplicate RubyGems platform-variant versions in Bundler hover]] | specify | draft — bug, P1, 3 open `[NEEDS CLARIFICATION]` items |
-| 017 | [[017-hover-latest-marker-prerelease-mismatch/spec\|Hover "Recent versions" `(latest)` marker can disagree with the header's `Latest` field]] | specify | draft — bug, P2, 2 open `[NEEDS CLARIFICATION]` items |
-| 018 | [[018-clippy-dashmap-await-guard/spec\|Add clippy.toml await-holding-invalid-types config for DashMap Ref guards]] | plan | draft — tooling/enhancement, P2, 2 open `[NEEDS CLARIFICATION]` items, plan complete |
-| 019 | [[019-npm-all-deprecated-unknown-package/spec\|npm/JSR packages whose every published version is deprecated must not be reported "Unknown package"]] | specify | draft — bug, P1, 2 open `[NEEDS CLARIFICATION]` items |
-| 020 | [[020-freshness-cooldown-diagnostics-blind/spec\|Release-cooldown callout never reaches diagnostics for registries that gate freshness behind get_versions_with]] | specify | draft — bug, P1, 1 open `[NEEDS CLARIFICATION]` item |
-| 021 | [[021-maven-wildcard-latest-ignores-prerelease/spec\|Maven/Gradle "Newer version available" diagnostic and quick-fix must not recommend a prerelease when a stable release is newer]] | specify | draft — bug, P1, 1 open `[NEEDS CLARIFICATION]` item |
-| 022 | [[022-pypi-package-completion-broken/spec\|PyPI package-name completion never returns results for any valid pyproject.toml shape]] | specify | draft — bug, P1, 2 open `[NEEDS CLARIFICATION]` items |
+| 016 | [[016-bundler-platform-duplicate-versions/spec\|Deduplicate RubyGems platform-variant versions in Bundler hover]] | specify | shipped — bug, P1 (PR #321, issue #311) |
+| 017 | [[017-hover-latest-marker-prerelease-mismatch/spec\|Hover "Recent versions" `(latest)` marker can disagree with the header's `Latest` field]] | specify | shipped — bug, P2 (PR #321, issue #313) |
+| 018 | [[018-clippy-dashmap-await-guard/spec\|Add clippy.toml await-holding-invalid-types config for DashMap Ref guards]] | plan | shipped — tooling/enhancement, P2 (PR #354, issue #334) |
+| 019 | [[019-npm-all-deprecated-unknown-package/spec\|npm/JSR packages whose every published version is deprecated must not be reported "Unknown package"]] | specify | shipped — bug, P1 (PR #352, issue #338) |
+| 020 | [[020-freshness-cooldown-diagnostics-blind/spec\|Release-cooldown callout never reaches diagnostics for registries that gate freshness behind get_versions_with]] | specify | shipped — bug, P1 (PR #352, issue #339) |
+| 021 | [[021-maven-wildcard-latest-ignores-prerelease/spec\|Maven/Gradle "Newer version available" diagnostic and quick-fix must not recommend a prerelease when a stable release is newer]] | specify | shipped — bug, P1 (PR #352, issue #340) |
+| 022 | [[022-pypi-package-completion-broken/spec\|PyPI package-name completion never returns results for any valid pyproject.toml shape]] | specify | shipped — bug, P1 (PR #397, issue #390) |
 | 023 | [[023-cargo-custom-registries/spec\|Cargo custom/private registry & source-replacement resolution]] | specify | shipped — enhancement/security, P4 (PR 1a #440, PR 1b #447) |
 | 023 | [[023-cargo-custom-registries/plan\|Cargo custom/private registry & source-replacement resolution]] | plan | shipped — 1a/1b PR sequencing delivered as PR #440 and PR #447 |
 | 024 | [[024-net-policy-dns-rebinding/spec\|DNS-rebinding bypass of the workspace-registry SSRF host classifier (net_policy)]] | specify | shipped — security-hardening, P3, closed in two stages (PR #457 issue #449, PR #460 issue #455) |
-| 025 | [[025-osv-fix-target-scan-gap/spec\|OSV fix-target scan gap — recommended fix version is never independently scanned]] | specify | draft — bug, P2, 4 open `[NEEDS CLARIFICATION]` items |
 | 026 | [[026-deno-npm-yanked-diagnostic-alignment/spec\|Align Deno npm: yanked diagnostic with npm's suppressed behavior]] | specify | shipped — bug, P2 (PR #456, issue #448) |
 | 027 | [[027-nuget-unlisted-version-and-multiproject-lockfile/spec\|NuGet unlisted-version hover marker and multi-project lock file matching]] | specify | shipped — bug, P2 (PR #458, issue #451) |
 | 028 | [[028-pypi-requirements-documentlinks-and-directory-layout/spec\|PyPI requirements.txt -r/-c documentLinks and requirements/*.txt directory-layout recognition]] | specify | shipped — enhancement/security-hardening, P3 (PR #458, issue #452) |
@@ -59,28 +69,19 @@ status: moc
 | 035 | [[035-nuget-private-feed-support/spec\|NuGet private/custom feed support (NuGet.Config packageSources)]] | specify | shipped — research/parity, P3 (PR #560, issue #523) |
 | 036 | [[036-composer-uppercase-v-prefix-bug/spec\|Composer requirement matching fails for uppercase-V-prefixed versions]] | specify | shipped — bug, P1 (PR #538, issue #534) |
 | 037 | [[037-supply-chain-trust-signal/spec\|Supply-chain trust signal (OpenSSF Scorecard + SLSA provenance) via deps.dev]] | plan | shipped — research/parity, P3 (PR #554, issue #543) |
-| 038 | [[038-workspace-diagnostics-pull-support/spec\|Workspace Diagnostics Pull Support]] | specify | parked — research/enhancement, P4, adoption-question resolved 2026-09-08 (wait for client support), 3 open plan-level `[NEEDS CLARIFICATION]` items remain moot until revisited (issue #547) |
 | 039 | [[039-github-rate-limit-actionable-diagnostic/spec\|Actionable rate-limit hint in registry diagnostics]] | specify | shipped — bug, P1 (PR #485, issue #478) |
 | 040 | [[040-github-token-redaction-trusted-origin-pin/spec\|GitHub auth token redaction and trusted-origin pinning]] | specify | shipped — security/hardening, P3 (PR #487, issue #484) |
 | 041 | [[041-credential-redaction-hardening/spec\|Redact user:pass@ credentials from registry-index logs and errors]] | specify | shipped — security, P2, two stages (PR #529 issue #522, PR #540 issue #536) |
-| 042 | [[042-docker-base-image-ecosystem/spec\|New ecosystem: Dockerfile FROM base-image tag/digest freshness]] | specify | draft — research/new ecosystem, P4, 5 open `[NEEDS CLARIFICATION]` items, no user demand signal (issue #557) |
 | 043 | [[043-nuget-feed-authentication/spec\|NuGet Feed Authentication (credentialed NuGet.Config sources)]] | specify | shipped — enhancement/security, P3 (PR #572, issues #561, #562) |
-| 044 | [[044-precommit-hooks-ecosystem/spec\|New ecosystem: pre-commit hooks (.pre-commit-config.yaml repo/rev pins)]] | specify | draft — research/new ecosystem, P4, 6 open `[NEEDS CLARIFICATION]` items, no tracking issue filed yet |
 | 045 | [[045-secret-accessor-auditable-naming/spec\|Rename Redacted<T>/wrapper as_str() secret accessors to an auditable name]] | specify | shipped — enhancement/security, P3 (PR #582, issue #581) |
 | 046 | [[046-pnpm-catalogs/spec\|pnpm catalogs + workspace: protocol resolution support]] | specify | shipped — research/enhancement, P3 (PR #589, issue #587) |
-| 047 | [[047-elixir-hex-ecosystem/spec\|New ecosystem: Elixir Hex (mix.exs dependency version hints)]] | specify | draft — research/new-ecosystem, P4, 6 open `[NEEDS CLARIFICATION]` items, issue #642 |
 | 048 | [[048-gitlab-ci-mutable-pin-message-contradicts-quickfix/spec\|GitLab CI mutable-ref-pin diagnostic wrongly claims no automated fix for component Latest/Partial pins]] | specify | shipped — bug, P2 (PR #645, issues #640, #643) |
 | 049 | [[049-osv-malicious-package-severity/spec\|OSV malicious-package (MAL-*) advisory severity distinguishing]] | specify | shipped — research/correctness, P2 (PR #652, issue #646) |
 | 050 | [[050-cargo-renamed-dependency-lockfile-resolution/spec\|Per-occurrence lockfile version resolution for renamed/aliased dependencies]] | specify | shipped — bug, P1 (PR #653, issue #649) |
-| 051 | [[051-disk-persistent-registry-cache/spec\|Disk-persistent registry cache]] | specify | research/parity, P3, 9 open `[NEEDS CLARIFICATION]` items |
 | 052 | [[052-pnpm-lockfile-provider/spec\|pnpm-lock.yaml lock file provider (npm ecosystem)]] | specify | shipped — enhancement/cross-ecosystem, P3 (PR #719, issue #709; scoped to pnpm-lock.yaml only) |
-| 053 | [[053-ecosystem-sealing-inversion-decision-record/spec\|Ecosystem sealing inversion decision record]] | specify | research/decision-record, P4, shipped — won't-do, spec is the artifact (issue #774 to be closed referencing this spec) |
+| 053 | [[053-ecosystem-sealing-inversion-decision-record/spec\|Ecosystem sealing inversion decision record]] | specify | shipped — research/decision-record, P4, won't-do, spec is the artifact (issue #774 to be closed referencing this spec) |
 | 054 | [[054-redacted-url-structural-chokepoint/spec\|Structural chokepoint for outbound-URL redaction in error/log output]] | specify | shipped — enhancement/security, P2 (PR #800 issue #789, PR #807 issue #801) — follow-up to #767/#775 |
-
-## Completed Specs
-
-(none yet)
 
 ## Project Foundation
 
-- [[constitution]] — non-negotiable project principles (not yet created)
+- [[constitution]] — non-negotiable project principles

--- a/specs/constitution.md
+++ b/specs/constitution.md
@@ -1,0 +1,62 @@
+---
+aliases:
+  - Project Constitution
+tags:
+  - sdd
+  - constitution
+created: 2026-09-12
+status: active
+---
+
+# Constitution
+
+> [!abstract]
+> Non-negotiable principles for `deps-lsp`. These are the constraints every
+> spec, plan, and implementation must satisfy — not a restatement of
+> `.claude/CLAUDE.md` or `.claude/rules/*.md`, which hold the full day-to-day
+> conventions this constitution distills from.
+
+## Principles
+
+1. **One fix, one place.** A behavior shared by more than one ecosystem crate
+   belongs in `deps-core`, not duplicated per crate. A feature or bugfix
+   landing in only one ecosystem when the same defect class applies to others
+   is treated as incomplete, not merely a follow-up.
+
+2. **`EcosystemId` matches are exhaustive.** Code that branches on ecosystem
+   identity must match `EcosystemId` exhaustively so adding a 15th ecosystem
+   is a compile error at every call site, not a silent fallthrough — an
+   incomplete match on ecosystem identity was a real bug class (issue #118).
+   Whether any *other* enum should be exhaustive or `#[non_exhaustive]` is a
+   case-by-case call, not a blanket rule — see `deps-core`'s own
+   per-enum API-stability policy (`deps-core/src/lib.rs`, issue #769).
+
+3. **Non-blocking LSP surface.** Hover, completion, and other latency-critical
+   handlers must return from cached/pre-fetched state; registry I/O is
+   delegated to background tasks, never awaited inline on the request path.
+
+4. **No hand-rolled version comparison.** Version parsing and ordering use an
+   ecosystem-appropriate maintained crate (`semver`, `node-semver`,
+   `pep440_rs`, ...) or an explicitly documented algorithm modeled on the
+   registry's own real semantics — never ad hoc string/lexicographic
+   comparison.
+
+5. **Verify live, not just in CI.** Passing unit/integration tests are
+   necessary but not sufficient for a feature to be considered working;
+   nontrivial behavior is confirmed against a real registry and a real LSP
+   client interaction before being called done.
+
+6. **Secrets never touch plaintext at rest or in Debug output.** Tokens and
+   credentials are held behind `Redacted<T>`/`expose_secret()`; a
+   secret-holding type never exposes a plain string accessor, and `Debug`
+   always redacts.
+
+7. **Pre-1.0 means clean breaks.** Before v1.0.0, correctness and clarity win
+   over backward compatibility — breaking changes are made directly and
+   documented in `CHANGELOG.md`, not hidden behind deprecation shims.
+
+## See Also
+
+- [[MOC-specs]] — all specifications
+- `.claude/CLAUDE.md`, `.claude/rules/*.md` — full conventions these
+  principles are distilled from


### PR DESCRIPTION
## Summary

- Reconciles `specs/MOC-specs.md` against actual git/PR/issue history: 9 spec rows (003, 005, 006, 007, 016, 017, 018, 019, 020, 021, 022, plus 001, 002, 004, 009, 011, 012, 013) that read `draft` despite having shipped were verified against merged PRs and closed issues, corrected with accurate PR/issue references, and moved into a new "Completed Specs" section. Adds `specs/constitution.md`, previously listed as "not yet created" and dangling-wikilinked from several specs.
- Adds the per-enum `#[non_exhaustive]` justification that `deps-core`'s API-stability docs promise but never delivered, for `BracketStyle`, `WorkspaceRegistryAccess`, `PolicyGate`, `LoadingState`, `Provenance`, `IndexTrust` and `ChainSeparator` (kept exhaustive, justification moved from a stray `//` comment into real rustdoc). `HostClass` (the SSRF host classifier) and `deps_lsp::document::DocumentState` are marked `#[non_exhaustive]` instead, since both are plausible sites for a future non-breaking addition.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (5003 passed)
- [x] `cargo test --workspace --doc --all-features` (374 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` (strict rustdoc gate)
- [x] `cargo tree -p deps-lsp -e features,no-dev` (test-util leak guard)
- [x] Verified every reconciled spec's PR/issue reference against live GitHub state (`gh pr view` / `gh issue view`)
- [x] Verified no exhaustive `match` on `HostClass` exists outside `deps-core`, and no external struct-literal/destructuring of `DocumentState` exists outside its defining module — both `#[non_exhaustive]` additions are safe no-ops today

Closes #854
Closes #855