### PR TITLE
fix(deps-core): eliminate O(n^2) colon rescan in colon_credential_match_seeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `specs/`: reconciled `MOC-specs.md` against actual issue/PR state — stale "draft" spec rows marked shipped with their PR/issue references, all shipped specs moved into a "Completed Specs" section, and `specs/constitution.md` added (resolves #855) (#867)
 
 ### Fixed
-- **deps-core**: `net_policy`'s credential redaction no longer takes `O(n^2)` time on input alternating `[` with a non-colon byte, the sibling case #893's consecutive-`[` fix left open (resolves #894) (#TBD)
+- **deps-core**: `net_policy`'s credential redaction no longer takes `O(n^2)` time on input alternating `[` with a non-colon byte, the sibling case #893's consecutive-`[` fix left open (resolves #894) (#895)
 - **deps-core**: `net_policy`'s credential redaction no longer takes `O(n^2)` time on a run of consecutive `[` characters (resolves #891) (#893)
 - **deps-core**: `net_policy::redact_authority_suffix` now redacts a colon-only credential sitting in the window between two already-masked `@`-shaped decoys instead of emitting it verbatim (resolves #886) (#890)
 - **deps-core**: `net_policy::redact_userinfo` now redacts a colon-less `TOKEN@host` credential reachable only through `redact_authority_suffix`'s widen branch (e.g. behind an unclosed `[` that fails `Url::parse`), previously returned verbatim (resolves #887) (#892)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `specs/`: reconciled `MOC-specs.md` against actual issue/PR state — stale "draft" spec rows marked shipped with their PR/issue references, all shipped specs moved into a "Completed Specs" section, and `specs/constitution.md` added (resolves #855) (#867)
 
 ### Fixed
+- **deps-core**: `net_policy`'s credential redaction no longer takes `O(n^2)` time on input alternating `[` with a non-colon byte, the sibling case #893's consecutive-`[` fix left open (resolves #894) (#TBD)
 - **deps-core**: `net_policy`'s credential redaction no longer takes `O(n^2)` time on a run of consecutive `[` characters (resolves #891) (#893)
 - **deps-core**: `net_policy::redact_authority_suffix` now redacts a colon-only credential sitting in the window between two already-masked `@`-shaped decoys instead of emitting it verbatim (resolves #886) (#890)
 - **deps-core**: `net_policy::redact_userinfo` now redacts a colon-less `TOKEN@host` credential reachable only through `redact_authority_suffix`'s widen branch (e.g. behind an unclosed `[` that fails `Url::parse`), previously returned verbatim (resolves #887) (#892)

--- a/crates/deps-core/src/net_policy.rs
+++ b/crates/deps-core/src/net_policy.rs
@@ -1621,27 +1621,45 @@ fn redact_secondary_colon_credential(tail: &str) -> String {
 /// ≤5-digit credential collides with the `host:port` carve-out (`oauth2:12345` stays
 /// unredacted).
 ///
-/// Translates a previously-known `[` offset into "relative to `remaining`", a string that begins
-/// `consumed` bytes past whatever base `known` was itself relative to — or, when `known` has
-/// fallen *behind* `consumed` (the position it named has already been passed, either properly
+/// Translates a previously-known `needle` offset into "relative to `remaining`", a string that
+/// begins `consumed` bytes past whatever base `known` was itself relative to — or, when `known`
+/// has fallen *behind* `consumed` (the position it named has already been passed, either properly
 /// handled as a bracket span or silently swallowed inside an ordinary masked value), re-derives it
 /// fresh by scanning only `remaining` itself, never the longer string it came from. `None` stays
-/// `None` unconditionally: it means "provably no `[` anywhere in the string this offset is
+/// `None` unconditionally: it means "provably no `needle` anywhere in the string this offset is
 /// tracked against", and every `remaining` any caller here ever passes is a suffix of that string,
 /// so it can't have gained one.
 ///
-/// The one caching rule every place in this module that carries a bracket offset across a
-/// shrinking string uses, instead of three independently-maintained copies (impl-critic S1/S2's
-/// fix, then a DRY finding on its own near-duplicated call sites): [`colon_credential_match`]'s
-/// own loop (twice — once per iteration relative to `remaining`, once for the tail it returns) and
-/// [`redact_further_credential`]'s `@`-branch. See those functions' own doc comments for why this
-/// pattern is sound and what performance regression it fixes.
-fn translate_bracket(known: Option<usize>, consumed: usize, remaining: &str) -> Option<usize> {
+/// The one caching rule every place in this module that carries a `[` or `:` offset across a
+/// shrinking string uses, instead of independently-maintained copies of the same match arms
+/// (impl-critic S1/S2's fix for `[`, then a DRY finding on its own near-duplicated call sites,
+/// then #894, which needed the identical rule a second time for `:` and consolidated both into
+/// this one generic helper rather than adding a second copy): [`translate_bracket`] (itself called
+/// from [`colon_credential_match`]'s own loop twice — once per iteration relative to `remaining`,
+/// once for the tail it returns — and from [`redact_further_credential`]'s `@`-branch) and
+/// [`colon_credential_match_seeded`]'s own `next_colon` tracking, which calls this directly with
+/// `':'` since nothing outside that function's loop ever needs the colon offset. See those
+/// functions' own doc comments for why this pattern is sound and what performance regression it
+/// fixes.
+fn translate_offset(
+    known: Option<usize>,
+    consumed: usize,
+    remaining: &str,
+    needle: char,
+) -> Option<usize> {
     match known {
-        Some(b) if b >= consumed => Some(b - consumed),
-        Some(_) => remaining.find('['),
+        Some(o) if o >= consumed => Some(o - consumed),
+        Some(_) => remaining.find(needle),
         None => None,
     }
+}
+
+/// [`translate_offset`] specialized for the nearest `[` — the offset threaded as `next_bracket`
+/// across [`colon_credential_match_seeded`]'s own loop and [`redact_further_credential`]'s
+/// `@`-branch. See `translate_offset`'s own doc comment for the underlying translate-or-rescan
+/// rule and why it is sound.
+fn translate_bracket(known: Option<usize>, consumed: usize, remaining: &str) -> Option<usize> {
+    translate_offset(known, consumed, remaining, '[')
 }
 
 /// Returns `None` when the scan runs out of colons in `authority` (mirrors
@@ -1663,6 +1681,14 @@ fn translate_bracket(known: Option<usize>, consumed: usize, remaining: &str) -> 
 /// properly skipped as an IPv6-host span, or silently swallowed inside an ordinary masked value),
 /// and that rescan only ever covers `remaining` — not the original, much longer `authority` — so
 /// its cost is charged to the region it discovers, not repeated on every colon match before it.
+///
+/// The colon scan itself is amortized the same way (#894): #893 fixed the quadratic scan for a
+/// run of *consecutive* `[`, by threading `next_bracket` as above, but a pattern that alternates
+/// a `[` with an intervening non-`[`/non-`:` byte never takes the bracket-run-skip arm at all, so
+/// the loop's own `remaining.find(':')` — previously re-derived from scratch on every iteration
+/// regardless of how far `cursor` advanced — stayed `O(n)` per iteration. `next_colon` is now
+/// tracked and translated via [`translate_offset`] exactly like `next_bracket` is via
+/// [`translate_bracket`], closing this sibling gap.
 fn colon_credential_match(
     authority: &str,
     next_bracket: Option<usize>,
@@ -1696,6 +1722,10 @@ fn colon_credential_match_seeded(
     );
     let mut cursor = 0;
     let mut next_bracket = next_bracket;
+    // #894: seeded once here, up front, from the whole (uncursored) `authority` — mirrors how
+    // `next_bracket` arrives already seeded by the caller — then threaded/translated the same way
+    // on every iteration below instead of re-derived via `remaining.find(':')` each time.
+    let mut next_colon = authority.find(':');
     // impl-critic R3: sticky for the rest of the scan once any bracket span has been skipped —
     // not reset per colon like an earlier revision's `bracket_adjacent`/`colon_is_bracket_adjacent`
     // pairing (C2), and not a proxy check on `value` itself (the `value.contains(']')`
@@ -1719,7 +1749,11 @@ fn colon_credential_match_seeded(
             continue;
         }
 
-        let next_colon = remaining.find(':');
+        // #894: same `translate_offset` rule as `next_bracket` below, applied to the nearest
+        // `:` — see `translate_offset`'s own doc comment for why `next_bracket` and `next_colon`
+        // are tracked independently rather than sharing one cached offset.
+        let next_colon_here = translate_offset(next_colon, cursor, remaining, ':');
+        next_colon = next_colon_here.map(|c| cursor + c);
         // See `translate_bracket`'s own doc comment for the translate-or-rescan rule. The result
         // is re-absolutized (relative to `authority` again, via `cursor +`) so `next_bracket`
         // stays consistent for the next loop iteration — a no-op when the cheap path was taken
@@ -1731,7 +1765,7 @@ fn colon_credential_match_seeded(
             // start of `remaining`) opens an IPv6-host span that must be skipped as a unit
             // before any colon inside it — including its own `]:port` separator — can be
             // evaluated as a possible credential separator by the checks below.
-            if next_colon.is_none_or(|colon| bracket < colon) {
+            if next_colon_here.is_none_or(|colon| bracket < colon) {
                 cursor += bracket_host_shape_end(remaining, bracket);
                 // Deliberately unconditional, unlike `segment_has_credential_colon`'s own
                 // `bracket_adjacent` flag (which requires a genuinely *closed* bracket before
@@ -1746,7 +1780,7 @@ fn colon_credential_match_seeded(
             }
         }
 
-        let colon = next_colon?;
+        let colon = next_colon_here?;
 
         let value_start = colon + 1;
         let value_end = remaining[value_start..]
@@ -4013,6 +4047,34 @@ mod tests {
             elapsed < std::time::Duration::from_millis(300),
             "took {elapsed:?} for n={n} consecutive '[' — bracket_host_shape_end may have \
              regressed to quadratic behavior"
+        );
+    }
+
+    /// #894: #893 fixed the quadratic scan for a run of *consecutive* `[`, but
+    /// [`colon_credential_match_seeded`] still called `remaining.find(':')` unconditionally on
+    /// every loop iteration — a pattern that alternates `[` with an intervening non-`[`/non-`:`
+    /// byte never takes the bracket-run-skip arm (each `[` is followed by a `0`, not another `[`),
+    /// so every iteration only advances `cursor` by 2 while still re-scanning the whole shrinking
+    /// remainder for the next `:`, i.e. still `O(n²)` (measured, release build: ~1.6s at 400 KB
+    /// before this fix). Fixed by threading `next_colon` through the loop the same way
+    /// `next_bracket`/`translate_bracket` already are — see [`translate_offset`].
+    #[test]
+    fn test_redact_userinfo_alternating_bracket_run_is_linear_time() {
+        let n = 200_000;
+        let input = format!("a@{}", "[0".repeat(n));
+        let start = std::time::Instant::now();
+        let redacted = redact_userinfo(&input);
+        let elapsed = start.elapsed();
+        assert_eq!(
+            redacted,
+            format!("***@{}", "[0".repeat(n)),
+            "redacted len={}",
+            redacted.len()
+        );
+        assert!(
+            elapsed < std::time::Duration::from_millis(300),
+            "took {elapsed:?} for n={n} alternating '[0' pairs — colon_credential_match_seeded \
+             may have regressed to quadratic behavior on the colon rescan"
         );
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #893. `colon_credential_match_seeded` (`crates/deps-core/src/net_policy.rs`) called `remaining.find(':')` unconditionally on every loop iteration, scanning the whole remaining string each time regardless of how the bracket-shape scan advanced. #893 fixed the analogous quadratic scan for a run of consecutive `[` by threading a `next_bracket` offset through the loop; this sibling case (alternating `[` with an intervening non-colon byte) never took that run-skip arm, so the colon rescan stayed O(n) per iteration, i.e. O(n^2) overall.

## Changes

- Threads a `next_colon` offset through `colon_credential_match_seeded`'s loop the same way `next_bracket` already is.
- Consolidates the resulting `translate_bracket`/`translate_colon` duplication (flagged by an automated correctness-gate review) into one generic `translate_offset(known, consumed, remaining, needle: char)` helper. `translate_bracket` is kept as a thin `'['`-specialized wrapper (3 call sites).
- Adds a regression test (`test_redact_userinfo_alternating_bracket_run_is_linear_time`) proving linear-time scaling on the alternating-bracket repro from the issue (~1.6s -> ~0.02s at 400 KB).

## Verification

- Behavior-preserving: ran a 1,921,598-input exhaustive differential comparing pre-fix HEAD output against this branch — zero divergence, so no credential-redaction correctness regression (neither a new leak nor new over-redaction).
- All existing `net_policy` tests pass unchanged (1361 passed / 1 pre-existing skip via `cargo nextest run -p deps-core --all-features`), plus doctests and the strict `RUSTFLAGS/RUSTDOCFLAGS=-D warnings` rustdoc gate.
- `cargo +nightly fmt --all -- --check` and `cargo clippy -p deps-core --all-targets --all-features -- -D warnings` clean.
- Confirmed both callers of the fixed function (`redact_further_credential`, `redact_span_colon_credential` via `redact_colon_credential_seeded`) retain correct behavior.

## Out of scope

A separate, pre-existing quadratic scan was found in `segment_has_credential_colon` (`net_policy.rs:871-928`) during review of this fix — same unguarded per-iteration `find('[')`/`find(':')` pattern, measured ~591ms at 300KB through the public `redact_userinfo`. It predates this branch (identical timing on pre-fix HEAD) and is intentionally not fixed here; filed as its own issue.

Closes #894