### PR TITLE
fix(deps-github-actions, deps-core): stop YAML corruption on flow-style comment mis-attribution and eliminate a credential-redaction O(n^2) scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `specs/`: reconciled `MOC-specs.md` against actual issue/PR state — stale "draft" spec rows marked shipped with their PR/issue references, all shipped specs moved into a "Completed Specs" section, and `specs/constitution.md` added (resolves #855) (#867)
 
 ### Fixed
+- **deps-github-actions**: `extract_comment_tag` no longer mis-attributes a flow-style line's trailing comment to an unrelated SHA-pinned ref, which could corrupt YAML on version-update code action acceptance (resolves #898) (#TBD)
 - **deps-core**: `net_policy`'s credential redaction no longer takes `O(n^2)` time on input alternating `[` with a non-colon byte, the sibling case #893's consecutive-`[` fix left open (resolves #894) (#895)
 - **deps-core**: `net_policy`'s credential redaction no longer takes `O(n^2)` time on a run of consecutive `[` characters (resolves #891) (#893)
 - **deps-github-actions, deps-core**: fixed a quadratic-time parsing regression on single-line manifests with many ref-pinned GitHub Actions dependencies (resolves #885) (#897)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **deps-github-actions**: `extract_comment_tag` no longer mis-attributes a flow-style line's trailing comment to an unrelated SHA-pinned ref, which could corrupt YAML on version-update code action acceptance (resolves #898) (#TBD)
+- **deps-core**: `net_policy::segment_has_credential_colon` no longer takes `O(n^2)` time on a drive-letter-dense run, the same unguarded-scan pattern #893/#894 fixed in `colon_credential_match_seeded` (resolves #896) (#TBD)
 - **deps-core**: `net_policy`'s credential redaction no longer takes `O(n^2)` time on input alternating `[` with a non-colon byte, the sibling case #893's consecutive-`[` fix left open (resolves #894) (#895)
 - **deps-core**: `net_policy`'s credential redaction no longer takes `O(n^2)` time on a run of consecutive `[` characters (resolves #891) (#893)
 - **deps-github-actions, deps-core**: fixed a quadratic-time parsing regression on single-line manifests with many ref-pinned GitHub Actions dependencies (resolves #885) (#897)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `specs/`: reconciled `MOC-specs.md` against actual issue/PR state — stale "draft" spec rows marked shipped with their PR/issue references, all shipped specs moved into a "Completed Specs" section, and `specs/constitution.md` added (resolves #855) (#867)
 
 ### Fixed
-- **deps-github-actions**: `extract_comment_tag` no longer mis-attributes a flow-style line's trailing comment to an unrelated SHA-pinned ref, which could corrupt YAML on version-update code action acceptance (resolves #898) (#TBD)
-- **deps-core**: `net_policy::segment_has_credential_colon` no longer takes `O(n^2)` time on a drive-letter-dense run, the same unguarded-scan pattern #893/#894 fixed in `colon_credential_match_seeded` (resolves #896) (#TBD)
+- **deps-github-actions**: `extract_comment_tag` no longer mis-attributes a flow-style line's trailing comment to an unrelated SHA-pinned ref, which could corrupt YAML on version-update code action acceptance (resolves #898) (#900)
+- **deps-core**: `net_policy::segment_has_credential_colon` no longer takes `O(n^2)` time on a drive-letter-dense run, the same unguarded-scan pattern #893/#894 fixed in `colon_credential_match_seeded` (resolves #896) (#900)
 - **deps-core**: `net_policy`'s credential redaction no longer takes `O(n^2)` time on input alternating `[` with a non-colon byte, the sibling case #893's consecutive-`[` fix left open (resolves #894) (#895)
 - **deps-core**: `net_policy`'s credential redaction no longer takes `O(n^2)` time on a run of consecutive `[` characters (resolves #891) (#893)
 - **deps-github-actions, deps-core**: fixed a quadratic-time parsing regression on single-line manifests with many ref-pinned GitHub Actions dependencies (resolves #885) (#897)

--- a/crates/deps-core/src/net_policy.rs
+++ b/crates/deps-core/src/net_policy.rs
@@ -865,17 +865,34 @@ fn extend_credential_at(region: &str, at: usize) -> usize {
 /// immediately followed by a colon (`[:12345`) was wrongly treated as if it opened a genuine
 /// IPv6 host and had its own next colon exempted as a "port" — this scanner's contract is that
 /// only a real bracket licenses that carve-out, an ordinary (non-bracket) colon gets none.
+///
+/// `next_bracket`/`next_colon` are threaded and translated via [`translate_bracket`]/
+/// [`translate_offset`] exactly like [`colon_credential_match_seeded`]'s own loop (#896, the same
+/// pattern #893/#894 fixed there): an unconditional `remaining.find('[')` on every iteration must
+/// scan all of `remaining` just to *prove absence* of a bracket, and the drive-letter branch below
+/// only advances `cursor` by 2-3 bytes per iteration, so a long bracket-free run (e.g. a Windows
+/// path segment, `("c:/" * n) + "@x"`) turned this quadratic before caching — verified
+/// byte-for-byte equivalent to the pre-fix scan via `redact_userinfo`, over all 271,452 strings of
+/// length 1-5 drawn from the 12-character alphabet `[ ] : / ? # \ c a 0 x @` (not committed as a
+/// permanent test; see #896's own tracked follow-up for a durable equivalence harness).
 // `bracket`/`colon` come from `find`/`starts_with` of ASCII `[`/`]`/`:` bytes, so every slice
 // bound is always a char boundary.
 #[allow(clippy::string_slice)]
 fn segment_has_credential_colon(segment: &str) -> bool {
     let mut cursor = 0;
     let mut bracket_adjacent = false;
+    let mut next_bracket = segment.find('[');
+    let mut next_colon = segment.find(':');
     while cursor < segment.len() {
         let remaining = &segment[cursor..];
 
-        if let Some(bracket) = remaining.find('[') {
-            if let Some(colon) = remaining[..bracket].find(':') {
+        let colon_here = translate_offset(next_colon, cursor, remaining, ':');
+        next_colon = colon_here.map(|c| cursor + c);
+        let bracket_here = translate_bracket(next_bracket, cursor, remaining);
+        next_bracket = bracket_here.map(|b| cursor + b);
+
+        if let Some(bracket) = bracket_here {
+            if let Some(colon) = colon_here.filter(|&c| c < bracket) {
                 if !colon_is_drive_letter(segment, cursor + colon) {
                     return true;
                 }
@@ -902,7 +919,7 @@ fn segment_has_credential_colon(segment: &str) -> bool {
             continue;
         }
 
-        let Some(colon) = remaining.find(':') else {
+        let Some(colon) = colon_here else {
             return false;
         };
         let colon_is_bracket_adjacent = bracket_adjacent && colon == 0;
@@ -962,13 +979,13 @@ fn segment_has_credential_colon(segment: &str) -> bool {
 /// bytes) is not itself in the IPv6-literal alphabet, so every `[` in such a run except the *last*
 /// one is provably not a valid opener — its own fate never depends on what comes after it, only
 /// the last one's does (#891). Rather than returning `open + 1` and making the caller rediscover
-/// this one byte at a time (this function's only quadratic-prone caller,
-/// `colon_credential_match_seeded`, re-scans its own remaining tail with `find(':')` on every
-/// iteration — advancing 1 byte per call turned a long run of `[` into O(n²)), this scans the
-/// whole run in one pass and returns the offset of its *last* `[` (`open + L` for a run of length
-/// `L >= 2`) directly, so the caller's next iteration lands there and evaluates that one bracket as
-/// an ordinary (possibly-closed) opener — behavior-equivalent to the one-byte-at-a-time version
-/// since only `[` bytes (never a candidate opener) are skipped.
+/// this one byte at a time (this function's quadratic-prone callers — `colon_credential_match_seeded`,
+/// and, since #896, `segment_has_credential_colon` too — each re-scan their own remaining tail with
+/// `find(':')` on every iteration — advancing 1 byte per call turned a long run of `[` into O(n²)),
+/// this scans the whole run in one pass and returns the offset of its *last* `[` (`open + L` for a
+/// run of length `L >= 2`) directly, so the caller's next iteration lands there and evaluates that
+/// one bracket as an ordinary (possibly-closed) opener — behavior-equivalent to the
+/// one-byte-at-a-time version since only `[` bytes (never a candidate opener) are skipped.
 ///
 /// Deliberately restricted to `i == open + 1` (impl-critic C1): the alphabet-run loop below can
 /// also reach a *later* `[` after first consuming in-alphabet bytes (`:`, `.`, hex digits) — e.g.
@@ -1636,11 +1653,11 @@ fn redact_secondary_colon_credential(tail: &str) -> String {
 /// then #894, which needed the identical rule a second time for `:` and consolidated both into
 /// this one generic helper rather than adding a second copy): [`translate_bracket`] (itself called
 /// from [`colon_credential_match`]'s own loop twice — once per iteration relative to `remaining`,
-/// once for the tail it returns — and from [`redact_further_credential`]'s `@`-branch) and
-/// [`colon_credential_match_seeded`]'s own `next_colon` tracking, which calls this directly with
-/// `':'` since nothing outside that function's loop ever needs the colon offset. See those
-/// functions' own doc comments for why this pattern is sound and what performance regression it
-/// fixes.
+/// once for the tail it returns — and from [`redact_further_credential`]'s `@`-branch) and both
+/// [`colon_credential_match_seeded`]'s and [`segment_has_credential_colon`]'s own `next_colon`
+/// tracking (#896), each of which calls this directly with `':'` since nothing outside their own
+/// loop ever needs the colon offset. See those functions' own doc comments for why this pattern is
+/// sound and what performance regression it fixes.
 fn translate_offset(
     known: Option<usize>,
     consumed: usize,
@@ -1655,9 +1672,9 @@ fn translate_offset(
 }
 
 /// [`translate_offset`] specialized for the nearest `[` — the offset threaded as `next_bracket`
-/// across [`colon_credential_match_seeded`]'s own loop and [`redact_further_credential`]'s
-/// `@`-branch. See `translate_offset`'s own doc comment for the underlying translate-or-rescan
-/// rule and why it is sound.
+/// across [`colon_credential_match_seeded`]'s own loop, [`segment_has_credential_colon`]'s own
+/// loop (#896), and [`redact_further_credential`]'s `@`-branch. See `translate_offset`'s own doc
+/// comment for the underlying translate-or-rescan rule and why it is sound.
 fn translate_bracket(known: Option<usize>, consumed: usize, remaining: &str) -> Option<usize> {
     translate_offset(known, consumed, remaining, '[')
 }
@@ -4706,5 +4723,70 @@ mod tests {
                 "Display: {err}"
             );
         }
+    }
+
+    /// #896: a long, bracket-free run of drive-letter-shaped colons ahead of the loop's cursor
+    /// (the issue's own repro shape, `("c:/" * n) + "@x"`) must stay linear —
+    /// `segment_has_credential_colon`'s per-iteration `remaining.find('[')`/`remaining.find(':')`
+    /// used to have to rescan the whole shrinking `remaining` on every 2-3-byte drive-letter
+    /// step just to prove no bracket/colon was ahead, mirroring
+    /// `test_redact_authority_suffix_mask_site_colon_dense_streak_is_linear_time`'s methodology
+    /// but through `find_credential_at`'s segment scan instead of the mask-site tail.
+    #[test]
+    fn test_redact_userinfo_drive_letter_dense_streak_is_linear_time() {
+        let k = 400_000;
+        let raw = format!("{}@x", "c:/".repeat(k));
+        let start = std::time::Instant::now();
+        let redacted = redact_userinfo(&raw);
+        let elapsed = start.elapsed();
+        assert_eq!(redacted, raw, "redacted len={}", redacted.len());
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "took {elapsed:?} for a {k}-segment drive-letter-dense run before a single `@` — \
+             segment_has_credential_colon may have regressed to quadratic behavior"
+        );
+    }
+
+    /// #896 correctness companion: the drive-letter-dense repro shape itself (many `c:/`
+    /// segments, no bracket, no real credential colon) must remain a no-op regardless of how
+    /// many drive-letter steps the cached `next_bracket`/`next_colon` offsets have to be
+    /// re-derived across.
+    #[test]
+    fn test_redact_userinfo_dense_drive_letter_run_before_unrelated_at_is_noop() {
+        let raw = format!("{}@x", "c:/".repeat(50));
+        assert_eq!(redact_userinfo(&raw), raw);
+    }
+
+    /// #896 correctness companion: a bracket appearing after one or more drive-letter colons
+    /// must still be recognized once `next_bracket` is re-derived past the drive-letter cursor
+    /// advances — the well-formed-port carve-out this mirrors
+    /// (`test_redact_userinfo_bracketed_ipv6_well_formed_port_is_noop`) must not regress when
+    /// more than one drive-letter segment precedes the bracket.
+    #[test]
+    fn test_redact_userinfo_drive_letter_run_then_bracket_is_noop() {
+        assert_eq!(
+            redact_userinfo("c:/c:/c:/[::1]:8443/pkg@1.0.0"),
+            "c:/c:/c:/[::1]:8443/pkg@1.0.0"
+        );
+    }
+
+    /// #896 correctness companion: a real, non-drive-letter credential colon following one or
+    /// more drive-letter colons must still be found once the cached `next_colon` offset has
+    /// fallen behind the cursor and is re-derived from the shrinking `remaining` — same shape
+    /// as `test_redact_userinfo_unclosed_bracket_before_port_like_value_is_not_exempted`'s
+    /// single-drive-letter case, extended to several.
+    #[test]
+    fn test_redact_userinfo_drive_letter_run_then_real_credential_is_redacted() {
+        let redacted = redact_userinfo("c:/c:/user:hunter2@evil");
+        assert!(!redacted.contains("hunter2"), "redacted={redacted:?}");
+        assert_eq!(redacted, "c:***@evil");
+    }
+
+    /// #896 correctness companion: a segment with neither a bracket nor any colon at all must
+    /// return `false` immediately from `segment_has_credential_colon`'s no-colon fallback arm,
+    /// unaffected by the `next_bracket`/`next_colon` seeding this fix introduced.
+    #[test]
+    fn test_redact_userinfo_no_colon_no_bracket_segment_is_noop() {
+        assert_eq!(redact_userinfo("path/to/pkg@1.0.0"), "path/to/pkg@1.0.0");
     }
 }

--- a/crates/deps-github-actions/src/formatter.rs
+++ b/crates/deps-github-actions/src/formatter.rs
@@ -179,14 +179,20 @@ impl PackageRendering for GithubActionsFormatter {
             // scalar, `version_range` sits inside the quotes, so appending `# {tag}`
             // would place a `#` inside the string instead of starting a YAML comment —
             // the same corruption the mutable-ref-pin SHA-pin action guards against.
-            // Falls straight to the no-op fallback without even consulting `TagIndex`,
-            // identical to a cache miss.
-            Some(PinStyle::Sha { .. }) if gha_dep.is_plain_scalar => self
-                .tag_index
-                .get(dep.name())
-                .and_then(|index| index.tag_to_sha.get(version.as_str()).cloned())
-                .map(|sha| format!("{sha} # {}", version.as_str()))
-                .unwrap_or_else(|| dep.version_literal().unwrap_or(current).to_string()),
+            // `is_last_on_line` guard (issue #898 critic follow-up): for a flow-style
+            // step with real YAML content after the ref (`, with: {...}}`), appending
+            // `# {tag}` here would comment out that content, producing an unterminated
+            // flow mapping — the same corruption class #633 fixed for the bulk SHA-pin
+            // action, reached here through the version-update code action instead.
+            // Both guards fall straight to the no-op fallback without even consulting
+            // `TagIndex`, identical to a cache miss.
+            Some(PinStyle::Sha { .. }) if gha_dep.is_plain_scalar && gha_dep.is_last_on_line => {
+                self.tag_index
+                    .get(dep.name())
+                    .and_then(|index| index.tag_to_sha.get(version.as_str()).cloned())
+                    .map(|sha| format!("{sha} # {}", version.as_str()))
+                    .unwrap_or_else(|| dep.version_literal().unwrap_or(current).to_string())
+            }
             Some(PinStyle::Sha { .. } | PinStyle::Branch) | None => {
                 dep.version_literal().unwrap_or(current).to_string()
             }
@@ -789,6 +795,68 @@ mod tests {
         let new_text =
             fmt.format_version_replacing_for(&d, &ConcreteVersion::new("v5.0.0"), "v4.2.0");
         assert_eq!(new_text, "oldsha # v4.2.0");
+    }
+
+    /// Issue #898 critic follow-up (S1): a flow-style SHA ref with sibling YAML content
+    /// (`, with: {node-version: 20}}`) must withhold the `# {tag}`-appending edit even on
+    /// a `TagIndex` hit, exactly like the quoted-scalar guard above — otherwise accepting
+    /// the version-update code action comments out the sibling content, producing an
+    /// unterminated flow mapping. Manifest shape from the issue's exact repro:
+    /// `- {uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683, with: {node-version: 20}}`.
+    #[test]
+    fn test_format_version_replacing_for_sha_flow_style_not_last_on_line_falls_back_to_literal() {
+        let fmt = formatter();
+        let name = PackageName::new("actions/checkout");
+        let mut index = TagIndex::default();
+        index
+            .tag_to_sha
+            .insert("v5.0.0".to_string(), "deadbeef".repeat(5));
+        fmt.tag_index.insert(name, Arc::new(index));
+
+        let sha = "11bd71901bbe5b1630ceea73d27597364c9af683";
+        let mut d = dep(
+            Some(PinStyle::Sha { comment_tag: None }),
+            "actions/checkout",
+            None,
+        );
+        d.is_last_on_line = false;
+
+        // Mirrors the real caller: for a commentless flow-style SHA ref, `current` is
+        // the raw declared SHA itself (`version_req`), since `version_literal` is `None`.
+        let new_text = fmt.format_version_replacing_for(&d, &ConcreteVersion::new("v5.0.0"), sha);
+        assert_eq!(
+            new_text, sha,
+            "a flow-style SHA ref with sibling content must never gain a `# {{tag}}` suffix"
+        );
+        assert!(!new_text.contains('#'));
+    }
+
+    /// Positive-control companion to the withhold test above: an ordinary,
+    /// genuinely-last-on-line SHA ref (the overwhelming common case) must keep resolving
+    /// through `TagIndex` and appending `# {tag}` — the #898 fix must not become overly
+    /// conservative and silently withhold a safe, correct edit.
+    #[test]
+    fn test_format_version_replacing_for_sha_last_on_line_still_appends_tag_comment() {
+        let fmt = formatter();
+        let name = PackageName::new("actions/checkout");
+        let mut index = TagIndex::default();
+        index
+            .tag_to_sha
+            .insert("v5.0.0".to_string(), "deadbeef".repeat(5));
+        fmt.tag_index.insert(name, Arc::new(index));
+
+        let d = dep(
+            Some(PinStyle::Sha {
+                comment_tag: Some("v4.2.0".to_string()),
+            }),
+            "actions/checkout",
+            Some("11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.0"),
+        );
+        assert!(d.is_last_on_line);
+
+        let new_text =
+            fmt.format_version_replacing_for(&d, &ConcreteVersion::new("v5.0.0"), "v4.2.0");
+        assert_eq!(new_text, format!("{} # v5.0.0", "deadbeef".repeat(5)));
     }
 
     #[test]

--- a/crates/deps-github-actions/src/parser.rs
+++ b/crates/deps-github-actions/src/parser.rs
@@ -598,7 +598,15 @@ fn build_dependency(
             let is_last_on_line = ref_is_last_token_on_line(rest_of_line, window);
 
             if is_full_sha(&ref_text) {
-                let comment = is_plain_scalar
+                // `extract_comment_tag` takes the first whitespace-preceded `#` anywhere
+                // in `rest_of_line`, with no notion of whether that `#` is genuinely this
+                // ref's own trailing comment or belongs to an unrelated later token on the
+                // same flow-style line (issue #898). `is_last_on_line` already answers
+                // exactly that question (see the #633 comment above): reuse it as a gate
+                // so a flow-style continuation (`, with: {...}}`) is never misread as this
+                // ref's comment, which previously computed an over-wide `version_range`
+                // spanning real YAML content past the ref.
+                let comment = (is_plain_scalar && is_last_on_line)
                     .then(|| extract_comment_tag(rest_of_line, window))
                     .flatten();
 
@@ -1521,6 +1529,115 @@ mod tests {
              expected the O(1) line-end lookup to make this independent of the trailing \
              content size instead of re-scanning ~8MB per call"
         );
+    }
+
+    // --- issue #898: comment-tag mis-attribution across sibling flow-mapping keys ---
+    //
+    // `extract_comment_tag` takes the first whitespace-preceded `#` anywhere in
+    // `rest_of_line`, with no notion of whether that `#` is genuinely the ref's own
+    // trailing comment or belongs to an unrelated later token on the same flow-style
+    // line. The fix gates the call on `is_last_on_line` (already computed for the #633
+    // guard) so a flow-style continuation is never misread as this ref's comment.
+
+    #[test]
+    fn test_flow_style_sha_pin_trailing_comment_not_attributed_across_sibling_key() {
+        // Exact issue repro: a flow-style step where `, with: {node: 20}}` sits between
+        // the SHA ref and the line's only `#`. Before the fix, `version_range` swallowed
+        // that whole span as a "trailing comment"; the fix must leave it un-attributed.
+        let sha = "a".repeat(40);
+        let content =
+            format!("steps:\n  - {{uses: actions/checkout@{sha}, with: {{node: 20}}}} # v4.2.0\n");
+        let result = parse_workflow_yaml(&content, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        let dep = &result.dependencies[0];
+        assert_eq!(dep.name(), "actions/checkout");
+        assert!(!dep.is_last_on_line);
+        assert_eq!(dep.pin, Some(PinStyle::Sha { comment_tag: None }));
+        assert_eq!(dep.version_literal, None);
+        assert_eq!(
+            slice(&content, dep.version_range().unwrap()),
+            sha,
+            "version_range must span only the ref itself, never the sibling `with:` key"
+        );
+    }
+
+    #[test]
+    fn test_two_sha_pins_on_one_flow_style_line_get_distinct_non_overlapping_ranges() {
+        // Issue #898 explicitly calls out this variant as worse: two SHA-pinned steps
+        // sharing one flow-style line previously both got the line's single trailing
+        // comment attributed, producing overlapping `version_range`s.
+        let sha1 = "a".repeat(40);
+        let sha2 = "b".repeat(40);
+        let content = format!(
+            "steps: [{{uses: actions/checkout@{sha1}}}, {{uses: actions/setup-node@{sha2}}}] # v4.2.0\n"
+        );
+        let result = parse_workflow_yaml(&content, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 2);
+        let dep0 = &result.dependencies[0];
+        let dep1 = &result.dependencies[1];
+
+        assert!(!dep0.is_last_on_line);
+        assert!(!dep1.is_last_on_line);
+        assert_eq!(dep0.pin, Some(PinStyle::Sha { comment_tag: None }));
+        assert_eq!(dep1.pin, Some(PinStyle::Sha { comment_tag: None }));
+
+        let range0 = dep0.version_range().unwrap();
+        let range1 = dep1.version_range().unwrap();
+        assert_eq!(slice(&content, range0), sha1);
+        assert_eq!(slice(&content, range1), sha2);
+        assert!(
+            range0.end.character <= range1.start.character,
+            "ranges must not overlap: {range0:?} vs {range1:?}"
+        );
+    }
+
+    #[test]
+    fn test_block_style_sha_pin_last_on_line_still_attributes_trailing_comment() {
+        // Non-regression: an ordinary block-style SHA pin (the overwhelming common
+        // case, and the whole reason `extract_comment_tag` exists) must keep resolving
+        // its trailing `# vX.Y.Z` comment — the fix must not become overly conservative.
+        let sha = "a".repeat(40);
+        let content = format!("steps:\n  - uses: actions/checkout@{sha} # v4.2.0\n");
+        let result = parse_workflow_yaml(&content, &test_uri()).unwrap();
+        assert_eq!(result.dependencies.len(), 1);
+        let dep = &result.dependencies[0];
+        assert!(dep.is_last_on_line);
+        assert_eq!(
+            dep.pin,
+            Some(PinStyle::Sha {
+                comment_tag: Some("v4.2.0".to_string())
+            })
+        );
+        assert_eq!(
+            dep.version_requirement().map(deps_core::VersionReq::as_str),
+            Some("v4.2.0")
+        );
+        assert_eq!(dep.version_literal, Some(format!("{sha} # v4.2.0")));
+        assert_eq!(
+            slice(&content, dep.version_range().unwrap()),
+            format!("{sha} # v4.2.0")
+        );
+    }
+
+    #[test]
+    fn test_flow_style_sha_pin_version_range_excludes_sibling_key_text() {
+        // End-to-end corruption-vector check for issue #898: every code action in this
+        // workspace writes its `TextEdit` scoped exactly to `version_range` (see
+        // `ecosystem::sha_pin_text_edit_for`/`deps_core::lsp_helpers::code_actions`'s
+        // `single_file_edit` calls). Proving `version_range` never extends past the
+        // ref's own text is therefore sufficient to prove no such edit could delete the
+        // sibling `with:` key's content — a wider integration test would need to
+        // replicate that same scoping rule to assert anything beyond this.
+        let sha = "a".repeat(40);
+        let content =
+            format!("steps:\n  - {{uses: actions/checkout@{sha}, with: {{node: 20}}}} # v4.2.0\n");
+        let result = parse_workflow_yaml(&content, &test_uri()).unwrap();
+        let dep = &result.dependencies[0];
+        let range = dep.version_range().unwrap();
+        let spanned = slice(&content, range);
+        assert_eq!(spanned, sha);
+        assert!(!spanned.contains("with"));
+        assert!(!spanned.contains('}'));
     }
 
     // --- issue #706: composite action.yml routing (parsing side) ---


### PR DESCRIPTION
## Summary

Two independent bug fixes bundled per triage (both P1/P2, no cross-dependency):

- **deps-github-actions**: `extract_comment_tag` took the first whitespace-preceded `#` anywhere on the rest of a line without checking whether it genuinely belonged to the current ref. On a flow-style GitHub Actions step like `{uses: actions/checkout@<sha>, with: {node: 20}}} # v4.2.0`, this attributed the trailing comment to the SHA ref and computed an over-wide `version_range`. Accepting a version-update code action then wrote `# {tag}` over sibling YAML content (`, with: {node: 20}}`), producing an unterminated flow mapping — the same corruption class as #633, reached through the version-update path instead of the SHA-pin path. Fixed by gating comment-tag extraction (in both the parser and the formatter's `format_version_replacing_for`) on `is_plain_scalar && is_last_on_line`, so the trailing comment is only attributed to a ref that is genuinely the last token on its line; every downstream consumer (update-version/vulnerability-fix/unsatisfiable-fix code actions, the code lens) now withholds the edit instead of writing over sibling content.

- **deps-core**: `segment_has_credential_colon` repeated the unguarded find-scan pattern #893/#894 removed from the sibling function `colon_credential_match_seeded` — unconditional `remaining.find('[')`/`remaining.find(':')` on every loop iteration against a drive-letter branch that advances the cursor by only 2-3 bytes. On a 300 KB adversarial input this was ~290x slower than linear. Fixed by threading the existing `translate_offset`/`translate_bracket` caching helpers through the loop, mirroring #895's fix. Verified byte-for-byte equivalent to the pre-fix scan via exhaustive differential testing.

## Test plan

- [x] New regression tests: flow-style exact repro, two-SHA-pins-on-one-line, positive control (block-style still attributes the comment correctly), and a formatter-level withhold/positive-control pair for the S1 follow-up found during review
- [x] New regression tests for the O(n^2) fix: linear-time scaling assertion plus correctness cases (drive-letter-dense repro, drive-letter-then-bracket, drive-letter-then-real-credential, neither-shape)
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` — 5118 passed, 60 skipped, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- [x] Rebased onto current `origin/main` (includes #897) and manually re-verified the merge of the `is_last_on_line` gate with #897's new `window` parameter

Closes #898
Closes #896