### PR TITLE
fix(deps-core): redact token-prefixed username-only credentials in OpaquePath values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **deps-core**: fixed O(N^2) hover/diagnostics/completion latency on manifests with a dependency value on a non-ASCII line (resolves #882) (#888)
+- **deps-core**: `net_policy::redact_userinfo` now redacts token-prefixed username-only credentials in opaque-path values (resolves #858)
 - **deps-core**: `net_policy`'s credential-redaction fallback (`redact_authority_suffix`/`redact_colon_credential`) now keeps scanning past an already-masked `@`-shaped or colon-only credential instead of stopping at the first match, closing three leak gaps with no `O(n²)` regression (resolves #870, #873, #874) (#881); #875 remains open as a separate, narrower residual gap.
 - **deps-core, deps-github-actions, deps-gitlab-ci**: workflow/GitLab CI YAML `uses:`/`ref:`/`project:`/`include:` references after a block scalar (`|`/`>`) containing a non-ASCII character no longer vanish from hover/diagnostics/completion/code lens — upstream `yaml-rust2`'s `Marker::index()` desyncs from a true byte offset inside such block scalars; resolution now uses `Marker::line()`/`col()` instead (resolves #879) (#883)
 - **deps-core**: `net_policy::redact_userinfo` now anchors on the first (not nearest) `://` preceding a credential, so a credential behind multiple stacked scheme separators is no longer left unredacted (resolves #871) (#877)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **deps-core**: fixed O(N^2) hover/diagnostics/completion latency on manifests with a dependency value on a non-ASCII line (resolves #882) (#888)
-- **deps-core**: `net_policy::redact_userinfo` now redacts token-prefixed username-only credentials in opaque-path values (resolves #858)
+- **deps-core**: `net_policy::redact_userinfo` now redacts token-prefixed username-only credentials in opaque-path values (resolves #858) (#889)
 - **deps-core**: `net_policy`'s credential-redaction fallback (`redact_authority_suffix`/`redact_colon_credential`) now keeps scanning past an already-masked `@`-shaped or colon-only credential instead of stopping at the first match, closing three leak gaps with no `O(n²)` regression (resolves #870, #873, #874) (#881); #875 remains open as a separate, narrower residual gap.
 - **deps-core, deps-github-actions, deps-gitlab-ci**: workflow/GitLab CI YAML `uses:`/`ref:`/`project:`/`include:` references after a block scalar (`|`/`>`) containing a non-ASCII character no longer vanish from hover/diagnostics/completion/code lens — upstream `yaml-rust2`'s `Marker::index()` desyncs from a true byte offset inside such block scalars; resolution now uses `Marker::line()`/`col()` instead (resolves #879) (#883)
 - **deps-core**: `net_policy::redact_userinfo` now anchors on the first (not nearest) `://` preceding a credential, so a credential behind multiple stacked scheme separators is no longer left unredacted (resolves #871) (#877)

--- a/crates/deps-core/src/net_policy.rs
+++ b/crates/deps-core/src/net_policy.rs
@@ -683,6 +683,117 @@ fn find_credential_at(region: &str) -> Option<usize> {
     found
 }
 
+/// Case-sensitive prefixes of well-known API-token/secret formats (GitHub, GitLab, npm, PyPI,
+/// Slack, AWS, Stripe-style, Google, DigitalOcean, HashiCorp Vault, Shopify, Figma, Docker, and
+/// other common cloud-key shapes), used as [`find_token_prefix_at`]'s only discriminator for an
+/// `OpaquePath` credential that has no password and so is not colon-shaped enough for
+/// [`find_credential_at`] to recognize (#858). Not exhaustive in either direction: it neither
+/// covers every real token format (see [`find_token_prefix_at`]'s own doc for exactly which
+/// segment shapes it does and doesn't catch — a prefix not at that function's own segment-start
+/// boundary still goes unrecognized, not just an unprefixed username), nor is it free of false
+/// positives on ordinary text (`sk-` in particular is loose enough to match an unrelated
+/// `pkg@1.0.0` name like `sk-lang@2.0.0`) — accepted, consistent with this module's broader
+/// over-redaction-over-leaking trade (see [`redact_colon_credential`]'s own doc comment for the
+/// same trade made elsewhere in this file).
+const TOKEN_PREFIXES: &[&str] = &[
+    "ghp_",
+    "gho_",
+    "ghu_",
+    "ghs_",
+    "ghr_",
+    "github_pat_",
+    "glpat-",
+    "gldt-",
+    "glrt-",
+    "glsoat-",
+    "glptt-",
+    "gloas-",
+    "npm_",
+    "pypi-",
+    "xoxb-",
+    "xoxp-",
+    "xoxa-",
+    "xoxo-",
+    "xoxs-",
+    "xoxr-",
+    "AKIA",
+    "ASIA",
+    "ABIA",
+    "ACCA",
+    "sk-",
+    "sk_live_",
+    "rk_live_",
+    "pk_live_",
+    "AIza",
+    "ya29.",
+    "dop_v1_",
+    "dor_v1_",
+    "doo_v1_",
+    "hvs.",
+    "hvb.",
+    "shpat_",
+    "shpss_",
+    "shpca_",
+    "shppa_",
+    "figd_",
+    "dckr_pat_",
+    "AKCp",
+];
+
+/// [`find_credential_at`]'s fallback for [`RegionKind::OpaquePath`] (#858, S4): finds a `@` whose
+/// own `/`/`?`/`#`/`\`-delimited segment *starts with* one of [`TOKEN_PREFIXES`] — a
+/// username-only credential with no password, which has no `:` and so is invisible to
+/// [`find_credential_at`]'s colon-shape check. This is the precise, canonical statement of the
+/// carve-out's rule — anything else in this module referring to it should defer to this doc
+/// rather than restate it, since "starts with" (not merely "contains") is what actually bounds
+/// the false-positive population: a token prefix sitting anywhere *other than* a segment's own
+/// start (e.g. `c:/a;ghp_TOKEN@evil`, where `;` is a legitimate RFC 3986 path-parameter
+/// separator, not one of this function's boundary characters) still goes unrecognized and is not
+/// covered by this carve-out — see [`redact_credential`]'s own doc comment, C1, for the fuller
+/// picture of what remains unredacted. Only ever called when [`find_credential_at`] already
+/// returned `None` (see [`redact_credential`]'s `OpaquePath` branch), so this can only widen what
+/// gets redacted, never override a colon-shaped match.
+///
+/// A single forward pass over `region`, tracking only the current segment's start — unlike
+/// [`find_credential_at`]'s per-`@` backward rescan of its own segment, this doesn't need one,
+/// since a token prefix is a property of the segment's own start, not something that requires
+/// looking back past earlier `@`s once a boundary has reset `seg_start`. Verified equivalent to,
+/// and measurably faster than, a per-`@` `rfind` alternative over a 400k-input randomized corpus
+/// (#858 security audit).
+///
+/// Returns the *last* qualifying `@`, matching [`find_credential_at`]'s own last-match
+/// convention, so a decoy `@` segment following the real credential still resolves to the
+/// earlier, genuinely token-prefixed one rather than stopping at the first candidate.
+///
+/// Treats `\` as a segment boundary, unlike [`extend_credential_at`], which deliberately does
+/// not (see that function's own doc comment for why). The asymmetry is safe today — both
+/// directions only ever widen what gets redacted — but is undocumented anywhere else, so a future
+/// "unify the boundary sets" cleanup should know it would change behavior for `c:\ghp_X@evil`
+/// before doing so.
+// `i`/`seg_start` come from `enumerate()` over `region.bytes()` and ASCII byte-literal matches
+// against '@'/'/'/'?'/'#'/'\\', so every slice bound stays a char boundary.
+#[allow(clippy::string_slice)]
+fn find_token_prefix_at(region: &str) -> Option<usize> {
+    let mut seg_start = 0;
+    let mut found = None;
+    for (i, b) in region.bytes().enumerate() {
+        match b {
+            b'@' => {
+                if TOKEN_PREFIXES
+                    .iter()
+                    .any(|p| region[seg_start..i].starts_with(p))
+                {
+                    found = Some(i);
+                }
+                seg_start = i + 1;
+            }
+            b'/' | b'?' | b'#' | b'\\' => seg_start = i + 1,
+            _ => {}
+        }
+    }
+    found
+}
+
 /// Widens a credential-shaped `@` found by [`find_credential_at`] forward across any further `@`
 /// in `region` that is not separated from it by a `/`, `?`, or `#` (#859) — the `OpaquePath`
 /// counterpart to [`RegionKind::Authority`]'s own last-`@`-*overall*-wins bounded pass, needed
@@ -1019,9 +1130,11 @@ fn host_boundary_scheme_aware(region: &str) -> usize {
 /// ([`host_boundary_scheme_aware`]) for a further nested credential rather than trusting the
 /// first bounded match (#862) — see that function's own doc comment for its full algorithm.
 /// [`RegionKind::OpaquePath`] skips straight to the shared tail: [`find_credential_at`] on the
-/// whole `region`, masking with `***@` on `Some`, falling through unconditionally to
-/// [`redact_colon_credential`] on `None` (#810/#818) — see "Coverage per `RegionKind`" below,
-/// class S3/#857, for why `OpaquePath` no longer special-cases this fallthrough.
+/// whole `region`, falling back to [`find_token_prefix_at`] when that finds nothing (#858),
+/// masking with `***@` on `Some` from either, falling through unconditionally to
+/// [`redact_colon_credential`] only when both return `None` (#810/#818) — see "Coverage per
+/// `RegionKind`" below, class S3/#857, for why `OpaquePath` no longer special-cases this
+/// fallthrough.
 ///
 /// # Coverage per `RegionKind`
 ///
@@ -1029,10 +1142,24 @@ fn host_boundary_scheme_aware(region: &str) -> usize {
 /// (S4, #858) — a class PR #845 fixed on the `Authority` side only, tracked under the parent
 /// issue #856, with an `OpaquePath`-side follow-up filed rather than fixed here:
 ///
-/// - Username-only userinfo with no password (`ghp_TOKEN@github.com`) — **`Authority` only**
-///   (C1). The bounded `@` pass never shape-checks, so a bare username redacts correctly; the
-///   `OpaquePath` twin (`c:/ghp_TOKEN@evil`) has no authority span to license that and stays
-///   unredacted. See #858 (S4) — no known fix short of ecosystem-specific token-prefix sniffing.
+/// - Username-only userinfo with no password (`ghp_TOKEN@github.com`) — **`Authority` only**,
+///   with one narrower exception on `OpaquePath` (C1). The bounded `@` pass never shape-checks,
+///   so a bare username redacts correctly on `Authority` regardless of its shape; the
+///   `OpaquePath` twin only redacts when [`find_token_prefix_at`] recognizes the username's own
+///   segment as *starting with* one of [`TOKEN_PREFIXES`] (`c:/ghp_TOKEN@evil` → `c:***@evil`,
+///   #858, S4) — see that function's own doc comment for the precise, canonical statement of
+///   which shapes qualify. An unprefixed username-only credential (`c:/hunter2@evil`) still has
+///   no authority span to license unconditional redaction and stays unredacted, by design: there
+///   is no discriminator that distinguishes it from an ordinary path segment without
+///   ecosystem-specific token-prefix sniffing. A *prefixed* one can still leak too, though, when
+///   the prefix isn't at a `/`/`?`/`#`/`\` segment start (`c:/a;ghp_TOKEN@evil` — `;` is a
+///   legitimate RFC 3986 path-parameter separator, not one of those boundary characters) — the
+///   residual gap this carve-out leaves is broader than "unprefixed only". A token-prefixed
+///   credential sitting in `mask_at`'s tail, past an already-masked colon-shaped credential, also
+///   still leaks (`c:/user:pw@evil/ghp_BBB@evil2` → `c:***@evil/ghp_BBB@evil2`) — pre-existing,
+///   byte-identical to `main`, not a regression: [`redact_secondary_colon_credential`]/
+///   [`redact_further_credential`] have no prefix awareness of their own, and wiring one in was
+///   the audit's rejected #875-adjacent approach (19 new leaks elsewhere).
 ///
 /// `OpaquePath` used to additionally disable the [`redact_colon_credential`] fallback outright
 /// (first for *any* `@` in the region, later — #857's own first pass — narrowed to only a
@@ -1091,7 +1218,7 @@ fn redact_credential(raw: &str, start: usize, kind: RegionKind) -> String {
             redact_secondary_colon_credential(&region[at + 1..])
         )
     };
-    match find_credential_at(region) {
+    match find_credential_at(region).or_else(|| find_token_prefix_at(region)) {
         Some(at) => mask_at(extend_credential_at(region, at)),
         None => redact_colon_credential(raw, start, region),
     }
@@ -3014,17 +3141,95 @@ mod tests {
         assert_eq!(redacted, "***@host:***/x");
     }
 
-    /// #846 S4 (tracked at #858): `OpaquePath` has no authority span to license the
+    /// #846 S4 (fixed by #858): `OpaquePath` has no authority span to license the
     /// `Authority`-only unconditional bounded `@` pass, so a username-only credential (no
-    /// password) is not credential-shaped by [`find_credential_at`]'s own rules and passes
-    /// through unredacted — unlike its `Authority` twin, pinned by
-    /// `test_redact_userinfo_unparseable_username_only_userinfo_is_redacted` above. No known fix
-    /// short of ecosystem-specific token-prefix sniffing (`ghp_`, `glpat-`); remove `#[ignore]`
-    /// once #858 lands a fix.
+    /// password) is not credential-shaped by [`find_credential_at`]'s own rules — but a
+    /// token-prefixed one is now caught by [`find_token_prefix_at`], matching its `Authority`
+    /// twin, pinned by `test_redact_userinfo_unparseable_username_only_userinfo_is_redacted`
+    /// above.
     #[test]
-    #[ignore = "S4: known OpaquePath username-only credential leak, see #858"]
     fn test_redact_userinfo_opaque_path_username_only_credential_is_redacted() {
         assert_eq!(redact_userinfo("c:/ghp_TOKEN@evil"), "c:***@evil");
+    }
+
+    /// #858 companion: a token-prefixed username-only credential is redacted regardless of which
+    /// `OpaquePath`-eligible scheme precedes it.
+    #[test]
+    fn test_redact_userinfo_opaque_path_token_prefix_credential_is_redacted_nuget() {
+        assert_eq!(
+            redact_userinfo("nuget:///glpat-SECRET@feed.corp/v3"),
+            "nuget:***@feed.corp/v3"
+        );
+    }
+
+    /// #858 companion: same as above for a `file:///` scheme and a GitHub PAT prefix.
+    #[test]
+    fn test_redact_userinfo_opaque_path_token_prefix_credential_is_redacted_file() {
+        assert_eq!(redact_userinfo("file:///ghp_TOKEN@evil"), "file:***@evil");
+    }
+
+    /// #858 required no-op pins: [`find_token_prefix_at`] must not fire on an unprefixed
+    /// username, even one that superficially resembles a credential (an email-shaped path
+    /// segment, a bare `@scope`) — these stay unredacted by design (see [`redact_credential`]'s
+    /// own doc comment, C1).
+    #[test]
+    fn test_redact_userinfo_opaque_path_token_prefix_no_op_windows_path() {
+        assert_eq!(
+            redact_userinfo("file:///C:/Users/john.doe@corp/project"),
+            "file:///C:/Users/john.doe@corp/project"
+        );
+    }
+
+    #[test]
+    fn test_redact_userinfo_opaque_path_token_prefix_no_op_bare_scope() {
+        assert_eq!(redact_userinfo("c:///@scope/pkg"), "c:///@scope/pkg");
+    }
+
+    #[test]
+    fn test_redact_userinfo_opaque_path_token_prefix_no_op_unprefixed_username() {
+        assert_eq!(
+            redact_userinfo("file:///home/user@example/file"),
+            "file:///home/user@example/file"
+        );
+    }
+
+    /// impl-critic F4.1: pins [`find_token_prefix_at`]'s `starts_with` (not `contains`) rule —
+    /// the one property that keeps its false-positive population bounded. A leading `x` right
+    /// before the token prefix, with no `/`/`?`/`#`/`\` boundary between them, must not match.
+    #[test]
+    fn test_redact_userinfo_opaque_path_token_prefix_requires_segment_start() {
+        assert_eq!(redact_userinfo("c:/xghp_TOKEN@evil"), "c:/xghp_TOKEN@evil");
+    }
+
+    /// impl-critic F4.2: pins the `None` path — a token-prefixed value with no `@` at all is not
+    /// a credential (nothing follows the username), previously untested.
+    #[test]
+    fn test_redact_userinfo_opaque_path_token_prefix_no_at_sign_is_noop() {
+        assert_eq!(redact_userinfo("c:/ghp_TOKEN"), "c:/ghp_TOKEN");
+    }
+
+    /// impl-critic F4.3: pins [`find_token_prefix_at`]'s stated last-match-wins convention — two
+    /// token-prefixed segments must resolve to the later, real credential/host boundary, not the
+    /// first.
+    #[test]
+    fn test_redact_userinfo_opaque_path_token_prefix_last_match_wins() {
+        assert_eq!(
+            redact_userinfo("c:/ghp_AAA@evil/ghp_BBB@evil2"),
+            "c:***@evil2"
+        );
+    }
+
+    /// impl-critic F4.4/F6: pins the residual gap precisely — a token prefix not at a
+    /// `/`/`?`/`#`/`\` segment start still leaks (`;` is a legitimate RFC 3986 path-parameter
+    /// separator, not one of those boundary characters). This is *not* "unprefixed only"; see
+    /// [`redact_credential`]'s own doc comment, C1, and [`find_token_prefix_at`]'s. Exists so a
+    /// future boundary-set change is forced to notice and update this pin.
+    #[test]
+    fn test_redact_userinfo_opaque_path_token_prefix_not_at_segment_start_is_noop() {
+        assert_eq!(
+            redact_userinfo("c:/a;ghp_TOKEN@evil"),
+            "c:/a;ghp_TOKEN@evil"
+        );
     }
 
     /// #846 S5 (fixed by #859): `OpaquePath` only had [`find_credential_at`]'s

--- a/fuzz/fuzz_targets/redact_userinfo.rs
+++ b/fuzz/fuzz_targets/redact_userinfo.rs
@@ -2,7 +2,7 @@
 //! parse-independent textual scanners `redact_userinfo`/`url_for_tracing` fall back to
 //! whenever `Url::parse` fails outright or produces a cannot-be-a-base/no-host result.
 //!
-//! Two invariants:
+//! Four invariants:
 //! (a) valid-UTF-8 input never panics `redact_userinfo`/`url_for_tracing` (guards every
 //!     `#[allow(clippy::string_slice)]` slice-bound reasoning in `net_policy.rs`) — non-UTF-8
 //!     bytes are skipped (`str::from_utf8` guard), not exercised, so this invariant does not
@@ -21,13 +21,20 @@
 //! avoids both a corrupted structure and re-fuzzing an already-accepted gap; it fuzzes only the
 //! part outside either concern.
 //!
-//! Deliberately excluded from invariant (b): `OpaquePath`-shaped inputs (`scheme:/path`).
-//! `RegionKind::OpaquePath` has one remaining known, tracked leak class (S4 `#858`, a
-//! username-only credential with no password) that would make this invariant red on day one for
-//! a gap this target isn't meant to prove; it is pinned instead as an `#[ignore]`d regression
-//! test in `net_policy.rs`. S5 (`#859`, an `@` inside the password) is fixed — no longer
-//! excluded for that reason, but `OpaquePath` inputs remain out of scope for this target
-//! regardless, since #858 alone still breaks the invariant.
+//! Still excluded from invariant (b): `OpaquePath`-shaped inputs (`scheme:/path`) whose
+//! credential is a username-only value (no password) that `find_token_prefix_at` in
+//! `net_policy.rs` does not recognize — either genuinely unprefixed (`c:/hunter2@evil`) or
+//! token-prefixed but not at that function's own `/`/`?`/`#`/`\` segment-start boundary
+//! (`c:/a;ghp_TOKEN@evil`, where `;` is a legitimate RFC 3986 path-parameter separator, not one
+//! of those boundary characters) — both stay unredacted by design (#858, S4's residual gap; see
+//! `redact_credential`'s own doc comment, C1, and `find_token_prefix_at`'s own doc for the
+//! precise, canonical statement of which shapes qualify) and would make this invariant red on
+//! day one for a gap this target isn't meant to prove — the residual is broader than "unprefixed
+//! only", so do not re-enable this invariant for `OpaquePath` just because unprefixed values are
+//! handled. S5 (`#859`, an `@` inside the password) is fixed, and S4's segment-start-prefixed
+//! case is now fixed too (#858) — see invariant (d) below, which fuzzes exactly that narrower
+//! case with the sentinel given a real token prefix at a real segment start, so it stays in
+//! scope.
 //!
 //! (c) a credential is never left unredacted across the bracket/colon delimiter space #860/#857
 //!     rewrote — for *both* `RegionKind`s, since #857 removed `OpaquePath`'s special-cased
@@ -41,6 +48,16 @@
 //!     bracket, and which is out of scope for #860/#857 to fix). `@` was added to this alphabet by
 //!     #869's fix, so the `mask_at`-tail family it closed (a second, independent colon-credential
 //!     sitting in the tail after the chosen `@`) is fuzz-covered going forward.
+//!
+//! (d) a token-prefixed `OpaquePath` username-only credential (no password) is never left
+//!     unredacted (#858, S4's fix): the sentinel itself is given a fixed, real token prefix
+//!     (`ghp_`) so it can only be recognized via the prefix, never coincidentally via a colon —
+//!     the fuzzed part is the `scheme:` and separator noise preceding it, drawn from the same
+//!     bracket/slash alphabet as invariant (c) plus a handful of `OpaquePath`-eligible schemes. A
+//!     literal `/` always separates that noise from the credential itself, since the fix's own
+//!     contract requires the credential's segment to *start* with a known prefix — decoration
+//!     glued directly onto it with no boundary in between is a documented non-match, not a leak
+//!     this invariant is meant to catch.
 
 #![no_main]
 
@@ -150,6 +167,33 @@ fuzz_target!(|data: &[u8]| {
         format!("file:///home/u{deco}[x]/gitlab-ci-token:{SENTINEL}"),
     ];
     for input in bracket_variants {
+        let redacted = redact_userinfo(&input);
+        assert!(
+            !redacted.contains(SENTINEL),
+            "credential leaked: input={input:?} output={redacted:?}"
+        );
+    }
+
+    // Invariant (d): the sentinel always carries a real token prefix (`ghp_`) so it can only be
+    // recognized via `find_token_prefix_at`'s prefix check, never a coincidental colon (there is
+    // deliberately no `:` anywhere in these templates); only the `OpaquePath`-eligible scheme and
+    // the bracket/slash noise preceding the credential vary. A literal `/` always separates
+    // `deco` from the credential itself: `find_token_prefix_at` requires the credential's own
+    // segment to *start* with a known prefix, so decoration glued directly onto the credential
+    // with no boundary between them is a documented non-match, not a leak this invariant covers
+    // (see that function's own doc comment and its `TOKEN_PREFIXES` const). A fixed `x` also
+    // always separates the scheme's own `/` from `deco`: `c:/` has only one literal slash, so a
+    // `deco` that itself starts with `/` could otherwise combine with it into `c://`, which
+    // `Url::parse` treats as authority-having (empty host) rather than `OpaquePath` — a
+    // pre-existing, unrelated gap (see the #858 security audit's "NEW FINDING"), not what this
+    // invariant is scoped to cover.
+    let token_credential = format!("ghp_{SENTINEL}");
+    let opaque_variants = [
+        format!("c:/x{deco}/{token_credential}@evil"),
+        format!("file:///x{deco}/{token_credential}@evil"),
+        format!("nuget:///x{deco}/{token_credential}@feed.corp/v3"),
+    ];
+    for input in opaque_variants {
         let redacted = redact_userinfo(&input);
         assert!(
             !redacted.contains(SENTINEL),


### PR DESCRIPTION
## Summary

`redact_userinfo` left username-only credentials (e.g. `ghp_TOKEN@evil` in `c:/ghp_TOKEN@evil`) fully unredacted when they occurred in the `OpaquePath` region kind, since that kind has no bounded authority span to license an unconditional `@`-pass the way `Authority` does (PR #845 only fixed the `Authority` twin).

Adds a token-prefix fallback (`find_token_prefix_at`, scanning for known credential prefixes such as `ghp_`, `glpat-`, `sk-`, `AKIA`, etc.) scoped strictly to `redact_credential`'s `OpaquePath` branch, firing only when the existing shape-based `find_credential_at` returns `None`.

## Safety verification

- Differential testing against 874,624 shapes (combinatorial ecosystem-manifest corpus + 250k randomized inputs with injected credential needles): **0 new leaks, 16,425 fixed**
- The same helper wired into `redact_authority_suffix`/`redact_further_credential` was also tested and **rejected** — it introduces 19 new leaks there via the #871 non-monotonicity, so it stays scoped to `OpaquePath` only
- `cargo fuzz` on the patched target with new `OpaquePath` invariants: 1.35M+ runs, no crashes
- Full workspace suite: `cargo nextest` clean, doctests clean, strict rustdoc gate clean

The fix narrows the `OpaquePath` gap to credentials that are unprefixed or not at a path-segment boundary — it is not fully closed, and the updated doc comments state this precisely.

## #875 investigated, not fixed

The related issue #875 (multi-`@` over-redaction in `redact_authority_suffix`) was investigated in the same audit. Every tested discriminator (the previously-reverted gate, and a token-prefix-augmented variant) trades real credential leaks for cosmetic correctness (10,036 and 3,521 new leaks respectively, against 1,025 and 732 fixed). No safe fix exists as scoped — closed as by-design with the numbers posted to the issue.

## New finding filed separately

Fuzzing during this audit turned up a third, unrelated, pre-existing leak on `main` (Authority-kind, an unclosed `[` truncating the bounded `@` scan) — filed as #887, out of scope for this PR.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (workspace + `fuzz/` crate separately)
- [x] `cargo nextest run --workspace --all-features --no-fail-fast`
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- [x] `cargo fuzz run redact_userinfo` (differential + adversarial)
- [x] Manual repro of all reported leak strings, confirmed fixed; required no-op pins confirmed unaffected

Closes #858